### PR TITLE
feat(BA-7170): add UPSERT operation and check permission masks as a subset

### DIFF
--- a/changes/13428.fix.md
+++ b/changes/13428.fix.md
@@ -1,0 +1,1 @@
+Require both the create and update permissions for upsert operations, and check permission masks as a subset so that holding one of the required bits no longer passes the check.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -591,6 +591,14 @@ class Permission(enum.IntFlag):
         """The full permission cap — every operation allowed."""
         return cls.READ | cls.UPDATE | cls.CREATE | cls.SOFT_DELETE | cls.HARD_DELETE
 
+    def covers(self, required: Permission) -> bool:
+        """Whether this mask holds *every* bit of ``required``.
+
+        A requirement may be a mask rather than a single bit (``UPSERT`` requires
+        ``CREATE | UPDATE``), so holding any one of its bits is not enough.
+        """
+        return (required & ~self) == Permission.NONE
+
     @classmethod
     def from_operation(cls, operation: OperationType) -> Permission:
         """Map a single :class:`OperationType` to its corresponding bit.

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -38,6 +38,7 @@ class ActionOperationType(enum.StrEnum):
     SEARCH = "search"
     CREATE = "create"
     UPDATE = "update"
+    UPSERT = "upsert"
     DELETE = "delete"
     PURGE = "purge"
     RESTORE = "restore"
@@ -52,6 +53,11 @@ class ActionOperationType(enum.StrEnum):
         return frozenset({cls.GET, cls.SEARCH})
 
     def to_permission_operation(self) -> OperationType:
+        """The legacy single :class:`OperationType` this operation maps to.
+
+        ``UPSERT`` narrows to ``CREATE``: this axis carries one value and cannot
+        express the ``CREATE | UPDATE`` mask, so it keeps the stronger of the two.
+        """
         match self:
             case ActionOperationType.GET:
                 return OperationType.READ
@@ -61,6 +67,8 @@ class ActionOperationType(enum.StrEnum):
                 return OperationType.CREATE
             case ActionOperationType.UPDATE:
                 return OperationType.UPDATE
+            case ActionOperationType.UPSERT:
+                return OperationType.CREATE
             case ActionOperationType.DELETE:
                 return OperationType.SOFT_DELETE
             case ActionOperationType.PURGE:
@@ -70,6 +78,10 @@ class ActionOperationType(enum.StrEnum):
 
     def to_permission(self) -> Permission:
         """The permission an action performing this operation must hold.
+
+        The result is a mask, not necessarily a single bit, and every bit in it is
+        required: ``UPSERT`` may insert or overwrite, so demanding only ``CREATE``
+        would let it overwrite without ``UPDATE`` and vice versa.
 
         ``RESTORE`` shares ``SOFT_DELETE``: undoing a soft delete flips one status
         flag back and reaches nothing the deleter could not already reach.
@@ -81,6 +93,8 @@ class ActionOperationType(enum.StrEnum):
                 return Permission.CREATE
             case ActionOperationType.UPDATE:
                 return Permission.UPDATE
+            case ActionOperationType.UPSERT:
+                return Permission.CREATE | Permission.UPDATE
             case ActionOperationType.DELETE | ActionOperationType.RESTORE:
                 return Permission.SOFT_DELETE
             case ActionOperationType.PURGE:

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -1203,10 +1203,11 @@ class PermissionDBSource:
         """Return whether the user holds *permission* on the key's entity via a virtual scope.
 
         Resolves the effective permission through the virtual-scope chain and tests
-        it bitwise (``effective & permission != NONE``).
+        that it covers *every* bit of ``permission``, which may be a mask
+        (``UPSERT`` requires ``CREATE | UPDATE``) rather than a single bit.
         """
         resolved = await self.resolve_effective_permissions_via_virtual_scope([key])
-        return bool(resolved.get(key, Permission.NONE) & permission)
+        return resolved.get(key, Permission.NONE).covers(permission)
 
     async def check_bulk_permission_via_virtual_scope(
         self,
@@ -1215,12 +1216,13 @@ class PermissionDBSource:
     ) -> Mapping[EntityPermissionCheckKey, bool]:
         """Check *permission* on each target entity through the virtual-scope chain in one go.
 
-        Returns a mapping from each input key to whether the permission is granted.
+        Returns a mapping from each input key to whether every bit of ``permission``
+        is granted.
         """
         if not keys:
             return {}
         resolved = await self.resolve_effective_permissions_via_virtual_scope(keys)
-        return {key: bool(resolved.get(key, Permission.NONE) & permission) for key in keys}
+        return {key: resolved.get(key, Permission.NONE).covers(permission) for key in keys}
 
     async def check_scope_permission_via_virtual_scope(
         self,
@@ -1229,12 +1231,13 @@ class PermissionDBSource:
     ) -> Mapping[ScopePermissionCheckKey, bool]:
         """Check *permission* on each target scope through the virtual-scope chain in one go.
 
-        Returns a mapping from each input key to whether the permission is granted.
+        Returns a mapping from each input key to whether every bit of ``permission``
+        is granted.
         """
         if not keys:
             return {}
         resolved = await self._resolve_effective_scope_permissions_via_virtual_scope(keys)
-        return {key: bool(resolved.get(key, Permission.NONE) & permission) for key in keys}
+        return {key: resolved.get(key, Permission.NONE).covers(permission) for key in keys}
 
     async def resolve_effective_permissions_via_virtual_scope(
         self,

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -452,7 +452,8 @@ class PermissionControllerRepository:
 
         Resolves the effective permission via
         ``entity -> entity_memberships -> scope_bindings -> scope`` with per-hop
-        cap clipping and tests it bitwise against ``permission``.
+        cap clipping and grants only when it covers every bit of ``permission``,
+        which may be a mask (``UPSERT`` requires ``CREATE | UPDATE``).
         """
         return await self._db_source.check_single_entity_permission_via_virtual_scope(
             key, permission

--- a/tests/unit/common/data/permission/test_types.py
+++ b/tests/unit/common/data/permission/test_types.py
@@ -122,6 +122,24 @@ class TestPermission:
         assert (within & ~cap) == Permission.NONE
         assert (exceeding & ~cap) != Permission.NONE
 
+    def test_covers_requires_every_required_bit(self) -> None:
+        """``covers`` is ALL-bits, not ANY-bit: a partial hold is not enough."""
+        required = Permission.CREATE | Permission.UPDATE
+        assert not Permission.CREATE.covers(required)
+        assert not Permission.UPDATE.covers(required)
+        assert not Permission.NONE.covers(required)
+        assert (Permission.CREATE | Permission.UPDATE).covers(required)
+        assert Permission.full().covers(required)
+
+    def test_covers_matches_any_bit_for_a_single_bit_requirement(self) -> None:
+        """Single-bit requirements keep the pre-mask behavior unchanged."""
+        for effective in (Permission.NONE, Permission.READ | Permission.UPDATE, Permission.full()):
+            for required in _ATOMIC_PERMISSIONS:
+                assert effective.covers(required) is bool(effective & required)
+
+    def test_covers_nothing_is_always_true(self) -> None:
+        assert Permission.NONE.covers(Permission.NONE)
+
     def test_cap_superset_check_is_not_magnitude(self) -> None:
         """Cap membership is a bitwise superset test, never an int >= comparison."""
         cap = Permission.HARD_DELETE

--- a/tests/unit/manager/actions/test_action_types.py
+++ b/tests/unit/manager/actions/test_action_types.py
@@ -26,10 +26,10 @@ _REPRESENTATIVE_ACTION_CLASSES: list[type[BaseAction]] = [
 
 
 class TestActionOperationType:
-    def test_has_exactly_seven_values(self) -> None:
+    def test_has_exactly_eight_values(self) -> None:
         values = list(ActionOperationType)
-        assert len(values) == 7
-        expected = {"get", "search", "create", "update", "delete", "purge", "restore"}
+        assert len(values) == 8
+        expected = {"get", "search", "create", "update", "upsert", "delete", "purge", "restore"}
         assert {v.value for v in values} == expected
 
     def test_to_permission_operation_mapping(self) -> None:
@@ -37,6 +37,7 @@ class TestActionOperationType:
         assert ActionOperationType.SEARCH.to_permission_operation() == OperationType.READ
         assert ActionOperationType.CREATE.to_permission_operation() == OperationType.CREATE
         assert ActionOperationType.UPDATE.to_permission_operation() == OperationType.UPDATE
+        assert ActionOperationType.UPSERT.to_permission_operation() == OperationType.CREATE
         assert ActionOperationType.DELETE.to_permission_operation() == OperationType.SOFT_DELETE
         assert ActionOperationType.PURGE.to_permission_operation() == OperationType.HARD_DELETE
         assert ActionOperationType.RESTORE.to_permission_operation() == OperationType.SOFT_DELETE
@@ -49,6 +50,14 @@ class TestActionOperationType:
         assert ActionOperationType.DELETE.to_permission() == Permission.SOFT_DELETE
         assert ActionOperationType.PURGE.to_permission() == Permission.HARD_DELETE
         assert ActionOperationType.RESTORE.to_permission() == Permission.SOFT_DELETE
+
+    def test_upsert_requires_both_create_and_update(self) -> None:
+        """An upsert may insert or overwrite, so neither bit alone is sufficient."""
+        required = ActionOperationType.UPSERT.to_permission()
+        assert required == Permission.CREATE | Permission.UPDATE
+        assert not Permission.CREATE.covers(required)
+        assert not Permission.UPDATE.covers(required)
+        assert (Permission.CREATE | Permission.UPDATE).covers(required)
 
     def test_to_permission_covers_every_operation(self) -> None:
         for op in ActionOperationType:
@@ -125,9 +134,14 @@ class TestAllActionClassesUseEnums:
     def test_covers_all_operation_types(self) -> None:
         """Ensure the representative classes cover every declarable operation.
 
-        ``RESTORE`` is excluded: no concrete action declares it yet.
+        ``RESTORE`` and ``UPSERT`` are excluded: no concrete action declares them
+        yet. The existing upsert actions still sit on the legacy base and are
+        re-declared once they move to the v2 bases.
         """
-        expected = set(ActionOperationType) - {ActionOperationType.RESTORE}
+        expected = set(ActionOperationType) - {
+            ActionOperationType.RESTORE,
+            ActionOperationType.UPSERT,
+        }
         covered = {cls.operation_type() for cls in _REPRESENTATIVE_ACTION_CLASSES}
         assert covered == expected, (
             f"Not all ActionOperationType values are covered. Missing: {expected - covered}"

--- a/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
@@ -11,7 +11,7 @@ not the recursive scope-walk.
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import override
@@ -142,6 +142,27 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
 
 
 @dataclass
+class _VfolderUpsertAction(BaseSingleEntityAction):
+    """VFOLDER:UPSERT on a single vfolder — requires the ``CREATE | UPDATE`` mask."""
+
+    vfolder_id: EntityID = field(default_factory=lambda: _VFOLDER_ID)
+
+    @classmethod
+    @override
+    def entity_type(cls) -> EntityType:
+        return EntityType("vfolder")
+
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.UPSERT
+
+    @override
+    def entity_id(self) -> EntityID:
+        return self.vfolder_id
+
+
+@dataclass
 class _BulkVfolderUpdateAction(BaseBulkAction):
     """VFOLDER:UPDATE on multiple vfolders — exercises the bulk validator path."""
 
@@ -233,7 +254,14 @@ async def _grant_permission(
     scope_id: uuid.UUID,
     entity_type: PermEntityType,
     operation: OperationType,
+    permission: Permission | None = None,
 ) -> None:
+    """Grant *operation* on *entity_type* at the scope.
+
+    ``permission`` overrides the granted bitmask, which the resolution actually
+    reads; pass it to grant a multi-bit mask the single ``operation`` column
+    cannot express.
+    """
     async with db.begin_session() as db_sess:
         db_sess.add(
             PermissionRow(
@@ -242,7 +270,9 @@ async def _grant_permission(
                 scope_id=str(scope_id),
                 entity_type=entity_type,
                 operation=operation,
-                permission=Permission.from_operation(operation),
+                permission=permission
+                if permission is not None
+                else Permission.from_operation(operation),
             )
         )
         await db_sess.flush()
@@ -300,6 +330,7 @@ async def _seed_granted_user(
     perm_scope_type: PermScopeType,
     perm_entity_type: PermEntityType,
     operation: OperationType,
+    permission: Permission | None = None,
     scope_cap: Permission | None = None,
     entity_cap: Permission | None = None,
 ) -> UserData:
@@ -324,6 +355,7 @@ async def _seed_granted_user(
         scope_id=owner_scope_id,
         entity_type=perm_entity_type,
         operation=operation,
+        permission=permission,
     )
     return _make_user_data(user_id, is_superadmin=False)
 
@@ -494,6 +526,45 @@ async def user_with_read_capped_vfolder(
     )
 
 
+def _vfolder_user_with(
+    db: ExtendedAsyncSAEngine,
+    permission: Permission,
+) -> Awaitable[UserData]:
+    """A user whose effective VFOLDER permission at the project scope is *permission*."""
+    return _seed_granted_user(
+        db,
+        owner_scope_type="project",
+        owner_scope_id=_PROJECT_ID,
+        entity_type="vfolder",
+        entity_ids=[_VFOLDER_ID],
+        perm_scope_type=PermScopeType.PROJECT,
+        perm_entity_type=PermEntityType.VFOLDER,
+        operation=OperationType.CREATE,
+        permission=permission,
+    )
+
+
+@pytest.fixture
+async def user_with_vfolder_create_only(
+    db_with_rbac_tables: ExtendedAsyncSAEngine,
+) -> UserData:
+    return await _vfolder_user_with(db_with_rbac_tables, Permission.CREATE)
+
+
+@pytest.fixture
+async def user_with_vfolder_update_only(
+    db_with_rbac_tables: ExtendedAsyncSAEngine,
+) -> UserData:
+    return await _vfolder_user_with(db_with_rbac_tables, Permission.UPDATE)
+
+
+@pytest.fixture
+async def user_with_vfolder_create_and_update(
+    db_with_rbac_tables: ExtendedAsyncSAEngine,
+) -> UserData:
+    return await _vfolder_user_with(db_with_rbac_tables, Permission.CREATE | Permission.UPDATE)
+
+
 @pytest.fixture
 async def user_with_all_bulk_vfolders_granted(
     db_with_rbac_tables: ExtendedAsyncSAEngine,
@@ -645,6 +716,58 @@ class TestVirtualScopeSingleEntityActionRBACValidator:
         with with_user(user_with_read_capped_vfolder):
             with pytest.raises(NotEnoughPermission):
                 await single_entity_validator.validate(single_entity_action, trigger_meta)
+
+
+class TestUpsertRequiresBothCreateAndUpdate:
+    """An UPSERT action demands the ``CREATE | UPDATE`` mask, and the check is a
+    subset test — holding just one of the two bits must be rejected."""
+
+    @pytest.fixture
+    def upsert_action(self) -> _VfolderUpsertAction:
+        return _VfolderUpsertAction()
+
+    async def test_create_only_is_rejected(
+        self,
+        single_entity_validator: VirtualScopeSingleEntityActionRBACValidator,
+        upsert_action: _VfolderUpsertAction,
+        trigger_meta: BaseActionTriggerMeta,
+        user_with_vfolder_create_only: UserData,
+    ) -> None:
+        with with_user(user_with_vfolder_create_only):
+            with pytest.raises(NotEnoughPermission):
+                await single_entity_validator.validate(upsert_action, trigger_meta)
+
+    async def test_update_only_is_rejected(
+        self,
+        single_entity_validator: VirtualScopeSingleEntityActionRBACValidator,
+        upsert_action: _VfolderUpsertAction,
+        trigger_meta: BaseActionTriggerMeta,
+        user_with_vfolder_update_only: UserData,
+    ) -> None:
+        with with_user(user_with_vfolder_update_only):
+            with pytest.raises(NotEnoughPermission):
+                await single_entity_validator.validate(upsert_action, trigger_meta)
+
+    async def test_both_bits_pass(
+        self,
+        single_entity_validator: VirtualScopeSingleEntityActionRBACValidator,
+        upsert_action: _VfolderUpsertAction,
+        trigger_meta: BaseActionTriggerMeta,
+        user_with_vfolder_create_and_update: UserData,
+    ) -> None:
+        with with_user(user_with_vfolder_create_and_update):
+            await single_entity_validator.validate(upsert_action, trigger_meta)
+
+    async def test_single_bit_operation_still_passes_with_one_bit(
+        self,
+        single_entity_validator: VirtualScopeSingleEntityActionRBACValidator,
+        single_entity_action: _VfolderUpdateAction,
+        trigger_meta: BaseActionTriggerMeta,
+        user_with_vfolder_update_only: UserData,
+    ) -> None:
+        # Regression: the subset semantics must not tighten single-bit operations.
+        with with_user(user_with_vfolder_update_only):
+            await single_entity_validator.validate(single_entity_action, trigger_meta)
 
 
 class TestVirtualScopeBulkActionRBACValidator:

--- a/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
@@ -147,6 +147,7 @@ class TestCheckBulkPermissionWithScopeChain:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -191,6 +192,7 @@ class TestCheckBulkPermissionWithScopeChain:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -404,6 +406,7 @@ class TestCheckBulkPermissionWithScopeChain:
             db_sess.add(
                 UserRow(
                     uuid=other_user_id,
+                    username=f"user-{other_user_id.hex[:8]}",
                     email="other@test.com",
                     resource_policy="test-rbac-policy",
                     status=UserStatus.ACTIVE,

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -296,6 +296,35 @@ class TestCheckPermissionViaVirtualScope:
                 False,
                 id="inactive-role-denied",
             ),
+            # A multi-bit requirement (UPSERT wants CREATE | UPDATE) is a subset
+            # test: holding one of its bits must not pass.
+            pytest.param(
+                VSChainSpec(granted=Permission.READ | Permission.CREATE),
+                Permission.CREATE | Permission.UPDATE,
+                False,
+                id="mask-denied-with-create-only",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.READ | Permission.UPDATE),
+                Permission.CREATE | Permission.UPDATE,
+                False,
+                id="mask-denied-with-update-only",
+            ),
+            pytest.param(
+                VSChainSpec(granted=Permission.CREATE | Permission.UPDATE),
+                Permission.CREATE | Permission.UPDATE,
+                True,
+                id="mask-permitted-with-both-bits",
+            ),
+            pytest.param(
+                VSChainSpec(
+                    granted=Permission.CREATE | Permission.UPDATE,
+                    entity_cap=Permission.CREATE,
+                ),
+                Permission.CREATE | Permission.UPDATE,
+                False,
+                id="mask-denied-when-cap-clips-one-bit",
+            ),
         ],
         indirect=["chain"],
     )
@@ -368,6 +397,30 @@ class TestCheckPermissionViaVirtualScope:
             [reachable, unreachable], Permission.READ
         )
         assert result == {reachable: True, unreachable: False}
+
+    @pytest.mark.parametrize(
+        ("chain",),
+        [
+            pytest.param(
+                VSChainSpec(granted=Permission.CREATE),
+                id="bulk-mask",
+            )
+        ],
+        indirect=["chain"],
+    )
+    async def test_bulk_check_requires_every_bit_of_the_mask(
+        self,
+        db_source: PermissionDBSource,
+        chain: VSChainFixture,
+    ) -> None:
+        reachable = EntityPermissionCheckKey(
+            user_id=chain.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=chain.entity_id),
+        )
+        result = await db_source.check_bulk_permission_via_virtual_scope(
+            [reachable], Permission.CREATE | Permission.UPDATE
+        )
+        assert result == {reachable: False}
 
     @pytest.mark.parametrize(
         ("chain",),

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -145,6 +145,7 @@ class TestCheckPermissionViaVirtualScope:
             db_sess.add(policy)
             user = UserRow(
                 uuid=ids.user_id,
+                username=f"user-{ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
@@ -138,6 +138,7 @@ class TestCheckPermissionWithScopeChain:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -404,6 +405,7 @@ class TestCheckPermissionWithScopeChain:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -591,6 +593,7 @@ class TestCheckPermissionWithScopeChain:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -702,6 +705,7 @@ class TestCheckPermissionWithScopeChain:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -986,6 +990,7 @@ class TestCheckPermissionWithScopeChain:
             db_sess.add(policy)
             other_user = UserRow(
                 uuid=other_user_id,
+                username=f"user-{other_user_id.hex[:8]}",
                 email="otheruser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,

--- a/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
@@ -146,6 +146,7 @@ class TestResolveEffectivePermissions:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -190,6 +191,7 @@ class TestResolveEffectivePermissions:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -234,6 +236,7 @@ class TestResolveEffectivePermissions:
             db_sess.add(policy)
             user = UserRow(
                 uuid=fixture_ids.user_id,
+                username=f"user-{fixture_ids.user_id.hex[:8]}",
                 email="testuser@test.com",
                 resource_policy="test-rbac-policy",
                 status=UserStatus.ACTIVE,
@@ -754,6 +757,7 @@ class TestResolveEffectivePermissions:
             db_sess.add(
                 UserRow(
                     uuid=other_user_id,
+                    username=f"user-{other_user_id.hex[:8]}",
                     email="other@test.com",
                     resource_policy="test-rbac-policy",
                     status=UserStatus.ACTIVE,


### PR DESCRIPTION
## Summary

- Add `ActionOperationType.UPSERT`, whose `to_permission()` returns the `CREATE | UPDATE` mask. An upsert may insert or overwrite, so requiring only `UPDATE` would let a subject without `CREATE` create rows through it, and requiring only `CREATE` would let a subject without `UPDATE` overwrite existing ones — the nine upsert actions on the legacy base are split 8/1 between exactly those two wrong answers today.
- Move the three virtual-scope permission checks from any-bit (`effective & permission != NONE`) to a subset test via the new `Permission.covers()`. Any-bit is weaker than a single bit once a mask arrives; the semantics have to move before the first mask does. **No behavior change today** — the three v2 RBAC validators are the only callers and all pass a single bit, where any-bit and all-bits agree.
- `to_permission_operation()` maps `UPSERT` to `OperationType.CREATE`: that legacy axis carries one value and cannot narrow a mask, and `CREATE` is both the stronger bit and what `BulkUpsertAppConfigFragmentsAction` already declares.

The nine existing upsert actions are deliberately **not** re-declared. They all sit on the legacy base, where re-declaring would silently strengthen enforcement from `UPDATE` to `CREATE` and break roles that hold `UPDATE` without `CREATE`. That needs a role-fixture and permission-preset review, and belongs in a separate issue once those actions move to the v2 bases.

The first commit is an unrelated fix, included because CI runs these files as direct dependents of this change: #13390 made `users.username` NOT NULL and left four permission-controller test files building `UserRow` without it, so every test in them errors at fixture setup on `main` today. Reviewable separately as `2b33b6d`.

## Test plan

- [x] `CREATE`-only and `UPDATE`-only subjects are both denied an UPSERT action; a subject holding both passes (validator end-to-end, real DB)
- [x] Single-bit operations keep their previous verdicts — asserted both at the `Permission.covers()` level against every atomic bit and through the validator
- [x] Subset semantics at the db_source level, including a cap that clips one bit of the mask, on both the single-entity and bulk paths
- [x] `pants fmt / fix / lint / check` clean; `pants test --changed-since=origin/main --changed-dependents=direct` fully green (the four fixture files included)

Resolves BA-7170