### PR TITLE
feat(BA-7172): add filter and group labels to utilization checker spec

### DIFF
--- a/changes/13441.feature.md
+++ b/changes/13441.feature.md
@@ -1,0 +1,1 @@
+Add filter and group label parameters to the utilization idle checker spec for preset-backed Prometheus queries

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -22929,7 +22929,11 @@ type UtilizationIdleCheckerThreshold
 {
   presetId: UUID!
   threshold: Decimal!
+
+  """Added in 26.9.0. Label filters injected into the preset query."""
   filterLabels: [MetricLabelEntry!]!
+
+  """Added in 26.9.0. Group-by labels injected into the preset query."""
   groupLabels: [String!]!
 }
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -22929,6 +22929,8 @@ type UtilizationIdleCheckerThreshold
 {
   presetId: UUID!
   threshold: Decimal!
+  filterLabels: [MetricLabelEntry!]!
+  groupLabels: [String!]!
 }
 
 """Added in 26.8.0. Supplies a preset-backed utilization threshold."""
@@ -22940,6 +22942,14 @@ input UtilizationIdleCheckerThresholdInput
 
   """Underutilization threshold."""
   threshold: Decimal!
+
+  """Added in 26.9.0. Label filters injected into the preset query."""
+  filterLabels: [MetricLabelEntryInput!]! = []
+
+  """
+  Added in 26.9.0. Group-by labels injected into the preset query. Per-session mapping requires 'session_id'; when included, the query is also scoped to the sessions under evaluation.
+  """
+  groupLabels: [String!]! = ["session_id"]
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -16459,7 +16459,11 @@ input UtilizationIdleCheckerSpecInput {
 type UtilizationIdleCheckerThreshold {
   presetId: UUID!
   threshold: Decimal!
+
+  """Added in 26.9.0. Label filters injected into the preset query."""
   filterLabels: [MetricLabelEntry!]!
+
+  """Added in 26.9.0. Group-by labels injected into the preset query."""
   groupLabels: [String!]!
 }
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -16459,6 +16459,8 @@ input UtilizationIdleCheckerSpecInput {
 type UtilizationIdleCheckerThreshold {
   presetId: UUID!
   threshold: Decimal!
+  filterLabels: [MetricLabelEntry!]!
+  groupLabels: [String!]!
 }
 
 """Added in 26.8.0. Supplies a preset-backed utilization threshold."""
@@ -16468,6 +16470,14 @@ input UtilizationIdleCheckerThresholdInput {
 
   """Underutilization threshold."""
   threshold: Decimal!
+
+  """Added in 26.9.0. Label filters injected into the preset query."""
+  filterLabels: [MetricLabelEntryInput!]! = []
+
+  """
+  Added in 26.9.0. Group-by labels injected into the preset query. Per-session mapping requires 'session_id'; when included, the query is also scoped to the sessions under evaluation.
+  """
+  groupLabels: [String!]! = ["session_id"]
 }
 
 """Added in 25.16.0. VFS Storage configuration."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -10367,6 +10367,27 @@
         "title": "IdleCheckerSpecInputDTO",
         "type": "object"
       },
+      "MetricLabelEntry": {
+        "description": "A key-value label entry for executing a query definition.",
+        "properties": {
+          "key": {
+            "description": "Label key",
+            "title": "Key",
+            "type": "string"
+          },
+          "value": {
+            "description": "Label value",
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "key",
+          "value"
+        ],
+        "title": "MetricLabelEntry",
+        "type": "object"
+      },
       "NetworkTimeoutSpecInputDTO": {
         "properties": {
           "max_network_inactivity_seconds": {
@@ -10440,6 +10461,20 @@
               }
             ],
             "title": "Threshold"
+          },
+          "filter_labels": {
+            "items": {
+              "$ref": "#/components/schemas/MetricLabelEntry"
+            },
+            "title": "Filter Labels",
+            "type": "array"
+          },
+          "group_labels": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Group Labels",
+            "type": "array"
           }
         },
         "required": [
@@ -17856,27 +17891,6 @@
           }
         },
         "title": "ExecuteQueryDefinitionOptionsInput",
-        "type": "object"
-      },
-      "MetricLabelEntry": {
-        "description": "A key-value label entry for executing a query definition.",
-        "properties": {
-          "key": {
-            "description": "Label key",
-            "title": "Key",
-            "type": "string"
-          },
-          "value": {
-            "description": "Label value",
-            "title": "Value",
-            "type": "string"
-          }
-        },
-        "required": [
-          "key",
-          "value"
-        ],
-        "title": "MetricLabelEntry",
         "type": "object"
       },
       "QueryTimeRangeInputDTO": {

--- a/src/ai/backend/common/data/idle_checker/types.py
+++ b/src/ai/backend/common/data/idle_checker/types.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import enum
 from decimal import Decimal
-from typing import Self
+from typing import Final, Self
 
 from pydantic import Field, model_validator
 
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import BackendAISchema
+
+# Metric label carrying the session UUID; grouping by it enables per-session mapping.
+SESSION_ID_LABEL: Final = "session_id"
 
 
 class CheckerType(enum.StrEnum):
@@ -34,6 +37,20 @@ class UtilizationThresholdEntry(BackendAISchema):
     )
     threshold: Decimal = Field(
         description="Underutilization threshold compared against the preset's query result.",
+    )
+    filter_labels: dict[str, str] = Field(
+        default_factory=dict,
+        description="Label filters injected into the preset's {labels} placeholder.",
+    )
+    group_labels: list[str] = Field(
+        default_factory=lambda: [SESSION_ID_LABEL],
+        description=(
+            "Labels injected into the preset's {group_by} placeholder. "
+            "Must include 'session_id' for per-session values to be mapped. "
+            "When 'session_id' is grouped, the checker adds a session_id filter that "
+            "limits the query to the sessions being evaluated; a user-provided "
+            "'session_id' entry in filter_labels takes precedence over it."
+        ),
     )
 
 

--- a/src/ai/backend/common/data/idle_checker/types.py
+++ b/src/ai/backend/common/data/idle_checker/types.py
@@ -29,6 +29,13 @@ class IdleCheckPhase(enum.StrEnum):
     IDLE_EXPIRED = "idle_expired"
 
 
+class MetricLabel(BackendAISchema):
+    """Single metric label key-value pair."""
+
+    key: str = Field(description="Label key.")
+    value: str = Field(description="Label value.")
+
+
 class UtilizationThresholdEntry(BackendAISchema):
     """One preset-backed session utilization threshold."""
 
@@ -38,8 +45,8 @@ class UtilizationThresholdEntry(BackendAISchema):
     threshold: Decimal = Field(
         description="Underutilization threshold compared against the preset's query result.",
     )
-    filter_labels: dict[str, str] = Field(
-        default_factory=dict,
+    filter_labels: list[MetricLabel] = Field(
+        default_factory=list,
         description="Label filters injected into the preset's {labels} placeholder.",
     )
     group_labels: list[str] = Field(
@@ -52,6 +59,13 @@ class UtilizationThresholdEntry(BackendAISchema):
             "'session_id' entry in filter_labels takes precedence over it."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_unique_filter_label_keys(self) -> Self:
+        keys = [label.key for label in self.filter_labels]
+        if len(keys) != len(set(keys)):
+            raise ValueError("filter_labels must not contain duplicate keys.")
+        return self
 
 
 class SessionLifetimeSpec(BackendAISchema):

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
@@ -34,6 +34,13 @@ class UtilizationThresholdInputDTO(BaseRequestModel):
     filter_labels: list[MetricLabelEntry] = Field(default_factory=list)
     group_labels: list[str] = Field(default_factory=lambda: [SESSION_ID_LABEL])
 
+    @model_validator(mode="after")
+    def _validate_unique_filter_label_keys(self) -> Self:
+        keys = [entry.key for entry in self.filter_labels]
+        if len(keys) != len(set(keys)):
+            raise ValueError("filter_labels must not contain duplicate keys")
+        return self
+
 
 class UtilizationSpecInputDTO(BaseRequestModel):
     max_underutilized_duration_seconds: int = Field(ge=1)

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
@@ -6,6 +6,7 @@ from typing import Self
 from pydantic import ConfigDict, Field, model_validator
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.data.idle_checker.types import SESSION_ID_LABEL
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.idle_checker.types import (
@@ -13,6 +14,7 @@ from ai.backend.common.dto.manager.v2.idle_checker.types import (
     IdleCheckerInputTypeDTO,
     IdleCheckerOrderField,
 )
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import MetricLabelEntry
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionTypes
@@ -29,6 +31,8 @@ class NetworkTimeoutSpecInputDTO(BaseRequestModel):
 class UtilizationThresholdInputDTO(BaseRequestModel):
     preset_id: PrometheusQueryPresetID
     threshold: Decimal
+    filter_labels: list[MetricLabelEntry] = Field(default_factory=list)
+    group_labels: list[str] = Field(default_factory=lambda: [SESSION_ID_LABEL])
 
 
 class UtilizationSpecInputDTO(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/response.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/response.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.idle_checker.types import IdleCheckerTypeD
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import MetricLabelEntryInfo
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import SessionTypes
 
 
@@ -24,8 +25,14 @@ class NetworkTimeoutSpecInfo(BaseResponseModel):
 class UtilizationThresholdInfo(BaseResponseModel):
     preset_id: PrometheusQueryPresetID
     threshold: Decimal
-    filter_labels: list[MetricLabelEntryInfo]
-    group_labels: list[str]
+    filter_labels: list[MetricLabelEntryInfo] = Field(
+        description=f"Added in {NEXT_RELEASE_VERSION}. Label filters injected into the preset query."
+    )
+    group_labels: list[str] = Field(
+        description=(
+            f"Added in {NEXT_RELEASE_VERSION}. Group-by labels injected into the preset query."
+        )
+    )
 
 
 class UtilizationSpecInfo(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/response.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/response.py
@@ -7,6 +7,7 @@ from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.v2.idle_checker.types import IdleCheckerTypeDTO
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import MetricLabelEntryInfo
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionTypes
@@ -23,6 +24,8 @@ class NetworkTimeoutSpecInfo(BaseResponseModel):
 class UtilizationThresholdInfo(BaseResponseModel):
     preset_id: PrometheusQueryPresetID
     threshold: Decimal
+    filter_labels: list[MetricLabelEntryInfo]
+    group_labels: list[str]
 
 
 class UtilizationSpecInfo(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
@@ -42,6 +42,7 @@ from ai.backend.common.dto.manager.v2.idle_checker.types import (
     IdleCheckerOrderField,
     IdleCheckerTypeDTO,
 )
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import MetricLabelEntryInfo
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
@@ -231,6 +232,11 @@ class IdleCheckerAdapter(BaseAdapter):
                         threshold=UtilizationThresholdInfo(
                             preset_id=utilization.threshold.preset_id,
                             threshold=utilization.threshold.threshold,
+                            filter_labels=[
+                                MetricLabelEntryInfo(key=key, value=value)
+                                for key, value in utilization.threshold.filter_labels.items()
+                            ],
+                            group_labels=utilization.threshold.group_labels,
                         ),
                     ),
                 )
@@ -261,6 +267,10 @@ class IdleCheckerAdapter(BaseAdapter):
                 threshold=UtilizationThresholdEntry(
                     preset_id=utilization.threshold.preset_id,
                     threshold=utilization.threshold.threshold,
+                    filter_labels={
+                        entry.key: entry.value for entry in utilization.threshold.filter_labels
+                    },
+                    group_labels=utilization.threshold.group_labels,
                 ),
             ),
         )

--- a/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
@@ -10,6 +10,7 @@ from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    MetricLabel,
     NetworkTimeoutSpec,
     SessionLifetimeSpec,
     UtilizationSpec,
@@ -233,8 +234,8 @@ class IdleCheckerAdapter(BaseAdapter):
                             preset_id=utilization.threshold.preset_id,
                             threshold=utilization.threshold.threshold,
                             filter_labels=[
-                                MetricLabelEntryInfo(key=key, value=value)
-                                for key, value in utilization.threshold.filter_labels.items()
+                                MetricLabelEntryInfo(key=label.key, value=label.value)
+                                for label in utilization.threshold.filter_labels
                             ],
                             group_labels=utilization.threshold.group_labels,
                         ),
@@ -267,9 +268,10 @@ class IdleCheckerAdapter(BaseAdapter):
                 threshold=UtilizationThresholdEntry(
                     preset_id=utilization.threshold.preset_id,
                     threshold=utilization.threshold.threshold,
-                    filter_labels={
-                        entry.key: entry.value for entry in utilization.threshold.filter_labels
-                    },
+                    filter_labels=[
+                        MetricLabel(key=entry.key, value=entry.value)
+                        for entry in utilization.threshold.filter_labels
+                    ],
                     group_labels=utilization.threshold.group_labels,
                 ),
             ),

--- a/src/ai/backend/manager/api/gql/decorators.py
+++ b/src/ai/backend/manager/api/gql/decorators.py
@@ -242,12 +242,21 @@ def gql_added_field(
     *,
     name: str | None = None,
     default: Any = strawberry.UNSET,
+    default_factory: Callable[[], Any] | None = None,
     deprecation_reason: str | None = None,
 ) -> Any:
     """Field added after the parent type was released (has its own version).
 
     Automatically prefixes the description with "Added in {version}."
+    ``default_factory`` renders the default into the schema SDL (input fields).
     """
+    if default_factory is not None:
+        return strawberry.field(
+            description=_build_description(meta),
+            name=name,
+            default_factory=default_factory,
+            deprecation_reason=deprecation_reason,
+        )
     return strawberry.field(
         description=_build_description(meta),
         name=name,

--- a/src/ai/backend/manager/api/gql/idle_checker/types.py
+++ b/src/ai/backend/manager/api/gql/idle_checker/types.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from strawberry import UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID
 
+from ai.backend.common.data.idle_checker.types import SESSION_ID_LABEL
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
     CreateIdleCheckerInput as CreateIdleCheckerInputDTO,
 )
@@ -53,11 +54,13 @@ from ai.backend.common.dto.manager.v2.idle_checker.types import (
     CheckerTypeFilter as CheckerTypeFilterDTO,
 )
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -65,6 +68,8 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
+from ai.backend.manager.api.gql.prometheus_query_preset.types.inputs import MetricLabelEntryInput
+from ai.backend.manager.api.gql.prometheus_query_preset.types.payloads import MetricLabelEntryGQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 from ai.backend.manager.api.gql.utils import check_admin_only
@@ -142,6 +147,18 @@ class NetworkTimeoutIdleCheckerSpecGQL(PydanticOutputMixin[NetworkTimeoutSpecInf
 class UtilizationIdleCheckerThresholdGQL(PydanticOutputMixin[UtilizationThresholdInfo]):
     preset_id: UUID = gql_field(description="Prometheus query preset ID.")
     threshold: Decimal = gql_field(description="Underutilization threshold.")
+    filter_labels: list[MetricLabelEntryGQL] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Label filters injected into the preset query.",
+        )
+    )
+    group_labels: list[str] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Group-by labels injected into the preset query.",
+        )
+    )
 
 
 @gql_pydantic_type(
@@ -284,6 +301,24 @@ class NetworkTimeoutIdleCheckerSpecInputGQL(PydanticInputMixin[NetworkTimeoutSpe
 class UtilizationIdleCheckerThresholdInputGQL(PydanticInputMixin[UtilizationThresholdInputDTO]):
     preset_id: UUID = gql_field(description="Prometheus query preset ID.")
     threshold: Decimal = gql_field(description="Underutilization threshold.")
+    filter_labels: list[MetricLabelEntryInput] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Label filters injected into the preset query.",
+        ),
+        default_factory=list,
+    )
+    group_labels: list[str] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Group-by labels injected into the preset query. "
+                "Per-session mapping requires 'session_id'; when included, the query is "
+                "also scoped to the sessions under evaluation."
+            ),
+        ),
+        default_factory=lambda: [SESSION_ID_LABEL],
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/clients/prometheus/client.py
+++ b/src/ai/backend/manager/clients/prometheus/client.py
@@ -17,7 +17,7 @@ from ai.backend.common.exception import (
     FailedToGetMetric,
     PrometheusConnectionError,
 )
-from ai.backend.common.types import KernelId, SessionId
+from ai.backend.common.types import KernelId
 from ai.backend.manager.clients.prometheus.fixed_query_builder import (
     ContainerLiveStatQueryBuilder,
     ContainerMetricQueryBuilder,
@@ -29,7 +29,7 @@ from ai.backend.manager.clients.prometheus.metric_types import (
     KernelLiveStatBatchResult,
     MetricResultValue,
 )
-from ai.backend.manager.clients.prometheus.preset import LabelMatcher, MetricPreset, regex_union
+from ai.backend.manager.clients.prometheus.preset import MetricPreset
 
 DEFAULT_TIMEOUT_SECONDS: float = 30.0
 
@@ -121,25 +121,6 @@ class PrometheusClient:
             preset=preset,
             time_range=time_range,
         )
-
-    async def fetch_session_utilization(
-        self,
-        *,
-        query_template: str,
-        time_window: str,
-        session_ids: Sequence[SessionId],
-        evaluation_time: str,
-    ) -> PrometheusResponse:
-        session_id_pattern = regex_union([
-            str(session_id) for session_id in dict.fromkeys(session_ids)
-        ])
-        preset = MetricPreset(
-            template=query_template,
-            labels={"session_id": LabelMatcher.regex(session_id_pattern)},
-            group_by={"session_id"},
-            window=time_window,
-        )
-        return await self._query_instant(preset, time=evaluation_time)
 
     async def preview_query_template(
         self,

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Self
@@ -32,15 +31,17 @@ class SessionUtilizationQuery:
     """Hashable batching key: one Prometheus query per (preset, labels) combination."""
 
     preset_id: PrometheusQueryPresetID
-    filter_labels: Sequence[tuple[str, str]]
-    group_labels: Sequence[str]
+    filter_labels: tuple[tuple[str, str], ...]
+    group_labels: tuple[str, ...]
 
     @classmethod
     def from_threshold(cls, threshold: UtilizationThresholdEntry) -> Self:
         return cls(
             preset_id=threshold.preset_id,
-            filter_labels=tuple(sorted(threshold.filter_labels.items())),
-            group_labels=tuple(threshold.group_labels),
+            filter_labels=tuple(
+                sorted((label.key, label.value) for label in threshold.filter_labels)
+            ),
+            group_labels=tuple(sorted(set(threshold.group_labels))),
         )
 
 

--- a/src/ai/backend/manager/data/idle_checker/types.py
+++ b/src/ai/backend/manager/data/idle_checker/types.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Self
 
-from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    UtilizationThresholdEntry,
+)
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.idle_checker import IdleCheckerAssignmentID, IdleCheckerID
+from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionId, SessionTypes
 
 
@@ -18,6 +25,23 @@ class IdleCheckSession:
     created_at: datetime
     starts_at: datetime | None
     expire_at: datetime | None
+
+
+@dataclass(frozen=True)
+class SessionUtilizationQuery:
+    """Hashable batching key: one Prometheus query per (preset, labels) combination."""
+
+    preset_id: PrometheusQueryPresetID
+    filter_labels: Sequence[tuple[str, str]]
+    group_labels: Sequence[str]
+
+    @classmethod
+    def from_threshold(cls, threshold: UtilizationThresholdEntry) -> Self:
+        return cls(
+            preset_id=threshold.preset_id,
+            filter_labels=tuple(sorted(threshold.filter_labels.items())),
+            group_labels=tuple(threshold.group_labels),
+        )
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/repositories/metric/repositories.py
+++ b/src/ai/backend/manager/repositories/metric/repositories.py
@@ -15,5 +15,6 @@ class MetricRepositories:
             repository=MetricRepository(
                 db=args.db,
                 prometheus_client=args.prometheus_client,
+                default_timewindow=args.config_provider.config.metric.timewindow,
             ),
         )

--- a/src/ai/backend/manager/repositories/metric/repository.py
+++ b/src/ai/backend/manager/repositories/metric/repository.py
@@ -57,14 +57,17 @@ metric_repository_resilience = Resilience(
 class MetricRepository:
     _prometheus_client: PrometheusClient
     _prometheus_query_preset_db_source: PrometheusQueryPresetDBSource
+    _default_timewindow: str
 
     def __init__(
         self,
         db: ExtendedAsyncSAEngine,
         prometheus_client: PrometheusClient,
+        default_timewindow: str,
     ) -> None:
         self._prometheus_client = prometheus_client
         self._prometheus_query_preset_db_source = PrometheusQueryPresetDBSource(db)
+        self._default_timewindow = default_timewindow
 
     async def query_container_metric_metadata(self) -> list[str]:
         return await self._prometheus_client.fetch_available_container_metric_names()
@@ -181,7 +184,7 @@ class MetricRepository:
                     template=preset.query_template,
                     labels=filter_labels,
                     group_by=set(query.group_labels),
-                    window=preset.time_window or "",
+                    window=preset.time_window or self._default_timewindow,
                 ),
                 time_range=None,
                 time=evaluation_time.isoformat(),

--- a/src/ai/backend/manager/repositories/metric/repository.py
+++ b/src/ai/backend/manager/repositories/metric/repository.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from uuid import UUID
 
+from ai.backend.common.data.idle_checker.types import SESSION_ID_LABEL
 from ai.backend.common.dto.clients.prometheus.request import QueryTimeRange
 from ai.backend.common.exception import (
     BackendAIError,
@@ -24,8 +25,9 @@ from ai.backend.manager.clients.prometheus.metric_types import (
     ContainerMetricResult,
     KernelLiveStatBatchResult,
 )
+from ai.backend.manager.clients.prometheus.preset import LabelMatcher, MetricPreset, regex_union
+from ai.backend.manager.data.idle_checker.types import SessionUtilizationQuery
 from ai.backend.manager.data.prometheus_query_preset import PrometheusQueryPresetData
-from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.models.prometheus_query_preset.conditions import (
     PrometheusQueryPresetConditions,
 )
@@ -90,59 +92,99 @@ class MetricRepository:
 
     async def query_session_utilization_metrics(
         self,
-        session_ids_by_preset: Mapping[
-            PrometheusQueryPresetID,
+        session_ids_by_query: Mapping[
+            SessionUtilizationQuery,
             Sequence[SessionId],
         ],
         evaluation_time: datetime,
-    ) -> Mapping[PrometheusQueryPresetID, Mapping[SessionId, Decimal]]:
-        preset_ids = [
-            preset_id for preset_id, session_ids in session_ids_by_preset.items() if session_ids
-        ]
-        if not preset_ids:
+    ) -> Mapping[SessionUtilizationQuery, Mapping[SessionId, Decimal]]:
+        queries = {
+            query: session_ids for query, session_ids in session_ids_by_query.items() if session_ids
+        }
+        if not queries:
             return {}
         preset_result = await self._prometheus_query_preset_db_source.search(
             BatchQuerier(
                 pagination=NoPagination(),
-                conditions=[PrometheusQueryPresetConditions.by_ids(preset_ids)],
+                conditions=[
+                    PrometheusQueryPresetConditions.by_ids(
+                        list({query.preset_id for query in queries})
+                    )
+                ],
             )
         )
         presets_by_id = {
             PrometheusQueryPresetID(preset.id): preset for preset in preset_result.items
         }
 
-        values_by_preset: dict[
-            PrometheusQueryPresetID,
+        values_by_query: dict[
+            SessionUtilizationQuery,
             Mapping[SessionId, Decimal],
         ] = {}
-        for preset_id in preset_ids:
-            preset = presets_by_id.get(preset_id)
+        for query, session_ids in queries.items():
+            preset = presets_by_id.get(query.preset_id)
             if preset is None:
                 log.error(
                     "Prometheus query preset not found; skipping utilization query: ID - {}",
-                    preset_id,
+                    query.preset_id,
                 )
-                values_by_preset[preset_id] = {}
+                values_by_query[query] = {}
                 continue
-            values_by_preset[preset_id] = await self._query_session_utilization_metrics_for_preset(
+            values_by_query[query] = await self._query_session_utilization_metrics_for_preset(
                 preset,
-                session_ids_by_preset[preset_id],
+                query,
+                session_ids,
                 evaluation_time,
             )
-        return values_by_preset
+        return values_by_query
+
+    def _invalid_labels(
+        self,
+        preset: PrometheusQueryPresetData,
+        query: SessionUtilizationQuery,
+    ) -> set[str]:
+        """Spec labels the preset does not declare as allowed (empty allow-list allows all)."""
+        invalid: set[str] = set()
+        if preset.filter_labels:
+            invalid |= {name for name, _ in query.filter_labels} - set(preset.filter_labels)
+        if preset.group_labels:
+            invalid |= set(query.group_labels) - set(preset.group_labels)
+        return invalid
 
     async def _query_session_utilization_metrics_for_preset(
         self,
         preset: PrometheusQueryPresetData,
+        query: SessionUtilizationQuery,
         session_ids: Sequence[SessionId],
         evaluation_time: datetime,
     ) -> Mapping[SessionId, Decimal]:
+        invalid_labels = self._invalid_labels(preset, query)
+        if invalid_labels:
+            log.error(
+                "Utilization query labels not allowed by preset {}; skipping: {}",
+                preset.id,
+                sorted(invalid_labels),
+            )
+            return {}
+        filter_labels: dict[str, LabelMatcher] = {
+            name: LabelMatcher.exact(value) for name, value in query.filter_labels
+        }
+        # Scope to the current session batch unless the user set session_id themselves.
+        if SESSION_ID_LABEL in query.group_labels and SESSION_ID_LABEL not in filter_labels:
+            filter_labels[SESSION_ID_LABEL] = LabelMatcher.regex(
+                # remove duplicates while preserving order, then join into a regex union
+                regex_union([str(session_id) for session_id in dict.fromkeys(session_ids)])
+            )
         try:
-            response = await self._prometheus_client.fetch_session_utilization(
-                query_template=preset.query_template,
-                time_window=preset.time_window or "",
-                session_ids=session_ids,
-                evaluation_time=evaluation_time.isoformat(),
+            response = await self._prometheus_client.execute_preset(
+                MetricPreset(
+                    template=preset.query_template,
+                    labels=filter_labels,
+                    group_by=set(query.group_labels),
+                    window=preset.time_window or "",
+                ),
+                time_range=None,
+                time=evaluation_time.isoformat(),
             )
         except (PrometheusConnectionError, FailedToGetMetric, InvalidMetricPresetTemplate) as e:
             log.warning(
@@ -163,9 +205,15 @@ class MetricRepository:
                 continue
             if session_id not in requested_session_ids or not value.is_finite():
                 continue
-            if session_id in values:
-                raise InternalServerError(
-                    f"Utilization query returned multiple values for session {session_id}"
-                )
-            values[session_id] = value
+            # Extra group labels may yield multiple series per session;
+            # a session is active if any of its series is active, hence max.
+            existing = values.get(session_id)
+            values[session_id] = value if existing is None else max(existing, value)
+        if not values and response.data.result:
+            log.warning(
+                "Utilization query for preset {} returned {} series but none matched the "
+                "requested sessions; check that group_labels include 'session_id'",
+                preset.id,
+                len(response.data.result),
+            )
         return values

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -236,7 +236,10 @@ def create_services(args: ServiceArgs) -> Services:
             repositories.user.repository,
             args.scheduling_controller,
         ),
-        idle_checker=IdleCheckerService(repositories.idle_checker.repository),
+        idle_checker=IdleCheckerService(
+            repositories.idle_checker.repository,
+            repositories.prometheus_query_preset.repository,
+        ),
         image=ImageService(
             args.agent_registry, repositories.image.repository, args.config_provider
         ),

--- a/src/ai/backend/manager/services/idle_checker/service.py
+++ b/src/ai/backend/manager/services/idle_checker/service.py
@@ -1,4 +1,13 @@
+from typing import cast
+
+from ai.backend.common.data.idle_checker.types import IdleCheckerSpec
+from ai.backend.common.exception import PrometheusQueryPresetInvalidLabel
+from ai.backend.manager.repositories.idle_checker.creators import IdleCheckerCreatorSpec
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.updaters import IdleCheckerUpdaterSpec
+from ai.backend.manager.repositories.prometheus_query_preset.repository import (
+    PrometheusQueryPresetRepository,
+)
 from ai.backend.manager.services.idle_checker.actions.admin_search import (
     AdminSearchIdleCheckersAction,
     SearchIdleCheckersActionResult,
@@ -19,9 +28,36 @@ from ai.backend.manager.services.idle_checker.actions.update import (
 
 class IdleCheckerService:
     _repository: IdleCheckerRepository
+    _prometheus_query_preset_repository: PrometheusQueryPresetRepository
 
-    def __init__(self, repository: IdleCheckerRepository) -> None:
+    def __init__(
+        self,
+        repository: IdleCheckerRepository,
+        prometheus_query_preset_repository: PrometheusQueryPresetRepository,
+    ) -> None:
         self._repository = repository
+        self._prometheus_query_preset_repository = prometheus_query_preset_repository
+
+    async def _validate_utilization_labels(self, spec: IdleCheckerSpec) -> None:
+        """Reject spec labels the referenced preset does not declare as allowed."""
+        if spec.utilization is None:
+            return
+        threshold = spec.utilization.threshold
+        preset = await self._prometheus_query_preset_repository.get_by_id(threshold.preset_id)
+        if preset.filter_labels:
+            invalid = {label.key for label in threshold.filter_labels} - set(preset.filter_labels)
+            if invalid:
+                raise PrometheusQueryPresetInvalidLabel(
+                    f"Invalid filter labels: {sorted(invalid)}. "
+                    f"Allowed: {sorted(preset.filter_labels)}"
+                )
+        if preset.group_labels:
+            invalid = set(threshold.group_labels) - set(preset.group_labels)
+            if invalid:
+                raise PrometheusQueryPresetInvalidLabel(
+                    f"Invalid group labels: {sorted(invalid)}. "
+                    f"Allowed: {sorted(preset.group_labels)}"
+                )
 
     async def admin_search(
         self,
@@ -36,10 +72,16 @@ class IdleCheckerService:
         )
 
     async def create(self, action: CreateIdleCheckerAction) -> CreateIdleCheckerActionResult:
+        creator_spec = cast(IdleCheckerCreatorSpec, action.creator.spec)
+        await self._validate_utilization_labels(creator_spec.spec)
         data = await self._repository.create(action.creator)
         return CreateIdleCheckerActionResult(idle_checker=data)
 
     async def update(self, action: UpdateIdleCheckerAction) -> UpdateIdleCheckerActionResult:
+        updater_spec = cast(IdleCheckerUpdaterSpec, action.updater.spec)
+        spec = updater_spec.spec.optional_value()
+        if spec is not None:
+            await self._validate_utilization_labels(spec)
         data = await self._repository.update(action.updater)
         return UpdateIdleCheckerActionResult(idle_checker=data)
 

--- a/src/ai/backend/manager/sokovan/idle_check/checkers/utilization.py
+++ b/src/ai/backend/manager/sokovan/idle_check/checkers/utilization.py
@@ -6,9 +6,9 @@ from datetime import timedelta
 from typing import override
 
 from ai.backend.common.data.idle_checker.types import UtilizationSpec
-from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.idle_checker.types import SessionUtilizationQuery
 from ai.backend.manager.repositories.metric.repository import MetricRepository
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
     CheckerAssignment,
@@ -37,7 +37,7 @@ class UtilizationChecker(IdleChecker):
     ) -> Sequence[IdleActivityDecision]:
         # Unknown sessions are ignored because their utilization status cannot be determined.
         valid_assignments: list[tuple[CheckerAssignment, UtilizationSpec]] = []
-        session_ids_by_preset: dict[PrometheusQueryPresetID, list[SessionId]] = {}
+        session_ids_by_query: dict[SessionUtilizationQuery, list[SessionId]] = {}
         for assignment in assignments:
             spec = assignment.definition.spec.utilization
             if spec is None:
@@ -48,20 +48,21 @@ class UtilizationChecker(IdleChecker):
                 )
                 continue
             valid_assignments.append((assignment, spec))
-            session_ids = session_ids_by_preset.setdefault(spec.threshold.preset_id, [])
+            query = SessionUtilizationQuery.from_threshold(spec.threshold)
+            session_ids = session_ids_by_query.setdefault(query, [])
             for session in assignment.sessions:
                 session_ids.append(session.session_id)
-        if not session_ids_by_preset:
+        if not session_ids_by_query:
             return []
 
-        values_by_preset = await self._metric_repository.query_session_utilization_metrics(
-            session_ids_by_preset,
+        values_by_query = await self._metric_repository.query_session_utilization_metrics(
+            session_ids_by_query,
             evaluation_time=context.current_time,
         )
         decisions: list[IdleActivityDecision] = []
         for assignment, spec in valid_assignments:
             threshold = spec.threshold
-            values = values_by_preset.get(threshold.preset_id, {})
+            values = values_by_query.get(SessionUtilizationQuery.from_threshold(threshold), {})
             for session in assignment.sessions:
                 value = values.get(session.session_id)
                 if value is None:

--- a/tests/unit/manager/api/adapters/test_idle_checker_adapter.py
+++ b/tests/unit/manager/api/adapters/test_idle_checker_adapter.py
@@ -10,6 +10,7 @@ import pytest
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    MetricLabel,
     SessionLifetimeSpec,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
@@ -19,6 +20,8 @@ from ai.backend.common.dto.manager.v2.idle_checker.request import (
     UtilizationSpecInputDTO,
     UtilizationThresholdInputDTO,
 )
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import MetricLabelEntry
+from ai.backend.common.dto.manager.v2.prometheus_query_preset.types import MetricLabelEntryInfo
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionTypes
@@ -130,6 +133,38 @@ class TestIdleCheckerAdapter:
         assert info.utilization.max_underutilized_duration_seconds == 900
         assert info.utilization.threshold.preset_id == preset_id
         assert info.utilization.threshold.threshold == Decimal("0.25")
+
+    def test_converts_utilization_spec_labels_round_trip(
+        self,
+        adapter: IdleCheckerAdapter,
+    ) -> None:
+        spec = adapter._build_spec(
+            IdleCheckerSpecInputDTO(
+                utilization=UtilizationSpecInputDTO(
+                    max_underutilized_duration_seconds=900,
+                    threshold=UtilizationThresholdInputDTO(
+                        preset_id=PrometheusQueryPresetID(uuid4()),
+                        threshold=Decimal("0.25"),
+                        filter_labels=[
+                            MetricLabelEntry(key="container_metric_name", value="cpu_util")
+                        ],
+                        group_labels=["session_id", "device"],
+                    ),
+                )
+            )
+        )
+        info = adapter._spec_to_info(spec)
+
+        assert spec.utilization is not None
+        assert spec.utilization.threshold.filter_labels == [
+            MetricLabel(key="container_metric_name", value="cpu_util")
+        ]
+        assert spec.utilization.threshold.group_labels == ["session_id", "device"]
+        assert info.utilization is not None
+        assert info.utilization.threshold.filter_labels == [
+            MetricLabelEntryInfo(key="container_metric_name", value="cpu_util")
+        ]
+        assert info.utilization.threshold.group_labels == ["session_id", "device"]
 
     async def test_batch_load_preserves_input_order_and_missing_entries(
         self,

--- a/tests/unit/manager/clients/prometheus/test_client.py
+++ b/tests/unit/manager/clients/prometheus/test_client.py
@@ -1,6 +1,5 @@
 from typing import Any
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
 
 import aiohttp
 import pytest
@@ -14,7 +13,6 @@ from ai.backend.common.exception import (
     FailedToGetMetric,
     PrometheusConnectionError,
 )
-from ai.backend.common.types import SessionId
 from ai.backend.manager.clients.prometheus import (
     ContainerLiveStatQueryBuilder,
     ContainerMetricQueryBuilder,
@@ -243,35 +241,6 @@ class TestQueryInstant:
         mock_session.post.assert_called_once()
         form_data = mock_session.post.call_args.kwargs["data"]
         field_values = {field[0]["name"]: field[2] for field in form_data._fields}
-        assert field_values["time"] == "1704067200.123"
-
-    async def test_fetch_session_utilization_renders_stored_preset(
-        self,
-        prometheus_client: PrometheusClient,
-        mock_session: Mock,
-        success_response: AsyncMock,
-    ) -> None:
-        first_session_id = SessionId(uuid4())
-        second_session_id = SessionId(uuid4())
-        query_template = (
-            'min by ({group_by}) (backendai_container_utilization{{value_type="current",'
-            'container_metric_name="cpu_used",{labels}}})'
-        )
-
-        await prometheus_client.fetch_session_utilization(
-            query_template=query_template,
-            time_window="5m",
-            session_ids=[first_session_id, second_session_id, first_session_id],
-            evaluation_time="1704067200.123",
-        )
-
-        mock_session.post.assert_called_once()
-        form_data = mock_session.post.call_args.kwargs["data"]
-        field_values = {field[0]["name"]: field[2] for field in form_data._fields}
-        assert "min by (session_id)" in field_values["query"]
-        assert 'container_metric_name="cpu_used"' in field_values["query"]
-        assert 'value_type="current"' in field_values["query"]
-        assert f'session_id=~"{first_session_id}|{second_session_id}"' in field_values["query"]
         assert field_values["time"] == "1704067200.123"
 
     @pytest.fixture

--- a/tests/unit/manager/repositories/metric/test_session_utilization.py
+++ b/tests/unit/manager/repositories/metric/test_session_utilization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -16,11 +17,12 @@ from ai.backend.common.exception import (
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionId
 from ai.backend.manager.clients.prometheus.client import PrometheusClient
+from ai.backend.manager.clients.prometheus.preset import LabelMatcher, MetricPreset
+from ai.backend.manager.data.idle_checker.types import SessionUtilizationQuery
 from ai.backend.manager.data.prometheus_query_preset.types import (
     PrometheusQueryPresetData,
     PrometheusQueryPresetListResult,
 )
-from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.repositories.metric.repository import MetricRepository
 from ai.backend.manager.repositories.prometheus_query_preset.db_source import (
     PrometheusQueryPresetDBSource,
@@ -56,6 +58,18 @@ def _preset_result(
     )
 
 
+def _query(
+    preset_id: PrometheusQueryPresetID,
+    filter_labels: dict[str, str] | None = None,
+    group_labels: tuple[str, ...] = ("session_id",),
+) -> SessionUtilizationQuery:
+    return SessionUtilizationQuery(
+        preset_id=preset_id,
+        filter_labels=tuple(sorted((filter_labels or {}).items())),
+        group_labels=group_labels,
+    )
+
+
 class TestSessionUtilizationMetrics:
     @pytest.fixture()
     def preset(self) -> PrometheusQueryPresetData:
@@ -68,12 +82,12 @@ class TestSessionUtilizationMetrics:
             category_id=None,
             metric_name="cpu_used",
             query_template=(
-                'avg by (session_id) (backendai_container_utilization{{value_type="current",'
-                'container_metric_name="cpu_used",{labels}}})'
+                'avg by ({group_by}) (backendai_container_utilization{{value_type="current",'
+                "{labels}}})"
             ),
             time_window="5m",
-            filter_labels=["session_id"],
-            group_labels=[],
+            filter_labels=["session_id", "container_metric_name"],
+            group_labels=["session_id", "device", "project_id"],
             created_at=now,
             updated_at=now,
         )
@@ -81,7 +95,7 @@ class TestSessionUtilizationMetrics:
     @pytest.fixture()
     def prometheus_client(self) -> MagicMock:
         client = MagicMock(spec=PrometheusClient)
-        client.fetch_session_utilization = AsyncMock()
+        client.execute_preset = AsyncMock()
         return client
 
     @pytest.fixture()
@@ -105,103 +119,170 @@ class TestSessionUtilizationMetrics:
                 prometheus_client=prometheus_client,
             )
 
-    async def test_queries_stored_preset(
+    async def test_queries_stored_preset_with_spec_labels(
         self,
         repository: MetricRepository,
         prometheus_client: MagicMock,
         preset_db_source: MagicMock,
         preset: PrometheusQueryPresetData,
     ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
+        query = _query(
+            PrometheusQueryPresetID(preset.id),
+            filter_labels={"container_metric_name": "cpu_used"},
+        )
         session_id = SessionId(uuid4())
-        prometheus_client.fetch_session_utilization.return_value = _response([
-            (str(session_id), "9.9")
-        ])
+        prometheus_client.execute_preset.return_value = _response([(str(session_id), "9.9")])
 
         result = await repository.query_session_utilization_metrics(
-            {preset_id: [session_id]},
+            {query: [session_id]},
             _EVALUATION_TIME,
         )
 
-        assert result == {preset_id: {session_id: Decimal("9.9")}}
+        assert result == {query: {session_id: Decimal("9.9")}}
         preset_db_source.search.assert_awaited_once()
-        prometheus_client.fetch_session_utilization.assert_awaited_once_with(
-            query_template=preset.query_template,
-            time_window="5m",
-            session_ids=[session_id],
-            evaluation_time=_EVALUATION_TIME.isoformat(),
+        prometheus_client.execute_preset.assert_awaited_once_with(
+            MetricPreset(
+                template=preset.query_template,
+                labels={
+                    "container_metric_name": LabelMatcher.exact("cpu_used"),
+                    "session_id": LabelMatcher.regex(str(session_id)),
+                },
+                group_by={"session_id"},
+                window="5m",
+            ),
+            time_range=None,
+            time=_EVALUATION_TIME.isoformat(),
         )
 
-    async def test_queries_all_sessions_for_preset(
+    async def test_scopes_query_to_deduplicated_session_batch(
         self,
         repository: MetricRepository,
         prometheus_client: MagicMock,
-        preset_db_source: MagicMock,
         preset: PrometheusQueryPresetData,
     ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
+        query = _query(PrometheusQueryPresetID(preset.id))
         first_session_id = SessionId(uuid4())
         second_session_id = SessionId(uuid4())
-        prometheus_client.fetch_session_utilization.return_value = _response([
-            (str(first_session_id), "5"),
-            (str(second_session_id), "15"),
-        ])
+        prometheus_client.execute_preset.return_value = _response([])
 
-        result = await repository.query_session_utilization_metrics(
-            {preset_id: [first_session_id, second_session_id]},
+        await repository.query_session_utilization_metrics(
+            {query: [first_session_id, second_session_id, first_session_id]},
             _EVALUATION_TIME,
         )
 
-        assert result == {
-            preset_id: {
-                first_session_id: Decimal("5"),
-                second_session_id: Decimal("15"),
-            }
-        }
-        preset_db_source.search.assert_awaited_once()
-        prometheus_client.fetch_session_utilization.assert_awaited_once_with(
-            query_template=preset.query_template,
-            time_window=preset.time_window,
-            session_ids=[first_session_id, second_session_id],
-            evaluation_time=_EVALUATION_TIME.isoformat(),
+        sent_labels = prometheus_client.execute_preset.await_args.args[0].labels
+        assert sent_labels["session_id"] == LabelMatcher.regex(
+            f"{first_session_id}|{second_session_id}"
         )
 
-    async def test_partitions_results_by_preset(
+    async def test_no_session_scope_without_session_id_grouping(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset: PrometheusQueryPresetData,
+    ) -> None:
+        query = _query(PrometheusQueryPresetID(preset.id), group_labels=("project_id",))
+        prometheus_client.execute_preset.return_value = _response([])
+
+        await repository.query_session_utilization_metrics(
+            {query: [SessionId(uuid4())]},
+            _EVALUATION_TIME,
+        )
+
+        sent_labels = prometheus_client.execute_preset.await_args.args[0].labels
+        assert "session_id" not in sent_labels
+
+    async def test_user_session_id_filter_is_not_overridden(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset: PrometheusQueryPresetData,
+    ) -> None:
+        pinned_session_id = str(SessionId(uuid4()))
+        query = _query(
+            PrometheusQueryPresetID(preset.id),
+            filter_labels={"session_id": pinned_session_id},
+        )
+        prometheus_client.execute_preset.return_value = _response([])
+
+        await repository.query_session_utilization_metrics(
+            {query: [SessionId(uuid4())]},
+            _EVALUATION_TIME,
+        )
+
+        sent_labels = prometheus_client.execute_preset.await_args.args[0].labels
+        assert sent_labels["session_id"] == LabelMatcher.exact(pinned_session_id)
+
+    async def test_partitions_results_by_query(
         self,
         repository: MetricRepository,
         prometheus_client: MagicMock,
         preset_db_source: MagicMock,
         preset: PrometheusQueryPresetData,
     ) -> None:
-        first_preset_id = PrometheusQueryPresetID(preset.id)
         second_preset = replace(
             preset,
             id=uuid4(),
             name="session-memory-utilization",
             metric_name="mem",
         )
-        second_preset_id = PrometheusQueryPresetID(second_preset.id)
+        first_query = _query(PrometheusQueryPresetID(preset.id))
+        second_query = _query(PrometheusQueryPresetID(second_preset.id))
         first_session_id = SessionId(uuid4())
         second_session_id = SessionId(uuid4())
         preset_db_source.search.return_value = _preset_result(preset, second_preset)
-        prometheus_client.fetch_session_utilization.side_effect = [
+        prometheus_client.execute_preset.side_effect = [
             _response([(str(first_session_id), "5")]),
             _response([(str(second_session_id), "15")]),
         ]
 
         result = await repository.query_session_utilization_metrics(
             {
-                first_preset_id: [first_session_id],
-                second_preset_id: [second_session_id],
+                first_query: [first_session_id],
+                second_query: [second_session_id],
             },
             _EVALUATION_TIME,
         )
 
         assert result == {
-            first_preset_id: {first_session_id: Decimal("5")},
-            second_preset_id: {second_session_id: Decimal("15")},
+            first_query: {first_session_id: Decimal("5")},
+            second_query: {second_session_id: Decimal("15")},
         }
         preset_db_source.search.assert_awaited_once()
+
+    async def test_same_preset_with_different_labels_queried_separately(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset: PrometheusQueryPresetData,
+    ) -> None:
+        cpu_query = _query(
+            PrometheusQueryPresetID(preset.id),
+            filter_labels={"container_metric_name": "cpu_used"},
+        )
+        mem_query = _query(
+            PrometheusQueryPresetID(preset.id),
+            filter_labels={"container_metric_name": "mem"},
+        )
+        session_id = SessionId(uuid4())
+        prometheus_client.execute_preset.side_effect = [
+            _response([(str(session_id), "5")]),
+            _response([(str(session_id), "15")]),
+        ]
+
+        result = await repository.query_session_utilization_metrics(
+            {
+                cpu_query: [session_id],
+                mem_query: [session_id],
+            },
+            _EVALUATION_TIME,
+        )
+
+        assert result == {
+            cpu_query: {session_id: Decimal("5")},
+            mem_query: {session_id: Decimal("15")},
+        }
+        assert prometheus_client.execute_preset.await_count == 2
 
     async def test_missing_preset_does_not_fail_other_queries(
         self,
@@ -211,29 +292,27 @@ class TestSessionUtilizationMetrics:
         preset: PrometheusQueryPresetData,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
-        missing_preset_id = PrometheusQueryPresetID(uuid4())
+        query = _query(PrometheusQueryPresetID(preset.id))
+        missing_query = _query(PrometheusQueryPresetID(uuid4()))
         session_id = SessionId(uuid4())
         preset_db_source.search.return_value = _preset_result(preset)
-        prometheus_client.fetch_session_utilization.return_value = _response([
-            (str(session_id), "5")
-        ])
+        prometheus_client.execute_preset.return_value = _response([(str(session_id), "5")])
 
         result = await repository.query_session_utilization_metrics(
             {
-                preset_id: [session_id],
-                missing_preset_id: [SessionId(uuid4())],
+                query: [session_id],
+                missing_query: [SessionId(uuid4())],
             },
             _EVALUATION_TIME,
         )
 
         assert result == {
-            preset_id: {session_id: Decimal("5")},
-            missing_preset_id: {},
+            query: {session_id: Decimal("5")},
+            missing_query: {},
         }
         assert "Prometheus query preset not found; skipping utilization query" in caplog.text
-        assert str(missing_preset_id) in caplog.text
-        prometheus_client.fetch_session_utilization.assert_awaited_once()
+        assert str(missing_query.preset_id) in caplog.text
+        prometheus_client.execute_preset.assert_awaited_once()
 
     @pytest.mark.parametrize(
         "error",
@@ -249,31 +328,15 @@ class TestSessionUtilizationMetrics:
         preset: PrometheusQueryPresetData,
         error: Exception,
     ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
-        prometheus_client.fetch_session_utilization.side_effect = error
+        query = _query(PrometheusQueryPresetID(preset.id))
+        prometheus_client.execute_preset.side_effect = error
 
         result = await repository.query_session_utilization_metrics(
-            {preset_id: [SessionId(uuid4())]},
+            {query: [SessionId(uuid4())]},
             _EVALUATION_TIME,
         )
 
-        assert result == {preset_id: {}}
-
-    async def test_missing_metric_value_returns_empty_session_mapping(
-        self,
-        repository: MetricRepository,
-        prometheus_client: MagicMock,
-        preset: PrometheusQueryPresetData,
-    ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
-        prometheus_client.fetch_session_utilization.return_value = _response([])
-
-        result = await repository.query_session_utilization_metrics(
-            {preset_id: [SessionId(uuid4())]},
-            _EVALUATION_TIME,
-        )
-
-        assert result == {preset_id: {}}
+        assert result == {query: {}}
 
     async def test_skips_malformed_and_non_finite_values(
         self,
@@ -281,10 +344,10 @@ class TestSessionUtilizationMetrics:
         prometheus_client: MagicMock,
         preset: PrometheusQueryPresetData,
     ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
+        query = _query(PrometheusQueryPresetID(preset.id))
         session_id = SessionId(uuid4())
         other_session_id = SessionId(uuid4())
-        prometheus_client.fetch_session_utilization.return_value = _response([
+        prometheus_client.execute_preset.return_value = _response([
             ("not-a-uuid", "1"),
             (str(SessionId(uuid4())), "not-a-number"),
             (str(SessionId(uuid4())), "NaN"),
@@ -293,30 +356,105 @@ class TestSessionUtilizationMetrics:
         ])
 
         result = await repository.query_session_utilization_metrics(
-            {preset_id: [session_id]},
+            {query: [session_id]},
             _EVALUATION_TIME,
         )
 
-        assert result == {preset_id: {session_id: Decimal("5")}}
+        assert result == {query: {session_id: Decimal("5")}}
 
-    async def test_duplicate_session_values_raise_internal_error(
+    async def test_multiple_series_per_session_fold_to_max(
         self,
         repository: MetricRepository,
         prometheus_client: MagicMock,
         preset: PrometheusQueryPresetData,
     ) -> None:
-        preset_id = PrometheusQueryPresetID(preset.id)
+        query = _query(
+            PrometheusQueryPresetID(preset.id),
+            group_labels=("session_id", "device"),
+        )
         session_id = SessionId(uuid4())
-        prometheus_client.fetch_session_utilization.return_value = _response([
+        prometheus_client.execute_preset.return_value = _response([
             (str(session_id), "1"),
+            (str(session_id), "7"),
             (str(session_id), "2"),
         ])
 
-        with pytest.raises(InternalServerError):
-            await repository.query_session_utilization_metrics(
-                {preset_id: [session_id]},
-                _EVALUATION_TIME,
-            )
+        result = await repository.query_session_utilization_metrics(
+            {query: [session_id]},
+            _EVALUATION_TIME,
+        )
+
+        assert result == {query: {session_id: Decimal("7")}}
+
+    async def test_no_matching_sessions_logs_warning(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset: PrometheusQueryPresetData,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        query = _query(PrometheusQueryPresetID(preset.id), group_labels=("project_id",))
+        prometheus_client.execute_preset.return_value = _response([
+            (str(SessionId(uuid4())), "5"),
+        ])
+
+        result = await repository.query_session_utilization_metrics(
+            {query: [SessionId(uuid4())]},
+            _EVALUATION_TIME,
+        )
+
+        assert result == {query: {}}
+        assert "none matched the requested sessions" in caplog.text
+
+    @pytest.mark.parametrize(
+        "query_kwargs",
+        [
+            {"filter_labels": {"unknown_label": "x"}},
+            {"group_labels": ("session_id", "unknown_group")},
+        ],
+    )
+    async def test_labels_not_allowed_by_preset_skip_query(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset: PrometheusQueryPresetData,
+        caplog: pytest.LogCaptureFixture,
+        query_kwargs: dict[str, Any],
+    ) -> None:
+        query = _query(PrometheusQueryPresetID(preset.id), **query_kwargs)
+
+        result = await repository.query_session_utilization_metrics(
+            {query: [SessionId(uuid4())]},
+            _EVALUATION_TIME,
+        )
+
+        assert result == {query: {}}
+        assert "labels not allowed by preset" in caplog.text
+        prometheus_client.execute_preset.assert_not_awaited()
+
+    async def test_empty_preset_allow_lists_allow_any_labels(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset_db_source: MagicMock,
+        preset: PrometheusQueryPresetData,
+    ) -> None:
+        preset_db_source.search.return_value = _preset_result(
+            replace(preset, filter_labels=[], group_labels=[])
+        )
+        query = _query(
+            PrometheusQueryPresetID(preset.id),
+            filter_labels={"anything": "goes"},
+            group_labels=("session_id", "any_group"),
+        )
+        prometheus_client.execute_preset.return_value = _response([])
+
+        await repository.query_session_utilization_metrics(
+            {query: [SessionId(uuid4())]},
+            _EVALUATION_TIME,
+        )
+
+        prometheus_client.execute_preset.assert_awaited_once()
 
     async def test_empty_queries_skip_data_sources(
         self,
@@ -328,7 +466,7 @@ class TestSessionUtilizationMetrics:
 
         assert result == {}
         preset_db_source.search.assert_not_awaited()
-        prometheus_client.fetch_session_utilization.assert_not_awaited()
+        prometheus_client.execute_preset.assert_not_awaited()
 
     async def test_query_without_sessions_skips_data_sources(
         self,
@@ -337,10 +475,10 @@ class TestSessionUtilizationMetrics:
         preset_db_source: MagicMock,
     ) -> None:
         result = await repository.query_session_utilization_metrics(
-            {PrometheusQueryPresetID(uuid4()): []},
+            {_query(PrometheusQueryPresetID(uuid4())): []},
             _EVALUATION_TIME,
         )
 
         assert result == {}
         preset_db_source.search.assert_not_awaited()
-        prometheus_client.fetch_session_utilization.assert_not_awaited()
+        prometheus_client.execute_preset.assert_not_awaited()

--- a/tests/unit/manager/repositories/metric/test_session_utilization.py
+++ b/tests/unit/manager/repositories/metric/test_session_utilization.py
@@ -117,6 +117,7 @@ class TestSessionUtilizationMetrics:
             return MetricRepository(
                 db=MagicMock(),
                 prometheus_client=prometheus_client,
+                default_timewindow="30s",
             )
 
     async def test_queries_stored_preset_with_spec_labels(
@@ -153,6 +154,25 @@ class TestSessionUtilizationMetrics:
             time_range=None,
             time=_EVALUATION_TIME.isoformat(),
         )
+
+    async def test_window_falls_back_to_server_default(
+        self,
+        repository: MetricRepository,
+        prometheus_client: MagicMock,
+        preset_db_source: MagicMock,
+        preset: PrometheusQueryPresetData,
+    ) -> None:
+        preset_db_source.search.return_value = _preset_result(replace(preset, time_window=None))
+        query = _query(PrometheusQueryPresetID(preset.id))
+        prometheus_client.execute_preset.return_value = _response([])
+
+        await repository.query_session_utilization_metrics(
+            {query: [SessionId(uuid4())]},
+            _EVALUATION_TIME,
+        )
+
+        sent_preset = prometheus_client.execute_preset.await_args.args[0]
+        assert sent_preset.window == "30s"
 
     async def test_scopes_query_to_deduplicated_session_batch(
         self,

--- a/tests/unit/manager/services/idle_checker/BUILD
+++ b/tests/unit/manager/services/idle_checker/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/services/idle_checker/test_service.py
+++ b/tests/unit/manager/services/idle_checker/test_service.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from ai.backend.common.data.idle_checker.types import (
+    CheckerType,
+    IdleCheckerSpec,
+    MetricLabel,
+    SessionLifetimeSpec,
+    UtilizationSpec,
+    UtilizationThresholdEntry,
+)
+from ai.backend.common.exception import PrometheusQueryPresetInvalidLabel
+from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
+from ai.backend.common.types import SessionTypes
+from ai.backend.manager.data.prometheus_query_preset.types import PrometheusQueryPresetData
+from ai.backend.manager.repositories.base import Creator, Updater
+from ai.backend.manager.repositories.idle_checker.creators import IdleCheckerCreatorSpec
+from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.updaters import IdleCheckerUpdaterSpec
+from ai.backend.manager.repositories.prometheus_query_preset.repository import (
+    PrometheusQueryPresetRepository,
+)
+from ai.backend.manager.services.idle_checker.actions.create import CreateIdleCheckerAction
+from ai.backend.manager.services.idle_checker.actions.update import UpdateIdleCheckerAction
+from ai.backend.manager.services.idle_checker.service import IdleCheckerService
+from ai.backend.manager.types import OptionalState
+
+_PRESET_ID = PrometheusQueryPresetID(uuid4())
+
+
+def _utilization_spec(
+    filter_labels: dict[str, str] | None = None,
+    group_labels: list[str] | None = None,
+) -> IdleCheckerSpec:
+    return IdleCheckerSpec(
+        type=CheckerType.UTILIZATION,
+        utilization=UtilizationSpec(
+            max_underutilized_duration_seconds=600,
+            threshold=UtilizationThresholdEntry(
+                preset_id=_PRESET_ID,
+                threshold=Decimal("5"),
+                filter_labels=[
+                    MetricLabel(key=key, value=value)
+                    for key, value in (filter_labels or {}).items()
+                ],
+                group_labels=group_labels or ["session_id"],
+            ),
+        ),
+    )
+
+
+def _create_action(spec: IdleCheckerSpec) -> CreateIdleCheckerAction:
+    return CreateIdleCheckerAction(
+        creator=Creator(
+            spec=IdleCheckerCreatorSpec(
+                name="test-checker",
+                description=None,
+                target_session_types=[SessionTypes.INTERACTIVE],
+                initial_grace_period_seconds=0,
+                spec=spec,
+            )
+        )
+    )
+
+
+class TestIdleCheckerSpecLabelValidation:
+    @pytest.fixture()
+    def preset(self) -> PrometheusQueryPresetData:
+        now = datetime.now(tz=UTC)
+        return PrometheusQueryPresetData(
+            id=_PRESET_ID,
+            name="container-utilization",
+            description=None,
+            rank=0,
+            category_id=None,
+            metric_name="backendai_container_utilization",
+            query_template="sum by ({group_by})(backendai_container_utilization{{{labels}}})",
+            time_window="5m",
+            filter_labels=["container_metric_name", "session_id"],
+            group_labels=["session_id", "device"],
+            created_at=now,
+            updated_at=now,
+        )
+
+    @pytest.fixture()
+    def repository(self) -> MagicMock:
+        repository = MagicMock(spec=IdleCheckerRepository)
+        repository.create = AsyncMock()
+        repository.update = AsyncMock()
+        return repository
+
+    @pytest.fixture()
+    def preset_repository(self, preset: PrometheusQueryPresetData) -> MagicMock:
+        preset_repository = MagicMock(spec=PrometheusQueryPresetRepository)
+        preset_repository.get_by_id = AsyncMock(return_value=preset)
+        return preset_repository
+
+    @pytest.fixture()
+    def service(
+        self,
+        repository: MagicMock,
+        preset_repository: MagicMock,
+    ) -> IdleCheckerService:
+        return IdleCheckerService(repository, preset_repository)
+
+    async def test_create_with_allowed_labels_passes(
+        self,
+        service: IdleCheckerService,
+        repository: MagicMock,
+    ) -> None:
+        spec = _utilization_spec(
+            filter_labels={"container_metric_name": "cpu_util"},
+            group_labels=["session_id", "device"],
+        )
+
+        await service.create(_create_action(spec))
+
+        repository.create.assert_awaited_once()
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            _utilization_spec(filter_labels={"unknown_label": "x"}),
+            _utilization_spec(group_labels=["project_id"]),
+        ],
+    )
+    async def test_create_with_unsupported_labels_rejected(
+        self,
+        service: IdleCheckerService,
+        repository: MagicMock,
+        spec: IdleCheckerSpec,
+    ) -> None:
+        with pytest.raises(PrometheusQueryPresetInvalidLabel):
+            await service.create(_create_action(spec))
+        repository.create.assert_not_awaited()
+
+    async def test_non_utilization_spec_skips_preset_lookup(
+        self,
+        service: IdleCheckerService,
+        preset_repository: MagicMock,
+    ) -> None:
+        spec = IdleCheckerSpec(
+            type=CheckerType.SESSION_LIFETIME,
+            session_lifetime=SessionLifetimeSpec(max_lifetime_seconds=3600),
+        )
+
+        await service.create(_create_action(spec))
+
+        preset_repository.get_by_id.assert_not_awaited()
+
+    async def test_update_validates_replacement_spec(
+        self,
+        service: IdleCheckerService,
+        repository: MagicMock,
+    ) -> None:
+        action = UpdateIdleCheckerAction(
+            updater=Updater(
+                spec=IdleCheckerUpdaterSpec(
+                    spec=OptionalState.update(
+                        _utilization_spec(filter_labels={"unknown_label": "x"})
+                    ),
+                ),
+                pk_value=uuid4(),
+            )
+        )
+
+        with pytest.raises(PrometheusQueryPresetInvalidLabel):
+            await service.update(action)
+        repository.update.assert_not_awaited()
+
+    async def test_update_without_spec_skips_validation(
+        self,
+        service: IdleCheckerService,
+        repository: MagicMock,
+        preset_repository: MagicMock,
+    ) -> None:
+        action = UpdateIdleCheckerAction(
+            updater=Updater(
+                spec=IdleCheckerUpdaterSpec(name=OptionalState.update("renamed")),
+                pk_value=uuid4(),
+            )
+        )
+
+        await service.update(action)
+
+        preset_repository.get_by_id.assert_not_awaited()
+        repository.update.assert_awaited_once()

--- a/tests/unit/manager/services/utilization_metric/test_container_metric.py
+++ b/tests/unit/manager/services/utilization_metric/test_container_metric.py
@@ -73,6 +73,7 @@ def _make_metric_repository(
     return MetricRepository(
         db=MagicMock(),
         prometheus_client=mock_prometheus_client,
+        default_timewindow=timewindow,
     )
 
 

--- a/tests/unit/manager/sokovan/idle_check/test_utilization_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_utilization_checker.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
+    MetricLabel,
     SessionLifetimeSpec,
     UtilizationSpec,
     UtilizationThresholdEntry,
@@ -80,6 +81,34 @@ class TestUtilizationSpec:
                 ),
             )
 
+    def test_rejects_duplicate_filter_label_keys(self) -> None:
+        with pytest.raises(ValidationError):
+            UtilizationThresholdEntry(
+                preset_id=PrometheusQueryPresetID(uuid4()),
+                threshold=Decimal("10"),
+                filter_labels=[
+                    MetricLabel(key="container_metric_name", value="cpu_util"),
+                    MetricLabel(key="container_metric_name", value="mem"),
+                ],
+            )
+
+    def test_query_key_canonicalizes_label_order(self) -> None:
+        preset_id = PrometheusQueryPresetID(uuid4())
+
+        def entry(filter_order: list[tuple[str, str]], group: list[str]) -> SessionUtilizationQuery:
+            return SessionUtilizationQuery.from_threshold(
+                UtilizationThresholdEntry(
+                    preset_id=preset_id,
+                    threshold=Decimal("10"),
+                    filter_labels=[MetricLabel(key=k, value=v) for k, v in filter_order],
+                    group_labels=group,
+                )
+            )
+
+        assert entry([("a", "1"), ("b", "2")], ["session_id", "device"]) == entry(
+            [("b", "2"), ("a", "1")], ["device", "session_id", "device"]
+        )
+
 
 class TestUtilizationChecker:
     @pytest.fixture()
@@ -114,7 +143,10 @@ class TestUtilizationChecker:
                             threshold=UtilizationThresholdEntry(
                                 preset_id=preset_id,
                                 threshold=threshold,
-                                filter_labels=filter_labels or {},
+                                filter_labels=[
+                                    MetricLabel(key=key, value=value)
+                                    for key, value in (filter_labels or {}).items()
+                                ],
                             ),
                         ),
                     ),

--- a/tests/unit/manager/sokovan/idle_check/test_utilization_checker.py
+++ b/tests/unit/manager/sokovan/idle_check/test_utilization_checker.py
@@ -20,7 +20,7 @@ from ai.backend.common.data.idle_checker.types import (
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.types import SessionId, SessionTypes
-from ai.backend.manager.data.idle_checker.types import IdleCheckSession
+from ai.backend.manager.data.idle_checker.types import IdleCheckSession, SessionUtilizationQuery
 from ai.backend.manager.repositories.idle_checker.types import IdleCheckerDefinitionData
 from ai.backend.manager.repositories.metric.repository import MetricRepository
 from ai.backend.manager.sokovan.idle_check.checkers.base import (
@@ -42,7 +42,19 @@ class AssignmentFactory(Protocol):
         threshold: Decimal,
         sessions: Sequence[IdleCheckSession],
         duration_seconds: int = _DURATION_SECONDS,
+        filter_labels: dict[str, str] | None = None,
     ) -> CheckerAssignment: ...
+
+
+def _query(
+    preset_id: PrometheusQueryPresetID,
+    filter_labels: dict[str, str] | None = None,
+) -> SessionUtilizationQuery:
+    return SessionUtilizationQuery(
+        preset_id=preset_id,
+        filter_labels=tuple(sorted((filter_labels or {}).items())),
+        group_labels=("session_id",),
+    )
 
 
 def _session(
@@ -88,6 +100,7 @@ class TestUtilizationChecker:
             threshold: Decimal,
             sessions: Sequence[IdleCheckSession],
             duration_seconds: int = _DURATION_SECONDS,
+            filter_labels: dict[str, str] | None = None,
         ) -> CheckerAssignment:
             return CheckerAssignment(
                 definition=IdleCheckerDefinitionData(
@@ -101,6 +114,7 @@ class TestUtilizationChecker:
                             threshold=UtilizationThresholdEntry(
                                 preset_id=preset_id,
                                 threshold=threshold,
+                                filter_labels=filter_labels or {},
                             ),
                         ),
                     ),
@@ -121,8 +135,8 @@ class TestUtilizationChecker:
         first_session = _session()
         second_session = _session()
         metric_repository.query_session_utilization_metrics.return_value = {
-            first_preset_id: {first_session.session_id: Decimal("5")},
-            second_preset_id: {second_session.session_id: Decimal("15")},
+            _query(first_preset_id): {first_session.session_id: Decimal("5")},
+            _query(second_preset_id): {second_session.session_id: Decimal("15")},
         }
 
         decisions = await checker.judge(
@@ -144,8 +158,8 @@ class TestUtilizationChecker:
         assert all(not decision.is_active for decision in decisions)
         metric_repository.query_session_utilization_metrics.assert_awaited_once_with(
             {
-                first_preset_id: [first_session.session_id],
-                second_preset_id: [second_session.session_id],
+                _query(first_preset_id): [first_session.session_id],
+                _query(second_preset_id): [second_session.session_id],
             },
             evaluation_time=_NOW,
         )
@@ -160,7 +174,7 @@ class TestUtilizationChecker:
         first_session = _session()
         second_session = _session()
         metric_repository.query_session_utilization_metrics.return_value = {
-            preset_id: {
+            _query(preset_id): {
                 first_session.session_id: Decimal("5"),
                 second_session.session_id: Decimal("15"),
             },
@@ -185,7 +199,50 @@ class TestUtilizationChecker:
         assert [decision.is_active for decision in decisions] == [False, True]
         metric_repository.query_session_utilization_metrics.assert_awaited_once_with(
             {
-                preset_id: [first_session.session_id, second_session.session_id],
+                _query(preset_id): [first_session.session_id, second_session.session_id],
+            },
+            evaluation_time=_NOW,
+        )
+
+    async def test_same_preset_with_different_labels_batches_separately(
+        self,
+        checker: UtilizationChecker,
+        metric_repository: MagicMock,
+        assignment_factory: AssignmentFactory,
+    ) -> None:
+        preset_id = PrometheusQueryPresetID(uuid4())
+        cpu_labels = {"container_metric_name": "cpu_util"}
+        mem_labels = {"container_metric_name": "mem"}
+        first_session = _session()
+        second_session = _session()
+        metric_repository.query_session_utilization_metrics.return_value = {
+            _query(preset_id, cpu_labels): {first_session.session_id: Decimal("5")},
+            _query(preset_id, mem_labels): {second_session.session_id: Decimal("15")},
+        }
+
+        decisions = await checker.judge(
+            [
+                assignment_factory(
+                    preset_id=preset_id,
+                    threshold=Decimal("10"),
+                    sessions=[first_session],
+                    filter_labels=cpu_labels,
+                ),
+                assignment_factory(
+                    preset_id=preset_id,
+                    threshold=Decimal("10"),
+                    sessions=[second_session],
+                    filter_labels=mem_labels,
+                ),
+            ],
+            context=IdleCheckerContext(current_time=_NOW),
+        )
+
+        assert [decision.is_active for decision in decisions] == [False, True]
+        metric_repository.query_session_utilization_metrics.assert_awaited_once_with(
+            {
+                _query(preset_id, cpu_labels): [first_session.session_id],
+                _query(preset_id, mem_labels): [second_session.session_id],
             },
             evaluation_time=_NOW,
         )
@@ -199,7 +256,7 @@ class TestUtilizationChecker:
         preset_id = PrometheusQueryPresetID(uuid4())
         session = _session()
         metric_repository.query_session_utilization_metrics.return_value = {
-            preset_id: {session.session_id: Decimal("9.9")},
+            _query(preset_id): {session.session_id: Decimal("9.9")},
         }
 
         decisions = await checker.judge(
@@ -227,7 +284,7 @@ class TestUtilizationChecker:
         preset_id = PrometheusQueryPresetID(uuid4())
         session = _session(expire_at=None)
         metric_repository.query_session_utilization_metrics.return_value = {
-            preset_id: {session.session_id: Decimal("9.9")},
+            _query(preset_id): {session.session_id: Decimal("9.9")},
         }
 
         decisions = await checker.judge(
@@ -256,7 +313,7 @@ class TestUtilizationChecker:
         preset_id = PrometheusQueryPresetID(uuid4())
         session = _session(expire_at=expire_at)
         metric_repository.query_session_utilization_metrics.return_value = {
-            preset_id: {session.session_id: Decimal("5")},
+            _query(preset_id): {session.session_id: Decimal("5")},
         }
 
         decisions = await checker.judge(
@@ -285,7 +342,7 @@ class TestUtilizationChecker:
         preset_id = PrometheusQueryPresetID(uuid4())
         session = _session()
         metric_repository.query_session_utilization_metrics.return_value = {
-            preset_id: {session.session_id: value},
+            _query(preset_id): {session.session_id: value},
         }
 
         decisions = await checker.judge(


### PR DESCRIPTION
## Summary
- `UtilizationThresholdEntry` gains `filter_labels` / `group_labels`, so each utilization idle checker can parameterize its Prometheus preset query (e.g. pin `container_metric_name="cpu_util"`) instead of aggregating across all metric labels; defaults (`{}` / `["session_id"]`) keep existing stored specs behaving as before
- The fields propagate through the v2 DTOs, GraphQL types (schema-level defaults: `groupLabels: [String!]! = ["session_id"]`), and the idle-checker adapter
- `MetricRepository` now batches per `(preset, labels)` via `SessionUtilizationQuery`, validates spec labels against the preset's allow-lists at query time (invalid queries are skipped with an error log), scopes the query to the evaluated session batch when grouped by `session_id` without overriding a user-set filter, and folds multiple series per session with `max`
- Remove `PrometheusClient.fetch_session_utilization` in favor of the generalized `execute_preset` (BA-7171)

## Test plan
- [x] `pants fmt/fix/lint/check --changed-since` clean
- [x] `pants test` — client rendering, repository batching/scoping/validation/max-fold, checker batching, adapter round-trip

Resolves BA-7172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13441.org.readthedocs.build/en/13441/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13441.org.readthedocs.build/ko/13441/

<!-- readthedocs-preview sorna-ko end -->