### PR TITLE
fix: Destroy the endpoint when deployment create fails to add its first revision

### DIFF
--- a/changes/13395.fix.md
+++ b/changes/13395.fix.md
@@ -1,0 +1,1 @@
+Destroy the endpoint when deployment creation fails to add its first revision, instead of leaving it stuck in `PENDING` with no revision.

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -1,6 +1,8 @@
 """Deployment service for managing model deployments."""
 
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import cast
 from uuid import UUID
@@ -446,6 +448,36 @@ class DeploymentService:
 
     # ========== Deployment CRUD ==========
 
+    @asynccontextmanager
+    async def _teardown_on_revision_failure(
+        self, deployment_id: DeploymentID
+    ) -> AsyncIterator[None]:
+        """Tear the just-created endpoint down when its first revision fails.
+
+        Endpoint creation and revision creation commit separately, and only
+        ``activate_revision`` moves the endpoint out of ``PENDING``. A failure
+        in between would otherwise leave a ``PENDING`` endpoint with no
+        revision, which no lifecycle handler targets — invisible to the
+        coordinator and stuck forever.
+
+        Marking the endpoint ``DESTROYING`` hands it to the destroying handler,
+        which always ends at ``DESTROYED`` even with no revision and no routes.
+        A failure to tear down is logged and never masks the original error,
+        which is what the caller needs to see.
+        """
+        try:
+            yield
+        except Exception:
+            try:
+                await self._deployment_controller.destroy_deployment(deployment_id)
+            except Exception:
+                log.exception(
+                    "Failed to tear down deployment {} after its revision could not be created; "
+                    "it is left behind with no revision",
+                    deployment_id,
+                )
+            raise
+
     async def create_deployment(
         self, action: CreateDeploymentAction
     ) -> CreateDeploymentActionResult:
@@ -460,12 +492,13 @@ class DeploymentService:
         log.info("Creating deployment with name: {}", action.creator.metadata.name)
         deployment_info = await self._deployment_controller.create_deployment(action.creator)
         if action.creator.model_revision is not None:
-            await self._deployment_controller.add_deployment_revision(
-                deployment_id=DeploymentID(deployment_info.id),
-                revision=action.creator.model_revision,
-                requester_id=action.creator.metadata.created_user,
-                auto_activate=action.auto_activate,
-            )
+            async with self._teardown_on_revision_failure(DeploymentID(deployment_info.id)):
+                await self._deployment_controller.add_deployment_revision(
+                    deployment_id=DeploymentID(deployment_info.id),
+                    revision=action.creator.model_revision,
+                    requester_id=action.creator.metadata.created_user,
+                    auto_activate=action.auto_activate,
+                )
         updated_deployment_info = await self._deployment_repository.get_endpoint_info(
             deployment_info.id
         )
@@ -489,12 +522,13 @@ class DeploymentService:
             action.draft
         )
         deployment_info = await self._deployment_controller.create_deployment(creator)
-        await self._deployment_controller.add_deployment_revision(
-            deployment_id=DeploymentID(deployment_info.id),
-            revision=revision,
-            requester_id=creator.metadata.created_user,
-            auto_activate=True,
-        )
+        async with self._teardown_on_revision_failure(DeploymentID(deployment_info.id)):
+            await self._deployment_controller.add_deployment_revision(
+                deployment_id=DeploymentID(deployment_info.id),
+                revision=revision,
+                requester_id=creator.metadata.created_user,
+                auto_activate=True,
+            )
         # Legacy (REST v1) create re-reads through the *legacy* getter so the
         # response carries the eagerly-loaded current/deploying revision data.
         # The modern ``get_endpoint_info`` returns revision *ids* only, which

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_initializing.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_initializing.py
@@ -26,9 +26,11 @@ from .base import DeploymentHandler
 
 
 class DeployingInitializingHandler(DeploymentHandler):
-    """DEPLOYING / INITIALIZING: register the appproxy endpoint for deployments that entered
-    DEPLOYING via ActivateRevision (and so skipped check_pending), then hand off to
-    PROVISIONING which sets up the target replica group."""
+    """DEPLOYING / INITIALIZING: register the appproxy endpoint, then hand off to
+    PROVISIONING which sets up the target replica group.
+
+    ``ActivateRevision`` is the only way into this stage: it is what moves an
+    endpoint out of ``PENDING``, which no handler targets."""
 
     def __init__(
         self,

--- a/tests/unit/manager/services/deployment/test_deployment_service.py
+++ b/tests/unit/manager/services/deployment/test_deployment_service.py
@@ -41,6 +41,7 @@ from ai.backend.manager.clients.appproxy.client import AppProxyClient, AppProxyC
 from ai.backend.manager.data.deployment.access_token import ModelDeploymentAccessTokenCreator
 from ai.backend.manager.data.deployment.creator import (
     ModelRevisionCreator,
+    NewDeploymentCreator,
     VFolderMountsCreator,
 )
 from ai.backend.manager.data.deployment.types import (
@@ -71,6 +72,9 @@ from ai.backend.manager.repositories.deployment import DeploymentRepository
 from ai.backend.manager.repositories.deployment.creators import EndpointTokenCreatorSpec
 from ai.backend.manager.services.deployment.actions.access_token.create_access_token import (
     CreateAccessTokenAction,
+)
+from ai.backend.manager.services.deployment.actions.create_deployment import (
+    CreateDeploymentAction,
 )
 from ai.backend.manager.services.deployment.actions.deployment_policy import (
     SearchDeploymentPoliciesAction,
@@ -773,3 +777,126 @@ class TestConvertDeploymentInfoToData:
         legacy_data = _convert_deployment_info_to_legacy_data(deployment_info)
         assert legacy_data.revision is not None
         assert legacy_data.revision.id == current_data.id
+
+
+class TestCreateDeploymentTeardown(ModelRevisionFixtures):
+    """The endpoint and its first revision are created in two separate commits.
+
+    Nothing advances an endpoint that is still ``PENDING`` with no revision —
+    no lifecycle handler targets ``PENDING`` — so a revision failure must not
+    leave one behind.
+    """
+
+    @pytest.fixture
+    def created_deployment_info(self, deployment_id: uuid.UUID) -> DeploymentInfo:
+        """A freshly created endpoint: PENDING, no revision on either pointer."""
+        return DeploymentInfo(
+            id=DeploymentID(deployment_id),
+            metadata=DeploymentMetadata(
+                name="teardown-test",
+                domain="default",
+                project=uuid.uuid4(),
+                resource_group="default",
+                created_user=uuid.uuid4(),
+                session_owner=uuid.uuid4(),
+                created_at=datetime(2024, 1, 1, tzinfo=UTC),
+                revision_history_limit=10,
+            ),
+            state=DeploymentState(
+                lifecycle=EndpointLifecycle.PENDING,
+                scaling_state=ScalingState.STABLE,
+                retry_count=0,
+            ),
+            replica=ReplicaData(replica_count=1, desired_replica_count=None),
+            network=DeploymentNetworkData(
+                open_to_public=False, access_token_ids=None, url=None, preferred_domain_name=None
+            ),
+            options=DeploymentOptions(),
+            current_revision_id=None,
+            deploying_revision_id=None,
+            current_revision=None,
+            deploying_revision=None,
+        )
+
+    @pytest.fixture
+    def creator(
+        self, created_deployment_info: DeploymentInfo, revision_creator: ModelRevisionCreator
+    ) -> NewDeploymentCreator:
+        return NewDeploymentCreator(
+            metadata=created_deployment_info.metadata,
+            model_revision=revision_creator,
+        )
+
+    async def test_endpoint_is_destroyed_when_revision_creation_fails(
+        self,
+        deployment_service: DeploymentService,
+        mock_deployment_controller: MagicMock,
+        created_deployment_info: DeploymentInfo,
+        creator: NewDeploymentCreator,
+        deployment_id: uuid.UUID,
+    ) -> None:
+        """A revision failure tears the endpoint down and re-raises the cause."""
+        revision_error = ValueError("image_id is required to add a revision")
+        mock_deployment_controller.create_deployment = AsyncMock(
+            return_value=created_deployment_info
+        )
+        mock_deployment_controller.add_deployment_revision = AsyncMock(side_effect=revision_error)
+        mock_deployment_controller.destroy_deployment = AsyncMock(return_value=True)
+
+        with pytest.raises(ValueError) as exc_info:
+            await deployment_service.create_deployment(
+                CreateDeploymentAction(creator=creator, auto_activate=True)
+            )
+
+        assert exc_info.value is revision_error
+        mock_deployment_controller.destroy_deployment.assert_awaited_once_with(
+            DeploymentID(deployment_id)
+        )
+
+    async def test_teardown_failure_does_not_mask_the_original_error(
+        self,
+        deployment_service: DeploymentService,
+        mock_deployment_controller: MagicMock,
+        created_deployment_info: DeploymentInfo,
+        creator: NewDeploymentCreator,
+    ) -> None:
+        """The caller sees why the revision failed, not why the cleanup failed."""
+        revision_error = ValueError("image_id is required to add a revision")
+        mock_deployment_controller.create_deployment = AsyncMock(
+            return_value=created_deployment_info
+        )
+        mock_deployment_controller.add_deployment_revision = AsyncMock(side_effect=revision_error)
+        mock_deployment_controller.destroy_deployment = AsyncMock(
+            side_effect=RuntimeError("endpoint row vanished")
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            await deployment_service.create_deployment(
+                CreateDeploymentAction(creator=creator, auto_activate=True)
+            )
+
+        assert exc_info.value is revision_error
+
+    async def test_successful_create_does_not_destroy_the_endpoint(
+        self,
+        deployment_service: DeploymentService,
+        mock_deployment_controller: MagicMock,
+        mock_deployment_repository: MagicMock,
+        created_deployment_info: DeploymentInfo,
+        creator: NewDeploymentCreator,
+        revision_data: ModelRevisionData,
+    ) -> None:
+        mock_deployment_controller.create_deployment = AsyncMock(
+            return_value=created_deployment_info
+        )
+        mock_deployment_controller.add_deployment_revision = AsyncMock(return_value=revision_data)
+        mock_deployment_controller.destroy_deployment = AsyncMock()
+        mock_deployment_repository.get_endpoint_info = AsyncMock(
+            return_value=created_deployment_info
+        )
+
+        await deployment_service.create_deployment(
+            CreateDeploymentAction(creator=creator, auto_activate=True)
+        )
+
+        mock_deployment_controller.destroy_deployment.assert_not_awaited()


### PR DESCRIPTION
## Summary

- `create_deployment` and `create_legacy_deployment` commit the endpoint and its first revision separately. Only `activate_revision` moves an endpoint out of `PENDING`, and no lifecycle handler targets `PENDING` — so any failure in the revision step left an endpoint the coordinator never sees and never reaps, while the caller only saw an API error.
- Both paths now wrap the revision step in `_teardown_on_revision_failure`, which marks the endpoint `DESTROYING` and re-raises the original error unchanged. A cleanup that itself fails is logged and never masks the cause.
- Teardown goes through `destroy_deployment` rather than a hard delete: `deployment_revisions.endpoint` carries no FK, so deleting the row would orphan any revision written before the failure, and the destroying handler already ends at `DESTROYED` even with no revision and no routes.
- Drops the `check_pending` reference in `DeployingInitializingHandler`'s docstring — that stage no longer exists anywhere in the tree.

`createModelDeploymentV2 { initialRevision: null }` is untouched: it never enters the guarded branch, so a deliberately revision-less deployment stays supported.

## Test plan

- [x] `pants lint --changed-since=origin/main`
- [x] `pants test tests/unit/manager/services/deployment/test_deployment_service.py`
- [ ] Deploy from the model store with a preset that cannot resolve a revision; confirm no endpoint row is left behind and the API surfaces the real error

Resolves #13392
Part of #13391