### PR TITLE
refactor: make username non-nullable in user data types

### DIFF
--- a/changes/13429.enhance.md
+++ b/changes/13429.enhance.md
@@ -1,0 +1,1 @@
+Make `username` non-nullable in the internal user data types to match the `NOT NULL` database column

--- a/src/ai/backend/manager/data/auth/types.py
+++ b/src/ai/backend/manager/data/auth/types.py
@@ -26,7 +26,7 @@ class AuthorizationResult:
 @dataclass
 class UserData:
     uuid: uuid.UUID
-    username: str | None
+    username: str
     email: str
     password: str | None
     need_password_change: bool

--- a/src/ai/backend/manager/data/user/types.py
+++ b/src/ai/backend/manager/data/user/types.py
@@ -73,7 +73,7 @@ class SessionOwnerContext:
 class UserData:
     id: UUID = field(compare=False)
     uuid: UUID = field(compare=False)  # legacy
-    username: str | None
+    username: str
     email: str
     need_password_change: bool | None
     full_name: str | None

--- a/tests/unit/manager/api/user/test_adapter.py
+++ b/tests/unit/manager/api/user/test_adapter.py
@@ -526,7 +526,7 @@ class TestUserAdapterConversion:
         user_data = UserData(
             id=user_id,
             uuid=user_id,
-            username=None,
+            username="minimal",
             email="minimal@example.com",
             need_password_change=None,
             full_name=None,
@@ -554,7 +554,7 @@ class TestUserAdapterConversion:
 
         assert isinstance(dto, UserDTO)
         assert dto.id == user_id
-        assert dto.username is None
+        assert dto.username == "minimal"
         assert dto.email == "minimal@example.com"
         assert dto.need_password_change is None
         assert dto.full_name is None


### PR DESCRIPTION
## Summary
- Narrow `username` from `str | None` to `str` in the internal user data types (`manager/data/user/types.py`, `manager/data/auth/types.py`) to match the `users.username` column, which has been `NOT NULL` since migration `9fbeda8995ff`.
- External contracts are unchanged: REST response DTOs and GraphQL types still expose `username` as nullable.
- Update the user adapter unit test that constructed `UserData` with `username=None`.

## Test plan
- [x] `pants fmt` / `fix` / `lint` pass locally
- [x] CI type check and unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)