### PR TITLE
fix: Guard the preset-derived replica count and strategy fallbacks

### DIFF
--- a/changes/13397.fix.md
+++ b/changes/13397.fix.md
@@ -1,0 +1,1 @@
+Guard the preset-derived replica count and deployment strategy fallbacks so a schema change surfaces as a domain error.

--- a/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
+++ b/src/ai/backend/manager/sokovan/deployment/deployment_controller.py
@@ -774,7 +774,7 @@ class DeploymentController:
         if resolved_replica_spec is None:
             preset_replica = (
                 preset_data.replica_count
-                if preset_data is not None
+                if preset_data is not None and preset_data.replica_count is not None
                 else self._DEFAULT_REPLICA_COUNT
             )
             resolved_replica_spec = ReplicaSpec(replica_count=preset_replica)
@@ -804,7 +804,12 @@ class DeploymentController:
     def _build_policy_from_preset(
         preset_data: DeploymentRevisionPresetData,
     ) -> DeploymentPolicyConfig:
-        """Reconstruct a DeploymentPolicyConfig from preset-stored strategy fields."""
+        """Reconstruct a DeploymentPolicyConfig from preset-stored strategy fields.
+
+        Raises:
+            InvalidAPIParameters: If the preset carries a strategy this
+                method does not know how to build a spec for.
+        """
         spec_dict = preset_data.deployment_strategy_spec
         strategy_spec: RollingUpdateSpec | BlueGreenSpec
         match preset_data.deployment_strategy:
@@ -817,6 +822,13 @@ class DeploymentController:
             case DeploymentStrategy.BLUE_GREEN:
                 strategy_spec = (
                     BlueGreenSpec.model_validate(spec_dict) if spec_dict else BlueGreenSpec()
+                )
+            case unsupported:
+                # Without this arm ``strategy_spec`` stays unbound and the
+                # caller gets an UnboundLocalError instead of a domain error.
+                raise InvalidAPIParameters(
+                    f"Revision preset {preset_data.id} carries an unsupported "
+                    f"deployment strategy: {unsupported}"
                 )
         return DeploymentPolicyConfig(
             strategy=preset_data.deployment_strategy,

--- a/tests/unit/manager/sokovan/deployment/test_apply_deployment_level_preset.py
+++ b/tests/unit/manager/sokovan/deployment/test_apply_deployment_level_preset.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -37,6 +37,7 @@ from ai.backend.manager.data.deployment.types import (
 from ai.backend.manager.data.deployment_revision_preset.types import (
     DeploymentRevisionPresetData,
 )
+from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.repositories.deployment_revision_preset.repository import (
     DeploymentRevisionPresetRepository,
 )
@@ -306,3 +307,42 @@ class TestApplyDeploymentLevelPreset:
 
         assert resolved.policy is not None
         assert isinstance(resolved.policy.strategy_spec, RollingUpdateSpec)
+
+
+class TestPresetFallbackGuards:
+    """Both fallbacks below are unreachable through today's schema — the columns
+    are NOT NULL and the enum has two members — but neither is enforced in code,
+    so a schema change would surface as an IntegrityError or an
+    UnboundLocalError rather than a domain error."""
+
+    async def test_null_preset_replica_count_falls_back_to_system_default(
+        self,
+        deployment_controller: DeploymentController,
+        mock_preset_repository: MagicMock,
+    ) -> None:
+        preset_id = DeploymentPresetID(uuid.uuid4())
+        mock_preset_repository.get_by_id = AsyncMock(
+            return_value=_make_preset(replica_count=cast(int, None))
+        )
+        creator = _make_creator(preset_id=preset_id)
+
+        resolved = await deployment_controller._apply_deployment_level_preset(creator)
+
+        assert resolved.replica_spec is not None
+        assert resolved.replica_spec.replica_count == 1
+
+    async def test_unsupported_preset_strategy_raises_a_domain_error(
+        self,
+        deployment_controller: DeploymentController,
+        mock_preset_repository: MagicMock,
+    ) -> None:
+        preset_id = DeploymentPresetID(uuid.uuid4())
+        mock_preset_repository.get_by_id = AsyncMock(
+            return_value=_make_preset(
+                deployment_strategy=cast(DeploymentStrategy, "recreate"),
+            )
+        )
+        creator = _make_creator(preset_id=preset_id)
+
+        with pytest.raises(InvalidAPIParameters):
+            await deployment_controller._apply_deployment_level_preset(creator)


### PR DESCRIPTION
## Summary

Two fallbacks in `_apply_deployment_level_preset` that are safe only by accident today:

- The preset replica count was read with no null check, unlike the `open_to_public` branch immediately below it. It survives only because `DeploymentRevisionPresetData.replica_count` is a non-optional `int`; a null would reach the `NOT NULL` `endpoints.replicas` column as an integrity error at insert time.
- `_build_policy_from_preset` matched `ROLLING` and `BLUE_GREEN` with no fallback arm, so a third `DeploymentStrategy` member would leave `strategy_spec` unbound — an `UnboundLocalError` rather than a domain error.

Neither is reachable through today's schema. Both are on the path every preset-driven deploy takes, and the tests pin the intent so a schema change surfaces as a domain error.

## Test plan

- [x] `pants lint --changed-since=origin/main`
- [x] `pants test tests/unit/manager/sokovan/deployment/test_apply_deployment_level_preset.py`

Resolves #13394
Part of #13391