### PR TITLE
fix(BA-7156): preserve session ID in utilization queries (#13400)

### DIFF
--- a/changes/13400.fix.md
+++ b/changes/13400.fix.md
@@ -1,0 +1,1 @@
+Fix utilization idle checkers getting stuck in `ready_to_check` when evaluating session metrics.

--- a/src/ai/backend/manager/clients/prometheus/client.py
+++ b/src/ai/backend/manager/clients/prometheus/client.py
@@ -147,6 +147,7 @@ class PrometheusClient:
         preset = MetricPreset(
             template=query_template,
             labels={"session_id": LabelMatcher.regex(session_id_pattern)},
+            group_by={"session_id"},
             window=time_window,
         )
         return await self._query_instant(preset, time=evaluation_time)

--- a/tests/unit/manager/clients/prometheus/test_client.py
+++ b/tests/unit/manager/clients/prometheus/test_client.py
@@ -254,7 +254,7 @@ class TestQueryInstant:
         first_session_id = SessionId(uuid4())
         second_session_id = SessionId(uuid4())
         query_template = (
-            'min by (session_id) (backendai_container_utilization{{value_type="current",'
+            'min by ({group_by}) (backendai_container_utilization{{value_type="current",'
             'container_metric_name="cpu_used",{labels}}})'
         )
 


### PR DESCRIPTION
This is an auto-generated backport of #13400 to the 26.8 release.