### PR TITLE
fix(BA-7156): preserve session ID in utilization queries

### DIFF
--- a/changes/13400.fix.md
+++ b/changes/13400.fix.md
@@ -1,0 +1,1 @@
+Fix utilization idle checkers getting stuck in `ready_to_check` when evaluating session metrics.

--- a/src/ai/backend/manager/clients/prometheus/client.py
+++ b/src/ai/backend/manager/clients/prometheus/client.py
@@ -147,6 +147,7 @@ class PrometheusClient:
         preset = MetricPreset(
             template=query_template,
             labels={"session_id": LabelMatcher.regex(session_id_pattern)},
+            group_by={"session_id"},
             window=time_window,
         )
         return await self._query_instant(preset, time=evaluation_time)

--- a/tests/unit/manager/clients/prometheus/test_client.py
+++ b/tests/unit/manager/clients/prometheus/test_client.py
@@ -254,7 +254,7 @@ class TestQueryInstant:
         first_session_id = SessionId(uuid4())
         second_session_id = SessionId(uuid4())
         query_template = (
-            'min by (session_id) (backendai_container_utilization{{value_type="current",'
+            'min by ({group_by}) (backendai_container_utilization{{value_type="current",'
             'container_metric_name="cpu_used",{labels}}})'
         )
 


### PR DESCRIPTION
## Summary

- Preserve the `session_id` label in Prometheus results used by utilization idle checkers.
- Render session utilization presets with `session_id` as the grouping label.
- Cover `{group_by}` rendering in the Prometheus client regression test.

## Root cause

`fetch_session_utilization()` did not provide a value for the preset's `{group_by}` placeholder. Generic presets were rendered with `sum by ()`, which removed `session_id` from the result. The metric repository could not associate the value with a session and discarded it, leaving the utilization checker in `ready_to_check`.

## Test plan

- [x] Run formatting, lint, type checking, and unit tests for the changed code.
- [x] Verify locally that the rendered query returns a result with `session_id`.
- [x] Verify with a running session that the checker progresses from `not_checked` to `ready_to_check`, then to `active`.

## Out of scope

Filter-label bindings for selecting a meaningful metric and value type will be handled in a separate feature PR.

Resolves BA-7156
