### PR TITLE
fix: Default the model definition name in the revision merge baseline

### DIFF
--- a/changes/13396.fix.md
+++ b/changes/13396.fix.md
@@ -1,0 +1,1 @@
+Fix revision creation failing for runtime variants created through the API, whose empty default model definition left the merged model definition without a name.

--- a/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
 
 __all__ = ("RevisionDraftReader",)
 
+# Fallback identifier for the single model entry when no layer in the merge
+# chain names one. Matches the conventional single-model definition.
+_DEFAULT_MODEL_NAME = "model"
+
 
 class RevisionDraftReader:
     """Fan out the DB + storage reads that feed the revision merge chain.
@@ -146,9 +150,23 @@ class RevisionDraftReader:
         self,
         mounts: MountMetadata,
     ) -> RevisionDraft:
-        """Build the lowest-priority model_path default draft."""
+        """Build the lowest-priority ``name`` / ``model_path`` default draft.
+
+        Both fields are required by the strict :class:`ModelConfig` that
+        ``to_resolved()`` produces at the persistence boundary, so this draft
+        supplies both. Without the ``name`` default, a variant whose
+        ``default_model_definition`` is empty — which is every variant created
+        through the API, since the write path does not expose the field — makes
+        every revision on it unresolvable. Any layer above (variant baseline,
+        preset, vfolder yaml, request) overrides these.
+        """
         model_definition = ModelDefinitionDraft(
-            models=[ModelConfigDraft(model_path=mounts.model_mount_destination)]
+            models=[
+                ModelConfigDraft(
+                    name=_DEFAULT_MODEL_NAME,
+                    model_path=mounts.model_mount_destination,
+                )
+            ]
         )
         return RevisionDraft(mounts=mounts, model_definition=model_definition)
 

--- a/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
+++ b/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
@@ -373,3 +373,43 @@ class TestRevisionDraftReaderVFolderDrafts:
         assert merged.model_definition is not None
         assert merged.model_definition.models is not None
         assert merged.model_definition.models[0].name == "from-file"
+
+
+class TestRevisionDraftReaderModelNameDefault:
+    """``name`` is required by the strict ``ModelConfig``; the baseline supplies it.
+
+    Every runtime variant created through the API has an empty
+    ``default_model_definition`` — the write path does not expose the field —
+    so without this default no revision on such a variant could resolve.
+    """
+
+    def test_empty_variant_baseline_still_resolves(self) -> None:
+        merged = _merge_all(
+            _reader()._model_mount_path_default_draft(_mounts("/models")),
+            _reader()._variant_baseline_to_draft(_variant()),
+        )
+
+        assert merged.model_definition is not None
+        resolved = merged.model_definition.to_resolved()
+
+        assert len(resolved.models) == 1
+        assert resolved.models[0].name == "model"
+        assert resolved.models[0].model_path == "/models"
+
+    def test_higher_layer_name_wins(self) -> None:
+        merged = _merge_all(
+            _reader()._model_mount_path_default_draft(_mounts("/models")),
+            _reader()._variant_baseline_to_draft(
+                _variant(
+                    default_model_definition=ModelDefinitionDraft(
+                        models=[ModelConfigDraft(name="vllm")]
+                    )
+                )
+            ),
+        )
+
+        assert merged.model_definition is not None
+        resolved = merged.model_definition.to_resolved()
+
+        assert resolved.models[0].name == "vllm"
+        assert resolved.models[0].model_path == "/models"


### PR DESCRIPTION
## Summary

- `ModelConfig` requires both `name` and `model_path`, but `_model_mount_path_default_draft` — the lowest-priority layer of the revision merge chain — supplied only `model_path`. Everything above it is optional, so `name` had to come from the runtime variant baseline, the preset, a vfolder yaml, or the request.
- That baseline is empty for **every runtime variant created through the API**: `RuntimeVariantCreatorSpec.build_row()` hardcodes `ModelDefinitionDraft()`, `RuntimeVariantUpdaterSpec` exposes only `name` and `description`, and no input DTO anywhere carries the field. Only the alembic seed (b5c6d7e8f9a0) writes real values.
- Result: a model-store deploy against a preset bound to an API-created variant always failed at `to_resolved()` — after the endpoint row was already committed. The baseline now supplies both fields; any higher layer still overrides them.

Follow-up, deliberately not in scope: `runtime_variants.default_model_definition` is still not writable through any API. This makes such variants deployable, but a custom variant still cannot ship its own baseline definition.

## Test plan

- [x] `pants lint --changed-since=origin/main`
- [x] `pants test tests/unit/manager/sokovan/deployment:: tests/unit/manager/data/deployment::`
- [ ] Create a runtime variant through the API, bind a preset to it, deploy from the model store

Resolves #13393
Part of #13391