### PR TITLE
feat(BA-7162): add the agent_installed_images table

### DIFF
--- a/changes/13430.feature.md
+++ b/changes/13430.feature.md
@@ -1,1 +1,1 @@
-Add the agent_images table to record which images are installed on which agents in the database
+Add the agent_installed_images table to record which images are installed on which agents in the database

--- a/changes/13430.feature.md
+++ b/changes/13430.feature.md
@@ -1,0 +1,1 @@
+Add the agent_images table to record which images are installed on which agents in the database

--- a/src/ai/backend/manager/models/agent_image/row.py
+++ b/src/ai/backend/manager/models/agent_image/row.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.types import ImageID
+from ai.backend.common.types import AgentId, ImageID
 from ai.backend.manager.models.base import GUID, Base
 from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
@@ -22,7 +22,7 @@ class AgentImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
 
     __tablename__ = "agent_images"
 
-    agent_id: Mapped[str] = mapped_column("agent_id", sa.String(length=64), primary_key=True)
+    agent_id: Mapped[AgentId] = mapped_column("agent_id", sa.String(length=64), primary_key=True)
     image_id: Mapped[ImageID] = mapped_column("image_id", GUID(ImageID), primary_key=True)
 
     __table_args__ = (

--- a/src/ai/backend/manager/models/agent_image/row.py
+++ b/src/ai/backend/manager/models/agent_image/row.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -15,18 +13,19 @@ __all__ = ("AgentImageRow",)
 
 
 class AgentImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
-    """One row per (agent, image) installation."""
+    """One row per (agent, image) installation.
+
+    Composite primary key: (agent_id, image_id). All writes go through
+    natural-key upsert and condition-based deletes, so no surrogate key
+    is needed.
+    """
 
     __tablename__ = "agent_images"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        "id", GUID(), primary_key=True, server_default=sa.text("uuid_generate_v4()")
-    )
-    agent_id: Mapped[str] = mapped_column("agent_id", sa.String(length=64), nullable=False)
-    image_id: Mapped[ImageID] = mapped_column("image_id", GUID(ImageID), nullable=False)
+    agent_id: Mapped[str] = mapped_column("agent_id", sa.String(length=64), primary_key=True)
+    image_id: Mapped[ImageID] = mapped_column("image_id", GUID(ImageID), primary_key=True)
 
     __table_args__ = (
-        sa.UniqueConstraint("agent_id", "image_id", name="uq_agent_images_agent_id_image_id"),
         sa.ForeignKeyConstraint(
             ["agent_id"],
             ["agents.id"],

--- a/src/ai/backend/manager/models/agent_image/row.py
+++ b/src/ai/backend/manager/models/agent_image/row.py
@@ -1,0 +1,43 @@
+"""Junction table recording which images are installed on which agents."""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.types import ImageID
+from ai.backend.manager.models.base import GUID, Base
+from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
+
+__all__ = ("AgentImageRow",)
+
+
+class AgentImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
+    """One row per (agent, image) installation."""
+
+    __tablename__ = "agent_images"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        "id", GUID(), primary_key=True, server_default=sa.text("uuid_generate_v4()")
+    )
+    agent_id: Mapped[str] = mapped_column("agent_id", sa.String(length=64), nullable=False)
+    image_id: Mapped[ImageID] = mapped_column("image_id", GUID(ImageID), nullable=False)
+
+    __table_args__ = (
+        sa.UniqueConstraint("agent_id", "image_id", name="uq_agent_images_agent_id_image_id"),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            name="fk_agent_images_agent_id_agents",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["images.id"],
+            name="fk_agent_images_image_id_images",
+            ondelete="CASCADE",
+        ),
+        sa.Index("ix_agent_images_image_id", "image_id"),
+    )

--- a/src/ai/backend/manager/models/agent_installed_image/row.py
+++ b/src/ai/backend/manager/models/agent_installed_image/row.py
@@ -9,10 +9,10 @@ from ai.backend.common.types import AgentId, ImageID
 from ai.backend.manager.models.base import GUID, Base
 from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
-__all__ = ("AgentImageRow",)
+__all__ = ("AgentInstalledImageRow",)
 
 
-class AgentImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
+class AgentInstalledImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
     """One row per (agent, image) installation.
 
     Composite primary key: (agent_id, image_id). All writes go through
@@ -20,7 +20,7 @@ class AgentImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
     is needed.
     """
 
-    __tablename__ = "agent_images"
+    __tablename__ = "agent_installed_images"
 
     agent_id: Mapped[AgentId] = mapped_column("agent_id", sa.String(length=64), primary_key=True)
     image_id: Mapped[ImageID] = mapped_column("image_id", GUID(ImageID), primary_key=True)
@@ -29,14 +29,14 @@ class AgentImageRow(CreatedAtMixin, Base):  # type: ignore[misc]
         sa.ForeignKeyConstraint(
             ["agent_id"],
             ["agents.id"],
-            name="fk_agent_images_agent_id_agents",
+            name="fk_agent_installed_images_agent_id_agents",
             ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["image_id"],
             ["images.id"],
-            name="fk_agent_images_image_id_images",
+            name="fk_agent_installed_images_image_id_images",
             ondelete="CASCADE",
         ),
-        sa.Index("ix_agent_images_image_id", "image_id"),
+        sa.Index("ix_agent_installed_images_image_id", "image_id"),
     )

--- a/src/ai/backend/manager/models/alembic/versions/304bf67162d0_add_agent_images_junction_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/304bf67162d0_add_agent_images_junction_table.py
@@ -1,0 +1,56 @@
+"""add agent_images junction table
+
+Records which images are installed on which agents.
+
+Revision ID: 304bf67162d0
+Revises: 1e088322c207
+Create Date: 2026-08-04 11:52:45.315444
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "304bf67162d0"
+down_revision = "1e088322c207"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_images",
+        sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
+        sa.Column("agent_id", sa.String(length=64), nullable=False),
+        sa.Column("image_id", GUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_agent_images")),
+        sa.UniqueConstraint("agent_id", "image_id", name=op.f("uq_agent_images_agent_id_image_id")),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agents.id"],
+            name=op.f("fk_agent_images_agent_id_agents"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["images.id"],
+            name=op.f("fk_agent_images_image_id_images"),
+            ondelete="CASCADE",
+        ),
+    )
+    op.create_index(op.f("ix_agent_images_image_id"), "agent_images", ["image_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_agent_images_image_id"), table_name="agent_images")
+    op.drop_table("agent_images")

--- a/src/ai/backend/manager/models/alembic/versions/304bf67162d0_add_agent_images_junction_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/304bf67162d0_add_agent_images_junction_table.py
@@ -24,7 +24,6 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "agent_images",
-        sa.Column("id", GUID(), server_default=sa.text("uuid_generate_v4()"), nullable=False),
         sa.Column("agent_id", sa.String(length=64), nullable=False),
         sa.Column("image_id", GUID(), nullable=False),
         sa.Column(
@@ -33,8 +32,7 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.PrimaryKeyConstraint("id", name=op.f("pk_agent_images")),
-        sa.UniqueConstraint("agent_id", "image_id", name=op.f("uq_agent_images_agent_id_image_id")),
+        sa.PrimaryKeyConstraint("agent_id", "image_id", name=op.f("pk_agent_images")),
         sa.ForeignKeyConstraint(
             ["agent_id"],
             ["agents.id"],

--- a/src/ai/backend/manager/models/alembic/versions/304bf67162d0_add_agent_installed_images_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/304bf67162d0_add_agent_installed_images_table.py
@@ -1,4 +1,4 @@
-"""add agent_images junction table
+"""add agent_installed_images table
 
 Records which images are installed on which agents.
 
@@ -23,7 +23,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "agent_images",
+        "agent_installed_images",
         sa.Column("agent_id", sa.String(length=64), nullable=False),
         sa.Column("image_id", GUID(), nullable=False),
         sa.Column(
@@ -32,23 +32,28 @@ def upgrade() -> None:
             server_default=sa.text("now()"),
             nullable=False,
         ),
-        sa.PrimaryKeyConstraint("agent_id", "image_id", name=op.f("pk_agent_images")),
+        sa.PrimaryKeyConstraint("agent_id", "image_id", name=op.f("pk_agent_installed_images")),
         sa.ForeignKeyConstraint(
             ["agent_id"],
             ["agents.id"],
-            name=op.f("fk_agent_images_agent_id_agents"),
+            name=op.f("fk_agent_installed_images_agent_id_agents"),
             ondelete="CASCADE",
         ),
         sa.ForeignKeyConstraint(
             ["image_id"],
             ["images.id"],
-            name=op.f("fk_agent_images_image_id_images"),
+            name=op.f("fk_agent_installed_images_image_id_images"),
             ondelete="CASCADE",
         ),
     )
-    op.create_index(op.f("ix_agent_images_image_id"), "agent_images", ["image_id"], unique=False)
+    op.create_index(
+        op.f("ix_agent_installed_images_image_id"),
+        "agent_installed_images",
+        ["image_id"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
-    op.drop_index(op.f("ix_agent_images_image_id"), table_name="agent_images")
-    op.drop_table("agent_images")
+    op.drop_index(op.f("ix_agent_installed_images_image_id"), table_name="agent_installed_images")
+    op.drop_table("agent_installed_images")


### PR DESCRIPTION
## Summary
- Add the `agent_installed_images` table (alembic migration + `AgentInstalledImageRow` ORM model) recording which images are installed on which agents — the first step of migrating agent-image installation state off Valkey.
- Composite primary key `(agent_id, image_id)`: all writes go through natural-key upsert (`ON CONFLICT DO NOTHING`) and condition-based deletes with no updatable column, so no surrogate key is needed (same pattern as `agent_resources`). `ON DELETE CASCADE` on both FKs, plus an `image_id` index for the image-to-agents direction.
- The `digest` column is intentionally omitted: after migration, deletion is handled by diff-delete on heartbeat upsert, so digest reverse lookup becomes unnecessary.

## Test plan
- [x] `alembic upgrade head` creates the table; `downgrade` removes it (verified on the local halfstack DB)
- [x] Inserting a duplicate `(agent_id, image_id)` pair raises a primary-key violation
- [x] Deleting an agent or an image cascades to `agent_installed_images` rows
- [x] `pants fmt fix lint check test --changed-since` passes

Resolves BA-7162

🤖 Generated with [Claude Code](https://claude.com/claude-code)