### PR TITLE
feat: Expose the App Proxy backend connection pool limit as a config field

### DIFF
--- a/changes/13421.feature.md
+++ b/changes/13421.feature.md
@@ -1,0 +1,1 @@
+Add `proxy_worker.backend_connection_pool_limit` to tune the App Proxy worker per-route backend connection ceiling.

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -772,6 +772,24 @@ class ProxyWorkerConfig(BaseSchema):
         ),
     ]
 
+    backend_connection_pool_limit: Annotated[
+        int,
+        Field(default=100, ge=1),
+        BackendAIConfigMeta(
+            description=(
+                "The maximum number of concurrent connections the worker opens to a single "
+                "upstream route. The worker keeps one connection pool per route, so the "
+                "worker-wide ceiling is this value multiplied by the number of live routes, "
+                "not this value alone. Raise it for bursty high-concurrency workloads such as "
+                "model serving, and budget the result against the process file-descriptor "
+                "limit, since exhausting that affects every route rather than only the "
+                "saturated one."
+            ),
+            added_version="26.8.0",
+            example=ConfigExample(local="100", prod="500"),
+        ),
+    ]
+
     announce_addr: Annotated[
         HostPortPair | None,
         Field(default=None),

--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -62,14 +62,16 @@ class HTTPBackend(BaseBackend):
             sock_connect=10.0,
             sock_read=None,
         )
-        cleanup_interval = self.root_context.local_config.proxy_worker.client_pool_cleanup_interval
+        proxy_worker_config = self.root_context.local_config.proxy_worker
         self.client_pool = ClientPool(
             partial(
                 tcp_client_session_factory,
                 timeout=client_timeout,
                 auto_decompress=False,  # transparently pass the response body
+                # Applies per route, since each route gets its own ClientSession.
+                limit=proxy_worker_config.backend_connection_pool_limit,
             ),
-            cleanup_interval_seconds=cleanup_interval,
+            cleanup_interval_seconds=proxy_worker_config.client_pool_cleanup_interval,
         )
 
     @override

--- a/tests/unit/appproxy/worker/test_config.py
+++ b/tests/unit/appproxy/worker/test_config.py
@@ -8,7 +8,12 @@ import pytest
 from pydantic import TypeAdapter
 
 from ai.backend.appproxy.common.types import FrontendMode
-from ai.backend.appproxy.worker.config import TraefikConfig, TraefikPortProxyConfig
+from ai.backend.appproxy.worker.config import (
+    ProxyWorkerConfig,
+    TraefikConfig,
+    TraefikPortProxyConfig,
+)
+from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.typed_validators import AutoDirectoryPath
 
 
@@ -45,3 +50,66 @@ class TestTraefikConfig:
 
             assert config.last_used_time_marker_directory.exists()
             assert config.last_used_time_marker_directory.is_dir()
+
+
+@pytest.fixture
+def minimal_proxy_worker_config() -> dict[str, object]:
+    """The smallest payload that satisfies every required `ProxyWorkerConfig` field.
+
+    `user` and `group` are supplied explicitly because their default factories stat
+    `server.py` relative to the source tree, which is not resolvable under the test
+    sandbox.
+    """
+    return {
+        "coordinator_endpoint": "http://127.0.0.1:10200",
+        "authority": "worker-1",
+        "frontend_mode": "port",
+        "protocol": "http",
+        "accepted_traffics": ["inference", "interactive"],
+        "port_proxy": {
+            "bind_host": "0.0.0.0",
+            "bind_port_range": [10205, 10300],
+        },
+        "user": 1000,
+        "group": 1000,
+    }
+
+
+class TestBackendConnectionPoolLimit:
+    def test_defaults_to_the_previously_implicit_ceiling(
+        self,
+        minimal_proxy_worker_config: dict[str, object],
+    ) -> None:
+        """Upgrading without touching the config must not change the effective limit."""
+        config = ProxyWorkerConfig.model_validate(minimal_proxy_worker_config)
+
+        assert config.backend_connection_pool_limit == 100
+
+    def test_accepts_a_raised_limit(
+        self,
+        minimal_proxy_worker_config: dict[str, object],
+    ) -> None:
+        config = ProxyWorkerConfig.model_validate({
+            **minimal_proxy_worker_config,
+            "backend_connection_pool_limit": 500,
+        })
+
+        assert config.backend_connection_pool_limit == 500
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_rejects_non_positive_limits(
+        self,
+        minimal_proxy_worker_config: dict[str, object],
+        limit: int,
+    ) -> None:
+        """aiohttp reads `limit=0` as *unlimited*, which is a descriptor footgun here.
+
+        The pool is keyed per route, so an unbounded ceiling scales with the number of
+        live routes and can exhaust the process descriptor limit — which fails every
+        route at once rather than only the saturated one. Require an explicit bound.
+        """
+        with pytest.raises(BackendAISchemaValidationFailed):
+            ProxyWorkerConfig.model_validate({
+                **minimal_proxy_worker_config,
+                "backend_connection_pool_limit": limit,
+            })

--- a/tests/unit/appproxy/worker/test_config.py
+++ b/tests/unit/appproxy/worker/test_config.py
@@ -75,41 +75,39 @@ def minimal_proxy_worker_config() -> dict[str, object]:
     }
 
 
-class TestBackendConnectionPoolLimit:
-    def test_defaults_to_the_previously_implicit_ceiling(
-        self,
-        minimal_proxy_worker_config: dict[str, object],
-    ) -> None:
-        """Upgrading without touching the config must not change the effective limit."""
-        config = ProxyWorkerConfig.model_validate(minimal_proxy_worker_config)
+def test_backend_connection_pool_limit_defaults_to_the_implicit_ceiling(
+    minimal_proxy_worker_config: dict[str, object],
+) -> None:
+    """Upgrading without touching the config must not change the effective limit."""
+    config = ProxyWorkerConfig.model_validate(minimal_proxy_worker_config)
 
-        assert config.backend_connection_pool_limit == 100
+    assert config.backend_connection_pool_limit == 100
 
-    def test_accepts_a_raised_limit(
-        self,
-        minimal_proxy_worker_config: dict[str, object],
-    ) -> None:
-        config = ProxyWorkerConfig.model_validate({
+
+def test_backend_connection_pool_limit_accepts_a_raised_value(
+    minimal_proxy_worker_config: dict[str, object],
+) -> None:
+    config = ProxyWorkerConfig.model_validate({
+        **minimal_proxy_worker_config,
+        "backend_connection_pool_limit": 500,
+    })
+
+    assert config.backend_connection_pool_limit == 500
+
+
+@pytest.mark.parametrize("limit", [0, -1])
+def test_backend_connection_pool_limit_rejects_non_positive_values(
+    minimal_proxy_worker_config: dict[str, object],
+    limit: int,
+) -> None:
+    """aiohttp reads `limit=0` as *unlimited*, which is a descriptor footgun here.
+
+    The pool is keyed per route, so an unbounded ceiling scales with the number of
+    live routes and can exhaust the process descriptor limit — which fails every
+    route at once rather than only the saturated one. Require an explicit bound.
+    """
+    with pytest.raises(BackendAISchemaValidationFailed):
+        ProxyWorkerConfig.model_validate({
             **minimal_proxy_worker_config,
-            "backend_connection_pool_limit": 500,
+            "backend_connection_pool_limit": limit,
         })
-
-        assert config.backend_connection_pool_limit == 500
-
-    @pytest.mark.parametrize("limit", [0, -1])
-    def test_rejects_non_positive_limits(
-        self,
-        minimal_proxy_worker_config: dict[str, object],
-        limit: int,
-    ) -> None:
-        """aiohttp reads `limit=0` as *unlimited*, which is a descriptor footgun here.
-
-        The pool is keyed per route, so an unbounded ceiling scales with the number of
-        live routes and can exhaust the process descriptor limit — which fails every
-        route at once rather than only the saturated one. Require an explicit bound.
-        """
-        with pytest.raises(BackendAISchemaValidationFailed):
-            ProxyWorkerConfig.model_validate({
-                **minimal_proxy_worker_config,
-                "backend_connection_pool_limit": limit,
-            })


### PR DESCRIPTION
Resolves the remainder of #13408. Builds on #13420, which should merge first — both touch the same constructor.

## Summary

`HTTPBackend` never passed `limit` to `tcp_client_session_factory`, so aiohttp's default of 100 applied. Because `ClientPool` keys a session per `ClientKey`, and `HTTPBackend` builds that key from `route_id`, 100 is the ceiling *per route* — a two-replica model service tops out around 200 concurrent upstream connections regardless of what the backends can absorb.

This adds `proxy_worker.backend_connection_pool_limit` alongside the existing `client_pool_cleanup_interval`, and passes it through.

Two deliberate choices:

- **Default stays 100**, so upgrading changes nothing. Operators opt in to a higher ceiling.
- **Lower bound of 1.** aiohttp reads `limit=0` as unlimited, which was raised as an alternative in #13408, but the per-route keying means an unbounded ceiling scales descriptor usage with the number of live routes. Exhausting the process descriptor limit fails every route at once, which is a worse failure than the one being fixed. Operators who want more can name a number.

`limit_per_host` is deliberately not exposed. Sessions are already keyed per endpoint and `limit_per_host` is 0, so it would be a knob that does nothing today.

## Notes for the reviewer

`configs/app-proxy-worker/sample.toml` is intentionally untouched. Per `configs/AGENTS.md` it is generated from the schema rather than hand-maintained, and the field's `BackendAIConfigMeta` description carries the documentation. Worth noting separately that `scripts/release.sh` regenerates the manager, agent, storage and webserver samples but not the two appproxy ones, so that file is already drifting from its schema — out of scope here, but probably worth a follow-up.

## Test plan

- [x] `pants test tests/unit/appproxy/worker/test_config.py` passes (5 tests)
- [x] Default resolves to 100 on a config that does not mention the field
- [x] An explicit 500 round-trips
- [x] 0 and -1 are rejected with a schema validation failure
- [x] `pants fmt` / `pants fix` / `pants lint --changed-since=origin/main` clean
- [ ] Reporter confirms a raised limit recovers throughput on the `vllm bench serve` workload from #13408

## Backport

Milestoned 26.4 per request. Note that this is a `feat:` PR, so it will not backport automatically — landing it on the 26.4 LTS line needs an explicit `Backport: 26.4` trailer, which is a release decision I have deliberately left to a maintainer. #13420 is the part that backports by default and is what stops the reported Gateway Timeouts.