### PR TITLE
test: add domain_id to the generic-services UserData fixture

### DIFF
--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -25,6 +25,7 @@ import sqlalchemy as sa
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.types import EntityData, EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.entity import EntityID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
@@ -684,6 +685,7 @@ def authenticated_user() -> UserData:
         is_superadmin=False,
         role=UserRole.USER,
         domain_name="default",
+        domain_id=DomainID(uuid.uuid4()),
     )
 
 


### PR DESCRIPTION
## Summary
- Fix the mypy break on `main`: `UserData` gained a required `domain_id` field (#13402, BA-7158) merged seconds before #13437 (BA-7169) added the `authenticated_user` fixture constructing `UserData` without it — each PR passed CI individually, but their combination fails `pants check`.
- Add `domain_id=DomainID(uuid.uuid4())` to the fixture, following the existing convention in `tests/unit/manager/services/test_users.py`.

## Test plan
- [x] `pants check tests/unit/manager/services/ops/test_generic_services.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)