### PR TITLE
feat(BA-7168): derive the RBAC permission from the action's operation

### DIFF
--- a/changes/13424.enhance.md
+++ b/changes/13424.enhance.md
@@ -1,0 +1,1 @@
+Derive an action's required RBAC permission from its operation type, and add the `restore` operation mapped to soft-delete permission

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Final
 
 from ai.backend.common.data.entity.types import EntityType, ScopeType
-from ai.backend.common.data.permission.types import OperationType
+from ai.backend.common.data.permission.types import OperationType, Permission
 
 # Placeholder substituted when an id (request_id, entity_id, ...) is absent while
 # materializing action metadata into audit/report records.
@@ -40,6 +40,7 @@ class ActionOperationType(enum.StrEnum):
     UPDATE = "update"
     DELETE = "delete"
     PURGE = "purge"
+    RESTORE = "restore"
 
     @classmethod
     def read_operations(cls) -> frozenset["ActionOperationType"]:
@@ -64,6 +65,26 @@ class ActionOperationType(enum.StrEnum):
                 return OperationType.SOFT_DELETE
             case ActionOperationType.PURGE:
                 return OperationType.HARD_DELETE
+            case ActionOperationType.RESTORE:
+                return OperationType.SOFT_DELETE
+
+    def to_permission(self) -> Permission:
+        """The permission an action performing this operation must hold.
+
+        ``RESTORE`` shares ``SOFT_DELETE``: undoing a soft delete flips one status
+        flag back and reaches nothing the deleter could not already reach.
+        """
+        match self:
+            case ActionOperationType.GET | ActionOperationType.SEARCH:
+                return Permission.READ
+            case ActionOperationType.CREATE:
+                return Permission.CREATE
+            case ActionOperationType.UPDATE:
+                return Permission.UPDATE
+            case ActionOperationType.DELETE | ActionOperationType.RESTORE:
+                return Permission.SOFT_DELETE
+            case ActionOperationType.PURGE:
+                return Permission.HARD_DELETE
 
 
 @dataclass

--- a/src/ai/backend/manager/actions/v2/bulk/base.py
+++ b/src/ai/backend/manager/actions/v2/bulk/base.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.manager.actions.types import ActionOperationType, ActionSpec
 
@@ -25,12 +24,6 @@ class BaseBulkAction(ABC):
     @abstractmethod
     def entity_ids(self) -> Sequence[EntityID]:
         """Return the IDs of the entities that this action applies to."""
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def required_permission(cls) -> Permission:
-        """Return the permission required to perform this action."""
         raise NotImplementedError
 
     @classmethod

--- a/src/ai/backend/manager/actions/v2/bulk/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/bulk/validator/rbac.py
@@ -54,7 +54,7 @@ class VirtualScopeBulkActionRBACValidator(BulkActionValidator):
             )
             for entity_id in action.entity_ids()
         ]
-        permission = action.required_permission()
+        permission = action.operation_type().to_permission()
         permission_map = await self._repository.check_bulk_permission_via_virtual_scope(
             keys, permission
         )

--- a/src/ai/backend/manager/actions/v2/scope/base.py
+++ b/src/ai/backend/manager/actions/v2/scope/base.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.actions.types import ActionOperationType, ActionSpec
 
 
@@ -24,12 +23,6 @@ class BaseScopeAction(ABC):
     @abstractmethod
     def operation_type(cls) -> ActionOperationType:
         """Return the operation that this action performs within the scopes."""
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def required_permission(cls) -> Permission:
-        """Return the permission required to perform this action."""
         raise NotImplementedError
 
     @classmethod

--- a/src/ai/backend/manager/actions/v2/scope/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/scope/validator/rbac.py
@@ -53,7 +53,7 @@ class VirtualScopeScopeActionRBACValidator(ScopeActionValidator):
             )
             for scope in action.scope_targets()
         ]
-        permission = action.required_permission()
+        permission = action.operation_type().to_permission()
         permission_map = await self._repository.check_scope_permission_via_virtual_scope(
             keys, permission
         )

--- a/src/ai/backend/manager/actions/v2/single_entity/base.py
+++ b/src/ai/backend/manager/actions/v2/single_entity/base.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.manager.actions.types import ActionOperationType, ActionSpec
 
@@ -24,12 +23,6 @@ class BaseSingleEntityAction(ABC):
     @abstractmethod
     def entity_id(self) -> EntityID:
         """Return the ID of the entity that this action applies to."""
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def required_permission(cls) -> Permission:
-        """Return the permission required to perform this action."""
         raise NotImplementedError
 
     @classmethod

--- a/src/ai/backend/manager/actions/v2/single_entity/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/single_entity/validator/rbac.py
@@ -47,7 +47,7 @@ class VirtualScopeSingleEntityActionRBACValidator(SingleEntityActionValidator):
                 entity_id=action.entity_id(),
             ),
         )
-        permission = action.required_permission()
+        permission = action.operation_type().to_permission()
         allowed = await self._repository.check_single_entity_permission_via_virtual_scope(
             key, permission
         )

--- a/tests/unit/manager/actions/test_action_types.py
+++ b/tests/unit/manager/actions/test_action_types.py
@@ -1,6 +1,6 @@
 """Tests for the action type system: ActionOperationType, EntityType, and enum enforcement."""
 
-from ai.backend.common.data.permission.types import EntityType, OperationType
+from ai.backend.common.data.permission.types import EntityType, OperationType, Permission
 from ai.backend.manager.actions.action.base import BaseAction
 from ai.backend.manager.actions.types import ActionOperationType
 
@@ -26,10 +26,10 @@ _REPRESENTATIVE_ACTION_CLASSES: list[type[BaseAction]] = [
 
 
 class TestActionOperationType:
-    def test_has_exactly_six_values(self) -> None:
+    def test_has_exactly_seven_values(self) -> None:
         values = list(ActionOperationType)
-        assert len(values) == 6
-        expected = {"get", "search", "create", "update", "delete", "purge"}
+        assert len(values) == 7
+        expected = {"get", "search", "create", "update", "delete", "purge", "restore"}
         assert {v.value for v in values} == expected
 
     def test_to_permission_operation_mapping(self) -> None:
@@ -39,6 +39,20 @@ class TestActionOperationType:
         assert ActionOperationType.UPDATE.to_permission_operation() == OperationType.UPDATE
         assert ActionOperationType.DELETE.to_permission_operation() == OperationType.SOFT_DELETE
         assert ActionOperationType.PURGE.to_permission_operation() == OperationType.HARD_DELETE
+        assert ActionOperationType.RESTORE.to_permission_operation() == OperationType.SOFT_DELETE
+
+    def test_to_permission_mapping(self) -> None:
+        assert ActionOperationType.GET.to_permission() == Permission.READ
+        assert ActionOperationType.SEARCH.to_permission() == Permission.READ
+        assert ActionOperationType.CREATE.to_permission() == Permission.CREATE
+        assert ActionOperationType.UPDATE.to_permission() == Permission.UPDATE
+        assert ActionOperationType.DELETE.to_permission() == Permission.SOFT_DELETE
+        assert ActionOperationType.PURGE.to_permission() == Permission.HARD_DELETE
+        assert ActionOperationType.RESTORE.to_permission() == Permission.SOFT_DELETE
+
+    def test_to_permission_covers_every_operation(self) -> None:
+        for op in ActionOperationType:
+            assert op.to_permission() != Permission.NONE
 
     def test_all_values_are_unique(self) -> None:
         values = [v.value for v in ActionOperationType]
@@ -88,8 +102,8 @@ class TestEntityType:
 class TestAllActionClassesUseEnums:
     """Verify that representative concrete action classes return proper enum types.
 
-    These tests cover all six ActionOperationType values (GET, SEARCH, CREATE,
-    UPDATE, DELETE, PURGE) via representative concrete action classes.
+    These tests cover the operations concrete actions declare today (GET, SEARCH,
+    CREATE, UPDATE, DELETE, PURGE) via representative concrete action classes.
     """
 
     def test_entity_type_returns_enum(self) -> None:
@@ -109,9 +123,12 @@ class TestAllActionClassesUseEnums:
             )
 
     def test_covers_all_operation_types(self) -> None:
-        """Ensure the representative classes cover all six ActionOperationType values."""
+        """Ensure the representative classes cover every declarable operation.
+
+        ``RESTORE`` is excluded: no concrete action declares it yet.
+        """
+        expected = set(ActionOperationType) - {ActionOperationType.RESTORE}
         covered = {cls.operation_type() for cls in _REPRESENTATIVE_ACTION_CLASSES}
-        assert covered == set(ActionOperationType), (
-            f"Not all ActionOperationType values are covered. "
-            f"Missing: {set(ActionOperationType) - covered}"
+        assert covered == expected, (
+            f"Not all ActionOperationType values are covered. Missing: {expected - covered}"
         )

--- a/tests/unit/manager/actions/test_bulk_v2_processor.py
+++ b/tests/unit/manager/actions/test_bulk_v2_processor.py
@@ -15,7 +15,6 @@ from typing import override
 import pytest
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
@@ -52,11 +51,6 @@ class _Action(BaseBulkAction):
     @override
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.DELETE
-
-    @classmethod
-    @override
-    def required_permission(cls) -> Permission:
-        return Permission.SOFT_DELETE
 
 
 @dataclass

--- a/tests/unit/manager/actions/test_denied_recording.py
+++ b/tests/unit/manager/actions/test_denied_recording.py
@@ -13,7 +13,6 @@ from typing import override
 import pytest
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
@@ -45,11 +44,6 @@ class _Action(BaseSingleEntityAction):
     @override
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.DELETE
-
-    @classmethod
-    @override
-    def required_permission(cls) -> Permission:
-        return Permission.SOFT_DELETE
 
 
 @dataclass

--- a/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
@@ -119,11 +119,6 @@ class _ProjectCreateScopeAction(BaseScopeAction):
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.CREATE
 
-    @classmethod
-    @override
-    def required_permission(cls) -> Permission:
-        return Permission.CREATE
-
 
 @dataclass
 class _VfolderUpdateAction(BaseSingleEntityAction):
@@ -145,11 +140,6 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
     def entity_id(self) -> EntityID:
         return self.vfolder_id
 
-    @classmethod
-    @override
-    def required_permission(cls) -> Permission:
-        return Permission.UPDATE
-
 
 @dataclass
 class _BulkVfolderUpdateAction(BaseBulkAction):
@@ -170,11 +160,6 @@ class _BulkVfolderUpdateAction(BaseBulkAction):
     @override
     def entity_ids(self) -> Sequence[EntityID]:
         return self.ids
-
-    @classmethod
-    @override
-    def required_permission(cls) -> Permission:
-        return Permission.UPDATE
 
 
 def _domain_scope(scope_id: ScopeID) -> ScopeRef:


### PR DESCRIPTION
## Summary

- Add `ActionOperationType.to_permission()`, mapping an operation straight to a
  `Permission` bit without going through the deprecated `OperationType` bridge:
  `GET|SEARCH`→READ, `CREATE`→CREATE, `UPDATE`→UPDATE, `DELETE|RESTORE`→SOFT_DELETE,
  `PURGE`→HARD_DELETE.
- Drop the abstract `required_permission()` from the v2 `single_entity` / `bulk` /
  `scope` action bases and point the three v2 RBAC validators at
  `operation_type().to_permission()`. An action declares what it is; the framework
  decides what to check, so the operation and the permission can no longer disagree.
- Add the `RESTORE` operation, sharing `SOFT_DELETE`: undoing a soft delete flips one
  status flag back and reaches nothing the deleter could not already reach, while the
  distinct operation keeps a restore apart from a plain update in the audit log.

No concrete action sits on the v2 bases yet, so there are no call sites to migrate —
which is why the contract changes now rather than after the legacy actions move over.
Legacy validators (`actions/validators/rbac/*`) and the RBAC permission-matrix API are
untouched; the latter reads a different `RBACRequiredPermission` type that only shares
the name.

## Test plan

- [x] `pants fmt/fix/lint/check` pass
- [x] `pants test --changed-since` passes: operation→permission mapping, the v2
      single-entity/bulk processors, and the virtual-scope RBAC validator suite
- [x] `to_permission()` covers every `ActionOperationType` value (no operation maps to
      `Permission.NONE`)

Resolves BA-7168