### PR TITLE
fix(BA-7147): purge trash-bin and stalled vfolders on user/group purge

### DIFF
--- a/changes/13399.fix.md
+++ b/changes/13399.fix.md
@@ -1,0 +1,1 @@
+Fix user/group purge silently skipping trash-bin (`DELETE_PENDING`) and stalled (`DELETE_ONGOING`, `DELETE_ERROR`) vfolders, which left permanently orphaned folder records and leaked storage

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -181,6 +181,12 @@ class VFolderStatusSet(enum.StrEnum):
     INACCESSIBLE = "inaccessible"
     """Represents VFolder which is now completely removed from storage and only its record is being kept"""
 
+    OWNER_PURGABLE = "owner-purgable"
+    """Represents VFolder whose storage payload must be reclaimed when its owning
+    user or group is purged. Unlike DELETABLE, this includes folders in the trash
+    bin and folders whose previous deletion stalled or failed, since the owner row
+    is removed right after and any skipped folder becomes a permanent orphan."""
+
 
 vfolder_status_map: Final[dict[VFolderStatusSet, set[VFolderOperationStatus]]] = {
     VFolderStatusSet.ALL: {
@@ -227,6 +233,14 @@ vfolder_status_map: Final[dict[VFolderStatusSet, set[VFolderOperationStatus]]] =
     },
     VFolderStatusSet.INACCESSIBLE: {
         VFolderOperationStatus.DELETE_COMPLETE,
+    },
+    # DELETE_COMPLETE is excluded: its storage payload is already gone, so there
+    # is nothing left to reclaim on owner purge.
+    VFolderStatusSet.OWNER_PURGABLE: {
+        VFolderOperationStatus.READY,
+        VFolderOperationStatus.DELETE_PENDING,
+        VFolderOperationStatus.DELETE_ONGOING,
+        VFolderOperationStatus.DELETE_ERROR,
     },
 }
 

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -562,7 +562,7 @@ class GroupDBSource:
         query = sa.select(VFolderRow).where(
             sa.and_(
                 VFolderRow.group == group_id,
-                VFolderRow.status.in_(vfolder_status_map[VFolderStatusSet.DELETABLE]),
+                VFolderRow.status.in_(vfolder_status_map[VFolderStatusSet.OWNER_PURGABLE]),
             )
         )
         result = await w.batch_query_in_global(query, BatchQuerier(pagination=NoPagination()))

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -849,7 +849,7 @@ class UserDBSource:
                 sa.select(VFolderRow).where(
                     sa.and_(
                         VFolderRow.user == user_uuid,
-                        VFolderRow.status.in_(vfolder_status_map[VFolderStatusSet.DELETABLE]),
+                        VFolderRow.status.in_(vfolder_status_map[VFolderStatusSet.OWNER_PURGABLE]),
                     )
                 ),
             )


### PR DESCRIPTION
## Summary
- `purge_user` (and the group purge path) deleted only `READY` vfolders while unconditionally removing the owner row, so folders in the trash bin (`DELETE_PENDING`) were silently skipped and became permanently orphaned with their files leaked on storage.
- Introduce a purge-specific status set `VFolderStatusSet.OWNER_PURGABLE` (`READY`, `DELETE_PENDING`, `DELETE_ONGOING`, `DELETE_ERROR`) and use it in both the user and group purge paths, so trash-bin folders and folders whose previous deletion stalled or failed are also reclaimed. `DELETE_COMPLETE` is excluded since its storage payload is already gone.
- The existing `DELETABLE` set is left untouched, so the semantics of the regular vfolder deletion APIs are unchanged.

## Test plan
- [x] Create a vfolder, move it to the trash bin (`DELETE_PENDING`), then purge the owner — the folder's storage deletion is initiated instead of being skipped.
- [x] Purge a user with only `READY` vfolders — behavior unchanged.
- [x] Group purge path (`_delete_group_vfolders`) picks up trash-bin folders the same way.

Resolves BA-7147

🤖 Generated with [Claude Code](https://claude.com/claude-code)