### PR TITLE
fix: Make the App Proxy worker backend connect timeout configurable

### DIFF
--- a/changes/13420.fix.md
+++ b/changes/13420.fix.md
@@ -1,0 +1,1 @@
+Fix App Proxy worker returning Gateway Timeout for requests queued behind a saturated backend connection pool.

--- a/changes/13420.fix.md
+++ b/changes/13420.fix.md
@@ -1,1 +1,1 @@
-Fix App Proxy worker returning Gateway Timeout for requests queued behind a saturated backend connection pool.
+Add `proxy_worker.backend_connect_timeout` to the App Proxy worker config so that requests queued behind a saturated backend connection pool can wait for a free slot (`0`) instead of failing with Gateway Timeout.

--- a/configs/app-proxy-worker/sample.toml
+++ b/configs/app-proxy-worker/sample.toml
@@ -175,6 +175,14 @@
   # connections.
   # Added in 25.9.0
   client_pool_cleanup_interval = 60.0
+  # The timeout in seconds for acquiring a connection to a backend, covering
+  # both the wait for a free slot in the connection pool and establishing the
+  # connection. When concurrent requests exceed the pool limit, requests queued
+  # longer than this fail with Gateway Timeout. Set to 0 to let them wait for a
+  # free slot indefinitely; an unreachable backend is still detected by the
+  # 10-second socket connect timeout.
+  # Added in 26.8.0
+  backend_connect_timeout = 10.0
   # The address this worker announces to the service discovery system. Other
   # components use this address to locate and connect to the worker. If not set,
   # defaults to api_bind_addr. Required when behind NAT or containers.

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -772,6 +772,22 @@ class ProxyWorkerConfig(BaseSchema):
         ),
     ]
 
+    backend_connect_timeout: Annotated[
+        float,
+        Field(default=10.0, ge=0),
+        BackendAIConfigMeta(
+            description=(
+                "The timeout in seconds for acquiring a connection to a backend, covering both "
+                "the wait for a free slot in the connection pool and establishing the connection. "
+                "When concurrent requests exceed the pool limit, requests queued longer than this "
+                "fail with Gateway Timeout. Set to 0 to let them wait for a free slot indefinitely; "
+                "an unreachable backend is still detected by the 10-second socket connect timeout."
+            ),
+            added_version="26.8.0",
+            example=ConfigExample(local="10.0", prod="10.0"),
+        ),
+    ]
+
     announce_addr: Annotated[
         HostPortPair | None,
         Field(default=None),

--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -40,6 +40,17 @@ HOP_ONLY_HEADERS: Final[CIMultiDict[int]] = CIMultiDict([
     ("Upgrade", 1),
 ])
 
+BACKEND_CLIENT_TIMEOUT: Final[aiohttp.ClientTimeout] = aiohttp.ClientTimeout(
+    total=None,
+    # `connect` budgets waiting for a free pool slot *and* establishing the
+    # connection, so any finite value turns pool saturation into a gateway timeout
+    # once concurrency exceeds the connector limit. Leave queueing unbounded and
+    # cap the socket connect alone, which is what detects an unreachable upstream.
+    connect=None,
+    sock_connect=10.0,
+    sock_read=None,
+)
+
 
 class HTTPBackend(BaseBackend):
     """HTTP proxy backend that keeps routes in a health-checked pool.
@@ -56,17 +67,11 @@ class HTTPBackend(BaseBackend):
     def __init__(self, routes: list[RouteInfo], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._pool = RoutePool(initial_routes=routes)
-        client_timeout = aiohttp.ClientTimeout(
-            total=None,
-            connect=10.0,
-            sock_connect=10.0,
-            sock_read=None,
-        )
         cleanup_interval = self.root_context.local_config.proxy_worker.client_pool_cleanup_interval
         self.client_pool = ClientPool(
             partial(
                 tcp_client_session_factory,
-                timeout=client_timeout,
+                timeout=BACKEND_CLIENT_TIMEOUT,
                 auto_decompress=False,  # transparently pass the response body
             ),
             cleanup_interval_seconds=cleanup_interval,

--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -40,17 +40,6 @@ HOP_ONLY_HEADERS: Final[CIMultiDict[int]] = CIMultiDict([
     ("Upgrade", 1),
 ])
 
-BACKEND_CLIENT_TIMEOUT: Final[aiohttp.ClientTimeout] = aiohttp.ClientTimeout(
-    total=None,
-    # `connect` budgets waiting for a free pool slot *and* establishing the
-    # connection, so any finite value turns pool saturation into a gateway timeout
-    # once concurrency exceeds the connector limit. Leave queueing unbounded and
-    # cap the socket connect alone, which is what detects an unreachable upstream.
-    connect=None,
-    sock_connect=10.0,
-    sock_read=None,
-)
-
 
 class HTTPBackend(BaseBackend):
     """HTTP proxy backend that keeps routes in a health-checked pool.
@@ -67,11 +56,18 @@ class HTTPBackend(BaseBackend):
     def __init__(self, routes: list[RouteInfo], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._pool = RoutePool(initial_routes=routes)
-        cleanup_interval = self.root_context.local_config.proxy_worker.client_pool_cleanup_interval
+        proxy_worker_config = self.root_context.local_config.proxy_worker
+        client_timeout = aiohttp.ClientTimeout(
+            total=None,
+            connect=proxy_worker_config.backend_connect_timeout,
+            sock_connect=10.0,
+            sock_read=None,
+        )
+        cleanup_interval = proxy_worker_config.client_pool_cleanup_interval
         self.client_pool = ClientPool(
             partial(
                 tcp_client_session_factory,
-                timeout=BACKEND_CLIENT_TIMEOUT,
+                timeout=client_timeout,
                 auto_decompress=False,  # transparently pass the response body
             ),
             cleanup_interval_seconds=cleanup_interval,

--- a/tests/unit/appproxy/worker/test_backend_client_timeout.py
+++ b/tests/unit/appproxy/worker/test_backend_client_timeout.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from functools import partial
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from ai.backend.appproxy.worker.proxy.backend.http import BACKEND_CLIENT_TIMEOUT
+from ai.backend.common.clients.http_client.client_pool import (
+    ClientKey,
+    ClientPool,
+    tcp_client_session_factory,
+)
+
+UPSTREAM_DELAY = 0.3
+"""How long the stub upstream holds a connection, in seconds."""
+
+
+async def _slow_upstream(request: web.Request) -> web.Response:
+    await asyncio.sleep(UPSTREAM_DELAY)
+    return web.Response(text="ok")
+
+
+@pytest.fixture
+async def upstream_url() -> AsyncIterator[str]:
+    app = web.Application()
+    app.router.add_get("/", _slow_upstream)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        _, port = runner.addresses[0][:2]
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        await runner.cleanup()
+
+
+def _make_pool(url: str, timeout: aiohttp.ClientTimeout) -> ClientPool:
+    return ClientPool(
+        partial(
+            tcp_client_session_factory,
+            timeout=timeout,
+            auto_decompress=False,
+            ssl=False,
+            limit=1,  # saturate the connector with the second concurrent request
+        ),
+        cleanup_interval_seconds=600,
+    )
+
+
+async def _fetch_concurrently(pool: ClientPool, url: str, count: int) -> list[int]:
+    session = pool.load_client_session(ClientKey(endpoint=url, domain="test"))
+
+    async def fetch() -> int:
+        async with session.get("/") as resp:
+            await resp.read()
+            return resp.status
+
+    return await asyncio.gather(*(fetch() for _ in range(count)))
+
+
+async def test_pool_wait_is_not_bounded_by_connect_timeout(upstream_url: str) -> None:
+    """Requests queued behind a saturated connector must complete, not time out.
+
+    With ``limit=1`` the second request waits for the first to release its
+    connection. aiohttp charges that wait to ``ClientTimeout.connect``, so the
+    production timeout must leave ``connect`` unset for the wait to be unbounded.
+    """
+    assert BACKEND_CLIENT_TIMEOUT.connect is None
+    pool = _make_pool(upstream_url, BACKEND_CLIENT_TIMEOUT)
+    try:
+        statuses = await _fetch_concurrently(pool, upstream_url, 2)
+    finally:
+        await pool.close()
+    assert statuses == [200, 200]
+
+
+async def test_finite_connect_timeout_fails_the_queued_request(upstream_url: str) -> None:
+    """Pins the regression: a finite ``connect`` budget kills the queued request.
+
+    This is the pre-fix configuration. It asserts the failure is caused by pool
+    queueing rather than by an unreachable upstream, so the fix above is not
+    merely masking a slow connect.
+    """
+    doomed_timeout = aiohttp.ClientTimeout(
+        total=None,
+        connect=UPSTREAM_DELAY / 2,
+        sock_connect=10.0,
+        sock_read=None,
+    )
+    pool = _make_pool(upstream_url, doomed_timeout)
+    try:
+        with pytest.raises(aiohttp.ConnectionTimeoutError):
+            await _fetch_concurrently(pool, upstream_url, 2)
+    finally:
+        await pool.close()

--- a/tests/unit/appproxy/worker/test_backend_client_timeout.py
+++ b/tests/unit/appproxy/worker/test_backend_client_timeout.py
@@ -8,7 +8,6 @@ import aiohttp
 import pytest
 from aiohttp import web
 
-from ai.backend.appproxy.worker.proxy.backend.http import BACKEND_CLIENT_TIMEOUT
 from ai.backend.common.clients.http_client.client_pool import (
     ClientKey,
     ClientPool,
@@ -19,82 +18,61 @@ UPSTREAM_DELAY = 0.3
 """How long the stub upstream holds a connection, in seconds."""
 
 
-async def _slow_upstream(request: web.Request) -> web.Response:
-    await asyncio.sleep(UPSTREAM_DELAY)
-    return web.Response(text="ok")
+class TestBackendConnectTimeout:
+    """``backend_connect_timeout`` bounds the wait for a free connector slot.
 
-
-@pytest.fixture
-async def upstream_url() -> AsyncIterator[str]:
-    app = web.Application()
-    app.router.add_get("/", _slow_upstream)
-    runner = web.AppRunner(app)
-    await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 0)
-    await site.start()
-    try:
-        _, port = runner.addresses[0][:2]
-        yield f"http://127.0.0.1:{port}"
-    finally:
-        await runner.cleanup()
-
-
-def _make_pool(url: str, timeout: aiohttp.ClientTimeout) -> ClientPool:
-    return ClientPool(
-        partial(
-            tcp_client_session_factory,
-            timeout=timeout,
-            auto_decompress=False,
-            ssl=False,
-            limit=1,  # saturate the connector with the second concurrent request
-        ),
-        cleanup_interval_seconds=600,
-    )
-
-
-async def _fetch_concurrently(pool: ClientPool, url: str, count: int) -> list[int]:
-    session = pool.load_client_session(ClientKey(endpoint=url, domain="test"))
-
-    async def fetch() -> int:
-        async with session.get("/") as resp:
-            await resp.read()
-            return resp.status
-
-    return await asyncio.gather(*(fetch() for _ in range(count)))
-
-
-async def test_pool_wait_is_not_bounded_by_connect_timeout(upstream_url: str) -> None:
-    """Requests queued behind a saturated connector must complete, not time out.
-
-    With ``limit=1`` the second request waits for the first to release its
-    connection. aiohttp charges that wait to ``ClientTimeout.connect``, so the
-    production timeout must leave ``connect`` unset for the wait to be unbounded.
+    With ``limit=1`` the second of two concurrent requests waits for the first to
+    release its connection, and aiohttp charges that wait to ``ClientTimeout.connect``.
     """
-    assert BACKEND_CLIENT_TIMEOUT.connect is None
-    pool = _make_pool(upstream_url, BACKEND_CLIENT_TIMEOUT)
-    try:
-        statuses = await _fetch_concurrently(pool, upstream_url, 2)
-    finally:
-        await pool.close()
-    assert statuses == [200, 200]
 
+    @pytest.fixture
+    async def upstream_url(self) -> AsyncIterator[str]:
+        async def slow_upstream(request: web.Request) -> web.Response:
+            await asyncio.sleep(UPSTREAM_DELAY)
+            return web.Response(text="ok")
 
-async def test_finite_connect_timeout_fails_the_queued_request(upstream_url: str) -> None:
-    """Pins the regression: a finite ``connect`` budget kills the queued request.
+        app = web.Application()
+        app.router.add_get("/", slow_upstream)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        try:
+            _, port = runner.addresses[0][:2]
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            await runner.cleanup()
 
-    This is the pre-fix configuration. It asserts the failure is caused by pool
-    queueing rather than by an unreachable upstream, so the fix above is not
-    merely masking a slow connect.
-    """
-    doomed_timeout = aiohttp.ClientTimeout(
-        total=None,
-        connect=UPSTREAM_DELAY / 2,
-        sock_connect=10.0,
-        sock_read=None,
-    )
-    pool = _make_pool(upstream_url, doomed_timeout)
-    try:
+    async def _fetch_twice(self, url: str, connect_timeout: float) -> list[int]:
+        pool = ClientPool(
+            partial(
+                tcp_client_session_factory,
+                timeout=aiohttp.ClientTimeout(
+                    total=None,
+                    connect=connect_timeout,
+                    sock_connect=10.0,
+                    sock_read=None,
+                ),
+                ssl=False,
+                limit=1,
+            ),
+            cleanup_interval_seconds=600,
+        )
+        session = pool.load_client_session(ClientKey(endpoint=url, domain="test"))
+
+        async def fetch() -> int:
+            async with session.get("/") as resp:
+                await resp.read()
+                return resp.status
+
+        try:
+            return list(await asyncio.gather(fetch(), fetch()))
+        finally:
+            await pool.close()
+
+    async def test_zero_leaves_pool_wait_unbounded(self, upstream_url: str) -> None:
+        assert await self._fetch_twice(upstream_url, 0) == [200, 200]
+
+    async def test_finite_value_fails_the_queued_request(self, upstream_url: str) -> None:
         with pytest.raises(aiohttp.ConnectionTimeoutError):
-            await _fetch_concurrently(pool, upstream_url, 2)
-    finally:
-        await pool.close()
+            await self._fetch_twice(upstream_url, UPSTREAM_DELAY / 2)


### PR DESCRIPTION
Resolves part of #13408.

## Summary

`HTTPBackend` built its `aiohttp.ClientTimeout` with a hardcoded `connect=10.0`. In aiohttp that budget covers *both* waiting for a free connector slot and establishing the connection — `BaseConnector.connect()` wraps `_wait_for_available_connection()` and `_create_connection()` in a single `ceil_timeout(timeout.connect, ...)`. With the connector limit at its default of 100 per route, any burst above that ceiling made queued requests fail with `ConnectionTimeoutError` after 10s, surfacing to the client as a Gateway Timeout — what #13408 reported.

This reads the value from a new `proxy_worker.backend_connect_timeout` config field instead. The default stays `10.0`, so existing deployments behave exactly as before. Setting it to `0` leaves the pool wait unbounded (aiohttp treats `0` as no timeout), while `sock_connect=10.0` still detects an unreachable upstream.

This does not raise the connection ceiling — it only lets operators stop saturation from being fatal. Making the ceiling configurable is a separate change.

## Test plan

- [x] `pants test tests/unit/appproxy/worker/test_backend_client_timeout.py` — with `limit=1` and a slow upstream, `connect=0` lets two concurrent requests both return 200, and a finite `connect` shorter than the upstream delay raises `ConnectionTimeoutError` on the queued request (proving the failure comes from pool queueing)
- [x] `pants check` / `pants fmt` / `pants fix` / `pants lint` clean on the changed files
- [x] Reporter re-ran `vllm bench serve` (ShareGPT, 500 prompts, `--request-rate inf`, `--seed 42`) with the pool wait unbounded: failures dropped from 55/500 to 0/500 (see comment below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbQfet1ukwMiqPAgHbwZt1
