### PR TITLE
feat(BA-7144): add a self-contained Searcher and its ops search methods

### DIFF
--- a/changes/13365.enhance.md
+++ b/changes/13365.enhance.md
@@ -1,0 +1,1 @@
+Add a `Searcher` spec that carries its own SELECT and row conversion, with matching scoped and global search methods on the DB ops surface

--- a/src/ai/backend/manager/repositories/base/__init__.py
+++ b/src/ai/backend/manager/repositories/base/__init__.py
@@ -58,10 +58,15 @@ from .purger import (
 from .querier import (
     BatchQuerier,
     BatchQuerierResult,
+    BatchQueryOptions,
     Querier,
     QuerierResult,
     execute_batch_querier,
     execute_querier,
+)
+from .searcher import (
+    Searcher,
+    SearcherResult,
 )
 from .types import (
     CursorConditionFactory,
@@ -126,7 +131,11 @@ __all__ = [
     # BatchQuerier
     "BatchQuerier",
     "BatchQuerierResult",
+    "BatchQueryOptions",
     "execute_batch_querier",
+    # Searcher
+    "Searcher",
+    "SearcherResult",
     # Creator
     "CreatorSpec",
     "Creator",

--- a/src/ai/backend/manager/repositories/base/querier.py
+++ b/src/ai/backend/manager/repositories/base/querier.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -96,6 +96,18 @@ async def execute_querier[TRow: Base](
 # =============================================================================
 
 
+class BatchQueryOptions(Protocol):
+    """The filtering, ordering, and pagination options a batch query reads.
+
+    Both :class:`BatchQuerier` and :class:`Searcher` satisfy this, so a batch query
+    runs against either while the two remain separate classes.
+    """
+
+    pagination: QueryPagination
+    conditions: list[QueryCondition]
+    orders: list[QueryOrder]
+
+
 @dataclass
 class BatchQuerier:
     """Bundles query conditions, orders, and pagination for batch repository queries."""
@@ -151,7 +163,7 @@ async def _validate_scope(
 
 def _apply_batch_querier(
     query: sa.sql.Select[Any],
-    querier: BatchQuerier,
+    querier: BatchQueryOptions,
     or_conditions: Sequence[QueryCondition],
 ) -> _QueryPair:
     """Apply query conditions, orders, and pagination to a SQLAlchemy select statement.
@@ -195,7 +207,7 @@ def _apply_batch_querier(
 async def execute_batch_querier(
     db_sess: SASession,
     query: sa.sql.Select[Any],
-    querier: BatchQuerier,
+    querier: BatchQueryOptions,
     scopes: Sequence[SearchScope] = (),
 ) -> BatchQuerierResult[Row[Any]]:
     """Execute query with batch querier and return rows with total_count and pagination info.

--- a/src/ai/backend/manager/repositories/base/searcher.py
+++ b/src/ai/backend/manager/repositories/base/searcher.py
@@ -1,0 +1,72 @@
+"""Searcher for repository list queries."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
+
+from .pagination import QueryPagination
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Row
+
+
+@dataclass
+class Searcher[TRow: Base, TData](ABC):
+    """Reads one entity as a list: what to select, how a row becomes data, and the query options.
+
+    Self-contained counterpart of :class:`Querier`, which already carries its own
+    ``row_class``: the caller hands a single object to the ops layer instead of a
+    SELECT statement plus a separate options bundle.
+
+    Subclasses live in the domain repository, so ``to_data`` names its row class
+    directly and the ORM row never leaves the repository layer.
+
+    Example:
+        @dataclass
+        class UserSearcher(Searcher[UserRow, UserData]):
+            def build_select(self) -> sa.sql.Select[Any]:
+                return sa.select(UserRow)
+
+            def to_data(self, row: Row[Any]) -> UserData:
+                user_row: UserRow = row.UserRow
+                return user_row.to_data()
+
+        async with ops.read_ops() as r:
+            result = await r.search_with_scopes(scopes, UserSearcher(pagination=...))
+    """
+
+    pagination: QueryPagination
+    conditions: list[QueryCondition] = field(default_factory=list)
+    orders: list[QueryOrder] = field(default_factory=list)
+
+    @abstractmethod
+    def build_select(self) -> sa.sql.Select[Any]:
+        """Build the base SELECT for ``TRow``, without filters, ordering, or pagination.
+
+        Joins are allowed for filtering or ordering, but the result stays a single
+        entity: an operation returning a composite row belongs in a domain-specific
+        repository method instead.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_data(self, row: Row[Any]) -> TData:
+        """Convert one fetched row into its ``data/`` type."""
+        raise NotImplementedError
+
+
+@dataclass
+class SearcherResult[TData]:
+    """Result of executing a search, carrying data types rather than ORM rows."""
+
+    items: list[TData]
+    total_count: int
+    has_next_page: bool
+    has_previous_page: bool

--- a/src/ai/backend/manager/repositories/ops/base/provider.py
+++ b/src/ai/backend/manager/repositories/ops/base/provider.py
@@ -39,6 +39,8 @@ from ai.backend.manager.repositories.base import (
     PurgerResult,
     Querier,
     QuerierResult,
+    Searcher,
+    SearcherResult,
     Updater,
     UpdaterResult,
     Upserter,
@@ -129,6 +131,49 @@ class ReadOps:
                 "use batch_query_in_global for an explicit unscoped global query."
             )
         return await execute_batch_querier(self._sess, query, querier, scopes)
+
+    async def search_with_scopes[TRow: Base, TData](
+        self,
+        scopes: Sequence[SearchScope],
+        searcher: Searcher[TRow, TData],
+    ) -> SearcherResult[TData]:
+        """Run a searcher restricted to the given scopes and return converted data.
+
+        Same scope rules as :meth:`batch_query_with_scopes`; the searcher carries its
+        own SELECT and row conversion, so no ORM row is returned to the caller.
+        """
+        if not scopes:
+            raise EmptySearchScopeError(
+                "search_with_scopes requires at least one scope; "
+                "use search_in_global for an explicit unscoped global search."
+            )
+        return await self._search(searcher, scopes)
+
+    async def search_in_global[TRow: Base, TData](
+        self,
+        searcher: Searcher[TRow, TData],
+    ) -> SearcherResult[TData]:
+        """Run a searcher across the entire table, with NO scope filter.
+
+        WARNING: carries the same authority requirement as
+        :meth:`batch_query_in_global` — superadmin-only endpoints or internal system
+        operations. For any request acting on behalf of a regular user, use
+        :meth:`search_with_scopes` instead.
+        """
+        return await self._search(searcher, ())
+
+    async def _search[TRow: Base, TData](
+        self,
+        searcher: Searcher[TRow, TData],
+        scopes: Sequence[SearchScope],
+    ) -> SearcherResult[TData]:
+        result = await execute_batch_querier(self._sess, searcher.build_select(), searcher, scopes)
+        return SearcherResult(
+            items=[searcher.to_data(row) for row in result.rows],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
 
 
 class WriteOps(ReadOps):

--- a/tests/unit/manager/repositories/base/test_searcher.py
+++ b/tests/unit/manager/repositories/base/test_searcher.py
@@ -1,0 +1,348 @@
+"""Integration tests for searcher with real database."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, override
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.identifier.role_preset import RolePresetID
+from ai.backend.manager.data.role_preset.types import (
+    RolePresetData,
+    RolePresetSearchResult,
+)
+from ai.backend.manager.errors.repository import EmptySearchScopeError
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.models.scopes import ExistenceCheck, SearchScope
+from ai.backend.manager.repositories.base import (
+    OffsetPagination,
+    Searcher,
+)
+from ai.backend.manager.repositories.ops import DBOpsProvider
+from ai.backend.testutils.db import with_tables
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Row
+
+    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+# =============================================================================
+# Fixtures shared by the searcher behavior tests
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ItemData:
+    """`data/` type the searcher converts rows into."""
+
+    id: int
+    name: str
+    category: str
+
+
+class ItemRow(Base):  # type: ignore[misc]
+    """ORM model for searcher testing."""
+
+    __tablename__ = "test_searcher_item"
+    __table_args__ = {"extend_existing": True}
+
+    id: Mapped[int] = mapped_column(sa.Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(sa.String(50), nullable=False)
+    category: Mapped[str] = mapped_column(sa.String(50), nullable=False)
+
+    def to_data(self) -> ItemData:
+        return ItemData(id=self.id, name=self.name, category=self.category)
+
+
+@dataclass
+class ItemSearcher(Searcher[ItemRow, ItemData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(ItemRow)
+
+    @override
+    def to_data(self, row: Row[Any]) -> ItemData:
+        item_row: ItemRow = row.ItemRow
+        return item_row.to_data()
+
+
+@dataclass(frozen=True)
+class CategoryScope(SearchScope):
+    """SearchScope restricting rows to a single category."""
+
+    category: str
+    checks: Sequence[ExistenceCheck[Any]] = field(default_factory=tuple)
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        category = self.category
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ItemRow.category == category
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return self.checks
+
+
+class TestSearcher:
+    """Tests for executing a searcher against a real database."""
+
+    @pytest.fixture
+    async def database(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(database_connection, [ItemRow]):
+            yield database_connection
+
+    @pytest.fixture
+    async def sample_items(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[list[dict[str, int | str]], None]:
+        data: list[dict[str, int | str]] = [
+            {"id": 1, "name": "item-a", "category": "cat1"},
+            {"id": 2, "name": "item-b", "category": "cat1"},
+            {"id": 3, "name": "item-c", "category": "cat2"},
+            {"id": 4, "name": "item-d", "category": "cat2"},
+            {"id": 5, "name": "item-e", "category": "cat3"},
+        ]
+
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(sa.insert(ItemRow), data)
+
+        yield data
+
+    @pytest.fixture
+    def ops(self, database: ExtendedAsyncSAEngine) -> DBOpsProvider:
+        return DBOpsProvider(database)
+
+    async def test_returns_data_instead_of_rows(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """The searcher converts every fetched row, so no ORM row is returned."""
+        async with ops.read_ops() as r:
+            result = await r.search_in_global(
+                ItemSearcher(pagination=OffsetPagination(offset=0, limit=10)),
+            )
+
+            assert [item.name for item in result.items] == [
+                "item-a",
+                "item-b",
+                "item-c",
+                "item-d",
+                "item-e",
+            ]
+            assert all(isinstance(item, ItemData) for item in result.items)
+
+    async def test_applies_conditions(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """Conditions carried by the searcher filter the result."""
+        async with ops.read_ops() as r:
+            result = await r.search_in_global(
+                ItemSearcher(
+                    pagination=OffsetPagination(offset=0, limit=10),
+                    conditions=[lambda: ItemRow.category == "cat1"],
+                ),
+            )
+
+            assert {item.name for item in result.items} == {"item-a", "item-b"}
+            assert result.total_count == 2
+
+    async def test_applies_orders(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """Orders carried by the searcher sort the result."""
+        async with ops.read_ops() as r:
+            result = await r.search_in_global(
+                ItemSearcher(
+                    pagination=OffsetPagination(offset=0, limit=10),
+                    orders=[ItemRow.name.desc()],
+                ),
+            )
+
+            assert [item.name for item in result.items] == [
+                "item-e",
+                "item-d",
+                "item-c",
+                "item-b",
+                "item-a",
+            ]
+
+    async def test_reports_pagination_info(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """Page flags and total_count describe the whole match set, not the page."""
+        async with ops.read_ops() as r:
+            result = await r.search_in_global(
+                ItemSearcher(pagination=OffsetPagination(offset=2, limit=2)),
+            )
+
+            assert len(result.items) == 2
+            assert result.total_count == 5
+            assert result.has_next_page is True
+            assert result.has_previous_page is True
+
+    async def test_scopes_restrict_the_result(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """Scopes are applied exactly as they are for a batch query."""
+        async with ops.read_ops() as r:
+            result = await r.search_with_scopes(
+                [CategoryScope(category="cat1"), CategoryScope(category="cat3")],
+                ItemSearcher(pagination=OffsetPagination(offset=0, limit=10)),
+            )
+
+            assert {item.name for item in result.items} == {"item-a", "item-b", "item-e"}
+            assert result.total_count == 3
+
+    async def test_rejects_empty_scopes(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """An empty scope list would degrade into an unscoped scan, so it is refused."""
+        async with ops.read_ops() as r:
+            with pytest.raises(EmptySearchScopeError):
+                await r.search_with_scopes(
+                    [],
+                    ItemSearcher(pagination=OffsetPagination(offset=0, limit=10)),
+                )
+
+    async def test_global_search_applies_no_scope_filter(
+        self,
+        ops: DBOpsProvider,
+        sample_items: list[dict[str, int | str]],
+    ) -> None:
+        """The global path returns rows from every category."""
+        async with ops.read_ops() as r:
+            result = await r.search_in_global(
+                ItemSearcher(pagination=OffsetPagination(offset=0, limit=10)),
+            )
+
+            assert {item.category for item in result.items} == {"cat1", "cat2", "cat3"}
+            assert result.total_count == 5
+
+
+# =============================================================================
+# Wiring a pass-through domain on the searcher
+# =============================================================================
+
+
+@dataclass
+class RolePresetSearcher(Searcher[RolePresetRow, RolePresetData]):
+    """The searcher `role_preset` would own once it moves onto this foundation."""
+
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(RolePresetRow)
+
+    @override
+    def to_data(self, row: Row[Any]) -> RolePresetData:
+        preset_row: RolePresetRow = row.RolePresetRow
+        return preset_row.to_data()
+
+
+class TestPassThroughDomainWiring:
+    """`role_preset.search` — a pass-through search — rebuilt on the searcher."""
+
+    @pytest.fixture
+    async def database(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(database_connection, [RolePresetRow]):
+            yield database_connection
+
+    @pytest.fixture
+    async def sample_presets(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[list[RolePresetID], None]:
+        preset_ids = [RolePresetID(uuid4()) for _ in range(3)]
+        async with database.begin_session() as db_sess:
+            await db_sess.execute(
+                sa.insert(RolePresetRow),
+                [
+                    {
+                        "id": preset_ids[0],
+                        "name": "domain-admin",
+                        "scope_type": ScopeType.DOMAIN,
+                        "auto_assign": False,
+                        "deleted": False,
+                    },
+                    {
+                        "id": preset_ids[1],
+                        "name": "project-member",
+                        "scope_type": ScopeType.PROJECT,
+                        "auto_assign": True,
+                        "deleted": False,
+                    },
+                    {
+                        "id": preset_ids[2],
+                        "name": "retired",
+                        "scope_type": ScopeType.PROJECT,
+                        "auto_assign": False,
+                        "deleted": True,
+                    },
+                ],
+            )
+
+        yield preset_ids
+
+    async def test_search_collapses_to_a_single_ops_call(
+        self,
+        database: ExtendedAsyncSAEngine,
+        sample_presets: list[RolePresetID],
+    ) -> None:
+        """The whole db_source.search body is one ops call plus the result wrapper."""
+        ops = DBOpsProvider(database)
+        searcher = RolePresetSearcher(
+            pagination=OffsetPagination(offset=0, limit=10),
+            conditions=[lambda: RolePresetRow.deleted.is_(False)],
+            orders=[RolePresetRow.name.asc()],
+        )
+
+        async with ops.read_ops() as r:
+            result = await r.search_in_global(searcher)
+        search_result = RolePresetSearchResult(
+            items=result.items,
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+        assert [preset.name for preset in search_result.items] == [
+            "domain-admin",
+            "project-member",
+        ]
+        assert search_result.items[0].id == sample_presets[0]
+        assert search_result.items[0].scope_type == ScopeType.DOMAIN.to_element()
+        assert search_result.items[1].auto_assign is True
+        assert search_result.total_count == 2
+        assert search_result.has_next_page is False
+        assert search_result.has_previous_page is False


### PR DESCRIPTION
## Summary
- Add `Searcher[TRow, TData]`, a list-query spec that carries its own SELECT (`build_select()`), its own row conversion (`to_data()`), and the pagination/conditions/orders — the self-contained counterpart of `Querier`, which already carries `row_class` while `BatchQuerier` carries only options.
- Add `ReadOps.search_with_scopes(scopes, searcher)` / `ReadOps.search_in_global(searcher)`, which return `SearcherResult[TData]`; the conversion happens inside ops so no ORM row leaves the repository layer.
- Leave `BatchQuerier` untouched — 106 actions hold one as a field. `BatchQueryOptions` is a temporary protocol naming the fields both specs share, so a batch query type-checks against either until the two are unified.

No domain code is wired onto this yet; the test shows a pass-through domain (`role_preset`) collapsing to a single ops call on top of it.

## Test plan
- [ ] `pants lint` / `pants check`
- [ ] `tests/unit/manager/repositories/base/test_searcher.py` — data conversion, conditions, orders, pagination flags, scope filtering, empty-scope rejection, global path, and the `role_preset` wiring
- [ ] `tests/unit/manager/repositories/base::` — existing querier/pagination tests unaffected by the widened parameter type

Resolves BA-7144

🤖 Generated with [Claude Code](https://claude.com/claude-code)