### PR TITLE
feat(BA-7149): purge app config fragments by config name

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, update, purge, bulk-purge) · my(get, update, purge) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-purge, purge-by-names) · my(get, update, purge) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, update, purge, bulk-purge) · my(get, update) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-purge) · my(get, update, purge) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/changes/13375.feature.md
+++ b/changes/13375.feature.md
@@ -1,0 +1,1 @@
+Add `./bai my app-config-fragment purge`, which purges the caller's own user-scope fragments for the given config names and aborts without purging anything when one of the names has no fragment.

--- a/changes/13375.feature.md
+++ b/changes/13375.feature.md
@@ -1,1 +1,1 @@
-Add `./bai my app-config-fragment purge`, which purges the caller's own user-scope fragments by config name.
+Add `POST /v2/app-config-fragments/my/bulk-delete` and `./bai my app-config-fragment purge`, which purge the caller's own user-scope fragments by config name, all-or-nothing.

--- a/changes/13375.feature.md
+++ b/changes/13375.feature.md
@@ -1,1 +1,1 @@
-Add `./bai my app-config-fragment purge`, which purges the caller's own user-scope fragments for the given config names and aborts without purging anything when one of the names has no fragment.
+Add `./bai my app-config-fragment purge`, which purges the caller's own user-scope fragments by config name.

--- a/changes/13375.feature.md
+++ b/changes/13375.feature.md
@@ -1,1 +1,1 @@
-Add `POST /v2/app-config-fragments/my/bulk-delete` and `./bai my app-config-fragment purge`, which purge the caller's own user-scope fragments by config name, all-or-nothing.
+Add `POST /v2/app-config-fragments/my/by-names/bulk-delete` and `POST /v2/app-config-fragments/scoped/by-names/bulk-delete`, with `./bai my app-config-fragment purge` and `./bai app-config-fragment purge-by-names`, which purge a scope's fragments by config name, all-or-nothing.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1171,6 +1171,25 @@
         "title": "MyUpsertAppConfigFragmentsInput",
         "type": "object"
       },
+      "MyPurgeAppConfigFragmentsByNamesInput": {
+        "description": "Purge the current user's own user-scope fragments for the given config names.",
+        "properties": {
+          "config_names": {
+            "description": "Config names whose fragments to purge. All-or-nothing: a name the scope holds no fragment for purges nothing and is reported as not found.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "config_names"
+        ],
+        "title": "MyPurgeAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
       "CreateAppConfigAllowListInput": {
         "description": "Input for registering a new app config allow-list entry.",
         "properties": {
@@ -42064,6 +42083,35 @@
         },
         "parameters": [],
         "description": "Upsert many fragments at the caller's own user scope, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/my/bulk-delete": {
+      "post": {
+        "operationId": "v2/app-config-fragments.my_bulk_purge",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MyPurgeAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Purge the caller's own user-scope fragments by config name, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1085,6 +1085,30 @@
         "title": "ScopedAppConfigFragmentsByNamesInput",
         "type": "object"
       },
+      "ScopedPurgeAppConfigFragmentsByNamesInput": {
+        "description": "Purge the fragments written at one scope for the given config names.",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/AppConfigScopeRef",
+            "description": "Scope whose fragments to purge."
+          },
+          "config_names": {
+            "description": "Config names whose fragments to purge. All-or-nothing: a name the scope holds no fragment for purges nothing and is reported as not found.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "scope",
+          "config_names"
+        ],
+        "title": "ScopedPurgeAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
       "AppConfigFragmentUpsertItem": {
         "description": "One (config_name, config) pair to upsert at the request's scope.",
         "properties": {
@@ -1152,25 +1176,6 @@
         "title": "MyAppConfigFragmentsByNamesInput",
         "type": "object"
       },
-      "MyUpsertAppConfigFragmentsInput": {
-        "description": "Upsert many fragments at the current user's own user scope.\n\nThe scope is the acting user, resolved server-side, so it carries no scope fields.",
-        "properties": {
-          "items": {
-            "description": "The (config_name, config) pairs to upsert.",
-            "items": {
-              "$ref": "#/components/schemas/AppConfigFragmentUpsertItem"
-            },
-            "minItems": 1,
-            "title": "Items",
-            "type": "array"
-          }
-        },
-        "required": [
-          "items"
-        ],
-        "title": "MyUpsertAppConfigFragmentsInput",
-        "type": "object"
-      },
       "MyPurgeAppConfigFragmentsByNamesInput": {
         "description": "Purge the current user's own user-scope fragments for the given config names.",
         "properties": {
@@ -1188,6 +1193,25 @@
           "config_names"
         ],
         "title": "MyPurgeAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
+      "MyUpsertAppConfigFragmentsInput": {
+        "description": "Upsert many fragments at the current user's own user scope.\n\nThe scope is the acting user, resolved server-side, so it carries no scope fields.",
+        "properties": {
+          "items": {
+            "description": "The (config_name, config) pairs to upsert.",
+            "items": {
+              "$ref": "#/components/schemas/AppConfigFragmentUpsertItem"
+            },
+            "minItems": 1,
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "MyUpsertAppConfigFragmentsInput",
         "type": "object"
       },
       "CreateAppConfigAllowListInput": {
@@ -41998,6 +42022,35 @@
         "description": "Read one scope's fragments for the given config names (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
+    "/v2/app-config-fragments/scoped/by-names/bulk-delete": {
+      "post": {
+        "operationId": "v2/app-config-fragments.scoped_bulk_purge_by_names",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScopedPurgeAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Purge one scope's fragments by config name, all-or-nothing (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
     "/v2/app-config-fragments/scoped/bulk-upsert": {
       "post": {
         "operationId": "v2/app-config-fragments.scoped_bulk_upsert",
@@ -42056,6 +42109,35 @@
         "description": "Read the caller's own user-scope fragments for the given config names (auth).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
+    "/v2/app-config-fragments/my/by-names/bulk-delete": {
+      "post": {
+        "operationId": "v2/app-config-fragments.my_bulk_purge_by_names",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MyPurgeAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Purge the caller's own user-scope fragments by config name, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
     "/v2/app-config-fragments/my/bulk-upsert": {
       "post": {
         "operationId": "v2/app-config-fragments.my_bulk_upsert",
@@ -42083,35 +42165,6 @@
         },
         "parameters": [],
         "description": "Upsert many fragments at the caller's own user scope, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
-      }
-    },
-    "/v2/app-config-fragments/my/bulk-delete": {
-      "post": {
-        "operationId": "v2/app-config-fragments.my_bulk_purge",
-        "tags": [
-          "v2/app-config-fragments"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "security": [
-          {
-            "TokenAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MyPurgeAppConfigFragmentsByNamesInput"
-              }
-            }
-          }
-        },
-        "parameters": [],
-        "description": "Purge the caller's own user-scope fragments by config name, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -137,6 +137,50 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     run_async(_run)
 
 
+@app_config_fragment.command(name="purge-by-names")
+@click.option(
+    "--scope-type",
+    required=True,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Scope whose fragments to purge (public | domain | user).",
+)
+@click.option(
+    "--scope-id",
+    default=None,
+    type=click.UUID,
+    help="Domain id or user id; omit for the public scope.",
+)
+@click.argument("config_names", nargs=-1, required=True)
+def purge_by_names(
+    scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]
+) -> None:
+    """Purge one scope's fragments for CONFIG_NAMES, all-or-nothing.
+
+    A name the scope holds no fragment for purges nothing, so a typo cannot quietly destroy
+    a neighbouring config. Addresses the same (scope, config_name) pair that `get` and
+    `update` do, so no fragment id has to be resolved first.
+    """
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        ScopedPurgeAppConfigFragmentsByNamesInput,
+    )
+
+    scope = _resolve_scope(scope_type, scope_id)
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.scoped_purge_app_config_fragments_by_names(
+                ScopedPurgeAppConfigFragmentsByNamesInput(
+                    scope=scope, config_names=list(config_names)
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
 @app_config_fragment.command()
 @click.option(
     "--id",

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -83,37 +83,20 @@ def update(items: str) -> None:
 @app_config_fragment.command()
 @click.argument("config_names", nargs=-1, required=True)
 def purge(config_names: tuple[str, ...]) -> None:
-    """Purge my user-scope fragments for CONFIG_NAMES.
+    """Purge my user-scope fragments for CONFIG_NAMES, all-or-nothing.
 
-    The purge endpoint is addressed by fragment id, so this reads CONFIG_NAMES at my own
-    user scope first and purges the ids that read answers with. A name I hold no fragment
-    for aborts the whole command rather than silently purging the rest, so a typo cannot
-    quietly destroy a neighbouring config.
+    A name I hold no fragment for purges nothing, so a typo cannot quietly destroy a
+    neighbouring config.
     """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
-        BulkPurgeAppConfigFragmentInput,
-        MyAppConfigFragmentsByNamesInput,
+        MyPurgeAppConfigFragmentsByNamesInput,
     )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            answered = await registry.app_config_fragment.my_get_app_config_fragments_by_names(
-                MyAppConfigFragmentsByNamesInput(config_names=list(config_names))
-            )
-            missing = [
-                config_name
-                for config_name, node in zip(config_names, answered.root, strict=True)
-                if node is None
-            ]
-            if missing:
-                raise click.ClickException(
-                    f"No fragment at my user scope for: {', '.join(missing)}. Nothing was purged."
-                )
-            result = await registry.app_config_fragment.bulk_purge(
-                BulkPurgeAppConfigFragmentInput(
-                    ids=[node.id for node in answered.root if node is not None]
-                )
+            result = await registry.app_config_fragment.my_purge_app_config_fragments_by_names(
+                MyPurgeAppConfigFragmentsByNamesInput(config_names=list(config_names))
             )
             print_result(result)
         finally:

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -78,3 +78,45 @@ def update(items: str) -> None:
             await registry.close()
 
     run_async(_run)
+
+
+@app_config_fragment.command()
+@click.argument("config_names", nargs=-1, required=True)
+def purge(config_names: tuple[str, ...]) -> None:
+    """Purge my user-scope fragments for CONFIG_NAMES.
+
+    The purge endpoint is addressed by fragment id, so this reads CONFIG_NAMES at my own
+    user scope first and purges the ids that read answers with. A name I hold no fragment
+    for aborts the whole command rather than silently purging the rest, so a typo cannot
+    quietly destroy a neighbouring config.
+    """
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        BulkPurgeAppConfigFragmentInput,
+        MyAppConfigFragmentsByNamesInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            answered = await registry.app_config_fragment.my_get_app_config_fragments_by_names(
+                MyAppConfigFragmentsByNamesInput(config_names=list(config_names))
+            )
+            missing = [
+                config_name
+                for config_name, node in zip(config_names, answered.root, strict=True)
+                if node is None
+            ]
+            if missing:
+                raise click.ClickException(
+                    f"No fragment at my user scope for: {', '.join(missing)}. Nothing was purged."
+                )
+            result = await registry.app_config_fragment.bulk_purge(
+                BulkPurgeAppConfigFragmentInput(
+                    ids=[node.id for node in answered.root if node is not None]
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -12,6 +12,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -53,6 +54,21 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             f"{_PATH}/scoped/by-names",
             request=request,
             response_model=AppConfigFragmentsByNamesPayload,
+        )
+
+    async def scoped_purge_app_config_fragments_by_names(
+        self,
+        request: ScopedPurgeAppConfigFragmentsByNamesInput,
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge one scope's fragments for the given config names, all-or-nothing.
+
+        A name the scope holds no fragment for purges nothing and is reported as not found.
+        """
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped/by-names/bulk-delete",
+            request=request,
+            response_model=PurgeAppConfigFragmentsByNamesPayload,
         )
 
     async def scoped_bulk_upsert_app_config_fragments(
@@ -104,7 +120,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
         """
         return await self._client.typed_request(
             "POST",
-            f"{_PATH}/my/bulk-delete",
+            f"{_PATH}/my/by-names/bulk-delete",
             request=request,
             response_model=PurgeAppConfigFragmentsByNamesPayload,
         )

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -9,6 +9,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
@@ -18,6 +19,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -89,6 +91,22 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             f"{_PATH}/my/bulk-upsert",
             request=request,
             response_model=UpsertAppConfigFragmentsPayload,
+        )
+
+    async def my_purge_app_config_fragments_by_names(
+        self,
+        request: MyPurgeAppConfigFragmentsByNamesInput,
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge the caller's own user-scope fragments for the given config names.
+
+        All-or-nothing: a name the caller holds no fragment for purges nothing and is
+        reported as not found.
+        """
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/my/bulk-delete",
+            request=request,
+            response_model=PurgeAppConfigFragmentsByNamesPayload,
         )
 
     # --- By id ---

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -30,6 +30,7 @@ __all__ = (
     "MyPurgeAppConfigFragmentsByNamesInput",
     "MyUpsertAppConfigFragmentsInput",
     "ScopedAppConfigFragmentsByNamesInput",
+    "ScopedPurgeAppConfigFragmentsByNamesInput",
     "ScopedSearchAppConfigFragmentInput",
     "ScopedUpsertAppConfigFragmentsInput",
 )
@@ -77,6 +78,19 @@ class MyAppConfigFragmentsByNamesInput(BaseRequestModel):
         description=(
             "Config names whose fragments to read. Answered position by position, null "
             "where the scope holds no fragment for that name."
+        ),
+    )
+
+
+class ScopedPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
+    """Purge the fragments written at one scope for the given config names."""
+
+    scope: AppConfigScopeRef = Field(description="Scope whose fragments to purge.")
+    config_names: list[str] = Field(
+        min_length=1,
+        description=(
+            "Config names whose fragments to purge. All-or-nothing: a name the scope holds "
+            "no fragment for purges nothing and is reported as not found."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -27,6 +27,7 @@ __all__ = (
     "AppConfigScopeRef",
     "BulkPurgeAppConfigFragmentInput",
     "MyAppConfigFragmentsByNamesInput",
+    "MyPurgeAppConfigFragmentsByNamesInput",
     "MyUpsertAppConfigFragmentsInput",
     "ScopedAppConfigFragmentsByNamesInput",
     "ScopedSearchAppConfigFragmentInput",
@@ -76,6 +77,18 @@ class MyAppConfigFragmentsByNamesInput(BaseRequestModel):
         description=(
             "Config names whose fragments to read. Answered position by position, null "
             "where the scope holds no fragment for that name."
+        ),
+    )
+
+
+class MyPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
+    """Purge the current user's own user-scope fragments for the given config names."""
+
+    config_names: list[str] = Field(
+        min_length=1,
+        description=(
+            "Config names whose fragments to purge. All-or-nothing: a name the scope holds "
+            "no fragment for purges nothing and is reported as not found."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -18,6 +18,7 @@ __all__ = (
     "AppConfigFragmentsByNamesPayload",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
+    "PurgeAppConfigFragmentsByNamesPayload",
     "SearchAppConfigFragmentPayload",
     "UpsertAppConfigFragmentsPayload",
 )
@@ -51,6 +52,14 @@ class PurgeAppConfigFragmentPayload(BaseResponseModel):
     """Payload for app config fragment purge."""
 
     id: AppConfigFragmentID = Field(description="Id of the purged app config fragment.")
+
+
+class PurgeAppConfigFragmentsByNamesPayload(BaseResponseModel):
+    """Payload for an all-or-nothing purge of the fragments one scope holds for config names."""
+
+    items: list[AppConfigFragmentID] = Field(
+        description="Ids of the purged fragments, in the order their config names were given."
+    )
 
 
 class AppConfigFragmentBulkErrorInfo(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
     ScopedSearchAppConfigFragmentInput,
@@ -26,6 +27,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -73,6 +75,9 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
 )
 from ai.backend.manager.services.app_config_fragment.actions.purge import (
     PurgeAppConfigFragmentAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.purge_by_names import (
+    PurgeAppConfigFragmentsByNamesAction,
 )
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
@@ -170,6 +175,27 @@ class AppConfigFragmentAdapter(BaseAdapter):
                 AppConfigFragmentBulkErrorInfo(id=error.id, message=error.message)
                 for error in action_result.failed
             ],
+        )
+
+    async def my_purge_app_config_fragments_by_names(
+        self, input: MyPurgeAppConfigFragmentsByNamesInput
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge the current user's own ``user``-scope fragments for ``config_names``.
+
+        All-or-nothing: a name the caller holds no fragment for purges nothing. Calls
+        ``current_user()`` internally — the caller does not pass a scope.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        scope = AppConfigFragmentSearchScope(
+            scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(me.user_id)
+        )
+        action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
+            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
+        )
+        return PurgeAppConfigFragmentsByNamesPayload(
+            items=[fragment.id for fragment in action_result.fragments]
         )
 
     async def batch_load_by_ids(

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -19,6 +19,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedSearchAppConfigFragmentInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
@@ -177,13 +178,29 @@ class AppConfigFragmentAdapter(BaseAdapter):
             ],
         )
 
+    async def scoped_purge_app_config_fragments_by_names(
+        self, input: ScopedPurgeAppConfigFragmentsByNamesInput
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge the fragments written at the scope named in ``input`` for ``config_names``.
+
+        RBAC-authorized at that scope, so a caller purges only a scope they may write.
+        """
+        scope = AppConfigFragmentSearchScope(
+            scope_type=input.scope.scope_type, scope_id=input.scope.scope_id
+        )
+        action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
+            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
+        )
+        return PurgeAppConfigFragmentsByNamesPayload(
+            items=[fragment.id for fragment in action_result.fragments]
+        )
+
     async def my_purge_app_config_fragments_by_names(
         self, input: MyPurgeAppConfigFragmentsByNamesInput
     ) -> PurgeAppConfigFragmentsByNamesPayload:
         """Purge the current user's own ``user``-scope fragments for ``config_names``.
 
-        All-or-nothing: a name the caller holds no fragment for purges nothing. Calls
-        ``current_user()`` internally — the caller does not pass a scope.
+        Calls ``current_user()`` internally — the caller does not pass a scope.
         """
         me = current_user()
         if me is None:

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -107,7 +108,15 @@ class V2AppConfigFragmentHandler:
         result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
-    async def my_bulk_purge(
+    async def scoped_bulk_purge_by_names(
+        self,
+        body: BodyParam[ScopedPurgeAppConfigFragmentsByNamesInput],
+    ) -> APIResponse:
+        """Purge one scope's fragments by config name, all-or-nothing (auth, RBAC-authorized)."""
+        result = await self._adapter.scoped_purge_app_config_fragments_by_names(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def my_bulk_purge_by_names(
         self,
         body: BodyParam[MyPurgeAppConfigFragmentsByNamesInput],
     ) -> APIResponse:

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -11,6 +11,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
@@ -104,4 +105,12 @@ class V2AppConfigFragmentHandler:
     ) -> APIResponse:
         """Upsert many fragments at the caller's own user scope, all-or-nothing (auth)."""
         result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def my_bulk_purge(
+        self,
+        body: BodyParam[MyPurgeAppConfigFragmentsByNamesInput],
+    ) -> APIResponse:
+        """Purge the caller's own user-scope fragments by config name, all-or-nothing (auth)."""
+        result = await self._adapter.my_purge_app_config_fragments_by_names(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
@@ -20,25 +20,26 @@ def register_v2_app_config_fragment_routes(
     """Register all REST v2 app config fragment routes.
 
     Writes go through ``/upsert``: a fragment is addressed by ``(scope, config_name)`` rather
-    than by id, so there is no separate create or update endpoint. ``/my/bulk-delete`` deletes
-    by that same address, so a caller removing their own fragments never has to resolve an id
-    first. The paginated scoped search is not exposed either — ``/by-names`` is the read a
-    client needs before editing. Every
+    than by id, so there is no separate create or update endpoint. ``/by-names`` carries that
+    same address for the operations that share it — the read, and the delete beneath it — so a
+    caller removing a fragment never has to resolve an id first. The paginated scoped search is
+    not exposed either: ``/by-names`` is the read a client needs before editing. Every
     route but ``/admin/search`` is open to any authenticated user and gated by RBAC at the
     processor (a user acts on their own user-scope, a domain admin on their domain's, a
     superadmin on any; public is superadmin-only). Only the system-wide ``/admin/search``
     skips RBAC, being superadmin-only at the middleware.
 
     Layout:
-        POST   /bulk-delete       purge many by id               (auth, RBAC)
-        POST   /admin/search      system-wide paginated search   (superadmin)
-        POST   /scoped/by-names   read one scope's by names      (auth, RBAC)
-        POST   /scoped/bulk-upsert  upsert many at one scope     (auth, RBAC)
-        POST   /my/by-names       read own scope's by names      (auth)
-        POST   /my/bulk-upsert    upsert many at own scope       (auth)
-        POST   /my/bulk-delete    purge own scope's by names     (auth)
-        GET    /{fragment_id}     get by id                      (auth, RBAC)
-        DELETE /{fragment_id}     purge by id                    (auth, RBAC)
+        POST   /bulk-delete                  purge many by id              (auth, RBAC)
+        POST   /admin/search                 system-wide paginated search  (superadmin)
+        POST   /scoped/by-names              read one scope's by names     (auth, RBAC)
+        POST   /scoped/by-names/bulk-delete  purge one scope's by names    (auth, RBAC)
+        POST   /scoped/bulk-upsert           upsert many at one scope      (auth, RBAC)
+        POST   /my/by-names                  read own scope's by names     (auth)
+        POST   /my/by-names/bulk-delete      purge own scope's by names    (auth)
+        POST   /my/bulk-upsert               upsert many at own scope      (auth)
+        GET    /{fragment_id}                get by id                     (auth, RBAC)
+        DELETE /{fragment_id}                purge by id                   (auth, RBAC)
     """
     registry = RouteRegistry.create("app-config-fragments", route_deps.cors_options)
 
@@ -48,11 +49,22 @@ def register_v2_app_config_fragment_routes(
         "POST", "/scoped/by-names", handler.scoped_fragments_by_names, middlewares=[auth_required]
     )
     registry.add(
+        "POST",
+        "/scoped/by-names/bulk-delete",
+        handler.scoped_bulk_purge_by_names,
+        middlewares=[auth_required],
+    )
+    registry.add(
         "POST", "/scoped/bulk-upsert", handler.scoped_bulk_upsert, middlewares=[auth_required]
     )
     registry.add("POST", "/my/by-names", handler.my_fragments_by_names, middlewares=[auth_required])
+    registry.add(
+        "POST",
+        "/my/by-names/bulk-delete",
+        handler.my_bulk_purge_by_names,
+        middlewares=[auth_required],
+    )
     registry.add("POST", "/my/bulk-upsert", handler.my_bulk_upsert, middlewares=[auth_required])
-    registry.add("POST", "/my/bulk-delete", handler.my_bulk_purge, middlewares=[auth_required])
     registry.add("GET", "/{fragment_id}", handler.get, middlewares=[auth_required])
     registry.add("DELETE", "/{fragment_id}", handler.purge, middlewares=[auth_required])
 

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
@@ -20,8 +20,10 @@ def register_v2_app_config_fragment_routes(
     """Register all REST v2 app config fragment routes.
 
     Writes go through ``/upsert``: a fragment is addressed by ``(scope, config_name)`` rather
-    than by id, so there is no separate create or update endpoint. The paginated scoped search
-    is not exposed either — ``/by-names`` is the read a client needs before editing. Every
+    than by id, so there is no separate create or update endpoint. ``/my/bulk-delete`` deletes
+    by that same address, so a caller removing their own fragments never has to resolve an id
+    first. The paginated scoped search is not exposed either — ``/by-names`` is the read a
+    client needs before editing. Every
     route but ``/admin/search`` is open to any authenticated user and gated by RBAC at the
     processor (a user acts on their own user-scope, a domain admin on their domain's, a
     superadmin on any; public is superadmin-only). Only the system-wide ``/admin/search``
@@ -34,6 +36,7 @@ def register_v2_app_config_fragment_routes(
         POST   /scoped/bulk-upsert  upsert many at one scope     (auth, RBAC)
         POST   /my/by-names       read own scope's by names      (auth)
         POST   /my/bulk-upsert    upsert many at own scope       (auth)
+        POST   /my/bulk-delete    purge own scope's by names     (auth)
         GET    /{fragment_id}     get by id                      (auth, RBAC)
         DELETE /{fragment_id}     purge by id                    (auth, RBAC)
     """
@@ -49,6 +52,7 @@ def register_v2_app_config_fragment_routes(
     )
     registry.add("POST", "/my/by-names", handler.my_fragments_by_names, middlewares=[auth_required])
     registry.add("POST", "/my/bulk-upsert", handler.my_bulk_upsert, middlewares=[auth_required])
+    registry.add("POST", "/my/bulk-delete", handler.my_bulk_purge, middlewares=[auth_required])
     registry.add("GET", "/{fragment_id}", handler.get, middlewares=[auth_required])
     registry.add("DELETE", "/{fragment_id}", handler.purge, middlewares=[auth_required])
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -153,6 +153,48 @@ class AppConfigFragmentDBSource:
             return AppConfigFragmentBulkResult(succeeded=succeeded, failed=failed)
 
     @app_config_fragment_db_source_resilience.apply()
+    async def purge_by_config_names(
+        self,
+        scope: SearchScope,
+        config_names: Sequence[str],
+    ) -> list[AppConfigFragmentData]:
+        """Purge one scope's fragments for ``config_names``, all-or-nothing.
+
+        A scope holds at most one fragment per config name, so the names resolve to ids inside
+        the purging transaction and each row is unbound from its scope as a purge by id is. A
+        name the scope holds no fragment for raises before anything is deleted, so a typo
+        cannot take a neighbouring config with it.
+        """
+        # A name repeated in the request still names one fragment.
+        requested = list(dict.fromkeys(config_names))
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[AppConfigFragmentConditions.by_config_names(requested)],
+        )
+        async with self._rbac_ops_provider.write_ops() as w:
+            found = await w.batch_query_with_scopes(
+                sa.select(AppConfigFragmentRow), querier, [scope]
+            )
+            rows = {
+                row.AppConfigFragmentRow.config_name: row.AppConfigFragmentRow for row in found.rows
+            }
+            missing = [config_name for config_name in requested if config_name not in rows]
+            if missing:
+                raise AppConfigFragmentNotFound(
+                    f"No app config fragment at this scope for: {', '.join(missing)}"
+                )
+            purged: list[AppConfigFragmentData] = []
+            for config_name in requested:
+                fragment_id = AppConfigFragmentID(rows[config_name].id)
+                result = await w.purge_scoped(
+                    RBACEntityPurger(spec=AppConfigFragmentPurgerSpec(fragment_id=fragment_id))
+                )
+                if result is None:
+                    raise AppConfigFragmentNotFound(f"App config fragment {fragment_id} not found")
+                purged.append(result.row.to_data())
+            return purged
+
+    @app_config_fragment_db_source_resilience.apply()
     async def admin_search(self, querier: BatchQuerier) -> AppConfigFragmentSearchResult:
         """Superadmin/internal path: query across all fragments with no scope filter."""
         async with self._rbac_ops_provider.read_ops() as r:

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -75,6 +75,12 @@ class AppConfigFragmentRepository:
         return await self._db_source.purge(purger_spec)
 
     @app_config_fragment_repository_resilience.apply()
+    async def purge_by_config_names(
+        self, scope: SearchScope, config_names: Sequence[str]
+    ) -> list[AppConfigFragmentData]:
+        return await self._db_source.purge_by_config_names(scope, config_names)
+
+    @app_config_fragment_repository_resilience.apply()
     async def admin_search(self, querier: BatchQuerier) -> AppConfigFragmentSearchResult:
         return await self._db_source.admin_search(querier)
 

--- a/src/ai/backend/manager/services/app_config_fragment/actions/purge_by_names.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/purge_by_names.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.permission.types import RBACElementType, ScopeType
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.repositories.app_config_fragment.types import (
+    AppConfigFragmentSearchScope,
+)
+from ai.backend.manager.services.app_config_fragment.actions.base import (
+    AppConfigFragmentScopeAction,
+    AppConfigFragmentScopeActionResult,
+)
+
+
+@dataclass
+class PurgeAppConfigFragmentsByNamesAction(AppConfigFragmentScopeAction):
+    """Purge the fragments one scope holds for the given config names, all-or-nothing.
+
+    A fragment is addressed by ``(scope, config_name)``, so every name resolves at ``scope``
+    and the RBAC gate is the purge permission there — the same single-scope gate the scoped
+    upsert crosses, rather than the per-fragment gate a purge by id crosses.
+    """
+
+    scope: AppConfigFragmentSearchScope
+    config_names: list[str]
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.PURGE
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return self.scope.scope_type.to_rbac_scope_type()
+
+    @override
+    def scope_id(self) -> str:
+        return self.scope.scope_type.to_rbac_scope_id(self.scope.scope_id)
+
+    @override
+    def target_element(self) -> RBACElementRef:
+        owner_element = self.scope.scope_type.to_rbac_element_type()
+        if owner_element is None:
+            # ``public`` is global and owns no element; only a superadmin passes.
+            return RBACElementRef(RBACElementType.APP_CONFIG_FRAGMENT, "")
+        return RBACElementRef(owner_element, str(self.scope.scope_id))
+
+
+@dataclass
+class PurgeAppConfigFragmentsByNamesActionResult(AppConfigFragmentScopeActionResult):
+    fragments: list[AppConfigFragmentData]
+    #: The scope the purge ran at, carried only to report the RBAC scope.
+    _scope: AppConfigFragmentSearchScope
+
+    @override
+    def scope_type(self) -> ScopeType:
+        return self._scope.scope_type.to_rbac_scope_type()
+
+    @override
+    def scope_id(self) -> str:
+        return self._scope.scope_type.to_rbac_scope_id(self._scope.scope_id)

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -29,6 +29,10 @@ from ai.backend.manager.services.app_config_fragment.actions.purge import (
     PurgeAppConfigFragmentAction,
     PurgeAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.purge_by_names import (
+    PurgeAppConfigFragmentsByNamesAction,
+    PurgeAppConfigFragmentsByNamesActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
     ScopedSearchAppConfigFragmentActionResult,
@@ -51,6 +55,9 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
     ]
     purge: SingleEntityActionProcessor[
         PurgeAppConfigFragmentAction, PurgeAppConfigFragmentActionResult
+    ]
+    purge_by_names: ScopeActionProcessor[
+        PurgeAppConfigFragmentsByNamesAction, PurgeAppConfigFragmentsByNamesActionResult
     ]
     bulk_purge: BulkActionProcessor[
         BulkPurgeAppConfigFragmentAction, BulkPurgeAppConfigFragmentActionResult
@@ -79,6 +86,9 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
         self.purge = SingleEntityActionProcessor(
             service.purge, action_monitors, validators=[validators.rbac.single_entity]
         )
+        self.purge_by_names = ScopeActionProcessor(
+            service.purge_by_names, action_monitors, validators=[validators.rbac.scope]
+        )
         self.bulk_purge = BulkActionProcessor(
             service.bulk_purge, monitors=action_monitors, validators=[validators.rbac.bulk]
         )
@@ -91,5 +101,6 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
             AdminSearchAppConfigFragmentAction.spec(),
             ScopedSearchAppConfigFragmentAction.spec(),
             PurgeAppConfigFragmentAction.spec(),
+            PurgeAppConfigFragmentsByNamesAction.spec(),
             BulkPurgeAppConfigFragmentAction.spec(),
         ]

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -23,6 +23,10 @@ from ai.backend.manager.services.app_config_fragment.actions.purge import (
     PurgeAppConfigFragmentAction,
     PurgeAppConfigFragmentActionResult,
 )
+from ai.backend.manager.services.app_config_fragment.actions.purge_by_names import (
+    PurgeAppConfigFragmentsByNamesAction,
+    PurgeAppConfigFragmentsByNamesActionResult,
+)
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
     ScopedSearchAppConfigFragmentActionResult,
@@ -87,6 +91,12 @@ class AppConfigFragmentService:
     ) -> PurgeAppConfigFragmentActionResult:
         data = await self._repository.purge(action.purger_spec)
         return PurgeAppConfigFragmentActionResult(fragment=data)
+
+    async def purge_by_names(
+        self, action: PurgeAppConfigFragmentsByNamesAction
+    ) -> PurgeAppConfigFragmentsByNamesActionResult:
+        fragments = await self._repository.purge_by_config_names(action.scope, action.config_names)
+        return PurgeAppConfigFragmentsByNamesActionResult(fragments=fragments, _scope=action.scope)
 
     async def bulk_purge(
         self, action: BulkPurgeAppConfigFragmentAction

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -17,6 +17,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigScopeRef,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
@@ -26,6 +27,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -185,6 +187,27 @@ class TestMyBulkUpsert:
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/bulk-upsert")
         assert isinstance(result, UpsertAppConfigFragmentsPayload)
+
+
+class TestMyPurgeByNames:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        fragment_id: AppConfigFragmentID,
+    ) -> None:
+        mock_response.json = AsyncMock(return_value={"items": [str(fragment_id)]})
+
+        result = await client.my_purge_app_config_fragments_by_names(
+            MyPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/bulk-delete")
+        assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
+        assert result.items == [fragment_id]
 
 
 class TestGet:

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -20,6 +20,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -144,6 +145,33 @@ class TestScopedBulkUpsert:
         assert [item.config_name for item in result.items] == ["theme"]
 
 
+class TestScopedPurgeByNames:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        fragment_id: AppConfigFragmentID,
+    ) -> None:
+        mock_response.json = AsyncMock(return_value={"items": [str(fragment_id)]})
+
+        result = await client.scoped_purge_app_config_fragments_by_names(
+            ScopedPurgeAppConfigFragmentsByNamesInput(
+                scope=AppConfigScopeRef(
+                    scope_type=AppConfigScopeType.USER,
+                    scope_id=AppConfigScopeID(_USER_SCOPE_ID),
+                ),
+                config_names=["theme"],
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/by-names/bulk-delete")
+        assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
+        assert result.items == [fragment_id]
+
+
 class TestMyByNames:
     async def test_happy_path(
         self,
@@ -205,7 +233,7 @@ class TestMyPurgeByNames:
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
-        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/bulk-delete")
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/by-names/bulk-delete")
         assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
         assert result.items == [fragment_id]
 

--- a/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.exception import BackendAISchemaValidationFailed
@@ -150,6 +151,42 @@ class TestAppConfigFragmentsByNamesInput:
                 "scope_type": AppConfigScopeType.DOMAIN,
                 "scope_id": None,
                 "config_names": ["theme"],
+            })
+
+
+class TestScopedPurgeAppConfigFragmentsByNamesInput:
+    """The scoped purge names the scope like the by-names read does, plus the names to purge."""
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _ScopeCase(scope_type=AppConfigScopeType.PUBLIC, scope_id=None),
+            _ScopeCase(scope_type=AppConfigScopeType.DOMAIN, scope_id=_SCOPE_ID),
+            _ScopeCase(scope_type=AppConfigScopeType.USER, scope_id=_SCOPE_ID),
+        ],
+        ids=lambda case: case.scope_type.value,
+    )
+    def test_scope_id_matching_its_scope_type_is_accepted(self, case: _ScopeCase) -> None:
+        req = ScopedPurgeAppConfigFragmentsByNamesInput(
+            scope=AppConfigScopeRef(scope_type=case.scope_type, scope_id=case.scope_id),
+            config_names=["theme"],
+        )
+
+        assert req.scope.scope_type is case.scope_type
+        assert req.scope.scope_id == case.scope_id
+
+    def test_scope_id_disagreeing_with_its_scope_type_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            ScopedPurgeAppConfigFragmentsByNamesInput.model_validate({
+                "scope": {"scope_type": AppConfigScopeType.DOMAIN, "scope_id": None},
+                "config_names": ["theme"],
+            })
+
+    def test_an_empty_batch_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            ScopedPurgeAppConfigFragmentsByNamesInput.model_validate({
+                "scope": {"scope_type": AppConfigScopeType.PUBLIC, "scope_id": None},
+                "config_names": [],
             })
 
 

--- a/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
@@ -13,6 +13,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
     AppConfigScopeRef,
     BulkPurgeAppConfigFragmentInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
@@ -150,6 +151,20 @@ class TestAppConfigFragmentsByNamesInput:
                 "scope_id": None,
                 "config_names": ["theme"],
             })
+
+
+class TestMyPurgeAppConfigFragmentsByNamesInput:
+    """The self-service purge names configs, not ids, and carries no scope."""
+
+    def test_config_names_alone_are_a_complete_body(self) -> None:
+        req = MyPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
+
+        assert req.config_names == ["theme"]
+        assert not hasattr(req, "scope_type")
+
+    def test_an_empty_batch_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            MyPurgeAppConfigFragmentsByNamesInput.model_validate({"config_names": []})
 
 
 class TestBulkPurgeAppConfigFragmentInput:

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -105,6 +105,26 @@ def repository(database: ExtendedAsyncSAEngine) -> AppConfigFragmentRepository:
     return AppConfigFragmentRepository(RBACOpsProvider(database))
 
 
+@dataclass(frozen=True)
+class _ScopeBinding:
+    """One RBAC scope a fragment is bound to (a row of ``association_scopes_entities``)."""
+
+    scope_type: ScopeType
+    scope_id: str
+
+
+async def _scope_bindings(database: ExtendedAsyncSAEngine, entity_id: str) -> list[_ScopeBinding]:
+    """The RBAC scopes the fragment is currently bound to."""
+    async with database.begin_readonly_session() as db_sess:
+        rows = await db_sess.scalars(
+            sa.select(AssociationScopesEntitiesRow).where(
+                AssociationScopesEntitiesRow.entity_type == EntityType.APP_CONFIG_FRAGMENT,
+                AssociationScopesEntitiesRow.entity_id == entity_id,
+            )
+        )
+        return [_ScopeBinding(scope_type=row.scope_type, scope_id=row.scope_id) for row in rows]
+
+
 def _allow_list_row(config_name: str, scope_type: AppConfigScopeType) -> AppConfigAllowListRow:
     return AppConfigAllowListRow(
         config_name=config_name,
@@ -558,6 +578,92 @@ class TestBulkPurge:
             await repository.get_by_id(two_fragments[0].id)
 
 
+class TestPurgeByConfigNames:
+    """The scope's own fragments are addressed by config name, so no id has to be resolved
+    first, and the batch is all-or-nothing."""
+
+    async def test_purges_only_the_named_scope_fragments(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+        scope_owners: None,
+    ) -> None:
+        purged = await repository.purge_by_config_names(
+            AppConfigFragmentSearchScope(
+                scope_type=AppConfigScopeType.USER, scope_id=_USER_SCOPE_ID
+            ),
+            ["theme"],
+        )
+
+        expected = [
+            f
+            for f in fragments_across_scopes
+            if f.config_name == "theme"
+            and f.scope_type is AppConfigScopeType.USER
+            and f.scope_id == _USER_SCOPE_ID
+        ]
+        assert [f.id for f in purged] == [f.id for f in expected]
+        with pytest.raises(AppConfigFragmentNotFound):
+            await repository.get_by_id(expected[0].id)
+        # The same config name at every other scope is untouched.
+        survivors = [f for f in fragments_across_scopes if f.id != expected[0].id]
+        for fragment in survivors:
+            assert (await repository.get_by_id(fragment.id)).id == fragment.id
+
+    async def test_purges_nothing_when_one_name_has_no_fragment(
+        self,
+        repository: AppConfigFragmentRepository,
+        fragments_across_scopes: list[AppConfigFragmentData],
+        scope_owners: None,
+    ) -> None:
+        # `menu` exists, but only at the public scope, so the caller's user scope holds none.
+        with pytest.raises(AppConfigFragmentNotFound):
+            await repository.purge_by_config_names(
+                AppConfigFragmentSearchScope(
+                    scope_type=AppConfigScopeType.USER, scope_id=_USER_SCOPE_ID
+                ),
+                ["theme", "menu"],
+            )
+
+        for fragment in fragments_across_scopes:
+            assert (await repository.get_by_id(fragment.id)).id == fragment.id
+
+    async def test_purge_removes_the_scope_binding(
+        self,
+        repository: AppConfigFragmentRepository,
+        database: ExtendedAsyncSAEngine,
+        theme_registered: None,
+        scope_owners: None,
+    ) -> None:
+        """A purge by name unbinds the fragment, as a purge by id does.
+
+        Deleting the row alone would leave its scope association behind, pointing at a
+        fragment that no longer exists.
+        """
+        upserted = await repository.bulk_upsert([
+            AppConfigFragmentUpserterSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=_USER_SCOPE_ID,
+                config={"k": "v"},
+            )
+        ])
+        created = upserted[0]
+        assert await _scope_bindings(database, str(created.id)) == [
+            _ScopeBinding(scope_type=ScopeType.USER, scope_id=str(_USER_ID))
+        ]
+
+        purged = await repository.purge_by_config_names(
+            AppConfigFragmentSearchScope(
+                scope_type=AppConfigScopeType.USER, scope_id=_USER_SCOPE_ID
+            ),
+            ["theme"],
+        )
+
+        assert [f.id for f in purged] == [created.id]
+        assert await _scope_bindings(database, str(created.id)) == []
+
+
 class TestVisibilityConditions:
     async def test_public_visibility_selects_only_public(
         self,
@@ -721,14 +827,6 @@ class TestApplicableFragments:
 
 
 @dataclass(frozen=True)
-class _ScopeBinding:
-    """One RBAC scope a fragment is bound to (a row of ``association_scopes_entities``)."""
-
-    scope_type: ScopeType
-    scope_id: str
-
-
-@dataclass(frozen=True)
 class _FragmentScopeCase:
     """A fragment scope to write at, with the bindings a create at that scope must produce.
 
@@ -744,20 +842,6 @@ class _FragmentScopeCase:
 class TestRBACScopeAssociation:
     """Create binds a ``user`` / ``domain`` fragment to its RBAC scope so the RBAC validator can
     resolve ownership on a later update/purge; ``public`` (GLOBAL, no RBAC scope) gets none."""
-
-    @staticmethod
-    async def _scope_bindings(
-        database: ExtendedAsyncSAEngine, entity_id: str
-    ) -> list[_ScopeBinding]:
-        """The RBAC scopes the fragment is currently bound to."""
-        async with database.begin_readonly_session() as db_sess:
-            rows = await db_sess.scalars(
-                sa.select(AssociationScopesEntitiesRow).where(
-                    AssociationScopesEntitiesRow.entity_type == EntityType.APP_CONFIG_FRAGMENT,
-                    AssociationScopesEntitiesRow.entity_id == entity_id,
-                )
-            )
-            return [_ScopeBinding(scope_type=row.scope_type, scope_id=row.scope_id) for row in rows]
 
     @pytest.mark.parametrize(
         "case",
@@ -795,7 +879,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        assert await self._scope_bindings(database, str(upserted[0].id)) == case.expected_bindings
+        assert await _scope_bindings(database, str(upserted[0].id)) == case.expected_bindings
 
     @pytest.mark.parametrize(
         "case",
@@ -834,10 +918,10 @@ class TestRBACScopeAssociation:
             )
         ])
         created = upserted[0]
-        assert await self._scope_bindings(database, str(created.id)) == case.expected_bindings
+        assert await _scope_bindings(database, str(created.id)) == case.expected_bindings
         purged = await repository.purge(AppConfigFragmentPurgerSpec(fragment_id=created.id))
         assert purged.id == created.id
-        assert await self._scope_bindings(database, str(created.id)) == []
+        assert await _scope_bindings(database, str(created.id)) == []
 
     async def test_bulk_purge_removes_the_scope_binding(
         self,
@@ -859,12 +943,12 @@ class TestRBACScopeAssociation:
             )
         ])
         created = upserted[0]
-        assert await self._scope_bindings(database, str(created.id)) == [
+        assert await _scope_bindings(database, str(created.id)) == [
             _ScopeBinding(scope_type=ScopeType.USER, scope_id=str(_USER_ID))
         ]
         result = await repository.bulk_purge([AppConfigFragmentPurgerSpec(fragment_id=created.id)])
         assert [p.id for p in result.succeeded] == [created.id]
-        assert await self._scope_bindings(database, str(created.id)) == []
+        assert await _scope_bindings(database, str(created.id)) == []
         with pytest.raises(AppConfigFragmentNotFound):
             await repository.get_by_id(created.id)
 

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -52,6 +52,9 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
 from ai.backend.manager.services.app_config_fragment.actions.purge import (
     PurgeAppConfigFragmentAction,
 )
+from ai.backend.manager.services.app_config_fragment.actions.purge_by_names import (
+    PurgeAppConfigFragmentsByNamesAction,
+)
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
 )
@@ -289,6 +292,50 @@ class TestAppConfigFragmentService:
 
         assert result.fragment == fragment
         mock_repository.purge.assert_called_once_with(purger_spec)
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _RBACScopeCase(
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id=None,
+                expected_scope_type=ScopeType.GLOBAL,
+                expected_scope_id="",
+            ),
+            _RBACScopeCase(
+                scope_type=AppConfigScopeType.DOMAIN,
+                scope_id=_DOMAIN_SCOPE_ID,
+                expected_scope_type=ScopeType.DOMAIN,
+                expected_scope_id=str(_DOMAIN_ID),
+            ),
+            _RBACScopeCase(
+                scope_type=AppConfigScopeType.USER,
+                scope_id=_USER_SCOPE_ID,
+                expected_scope_type=ScopeType.USER,
+                expected_scope_id=str(_USER_ID),
+            ),
+        ],
+        ids=lambda case: case.scope_type.value,
+    )
+    async def test_purge_by_names_passes_the_names_through_and_reports_its_scope(
+        self,
+        service: AppConfigFragmentService,
+        mock_repository: MagicMock,
+        scoped_fragment: AppConfigFragmentData,
+        case: _RBACScopeCase,
+    ) -> None:
+        mock_repository.purge_by_config_names = AsyncMock(return_value=[scoped_fragment])
+        scope = AppConfigFragmentSearchScope(scope_type=case.scope_type, scope_id=case.scope_id)
+
+        result = await service.purge_by_names(
+            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=["theme"])
+        )
+
+        assert result.fragments == [scoped_fragment]
+        # The result reports the RBAC scope the purge was authorized at.
+        assert result.scope_type() == case.expected_scope_type
+        assert result.scope_id() == case.expected_scope_id
+        mock_repository.purge_by_config_names.assert_called_once_with(scope, ["theme"])
 
     # --- bulk ---
 


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the app config fragment client stack. **Merge in order (bottom-up):**

1. ✅ #13223 — `feat(BA-7064)`: add the app config fragment SDK v2
2. ✅ #13227 — `feat(BA-7065)`: add the app config fragment CLI v2
3. 👉 **#13375 — `feat(BA-7149)`: purge app config fragments by config name** ← you are here

Resolves #13374 (BA-7149)

## Summary

- A fragment is addressed by `(scope, config_name)` everywhere except delete: the purge routes take a fragment id. Removing one meant reading its id first, then leaving the addressing scheme behind for the top-level `purge --id`.
- `/by-names` already carried the `(scope, config_name)` address for the read, so the name-addressed delete goes **beneath that segment** rather than beside the id-addressed `/bulk-delete`:

  | | read | delete |
  |---|---|---|
  | scoped | `POST /scoped/by-names` | `POST /scoped/by-names/bulk-delete` |
  | my | `POST /my/by-names` | `POST /my/by-names/bulk-delete` |

- Names are resolved and purged **inside one write transaction**, so the read-then-purge cannot interleave with a concurrent write, which a client-side composition of two calls could not guarantee.
- A name the caller holds no fragment for raises before anything is deleted: a typo cannot take a neighbouring config with it.
- `./bai my app-config-fragment purge theme menu` and `./bai app-config-fragment purge-by-names --scope-type domain --scope-id <id> theme` are each a single SDK call.

**RBAC.** The action (`PurgeAppConfigFragmentsByNamesAction`) is scope-addressed, so it is gated by the purge permission at the scope written — the same single-scope gate the scoped upsert crosses, rather than the per-fragment gate a purge by id crosses. A user passes for their own user scope, a domain admin for their domain's, a superadmin for any. The `my` route names no scope at all, so a regular user cannot address anyone else's.

**No `admin_` variant.** The scoped and `my` callers differ only in which scope they may name, not in behaviour, so per `api/rest/v2/AGENTS.md` they share one route and RBAC decides. An `admin_` route would carry `superadmin_required`, which locks out the domain admins that `b3d9f7a2c184` grants `APP_CONFIG_FRAGMENT` owner operations at domain scope.

**Not in this PR.** Purge is not exposed on GraphQL at all — neither by id nor in bulk — so this stays REST-only like its siblings.

## Layers touched

| Layer | Change |
|-------|--------|
| DTO | `MyPurgeAppConfigFragmentsByNamesInput`, `ScopedPurgeAppConfigFragmentsByNamesInput`, `PurgeAppConfigFragmentsByNamesPayload` |
| REST v2 | `POST /{my,scoped}/by-names/bulk-delete` → `my_bulk_purge_by_names` / `scoped_bulk_purge_by_names` (`auth_required`) |
| Adapter | `my_purge_app_config_fragments_by_names` (resolves `current_user()`), `scoped_purge_app_config_fragments_by_names` (scope from the body) |
| Service | `purge_by_names` + `PurgeAppConfigFragmentsByNamesAction` (scope action, `PURGE`) |
| Repository | `purge_by_config_names(scope, config_names)` — one transaction, all-or-nothing |
| SDK / CLI | `{my,scoped}_purge_app_config_fragments_by_names` / `my app-config-fragment purge`, `app-config-fragment purge-by-names` |

## Test plan

- [x] Repository (real DB): purges only the named scope's fragments; a name with no fragment at the scope raises and leaves every row intact; the purge unbinds the fragment from its RBAC scope as a purge by id does.
- [x] Service (mocked): the names and scope reach the repository, and the result reports the RBAC scope it was authorized at (public / domain / user).
- [x] DTO: `config_names` alone is a complete body for the `my` input; the scoped input accepts every scope kind with a matching id and rejects a mismatch; an empty batch is rejected on both.
- [x] SDK: the calls land on `POST /{my,scoped}/by-names/bulk-delete` and parse the payload.
- [ ] Live verification against a local manager, as a regular (non-admin) user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13375.org.readthedocs.build/en/13375/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13375.org.readthedocs.build/ko/13375/

<!-- readthedocs-preview sorna-ko end -->