### PR TITLE
chore: merge diverged alembic heads b17bba59db34 and e88ba629994f

### DIFF
--- a/changes/13427.misc.md
+++ b/changes/13427.misc.md
@@ -1,0 +1,1 @@
+Merge the diverged Alembic migration heads into a single head with an empty merge revision

--- a/src/ai/backend/manager/models/alembic/versions/1e088322c207_merge_heads_b17bba59db34_and_.py
+++ b/src/ai/backend/manager/models/alembic/versions/1e088322c207_merge_heads_b17bba59db34_and_.py
@@ -1,0 +1,22 @@
+"""merge heads b17bba59db34 and e88ba629994f
+
+Revision ID: 1e088322c207
+Revises: b17bba59db34, e88ba629994f
+Create Date: 2026-08-04 13:57:21.030668
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "1e088322c207"
+down_revision = ("b17bba59db34", "e88ba629994f")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- Add an empty merge migration `1e088322c207` to reconcile the two diverged Alembic heads on main: `b17bba59db34` (add role_name_template to role_presets) and `e88ba629994f` (rekey sgroups_for_domains to domain uuid).

## Test plan
- [x] `alembic heads` shows a single head (`1e088322c207`)
- [x] `alembic upgrade head` applied cleanly on a local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)