### PR TITLE
feat(BA-6661): apply virtual scope logic to the resource group scope

### DIFF
--- a/changes/13438.feature.md
+++ b/changes/13438.feature.md
@@ -1,0 +1,1 @@
+Apply the virtual scope logic to the resource group scope: scaling groups are now created and purged with their virtual scope, and domain/project associations maintain the corresponding virtual-scope bindings so RBAC resolution reaches resource groups through the virtual-scope chain.

--- a/src/ai/backend/common/data/entity/resource_group.py
+++ b/src/ai/backend/common/data/entity/resource_group.py
@@ -1,7 +1,11 @@
-from ai.backend.common.data.entity.types import ScopeType
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 
-__all__ = ("RESOURCE_GROUP_SCOPE_TYPE",)
+__all__ = (
+    "RESOURCE_GROUP_ENTITY_TYPE",
+    "RESOURCE_GROUP_SCOPE_TYPE",
+)
 
 
-# Raw string mirroring the RBAC-managed RBACElementType.RESOURCE_GROUP value.
+# Raw strings mirroring the RBAC-managed RBACElementType.RESOURCE_GROUP value.
 RESOURCE_GROUP_SCOPE_TYPE = ScopeType("resource_group")
+RESOURCE_GROUP_ENTITY_TYPE = EntityType("resource_group")

--- a/src/ai/backend/manager/repositories/scaling_group/creators.py
+++ b/src/ai/backend/manager/repositories/scaling_group/creators.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
 from uuid import UUID
 
+from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE
+from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import ScalingGroupConflict
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
@@ -19,7 +22,12 @@ from ai.backend.manager.models.scaling_group import (
     ScalingGroupRow,
 )
 from ai.backend.manager.repositories.base.creator import CreatorSpec
+from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
 from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
+from ai.backend.manager.repositories.ops.rbac.provider import ScopeCreation
+from ai.backend.manager.repositories.permission_controller.role_manager import (
+    ScopeSystemRoleData,
+)
 
 
 @dataclass
@@ -65,6 +73,33 @@ class ScalingGroupCreatorSpec(CreatorSpec[ScalingGroupRow]):
             use_host_network=self.use_host_network,
             fair_share_spec=self.fair_share_spec,
         )
+
+
+@dataclass
+class ResourceGroupScopeCreation(ScopeCreation[ScalingGroupRow]):
+    """Creates a scaling group row and the resource-group scope it becomes.
+
+    A resource group declares no scope-local system roles: roles come only from
+    matching role presets, if any. Domain/project scope associations are written by
+    the allow/associate paths, not by this creator."""
+
+    spec: ScalingGroupCreatorSpec
+
+    @override
+    def creator(self) -> RBACEntityCreator[ScalingGroupRow]:
+        return RBACEntityCreator(
+            spec=self.spec,
+            element_type=RBACElementType.RESOURCE_GROUP,
+            scope_ref=None,
+        )
+
+    @override
+    def scope_of(self, row: ScalingGroupRow) -> ScopeRef:
+        return ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=row.id)
+
+    @override
+    def system_roles_of(self, row: ScalingGroupRow) -> Collection[ScopeSystemRoleData]:
+        return ()
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -73,13 +73,13 @@ from ai.backend.manager.repositories.scaling_group.creators import (
     ScalingGroupForProjectCreatorSpec,
 )
 from ai.backend.manager.repositories.scaling_group.purgers import (
-    DomainsForScalingGroupPurgerSpec,
-    ProjectsForScalingGroupPurgerSpec,
+    DomainsForResourceGroupPurgerSpec,
+    ProjectsForResourceGroupPurgerSpec,
+    ResourceGroupEndpointsPurgerSpec,
+    ResourceGroupKernelsPurgerSpec,
     ResourceGroupPurgerSpec,
-    ScalingGroupEndpointsPurgerSpec,
-    ScalingGroupKernelsPurgerSpec,
-    ScalingGroupRoutingsPurgerSpec,
-    ScalingGroupSessionsPurgerSpec,
+    ResourceGroupRoutingsPurgerSpec,
+    ResourceGroupSessionsPurgerSpec,
     ScalingGroupsForDomainPurgerSpec,
     ScalingGroupsForProjectPurgerSpec,
 )
@@ -123,7 +123,7 @@ class ScalingGroupDBSource:
             scope_id=uuid.UUID(ref.element_id),
         )
 
-    def _raise_non_duplicate_errors[TRow: Base](
+    def _tolerate_only_duplicates[TRow: Base](
         self, result: BulkCreatorResultWithFailures[TRow]
     ) -> None:
         """Re-raise partial-create failures that are not duplicate-row conflicts; an already
@@ -262,20 +262,22 @@ class ScalingGroupDBSource:
 
             await w.batch_purge(
                 BatchPurger(
-                    spec=ScalingGroupRoutingsPurgerSpec(resource_group_id=resource_group_id)
+                    spec=ResourceGroupRoutingsPurgerSpec(resource_group_id=resource_group_id)
                 )
             )
             await w.batch_purge(
                 BatchPurger(
-                    spec=ScalingGroupEndpointsPurgerSpec(resource_group_id=resource_group_id)
+                    spec=ResourceGroupEndpointsPurgerSpec(resource_group_id=resource_group_id)
                 )
             )
             await w.batch_purge(
-                BatchPurger(spec=ScalingGroupKernelsPurgerSpec(resource_group_id=resource_group_id))
+                BatchPurger(
+                    spec=ResourceGroupKernelsPurgerSpec(resource_group_id=resource_group_id)
+                )
             )
             await w.batch_purge(
                 BatchPurger(
-                    spec=ScalingGroupSessionsPurgerSpec(resource_group_id=resource_group_id)
+                    spec=ResourceGroupSessionsPurgerSpec(resource_group_id=resource_group_id)
                 )
             )
 
@@ -694,7 +696,7 @@ class ScalingGroupDBSource:
                         ]
                     )
                 )
-                self._raise_non_duplicate_errors(creation_result)
+                self._tolerate_only_duplicates(creation_result)
                 for rg_id in add:
                     await self._enroll_resource_group(w, domain_scope, rg_id)
 
@@ -747,7 +749,7 @@ class ScalingGroupDBSource:
                         ]
                     )
                 )
-                self._raise_non_duplicate_errors(creation_result)
+                self._tolerate_only_duplicates(creation_result)
                 for rg_id in add:
                     await self._enroll_resource_group(w, project_scope, rg_id)
 
@@ -780,7 +782,7 @@ class ScalingGroupDBSource:
                 ]
                 await w.batch_purge(
                     BatchPurger(
-                        spec=DomainsForScalingGroupPurgerSpec(
+                        spec=DomainsForResourceGroupPurgerSpec(
                             resource_group_id=resource_group_id,
                             domain_ids=remove_ids,
                         )
@@ -811,7 +813,7 @@ class ScalingGroupDBSource:
                         ]
                     )
                 )
-                self._raise_non_duplicate_errors(creation_result)
+                self._tolerate_only_duplicates(creation_result)
                 for domain_id in add_ids:
                     await self._enroll_resource_group(
                         w,
@@ -844,7 +846,7 @@ class ScalingGroupDBSource:
             if remove:
                 await w.batch_purge(
                     BatchPurger(
-                        spec=ProjectsForScalingGroupPurgerSpec(
+                        spec=ProjectsForResourceGroupPurgerSpec(
                             resource_group_id=resource_group_id,
                             projects=list(remove),
                         )
@@ -869,7 +871,7 @@ class ScalingGroupDBSource:
                         ]
                     )
                 )
-                self._raise_non_duplicate_errors(creation_result)
+                self._tolerate_only_duplicates(creation_result)
                 for project_id in add:
                     await self._enroll_resource_group(
                         w,

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -848,7 +848,7 @@ class ScalingGroupDBSource:
                     BatchPurger(
                         spec=ProjectsForResourceGroupPurgerSpec(
                             resource_group_id=resource_group_id,
-                            projects=list(remove),
+                            project_ids=[ProjectID(project_id) for project_id in remove],
                         )
                     )
                 )

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -3,34 +3,37 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from ai.backend.common.data.permission.types import RBACElementType, RelationType
+from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
+from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.resource_group import (
+    RESOURCE_GROUP_ENTITY_TYPE,
+    RESOURCE_GROUP_SCOPE_TYPE,
+)
+from ai.backend.common.data.entity.types import EntityRef, ScopeRef, ScopeType
 from ai.backend.common.exception import DomainNotFound
 from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.types import SlotQuantity
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.deployment.types import DeploymentOptions
+from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.scaling_group.types import (
     ResourceInfo,
     ScalingGroupData,
     ScalingGroupListResult,
 )
 from ai.backend.manager.data.session.options import DefaultSessionOptions
+from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.domain.row import DomainRow
-from ai.backend.manager.models.endpoint import EndpointRow
-from ai.backend.manager.models.kernel.row import KernelRow
-from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-    AssociationScopesEntitiesRow,
-)
 from ai.backend.manager.models.resource_slot import AgentResourceRow, ResourceSlotTypeRow
-from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scaling_group import (
     ScalingGroupForDomainRow,
     ScalingGroupForKeypairsRow,
@@ -38,34 +41,50 @@ from ai.backend.manager.models.scaling_group import (
     ScalingGroupRow,
     query_allowed_sgroups,
 )
-from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.base.creator import (
     BulkCreator,
+    BulkCreatorResultWithFailures,
     Creator,
     execute_bulk_creator,
-    execute_creator,
 )
+from ai.backend.manager.repositories.base.pagination import NoPagination
 from ai.backend.manager.repositories.base.purger import (
     BatchPurger,
     Purger,
     execute_batch_purger,
-    execute_purger,
 )
-from ai.backend.manager.repositories.base.rbac.scope_binder import (
-    RBACScopeBinder,
-    execute_rbac_scope_binder,
-)
-from ai.backend.manager.repositories.base.rbac.scope_unbinder import (
-    RBACScopeEntityUnbinder,
-    execute_rbac_scope_entity_unbinder,
-)
+from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurger
+from ai.backend.manager.repositories.base.rbac.scope_binder import RBACScopeBinder
+from ai.backend.manager.repositories.base.rbac.scope_unbinder import RBACScopeEntityUnbinder
 from ai.backend.manager.repositories.base.updater import Updater, execute_updater
+from ai.backend.manager.repositories.ops.rbac.provider import (
+    EntityMembersAddition,
+    RBACOpsProvider,
+    RBACWriteOps,
+    ScopeDeletion,
+    ScopeEntityMember,
+)
 from ai.backend.manager.repositories.resource_slot.types import subtract_quantities
+from ai.backend.manager.repositories.scaling_group.creators import (
+    ResourceGroupScopeCreation,
+    ScalingGroupCreatorSpec,
+    ScalingGroupForDomainCreatorSpec,
+    ScalingGroupForProjectCreatorSpec,
+)
+from ai.backend.manager.repositories.scaling_group.purgers import (
+    DomainsForScalingGroupPurgerSpec,
+    ProjectsForScalingGroupPurgerSpec,
+    ResourceGroupPurgerSpec,
+    ScalingGroupEndpointsPurgerSpec,
+    ScalingGroupKernelsPurgerSpec,
+    ScalingGroupRoutingsPurgerSpec,
+    ScalingGroupSessionsPurgerSpec,
+    ScalingGroupsForDomainPurgerSpec,
+    ScalingGroupsForProjectPurgerSpec,
+)
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import AsyncSession as SASession
-
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 
@@ -82,43 +101,83 @@ class ScalingGroupDBSource:
     """
 
     _db: ExtendedAsyncSAEngine
+    _rbac_ops_provider: RBACOpsProvider
 
     def __init__(
         self,
         db: ExtendedAsyncSAEngine,
     ) -> None:
         self._db = db
+        self._rbac_ops_provider = RBACOpsProvider(db)
 
-    async def _get_domain_id(self, session: SASession, domain_name: str) -> DomainID:
-        domain_id: DomainID | None = await session.scalar(
-            sa.select(DomainRow.id).where(DomainRow.name == domain_name)
+    def _resource_group_scope(self, resource_group_id: ResourceGroupID) -> ScopeRef:
+        return ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id)
+
+    def _resource_group_entity(self, resource_group_id: ResourceGroupID) -> EntityRef:
+        return EntityRef(entity_type=RESOURCE_GROUP_ENTITY_TYPE, entity_id=resource_group_id)
+
+    def _scope_ref_of(self, ref: RBACElementRef) -> ScopeRef:
+        """Convert an RBAC element ref addressing a scope-capable element to a ScopeRef."""
+        return ScopeRef(
+            scope_type=ScopeType(ref.element_type.value),
+            scope_id=uuid.UUID(ref.element_id),
         )
-        if domain_id is None:
+
+    def _raise_non_duplicate_errors[TRow: Base](
+        self, result: BulkCreatorResultWithFailures[TRow]
+    ) -> None:
+        """Re-raise partial-create failures that are not duplicate-row conflicts; an already
+        existing mapping row is fine (the add operations are idempotent)."""
+        for error in result.errors:
+            if not isinstance(error.exception, UniqueConstraintViolationError):
+                raise error.exception
+
+    async def _get_domain_id(self, w: RBACWriteOps, domain_name: str) -> DomainID:
+        result = await w.batch_query_in_global(
+            sa.select(DomainRow.id).where(DomainRow.name == domain_name),
+            BatchQuerier(pagination=NoPagination()),
+        )
+        if not result.rows:
             raise DomainNotFound(f"Domain '{domain_name}' not found")
-        return domain_id
+        return DomainID(result.rows[0].id)
 
     async def _get_domain_ids_by_names(
         self,
-        session: SASession,
+        w: RBACWriteOps,
         domain_names: list[str],
     ) -> dict[str, DomainID]:
         if not domain_names:
             return {}
-        rows = await session.execute(
-            sa.select(DomainRow.name, DomainRow.id).where(DomainRow.name.in_(domain_names))
+        result = await w.batch_query_in_global(
+            sa.select(DomainRow.name, DomainRow.id).where(DomainRow.name.in_(domain_names)),
+            BatchQuerier(pagination=NoPagination()),
         )
-        return {row.name: row.id for row in rows}
+        return {row.name: row.id for row in result.rows}
+
+    async def _get_resource_group_id(
+        self, w: RBACWriteOps, scaling_group_name: str
+    ) -> ResourceGroupID:
+        result = await w.batch_query_in_global(
+            sa.select(ScalingGroupRow.id).where(ScalingGroupRow.name == scaling_group_name),
+            BatchQuerier(pagination=NoPagination()),
+        )
+        if not result.rows:
+            raise ScalingGroupNotFound(scaling_group_name)
+        return ResourceGroupID(result.rows[0].id)
 
     async def create_scaling_group(
         self,
         creator: Creator[ScalingGroupRow],
     ) -> ScalingGroupData:
-        """Creates a new scaling group.
+        """Creates a new scaling group as a resource-group scope: the row is created
+        together with its virtual scope, so RBAC resolution reaches the resource group
+        and its entities through the virtual-scope chain.
 
         Raises ScalingGroupConflict if a scaling group with the same name already exists.
         """
-        async with self._db.begin_session() as session:
-            result = await execute_creator(session, creator)
+        spec = cast(ScalingGroupCreatorSpec, creator.spec)
+        async with self._rbac_ops_provider.write_ops() as w:
+            result = await w.create_scope(ResourceGroupScopeCreation(spec=spec))
             return result.row.to_dataclass()
 
     async def search_scaling_groups(
@@ -192,53 +251,47 @@ class ScalingGroupDBSource:
         self,
         purger: Purger[ScalingGroupRow],
     ) -> ScalingGroupData:
-        """Purges a scaling group and all related sessions, routes, endpoints, and kernels.
+        """Purges a scaling group and all related sessions, routes, endpoints, and
+        kernels, together with its RBAC entries and virtual scope.
 
         Raises ScalingGroupNotFound if scaling group doesn't exist.
         """
-        async with self._db.begin_session() as session:
-            scaling_group_name = purger.spec.pk_value()
+        scaling_group_name = cast(str, purger.spec.pk_value())
+        async with self._rbac_ops_provider.write_ops() as w:
+            resource_group_id = await self._get_resource_group_id(w, scaling_group_name)
 
-            # Step 1: Find all sessions belonging to this scaling group
-            session_ids_query = sa.select(SessionRow.id).where(
-                SessionRow.scaling_group_name == scaling_group_name
-            )
-            session_ids_result = await session.execute(session_ids_query)
-            session_ids = session_ids_result.scalars().all()
-
-            # Step 2: Delete all routings associated with these sessions
-            if session_ids:
-                delete_routings_stmt = sa.delete(RoutingRow).where(
-                    RoutingRow.session.in_(session_ids)
+            await w.batch_purge(
+                BatchPurger(
+                    spec=ScalingGroupRoutingsPurgerSpec(resource_group_id=resource_group_id)
                 )
-                await session.execute(delete_routings_stmt)
-
-            # Step 3: Delete all endpoints belonging to this scaling group
-            delete_endpoints_stmt = sa.delete(EndpointRow).where(
-                EndpointRow.resource_group == scaling_group_name
             )
-            await session.execute(delete_endpoints_stmt)
-
-            # Step 4: Delete all kernels belonging to these sessions
-            if session_ids:
-                delete_kernels_stmt = sa.delete(KernelRow).where(
-                    KernelRow.session_id.in_(session_ids)
+            await w.batch_purge(
+                BatchPurger(
+                    spec=ScalingGroupEndpointsPurgerSpec(resource_group_id=resource_group_id)
                 )
-                await session.execute(delete_kernels_stmt)
-
-            # Step 5: Delete all sessions belonging to this scaling group
-            delete_sessions_stmt = sa.delete(SessionRow).where(
-                SessionRow.scaling_group_name == scaling_group_name
             )
-            await session.execute(delete_sessions_stmt)
+            await w.batch_purge(
+                BatchPurger(spec=ScalingGroupKernelsPurgerSpec(resource_group_id=resource_group_id))
+            )
+            await w.batch_purge(
+                BatchPurger(
+                    spec=ScalingGroupSessionsPurgerSpec(resource_group_id=resource_group_id)
+                )
+            )
 
-            # Step 6: Delete the scaling group itself using purger
-            result = await execute_purger(session, purger)
-
+            result = await w.delete_scope(
+                ScopeDeletion(
+                    purger=RBACEntityPurger(
+                        spec=ResourceGroupPurgerSpec(
+                            name=scaling_group_name,
+                            resource_group_id=resource_group_id,
+                        )
+                    ),
+                    scope=self._resource_group_scope(resource_group_id),
+                )
+            )
             if result is None:
-                raise ScalingGroupNotFound(
-                    f"Scaling group not found (name:{purger.spec.pk_value()})"
-                )
+                raise ScalingGroupNotFound(f"Scaling group not found (name:{scaling_group_name})")
 
             return result.row.to_dataclass()
 
@@ -318,17 +371,93 @@ class ScalingGroupDBSource:
         self,
         binder: RBACScopeBinder[ScalingGroupForDomainRow],
     ) -> None:
-        """Associates a scaling group with multiple domains."""
-        async with self._db.begin_session() as session:
-            await execute_rbac_scope_binder(session, binder)
+        """Associates a scaling group with multiple domains, binding each domain scope
+        to the resource group's virtual scope."""
+        await self._associate_resource_groups(binder)
 
     async def disassociate_scaling_group_with_domains(
         self,
         unbinder: RBACScopeEntityUnbinder[ScalingGroupForDomainRow],
     ) -> None:
-        """Disassociates scaling groups from a domain."""
-        async with self._db.begin_session() as session:
-            await execute_rbac_scope_entity_unbinder(session, unbinder)
+        """Disassociates scaling groups from a domain, unbinding the domain scope from
+        each resource group's virtual scope."""
+        await self._disassociate_resource_groups(unbinder)
+
+    async def _associate_resource_groups[TRow: Base](self, binder: RBACScopeBinder[TRow]) -> None:
+        """Create the N:N mapping rows and enroll each pair's resource group into the
+        pair's scope (association row + membership), binding the scope to the resource
+        group's virtual scope so it reaches the resource group's entities."""
+        if not binder.pairs:
+            return
+        async with self._rbac_ops_provider.write_ops() as w:
+            await w.bulk_create(BulkCreator(specs=[pair.spec for pair in binder.pairs]))
+            for pair in binder.pairs:
+                accessor_scope = self._scope_ref_of(pair.scope_ref)
+                resource_group_id = ResourceGroupID(uuid.UUID(pair.entity_ref.element_id))
+                await self._enroll_resource_group(w, accessor_scope, resource_group_id)
+
+    async def _disassociate_resource_groups[TRow: Base](
+        self, unbinder: RBACScopeEntityUnbinder[TRow]
+    ) -> None:
+        """Delete the N:N mapping rows and withdraw each resource group from the
+        unbinder's scope (association row + membership + virtual-scope binding)."""
+        async with self._rbac_ops_provider.write_ops() as w:
+            accessor_scope = self._scope_ref_of(unbinder.scope_ref)
+            entity_ids = unbinder.entity_ids
+            if entity_ids is not None:
+                resource_group_ids = [ResourceGroupID(uuid.UUID(eid)) for eid in entity_ids]
+            else:
+                result = await w.batch_query_in_global(
+                    unbinder.build_purger_spec().build_subquery(),
+                    BatchQuerier(pagination=NoPagination()),
+                )
+                resource_group_ids = [
+                    ResourceGroupID(row[0].resource_group_id) for row in result.rows
+                ]
+            await w.batch_purge(BatchPurger(spec=unbinder.build_purger_spec()))
+            await self._withdraw_resource_groups(w, accessor_scope, resource_group_ids)
+
+    async def _enroll_resource_group(
+        self,
+        w: RBACWriteOps,
+        accessor_scope: ScopeRef,
+        resource_group_id: ResourceGroupID,
+    ) -> None:
+        """Enroll a resource group into ``accessor_scope`` with existing RBAC ops:
+        membership + association row via ``add_entity_members``, and the reverse
+        ``accessor_scope`` binding to the resource group's virtual scope via
+        ``ensure_scope`` (created lazily for pre-virtual-scope rows)."""
+        await w.ensure_scope(accessor_scope)
+        await w.add_entity_members(
+            EntityMembersAddition(
+                scope=accessor_scope,
+                members=[ScopeEntityMember(ref=self._resource_group_entity(resource_group_id))],
+            )
+        )
+        await w.ensure_scope(
+            self._resource_group_scope(resource_group_id), bound_scope=accessor_scope
+        )
+
+    async def _withdraw_resource_groups(
+        self,
+        w: RBACWriteOps,
+        accessor_scope: ScopeRef,
+        resource_group_ids: list[ResourceGroupID],
+    ) -> None:
+        """Withdraw resource groups from ``accessor_scope``: memberships + association
+        rows via ``remove_entity_members``, and the reverse scope bindings via
+        ``unbind_scope``. Each resource group's virtual scope is ensured first, since
+        ``unbind_scope`` requires it and pre-virtual-scope rows may not have one."""
+        if not resource_group_ids:
+            return
+        await w.remove_entity_members(
+            accessor_scope,
+            [self._resource_group_entity(rg_id) for rg_id in resource_group_ids],
+        )
+        for rg_id in resource_group_ids:
+            resource_group_scope = self._resource_group_scope(rg_id)
+            await w.ensure_scope(resource_group_scope)
+            await w.unbind_scope(accessor_scope, resource_group_scope)
 
     async def check_scaling_group_domain_association_exists(
         self,
@@ -388,17 +517,17 @@ class ScalingGroupDBSource:
         self,
         binder: RBACScopeBinder[ScalingGroupForProjectRow],
     ) -> None:
-        """Associates a scaling group with multiple user groups (projects)."""
-        async with self._db.begin_session() as session:
-            await execute_rbac_scope_binder(session, binder)
+        """Associates a scaling group with multiple user groups (projects), binding each
+        project scope to the resource group's virtual scope."""
+        await self._associate_resource_groups(binder)
 
     async def disassociate_scaling_group_with_user_groups(
         self,
         unbinder: RBACScopeEntityUnbinder[ScalingGroupForProjectRow],
     ) -> None:
-        """Disassociates scaling groups from a project."""
-        async with self._db.begin_session() as session:
-            await execute_rbac_scope_entity_unbinder(session, unbinder)
+        """Disassociates scaling groups from a project, unbinding the project scope from
+        each resource group's virtual scope."""
+        await self._disassociate_resource_groups(unbinder)
 
     async def check_scaling_group_user_group_association_exists(
         self,
@@ -534,59 +663,51 @@ class ScalingGroupDBSource:
     ) -> list[str]:
         """Atomically add/remove allowed resource groups for a domain.
 
+        Alongside the N:N mapping rows, maintains the domain scope's RBAC association
+        with each resource group (association row + membership + virtual-scope binding).
+
         Returns the current list of allowed resource group names after the update.
         """
-        async with self._db.begin_session_read_committed() as session:
-            domain_id = await self._get_domain_id(session, domain_name)
-            domain_scope_id = str(domain_id)
+        async with self._rbac_ops_provider.write_ops() as w:
+            domain_id = await self._get_domain_id(w, domain_name)
+            domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id)
             if remove:
-                await session.execute(
-                    sa.delete(ScalingGroupForDomainRow).where(
-                        ScalingGroupForDomainRow.domain_id == domain_id,
-                        ScalingGroupForDomainRow.resource_group_id.in_(remove),
+                await w.batch_purge(
+                    BatchPurger(
+                        spec=ScalingGroupsForDomainPurgerSpec(
+                            resource_group_ids=list(remove),
+                            domain_id=domain_id,
+                        )
                     )
                 )
-                await session.execute(
-                    sa.delete(AssociationScopesEntitiesRow).where(
-                        AssociationScopesEntitiesRow.scope_type
-                        == RBACElementType.DOMAIN.to_scope_type(),
-                        AssociationScopesEntitiesRow.scope_id == domain_scope_id,
-                        AssociationScopesEntitiesRow.entity_type
-                        == RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                        AssociationScopesEntitiesRow.entity_id.in_([
-                            str(rg_id) for rg_id in remove
-                        ]),
-                    )
-                )
+                await self._withdraw_resource_groups(w, domain_scope, list(remove))
 
             if add:
+                creation_result = await w.bulk_create_partial(
+                    BulkCreator(
+                        specs=[
+                            ScalingGroupForDomainCreatorSpec(
+                                resource_group_id=rg_id,
+                                domain_id=domain_id,
+                            )
+                            for rg_id in add
+                        ]
+                    )
+                )
+                self._raise_non_duplicate_errors(creation_result)
                 for rg_id in add:
-                    await session.execute(
-                        pg_insert(ScalingGroupForDomainRow.__table__)
-                        .values(resource_group_id=rg_id, domain_id=domain_id)
-                        .on_conflict_do_nothing()
-                    )
-                    await session.execute(
-                        pg_insert(AssociationScopesEntitiesRow.__table__)
-                        .values(
-                            scope_type=RBACElementType.DOMAIN.to_scope_type(),
-                            scope_id=domain_scope_id,
-                            entity_type=RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                            entity_id=str(rg_id),
-                            relation_type=RelationType.AUTO,
-                        )
-                        .on_conflict_do_nothing()
-                    )
+                    await self._enroll_resource_group(w, domain_scope, rg_id)
 
-            result = await session.execute(
+            result = await w.batch_query_in_global(
                 sa.select(ScalingGroupRow.name)
                 .join(
                     ScalingGroupForDomainRow,
                     ScalingGroupForDomainRow.resource_group_id == ScalingGroupRow.id,
                 )
-                .where(ScalingGroupForDomainRow.domain_id == domain_id)
+                .where(ScalingGroupForDomainRow.domain_id == domain_id),
+                BatchQuerier(pagination=NoPagination()),
             )
-            return [row[0] for row in result]
+            return [row.name for row in result.rows]
 
     async def update_allowed_resource_groups_for_project(
         self,
@@ -596,57 +717,50 @@ class ScalingGroupDBSource:
     ) -> list[str]:
         """Atomically add/remove allowed resource groups for a project.
 
+        Alongside the N:N mapping rows, maintains the project scope's RBAC association
+        with each resource group (association row + membership + virtual-scope binding).
+
         Returns the current list of allowed resource group names after the update.
         """
-        async with self._db.begin_session_read_committed() as session:
+        async with self._rbac_ops_provider.write_ops() as w:
+            project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(project_id))
             if remove:
-                await session.execute(
-                    sa.delete(ScalingGroupForProjectRow).where(
-                        ScalingGroupForProjectRow.group == project_id,
-                        ScalingGroupForProjectRow.resource_group_id.in_(remove),
+                await w.batch_purge(
+                    BatchPurger(
+                        spec=ScalingGroupsForProjectPurgerSpec(
+                            resource_group_ids=list(remove),
+                            project=project_id,
+                        )
                     )
                 )
-                await session.execute(
-                    sa.delete(AssociationScopesEntitiesRow).where(
-                        AssociationScopesEntitiesRow.scope_type
-                        == RBACElementType.PROJECT.to_scope_type(),
-                        AssociationScopesEntitiesRow.scope_id == str(project_id),
-                        AssociationScopesEntitiesRow.entity_type
-                        == RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                        AssociationScopesEntitiesRow.entity_id.in_([
-                            str(rg_id) for rg_id in remove
-                        ]),
-                    )
-                )
+                await self._withdraw_resource_groups(w, project_scope, list(remove))
 
             if add:
+                creation_result = await w.bulk_create_partial(
+                    BulkCreator(
+                        specs=[
+                            ScalingGroupForProjectCreatorSpec(
+                                resource_group_id=rg_id,
+                                project=project_id,
+                            )
+                            for rg_id in add
+                        ]
+                    )
+                )
+                self._raise_non_duplicate_errors(creation_result)
                 for rg_id in add:
-                    await session.execute(
-                        pg_insert(ScalingGroupForProjectRow.__table__)
-                        .values(resource_group_id=rg_id, group=project_id)
-                        .on_conflict_do_nothing()
-                    )
-                    await session.execute(
-                        pg_insert(AssociationScopesEntitiesRow.__table__)
-                        .values(
-                            scope_type=RBACElementType.PROJECT.to_scope_type(),
-                            scope_id=str(project_id),
-                            entity_type=RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                            entity_id=str(rg_id),
-                            relation_type=RelationType.AUTO,
-                        )
-                        .on_conflict_do_nothing()
-                    )
+                    await self._enroll_resource_group(w, project_scope, rg_id)
 
-            result = await session.execute(
+            result = await w.batch_query_in_global(
                 sa.select(ScalingGroupRow.name)
                 .join(
                     ScalingGroupForProjectRow,
                     ScalingGroupForProjectRow.resource_group_id == ScalingGroupRow.id,
                 )
-                .where(ScalingGroupForProjectRow.group == project_id)
+                .where(ScalingGroupForProjectRow.group == project_id),
+                BatchQuerier(pagination=NoPagination()),
             )
-            return [row[0] for row in result]
+            return [row.name for row in result.rows]
 
     async def update_allowed_domains_for_resource_group(
         self,
@@ -658,62 +772,63 @@ class ScalingGroupDBSource:
 
         Returns the current list of allowed domain names after the update.
         """
-        async with self._db.begin_session_read_committed() as session:
-            domain_ids_by_name = await self._get_domain_ids_by_names(session, [*add, *remove])
+        async with self._rbac_ops_provider.write_ops() as w:
+            domain_ids_by_name = await self._get_domain_ids_by_names(w, [*add, *remove])
             if remove:
                 remove_ids = [
                     domain_ids_by_name[name] for name in remove if name in domain_ids_by_name
                 ]
-                await session.execute(
-                    sa.delete(ScalingGroupForDomainRow).where(
-                        ScalingGroupForDomainRow.resource_group_id == resource_group_id,
-                        ScalingGroupForDomainRow.domain_id.in_(remove_ids),
+                await w.batch_purge(
+                    BatchPurger(
+                        spec=DomainsForScalingGroupPurgerSpec(
+                            resource_group_id=resource_group_id,
+                            domain_ids=remove_ids,
+                        )
                     )
                 )
-                await session.execute(
-                    sa.delete(AssociationScopesEntitiesRow).where(
-                        AssociationScopesEntitiesRow.entity_type
-                        == RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                        AssociationScopesEntitiesRow.entity_id == str(resource_group_id),
-                        AssociationScopesEntitiesRow.scope_type
-                        == RBACElementType.DOMAIN.to_scope_type(),
-                        AssociationScopesEntitiesRow.scope_id.in_([
-                            str(domain_id) for domain_id in remove_ids
-                        ]),
+                for domain_id in remove_ids:
+                    await self._withdraw_resource_groups(
+                        w,
+                        ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id),
+                        [resource_group_id],
                     )
-                )
 
             if add:
+                add_ids: list[DomainID] = []
                 for domain_name in add:
-                    domain_id = domain_ids_by_name.get(domain_name)
-                    if domain_id is None:
+                    added_domain_id = domain_ids_by_name.get(domain_name)
+                    if added_domain_id is None:
                         raise DomainNotFound(f"Domain '{domain_name}' not found")
-                    await session.execute(
-                        pg_insert(ScalingGroupForDomainRow.__table__)
-                        .values(resource_group_id=resource_group_id, domain_id=domain_id)
-                        .on_conflict_do_nothing()
+                    add_ids.append(added_domain_id)
+                creation_result = await w.bulk_create_partial(
+                    BulkCreator(
+                        specs=[
+                            ScalingGroupForDomainCreatorSpec(
+                                resource_group_id=resource_group_id,
+                                domain_id=domain_id,
+                            )
+                            for domain_id in add_ids
+                        ]
                     )
-                    await session.execute(
-                        pg_insert(AssociationScopesEntitiesRow.__table__)
-                        .values(
-                            scope_type=RBACElementType.DOMAIN.to_scope_type(),
-                            scope_id=str(domain_id),
-                            entity_type=RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                            entity_id=str(resource_group_id),
-                            relation_type=RelationType.AUTO,
-                        )
-                        .on_conflict_do_nothing()
+                )
+                self._raise_non_duplicate_errors(creation_result)
+                for domain_id in add_ids:
+                    await self._enroll_resource_group(
+                        w,
+                        ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id),
+                        resource_group_id,
                     )
 
-            result = await session.execute(
+            result = await w.batch_query_in_global(
                 sa.select(DomainRow.name)
                 .join(
                     ScalingGroupForDomainRow,
                     ScalingGroupForDomainRow.domain_id == DomainRow.id,
                 )
-                .where(ScalingGroupForDomainRow.resource_group_id == resource_group_id)
+                .where(ScalingGroupForDomainRow.resource_group_id == resource_group_id),
+                BatchQuerier(pagination=NoPagination()),
             )
-            return [row[0] for row in result]
+            return [row.name for row in result.rows]
 
     async def update_allowed_projects_for_resource_group(
         self,
@@ -725,50 +840,50 @@ class ScalingGroupDBSource:
 
         Returns the current list of allowed project IDs after the update.
         """
-        async with self._db.begin_session_read_committed() as session:
+        async with self._rbac_ops_provider.write_ops() as w:
             if remove:
-                await session.execute(
-                    sa.delete(ScalingGroupForProjectRow).where(
-                        ScalingGroupForProjectRow.resource_group_id == resource_group_id,
-                        ScalingGroupForProjectRow.group.in_(remove),
+                await w.batch_purge(
+                    BatchPurger(
+                        spec=ProjectsForScalingGroupPurgerSpec(
+                            resource_group_id=resource_group_id,
+                            projects=list(remove),
+                        )
                     )
                 )
-                await session.execute(
-                    sa.delete(AssociationScopesEntitiesRow).where(
-                        AssociationScopesEntitiesRow.entity_type
-                        == RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                        AssociationScopesEntitiesRow.entity_id == str(resource_group_id),
-                        AssociationScopesEntitiesRow.scope_type
-                        == RBACElementType.PROJECT.to_scope_type(),
-                        AssociationScopesEntitiesRow.scope_id.in_([str(pid) for pid in remove]),
+                for project_id in remove:
+                    await self._withdraw_resource_groups(
+                        w,
+                        ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(project_id)),
+                        [resource_group_id],
                     )
-                )
 
             if add:
-                for project_id in add:
-                    await session.execute(
-                        pg_insert(ScalingGroupForProjectRow.__table__)
-                        .values(resource_group_id=resource_group_id, group=project_id)
-                        .on_conflict_do_nothing()
+                creation_result = await w.bulk_create_partial(
+                    BulkCreator(
+                        specs=[
+                            ScalingGroupForProjectCreatorSpec(
+                                resource_group_id=resource_group_id,
+                                project=project_id,
+                            )
+                            for project_id in add
+                        ]
                     )
-                    await session.execute(
-                        pg_insert(AssociationScopesEntitiesRow.__table__)
-                        .values(
-                            scope_type=RBACElementType.PROJECT.to_scope_type(),
-                            scope_id=str(project_id),
-                            entity_type=RBACElementType.RESOURCE_GROUP.to_entity_type(),
-                            entity_id=str(resource_group_id),
-                            relation_type=RelationType.AUTO,
-                        )
-                        .on_conflict_do_nothing()
+                )
+                self._raise_non_duplicate_errors(creation_result)
+                for project_id in add:
+                    await self._enroll_resource_group(
+                        w,
+                        ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(project_id)),
+                        resource_group_id,
                     )
 
-            result = await session.execute(
+            result = await w.batch_query_in_global(
                 sa.select(ScalingGroupForProjectRow.group).where(
                     ScalingGroupForProjectRow.resource_group_id == resource_group_id
-                )
+                ),
+                BatchQuerier(pagination=NoPagination()),
             )
-            return [row[0] for row in result]
+            return [row.group for row in result.rows]
 
     # =========================================================================
     # Get allowed (read-only queries)

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -396,7 +396,7 @@ class ScalingGroupDBSource:
             for pair in binder.pairs:
                 accessor_scope = self._scope_ref_of(pair.scope_ref)
                 resource_group_id = ResourceGroupID(uuid.UUID(pair.entity_ref.element_id))
-                await self._enroll_resource_group(w, accessor_scope, resource_group_id)
+                await self._enroll_resource_groups(w, accessor_scope, [resource_group_id])
 
     async def _disassociate_resource_groups[TRow: Base](
         self, unbinder: RBACScopeEntityUnbinder[TRow]
@@ -419,25 +419,29 @@ class ScalingGroupDBSource:
             await w.batch_purge(BatchPurger(spec=unbinder.build_purger_spec()))
             await self._withdraw_resource_groups(w, accessor_scope, resource_group_ids)
 
-    async def _enroll_resource_group(
+    async def _enroll_resource_groups(
         self,
         w: RBACWriteOps,
         accessor_scope: ScopeRef,
-        resource_group_id: ResourceGroupID,
+        resource_group_ids: list[ResourceGroupID],
     ) -> None:
-        """Enroll a resource group into ``accessor_scope`` with existing RBAC ops:
-        membership + association row via ``add_entity_members``, and the reverse
-        ``accessor_scope`` binding to the resource group's virtual scope via
-        ``ensure_scope`` (created lazily for pre-virtual-scope rows)."""
+        """Enroll resource groups under ``accessor_scope`` via ``add_bulk_members``:
+        membership, the legacy scope association, and the scope's binding into each
+        resource group's virtual scope. The virtual scopes are ensured first, since
+        rows created before the virtual-scope rollout may not have one."""
+        if not resource_group_ids:
+            return
         await w.ensure_scope(accessor_scope)
-        await w.add_entity_members(
+        for resource_group_id in resource_group_ids:
+            await w.ensure_scope(self._resource_group_scope(resource_group_id))
+        await w.add_bulk_members(
             EntityMembersAddition(
                 scope=accessor_scope,
-                members=[ScopeEntityMember(ref=self._resource_group_entity(resource_group_id))],
+                members=[
+                    ScopeEntityMember(ref=self._resource_group_entity(resource_group_id))
+                    for resource_group_id in resource_group_ids
+                ],
             )
-        )
-        await w.ensure_scope(
-            self._resource_group_scope(resource_group_id), bound_scope=accessor_scope
         )
 
     async def _withdraw_resource_groups(
@@ -446,20 +450,15 @@ class ScalingGroupDBSource:
         accessor_scope: ScopeRef,
         resource_group_ids: list[ResourceGroupID],
     ) -> None:
-        """Withdraw resource groups from ``accessor_scope``: memberships + association
-        rows via ``remove_entity_members``, and the reverse scope bindings via
-        ``unbind_scope``. Each resource group's virtual scope is ensured first, since
-        ``unbind_scope`` requires it and pre-virtual-scope rows may not have one."""
+        """Withdraw resource groups from ``accessor_scope`` via ``remove_bulk_members``:
+        membership, the legacy scope association, and the scope's binding in each
+        resource group's virtual scope (missing virtual scopes never raise)."""
         if not resource_group_ids:
             return
-        await w.remove_entity_members(
+        await w.remove_bulk_members(
             accessor_scope,
             [self._resource_group_entity(rg_id) for rg_id in resource_group_ids],
         )
-        for rg_id in resource_group_ids:
-            resource_group_scope = self._resource_group_scope(rg_id)
-            await w.ensure_scope(resource_group_scope)
-            await w.unbind_scope(accessor_scope, resource_group_scope)
 
     async def check_scaling_group_domain_association_exists(
         self,
@@ -697,8 +696,7 @@ class ScalingGroupDBSource:
                     )
                 )
                 self._tolerate_only_duplicates(creation_result)
-                for rg_id in add:
-                    await self._enroll_resource_group(w, domain_scope, rg_id)
+                await self._enroll_resource_groups(w, domain_scope, list(add))
 
             result = await w.batch_query_in_global(
                 sa.select(ScalingGroupRow.name)
@@ -750,8 +748,7 @@ class ScalingGroupDBSource:
                     )
                 )
                 self._tolerate_only_duplicates(creation_result)
-                for rg_id in add:
-                    await self._enroll_resource_group(w, project_scope, rg_id)
+                await self._enroll_resource_groups(w, project_scope, list(add))
 
             result = await w.batch_query_in_global(
                 sa.select(ScalingGroupRow.name)
@@ -815,10 +812,10 @@ class ScalingGroupDBSource:
                 )
                 self._tolerate_only_duplicates(creation_result)
                 for domain_id in add_ids:
-                    await self._enroll_resource_group(
+                    await self._enroll_resource_groups(
                         w,
                         ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id),
-                        resource_group_id,
+                        [resource_group_id],
                     )
 
             result = await w.batch_query_in_global(
@@ -873,10 +870,10 @@ class ScalingGroupDBSource:
                 )
                 self._tolerate_only_duplicates(creation_result)
                 for project_id in add:
-                    await self._enroll_resource_group(
+                    await self._enroll_resource_groups(
                         w,
                         ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(project_id)),
-                        resource_group_id,
+                        [resource_group_id],
                     )
 
             result = await w.batch_query_in_global(

--- a/src/ai/backend/manager/repositories/scaling_group/purgers.py
+++ b/src/ai/backend/manager/repositories/scaling_group/purgers.py
@@ -7,16 +7,23 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey
+from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.kernel.row import KernelRow
+from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.scaling_group import (
     ScalingGroupForDomainRow,
     ScalingGroupForKeypairsRow,
     ScalingGroupForProjectRow,
     ScalingGroupRow,
 )
+from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.repositories.base.purger import BatchPurger, BatchPurgerSpec, PurgerSpec
+from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurgerSpec
 from ai.backend.manager.repositories.base.types import ConflictCheck
 
 
@@ -33,6 +40,117 @@ class ScalingGroupPurgerSpec(PurgerSpec[ScalingGroupRow]):
     @override
     def pk_value(self) -> str:
         return self.name
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ResourceGroupPurgerSpec(RBACEntityPurgerSpec[ScalingGroupRow]):
+    """PurgerSpec for purging a scaling group together with its RBAC entries."""
+
+    name: str
+    resource_group_id: ResourceGroupID
+
+    @override
+    def row_class(self) -> type[ScalingGroupRow]:
+        return ScalingGroupRow
+
+    @override
+    def pk_value(self) -> str:
+        return self.name
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.RESOURCE_GROUP
+
+    @override
+    def entity_ref(self) -> RBACElementRef:
+        return RBACElementRef(
+            element_type=RBACElementType.RESOURCE_GROUP,
+            element_id=str(self.resource_group_id),
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ScalingGroupRoutingsPurgerSpec(BatchPurgerSpec[RoutingRow]):
+    """PurgerSpec for deleting the routings of a scaling group's sessions."""
+
+    resource_group_id: ResourceGroupID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[RoutingRow]]:
+        return sa.select(RoutingRow).where(
+            RoutingRow.session.in_(
+                sa.select(SessionRow.id).where(
+                    SessionRow.resource_group_id == self.resource_group_id
+                )
+            )
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ScalingGroupEndpointsPurgerSpec(BatchPurgerSpec[EndpointRow]):
+    """PurgerSpec for deleting the endpoints of a scaling group.
+
+    ``endpoints.resource_group`` stores the scaling group name, so the id is
+    resolved to the name with a subquery."""
+
+    resource_group_id: ResourceGroupID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[EndpointRow]]:
+        return sa.select(EndpointRow).where(
+            EndpointRow.resource_group
+            == sa.select(ScalingGroupRow.name)
+            .where(ScalingGroupRow.id == self.resource_group_id)
+            .scalar_subquery()
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ScalingGroupKernelsPurgerSpec(BatchPurgerSpec[KernelRow]):
+    """PurgerSpec for deleting the kernels of a scaling group's sessions."""
+
+    resource_group_id: ResourceGroupID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[KernelRow]]:
+        return sa.select(KernelRow).where(
+            KernelRow.session_id.in_(
+                sa.select(SessionRow.id).where(
+                    SessionRow.resource_group_id == self.resource_group_id
+                )
+            )
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ScalingGroupSessionsPurgerSpec(BatchPurgerSpec[SessionRow]):
+    """PurgerSpec for deleting the sessions of a scaling group."""
+
+    resource_group_id: ResourceGroupID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[SessionRow]]:
+        return sa.select(SessionRow).where(SessionRow.resource_group_id == self.resource_group_id)
 
     @override
     def conflict_checks(self) -> Sequence[ConflictCheck]:
@@ -73,6 +191,27 @@ class ScalingGroupsForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]
             sa.and_(
                 ScalingGroupForDomainRow.resource_group_id.in_(self.resource_group_ids),
                 ScalingGroupForDomainRow.domain_id == self.domain_id,
+            )
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class DomainsForScalingGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]):
+    """PurgerSpec for disassociating multiple domains from a scaling group."""
+
+    resource_group_id: ResourceGroupID
+    domain_ids: list[DomainID]
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[ScalingGroupForDomainRow]]:
+        return sa.select(ScalingGroupForDomainRow).where(
+            sa.and_(
+                ScalingGroupForDomainRow.resource_group_id == self.resource_group_id,
+                ScalingGroupForDomainRow.domain_id.in_(self.domain_ids),
             )
         )
 
@@ -202,6 +341,27 @@ class ScalingGroupsForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRo
             sa.and_(
                 ScalingGroupForProjectRow.resource_group_id.in_(self.resource_group_ids),
                 ScalingGroupForProjectRow.group == self.project,
+            )
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+@dataclass
+class ProjectsForScalingGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRow]):
+    """PurgerSpec for disassociating multiple projects from a scaling group."""
+
+    resource_group_id: ResourceGroupID
+    projects: list[UUID]
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[ScalingGroupForProjectRow]]:
+        return sa.select(ScalingGroupForProjectRow).where(
+            sa.and_(
+                ScalingGroupForProjectRow.resource_group_id == self.resource_group_id,
+                ScalingGroupForProjectRow.group.in_(self.projects),
             )
         )
 

--- a/src/ai/backend/manager/repositories/scaling_group/purgers.py
+++ b/src/ai/backend/manager/repositories/scaling_group/purgers.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.identifier.domain import DomainID
+from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.permission.types import RBACElementRef
@@ -354,14 +355,14 @@ class ProjectsForResourceGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectR
     """PurgerSpec for disassociating multiple projects from a scaling group."""
 
     resource_group_id: ResourceGroupID
-    projects: list[UUID]
+    project_ids: list[ProjectID]
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[ScalingGroupForProjectRow]]:
         return sa.select(ScalingGroupForProjectRow).where(
             sa.and_(
                 ScalingGroupForProjectRow.resource_group_id == self.resource_group_id,
-                ScalingGroupForProjectRow.group.in_(self.projects),
+                ScalingGroupForProjectRow.group.in_(self.project_ids),
             )
         )
 

--- a/src/ai/backend/manager/repositories/scaling_group/purgers.py
+++ b/src/ai/backend/manager/repositories/scaling_group/purgers.py
@@ -78,7 +78,7 @@ class ResourceGroupPurgerSpec(RBACEntityPurgerSpec[ScalingGroupRow]):
 
 
 @dataclass
-class ScalingGroupRoutingsPurgerSpec(BatchPurgerSpec[RoutingRow]):
+class ResourceGroupRoutingsPurgerSpec(BatchPurgerSpec[RoutingRow]):
     """PurgerSpec for deleting the routings of a scaling group's sessions."""
 
     resource_group_id: ResourceGroupID
@@ -99,7 +99,7 @@ class ScalingGroupRoutingsPurgerSpec(BatchPurgerSpec[RoutingRow]):
 
 
 @dataclass
-class ScalingGroupEndpointsPurgerSpec(BatchPurgerSpec[EndpointRow]):
+class ResourceGroupEndpointsPurgerSpec(BatchPurgerSpec[EndpointRow]):
     """PurgerSpec for deleting the endpoints of a scaling group.
 
     ``endpoints.resource_group`` stores the scaling group name, so the id is
@@ -122,7 +122,7 @@ class ScalingGroupEndpointsPurgerSpec(BatchPurgerSpec[EndpointRow]):
 
 
 @dataclass
-class ScalingGroupKernelsPurgerSpec(BatchPurgerSpec[KernelRow]):
+class ResourceGroupKernelsPurgerSpec(BatchPurgerSpec[KernelRow]):
     """PurgerSpec for deleting the kernels of a scaling group's sessions."""
 
     resource_group_id: ResourceGroupID
@@ -143,7 +143,7 @@ class ScalingGroupKernelsPurgerSpec(BatchPurgerSpec[KernelRow]):
 
 
 @dataclass
-class ScalingGroupSessionsPurgerSpec(BatchPurgerSpec[SessionRow]):
+class ResourceGroupSessionsPurgerSpec(BatchPurgerSpec[SessionRow]):
     """PurgerSpec for deleting the sessions of a scaling group."""
 
     resource_group_id: ResourceGroupID
@@ -200,7 +200,7 @@ class ScalingGroupsForDomainPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]
 
 
 @dataclass
-class DomainsForScalingGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]):
+class DomainsForResourceGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForDomainRow]):
     """PurgerSpec for disassociating multiple domains from a scaling group."""
 
     resource_group_id: ResourceGroupID
@@ -350,7 +350,7 @@ class ScalingGroupsForProjectPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRo
 
 
 @dataclass
-class ProjectsForScalingGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRow]):
+class ProjectsForResourceGroupPurgerSpec(BatchPurgerSpec[ScalingGroupForProjectRow]):
     """PurgerSpec for disassociating multiple projects from a scaling group."""
 
     resource_group_id: ResourceGroupID

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -30,6 +30,11 @@ from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac_models import AssociationScopesEntitiesRow, RoleRow, UserRoleRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
 from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
@@ -50,6 +55,9 @@ from ai.backend.manager.models.session import SessionId, SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base import BatchQuerier, OffsetPagination
 from ai.backend.manager.repositories.base.creator import BulkCreator, Creator
 from ai.backend.manager.repositories.base.purger import Purger
@@ -102,13 +110,19 @@ class TestScalingGroupRepositoryDB:
                 DomainRow,
                 ScalingGroupRow,
                 AssociationScopesEntitiesRow,
+                RoleRow,
+                UserRoleRow,
+                PermissionRow,
+                RolePresetRow,
+                RolePermissionPresetRow,
+                VirtualScopeRow,
+                EntityMembershipRow,
+                ScopeBindingRow,
                 ScalingGroupForDomainRow,
                 ScalingGroupForProjectRow,
                 UserResourcePolicyRow,
                 ProjectResourcePolicyRow,
                 KeyPairResourcePolicyRow,
-                RoleRow,
-                UserRoleRow,
                 UserRow,
                 KeyPairRow,
                 ScalingGroupForKeypairsRow,  # depends on ScalingGroupRow and KeyPairRow

--- a/tests/unit/manager/services/scaling_group/conftest.py
+++ b/tests/unit/manager/services/scaling_group/conftest.py
@@ -26,30 +26,51 @@ from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.common.types import DefaultForUnspecified, ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.deployment_auto_scaling_policy import (
+    DeploymentAutoScalingPolicyRow,
+)
+from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain.row import DomainRow
-
-# Register ImageRow in the SQLAlchemy declarative registry. KernelRow (pulled in
-# transitively via the scaling_group models) declares a string-based
-# relationship("ImageRow"), which is resolved during mapper configuration when a
-# row is instantiated. Without this import the registry lacks ImageRow and mapper
-# configuration fails when this test target runs in isolation (outside the full
-# pytest batch that would otherwise import the image models).
-from ai.backend.manager.models.image import ImageRow  # noqa: F401
+from ai.backend.manager.models.endpoint import EndpointRow
+from ai.backend.manager.models.group import GroupRow
+from ai.backend.manager.models.image import ImageRow
+from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair.row import KeyPairRow
+from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy.row import (
     KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
+from ai.backend.manager.models.resource_preset import ResourcePresetRow
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.runtime_variant import RuntimeVariantRow
 from ai.backend.manager.models.scaling_group import (
     ScalingGroupForDomainRow,
     ScalingGroupForKeypairsRow,
+    ScalingGroupForProjectRow,
     ScalingGroupRow,
 )
+from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user.row import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import VFolderRow
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.manager.repositories.scaling_group.repository import ScalingGroupRepository
 from ai.backend.manager.services.scaling_group.processors import ScalingGroupProcessors
@@ -109,35 +130,52 @@ async def database_fixture(
 
     Overrides the guard fixture in tests/unit/manager/services/conftest.py.
 
-    Stub tables (sessions, kernels, endpoints, routings) are pre-created with
-    minimal schemas so that purge_scaling_group can SELECT/DELETE from them
-    without chasing the full FK dependency chain into unrelated models.
+    The purge and RBAC scope paths issue whole-entity SELECTs (batch purgers,
+    virtual-scope writes), so the real rows are created instead of minimal stub
+    tables, mirroring the repository-level test fixture.
     """
-    # Pre-create stub tables needed by purge_scaling_group.  These have only
-    # the columns accessed by the purge operation (no FK constraints) so we
-    # avoid pulling in the full FK dependency chain (groups, agents, vfolders…).
     async with database_engine.begin() as conn:
         await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'))
-        for stmt in [
-            "CREATE TABLE IF NOT EXISTS sessions (id UUID PRIMARY KEY, scaling_group_name VARCHAR)",
-            "CREATE TABLE IF NOT EXISTS kernels (id UUID PRIMARY KEY, session_id UUID)",
-            "CREATE TABLE IF NOT EXISTS endpoints (id UUID PRIMARY KEY, resource_group VARCHAR)",
-            "CREATE TABLE IF NOT EXISTS routings (id UUID PRIMARY KEY, session UUID)",
-        ]:
-            await conn.execute(text(stmt))
 
     async with with_tables(
         database_engine,
         [
+            # FK dependency order: parents before children
             DomainRow,
-            KeyPairResourcePolicyRow,
+            ScalingGroupRow,
+            AssociationScopesEntitiesRow,
+            RoleRow,
+            UserRoleRow,
+            PermissionRow,
+            RolePresetRow,
+            RolePermissionPresetRow,
+            VirtualScopeRow,
+            EntityMembershipRow,
+            ScopeBindingRow,
+            ScalingGroupForDomainRow,
+            ScalingGroupForProjectRow,
             UserResourcePolicyRow,
+            ProjectResourcePolicyRow,
+            KeyPairResourcePolicyRow,
             UserRow,
             KeyPairRow,
-            ScalingGroupRow,
-            ScalingGroupForDomainRow,
             ScalingGroupForKeypairsRow,
-            AssociationScopesEntitiesRow,
+            GroupRow,
+            ContainerRegistryRow,
+            ImageRow,
+            VFolderRow,
+            EndpointRow,
+            DeploymentPolicyRow,
+            DeploymentAutoScalingPolicyRow,
+            RuntimeVariantRow,
+            DeploymentRevisionPresetRow,
+            DeploymentRevisionRow,
+            SessionRow,
+            AgentRow,
+            KernelRow,
+            ReplicaGroupRow,
+            RoutingRow,
+            ResourcePresetRow,
         ],
     ):
         yield


### PR DESCRIPTION
## Summary
- Create scaling groups through `create_scope` with a new `ResourceGroupScopeCreation`, so every resource group is materialized with its virtual scope (self binding + self membership) at creation and RBAC resolution reaches it through the virtual-scope chain (`scope → virtual_scope → entity`).
- Purge scaling groups through `delete_scope` with a new `ResourceGroupPurgerSpec`, cleaning up the RBAC association rows, permissions, and the virtual scope that were previously left behind; the session/kernel/routing/endpoint cleanup moved from raw SQL to batch purger specs.
- Maintain domain/project ↔ resource group associations through the existing RBAC write ops in all allow/disallow and associate/disassociate paths: `add_entity_members`/`remove_entity_members` for the association row + membership, and `ensure_scope(bound_scope=...)`/`unbind_scope` for the accessor scope's binding to the resource group's virtual scope (created lazily for pre-virtual-scope rows).

## Test plan
- [x] CI: pants check / test
- [x] Create a resource group and verify `virtual_scopes` gets a row with self `scope_bindings`/`entity_memberships`
- [x] Allow the resource group for a domain/project and verify the accessor scope's binding row in the resource group's virtual scope, plus the legacy `association_scopes_entities` row
- [x] Disallow/disassociate and verify the binding, membership, and association rows are removed
- [x] Purge the resource group and verify its RBAC entries and virtual scope are gone

Resolves BA-6661

🤖 Generated with [Claude Code](https://claude.com/claude-code)