### PR TITLE
feat(BA-7174): unify RBAC member ops with virtual-scope wiring and fix purge leaks

### DIFF
--- a/changes/13444.feature.md
+++ b/changes/13444.feature.md
@@ -1,1 +1,1 @@
-Add bulk scope-member attachment to the RBAC ops and clean up the bindings and memberships a deleted scope left in other virtual scopes
+Unify RBAC member attachment so every member is wired as a scope-backed entity (membership, association, and scope binding in one op), and clean up the edges a removed member or deleted scope leaves in other virtual scopes

--- a/changes/13444.feature.md
+++ b/changes/13444.feature.md
@@ -1,0 +1,1 @@
+Add bulk scope-member attachment to the RBAC ops and clean up the bindings and memberships a deleted scope left in other virtual scopes

--- a/src/ai/backend/common/data/entity/project.py
+++ b/src/ai/backend/common/data/entity/project.py
@@ -1,7 +1,11 @@
-from ai.backend.common.data.entity.types import ScopeType
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 
-__all__ = ("PROJECT_SCOPE_TYPE",)
+__all__ = (
+    "PROJECT_ENTITY_TYPE",
+    "PROJECT_SCOPE_TYPE",
+)
 
 
-# Raw string mirroring the RBAC-managed RBACElementType.PROJECT value.
+# Raw strings mirroring the RBAC-managed RBACElementType.PROJECT value.
 PROJECT_SCOPE_TYPE = ScopeType("project")
+PROJECT_ENTITY_TYPE = EntityType("project")

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -396,7 +396,7 @@ class ContainerRegistryRepository:
         registry_scope = ScopeRef(scope_type=CONTAINER_REGISTRY_SCOPE_TYPE, scope_id=registry_id)
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
         await ops.ensure_scope(project_scope)
-        await ops.bulk_add_entity_members(
+        await ops.add_bulk_members(
             EntityMembersAddition(
                 scope=project_scope,
                 members=[

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -396,7 +396,7 @@ class ContainerRegistryRepository:
         registry_scope = ScopeRef(scope_type=CONTAINER_REGISTRY_SCOPE_TYPE, scope_id=registry_id)
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
         await ops.ensure_scope(project_scope)
-        await ops.add_entity_members(
+        await ops.bulk_add_entity_members(
             EntityMembersAddition(
                 scope=project_scope,
                 members=[

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -393,7 +393,6 @@ class ContainerRegistryRepository:
     ) -> None:
         """Enroll the registry in the project's virtual scope and let the project
         scope reach the registry's own entities."""
-        registry_scope = ScopeRef(scope_type=CONTAINER_REGISTRY_SCOPE_TYPE, scope_id=registry_id)
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
         await ops.ensure_scope(project_scope)
         await ops.add_bulk_members(
@@ -409,7 +408,6 @@ class ContainerRegistryRepository:
                 ],
             )
         )
-        await ops.bind_scope(project_scope, registry_scope, permission_cap=None)
 
     async def _withdraw_registry_from_project(
         self,
@@ -421,7 +419,6 @@ class ContainerRegistryRepository:
 
         Returns the number of deleted mapping rows.
         """
-        registry_scope = ScopeRef(scope_type=CONTAINER_REGISTRY_SCOPE_TYPE, scope_id=registry_id)
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
         purge_result = await ops.batch_purge(
             BatchPurger(
@@ -431,11 +428,10 @@ class ContainerRegistryRepository:
                 )
             )
         )
-        await ops.remove_entity_members(
+        await ops.remove_bulk_members(
             project_scope,
             [EntityRef(entity_type=CONTAINER_REGISTRY_ENTITY_TYPE, entity_id=registry_id)],
         )
-        await ops.unbind_scope(project_scope, registry_scope)
         return purge_result.deleted_count
 
     async def _get_by_registry_and_project(

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -17,7 +17,7 @@ from sqlalchemy.engine import CursorResult
 
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, PROJECT_SCOPE_TYPE
 from ai.backend.common.data.entity.types import EntityRef, ScopeRef
 from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
 from ai.backend.common.data.permission.types import RBACElementType
@@ -113,6 +113,7 @@ from ai.backend.manager.repositories.ops.rbac.provider import (
     RBACWriteOps,
     ScopeCreation,
     ScopeDeletion,
+    ScopeEntityMember,
     ScopeMember,
 )
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
@@ -183,15 +184,28 @@ class GroupDBSource:
 
         Domain/resource-policy existence and name-uniqueness are enforced by the group
         row's DB constraints, mapped to domain errors via the spec's
-        integrity_error_checks. The domain scope is bound to the new project's virtual
-        scope so domain-scoped permissions reach the project's entities.
+        integrity_error_checks. The new project joins its domain scope as a member.
         """
         spec = cast(GroupCreatorSpec, creator.spec)
         async with self._rbac_ops_provider.write_ops() as w:
             domain_id = await self._get_domain_id(w, spec.domain_name)
             creation = ProjectScopeCreation(spec=spec, domain_id=domain_id)
             domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id)
-            return (await w.create_scope(creation, bound_scope=domain_scope)).row.to_data()
+            data = (await w.create_scope(creation)).row.to_data()
+            await w.ensure_scope(domain_scope)
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=domain_scope,
+                    members=[
+                        ScopeEntityMember(
+                            ref=EntityRef(
+                                entity_type=PROJECT_ENTITY_TYPE, entity_id=ProjectID(data.id)
+                            )
+                        )
+                    ],
+                )
+            )
+            return data
 
     async def _get_domain_id(self, w: RBACWriteOps, domain_name: str) -> DomainID:
         result = await w.batch_query_in_global(
@@ -221,7 +235,7 @@ class GroupDBSource:
                 if user_update_mode == "add":
                     await self._add_users_to_project(w, project_id, user_ids)
                 elif user_update_mode == "remove":
-                    await w.remove_entity_members(
+                    await w.remove_bulk_members(
                         ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                         [
                             EntityRef(entity_type=USER_ENTITY_TYPE, entity_id=uid)
@@ -708,7 +722,7 @@ class GroupDBSource:
             assigned_ids = {row.uuid for row in assigned_rows}
             unassigned_users = [row.to_data() for row in assigned_rows]
 
-            await w.remove_entity_members(
+            await w.remove_bulk_members(
                 ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(unbinder.project_id)),
                 [
                     EntityRef(entity_type=USER_ENTITY_TYPE, entity_id=UserID(uid))
@@ -747,7 +761,7 @@ class GroupDBSource:
     async def unbind_user_from_project(self, user_id: UserID, project_id: ProjectID) -> None:
         """Remove a user from a project (membership writes only)."""
         async with self._rbac_ops_provider.write_ops() as w:
-            await w.remove_entity_members(
+            await w.remove_bulk_members(
                 ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                 [EntityRef(entity_type=USER_ENTITY_TYPE, entity_id=user_id)],
             )

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -279,7 +279,7 @@ class GroupDBSource:
         new_user_rows = await self._users_addable_to_project(w, project_id, user_ids)
         if not new_user_rows:
             return
-        await w.add_entity_members(
+        await w.bulk_add_entity_members(
             EntityMembersAddition(
                 scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                 members=[ProjectUserMember(user_id=UserID(row.uuid)) for row in new_user_rows],
@@ -654,7 +654,7 @@ class GroupDBSource:
             if not new_user_rows:
                 return []
 
-            await w.add_entity_members(
+            await w.bulk_add_entity_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                     members=[
@@ -737,7 +737,7 @@ class GroupDBSource:
         Idempotent: adding an existing member is a no-op.
         """
         async with self._rbac_ops_provider.write_ops() as w:
-            await w.add_entity_members(
+            await w.bulk_add_entity_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                     members=[ProjectUserMember(user_id=user_id, manage_roles=False)],

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -279,7 +279,7 @@ class GroupDBSource:
         new_user_rows = await self._users_addable_to_project(w, project_id, user_ids)
         if not new_user_rows:
             return
-        await w.bulk_add_entity_members(
+        await w.add_bulk_members(
             EntityMembersAddition(
                 scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                 members=[ProjectUserMember(user_id=UserID(row.uuid)) for row in new_user_rows],
@@ -654,7 +654,7 @@ class GroupDBSource:
             if not new_user_rows:
                 return []
 
-            await w.bulk_add_entity_members(
+            await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                     members=[
@@ -737,7 +737,7 @@ class GroupDBSource:
         Idempotent: adding an existing member is a no-op.
         """
         async with self._rbac_ops_provider.write_ops() as w:
-            await w.bulk_add_entity_members(
+            await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                     members=[ProjectUserMember(user_id=user_id, manage_roles=False)],

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -1161,7 +1161,7 @@ class RBACWriteOps(WriteOps):
         await self._bulk_create_dependent_ignore_conflicts(
             [
                 ScopeBindingCreatorSpec(
-                    owner=member_scope, scope=scope, permission_cap=permission_cap
+                    anchor_scope=member_scope, bound_scope=scope, permission_cap=permission_cap
                 )
                 for member_scope in member_scopes
             ],

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -25,7 +25,7 @@ from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
 from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE
-from ai.backend.common.data.entity.types import EntityRef, EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityRef, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE
 from ai.backend.common.data.permission.types import (
     Permission,
@@ -249,21 +249,6 @@ class EntityMemberCreationError:
 class EntityMembersResultWithFailures:
     successes: list[ScopeMember]
     errors: list[EntityMemberCreationError]
-
-
-@dataclass
-class ScopeMemberCreationError:
-    """A member scope whose attachment failed, with the exception that rolled it back."""
-
-    member: ScopeRef
-    exception: Exception
-    index: int
-
-
-@dataclass
-class ScopeMembersResultWithFailures:
-    successes: list[ScopeRef]
-    errors: list[ScopeMemberCreationError]
 
 
 @dataclass
@@ -682,22 +667,17 @@ class RBACWriteOps(WriteOps):
     async def create_scope[TRow: Base](
         self,
         creation: ScopeCreation[TRow],
-        bound_scope: ScopeRef | None = None,
     ) -> ScopeCreationResult[TRow]:
         """Create a scope in full: the real row with its parent scope association, its
         virtual scope node, its SYSTEM roles, and the roles from matching presets.
 
-        The row is inserted first, so ``creation`` sees the id the database assigned. When
-        ``bound_scope`` is given, it is bound to this scope's virtual scope so it can reach
-        this scope's entities. The roles are only created here; granting the returned
-        ``auto_grant_role_ids`` to a user is the caller's call via
-        :meth:`assign_roles_to_user`.
+        The row is inserted first, so ``creation`` sees the id the database assigned.
+        The roles are only created here; granting the returned ``auto_grant_role_ids``
+        to a user is the caller's call via :meth:`assign_roles_to_user`.
         """
         result = await self.create_scoped(creation.creator())
         scope = creation.scope_of(result.row)
         await self._insert_virtual_scopes([scope])
-        if bound_scope is not None:
-            await self.bind_scope(bound_scope, scope, permission_cap=None)
         created_roles = await self._provision_scope_roles({
             scope: creation.system_roles_of(result.row)
         })
@@ -932,139 +912,7 @@ class RBACWriteOps(WriteOps):
         await self._delete_virtual_scopes(deletion.scopes)
         return result
 
-    # -- Virtual scope: inbound edges (scope_bindings) ----------------------------
-
-    async def bind_scope(
-        self,
-        scope: ScopeRef,
-        owner: ScopeRef,
-        permission_cap: Permission | None,
-    ) -> None:
-        """Bind ``scope`` to ``owner``'s virtual scope so it reaches ``owner``'s entities.
-
-        Resolves ``owner``'s virtual scope (raises :class:`VirtualScopeNotFound` if
-        absent). Idempotent: ON CONFLICT DO NOTHING on the binding's primary key —
-        an existing binding keeps its ``permission_cap``.
-        """
-        virtual_scope_id = await self._resolve_virtual_scope_id(owner)
-        stmt = (
-            pg_insert(ScopeBindingRow)
-            .values(
-                virtual_scope_id=virtual_scope_id,
-                scope_type=scope.scope_type,
-                scope_id=scope.scope_id,
-                permission_cap=permission_cap,
-            )
-            .on_conflict_do_nothing()
-        )
-        await self._sess.execute(stmt)
-
-    async def unbind_scope(self, scope: ScopeRef, owner: ScopeRef) -> None:
-        """Remove ``scope``'s binding to ``owner``'s virtual scope."""
-        virtual_scope_id = await self._resolve_virtual_scope_id(owner)
-        stmt = sa.delete(ScopeBindingRow).where(
-            ScopeBindingRow.virtual_scope_id == virtual_scope_id,
-            ScopeBindingRow.scope_type == scope.scope_type,
-            ScopeBindingRow.scope_id == scope.scope_id,
-        )
-        await self._sess.execute(stmt)
-
-    async def add_bulk_scope_members(
-        self,
-        scope: ScopeRef,
-        members: Sequence[ScopeRef],
-        permission_cap: Permission | None = None,
-    ) -> None:
-        """Attach each member scope under ``scope``, wiring both sides: the member is
-        enrolled as an entity member of ``scope``'s virtual scope (with its legacy
-        scope association), and ``scope`` is bound into the member's virtual scope so
-        ``scope``'s permissions reach the member's entities.
-
-        The reverse binding — a member reaching ``scope``'s entities — is deliberately
-        not written: member access to the containing scope flows through roles granted
-        on that scope, and a blanket reverse binding would widen every member-scoped
-        role at once. Every virtual scope involved must already exist; missing ones
-        raise :class:`VirtualScopeNotFound`. Idempotent: existing rows are kept as-is,
-        including their ``permission_cap``, which applies to the new bindings only.
-        """
-        if not members:
-            return
-        virtual_scope_ids = await self._resolve_virtual_scope_ids(members)
-        await self.add_bulk_members(
-            EntityMembersAddition(
-                scope=scope,
-                members=[
-                    ScopeEntityMember(ref=self._scope_member_entity_ref(member))
-                    for member in members
-                ],
-            )
-        )
-        await self._bulk_create_dependent_ignore_conflicts(
-            [
-                ScopeBindingCreatorSpec(owner=member, scope=scope, permission_cap=permission_cap)
-                for member in members
-            ],
-            virtual_scope_ids,
-        )
-
-    async def add_bulk_scope_members_partial(
-        self,
-        scope: ScopeRef,
-        members: Sequence[ScopeRef],
-        permission_cap: Permission | None = None,
-    ) -> ScopeMembersResultWithFailures:
-        """Attach member scopes as :meth:`add_bulk_scope_members` does, isolating each
-        member for partial success.
-
-        A member's membership, association, and binding share one savepoint, so a
-        failed member — including one without a virtual scope — is reported in
-        ``errors`` and leaves the rest attached.
-        """
-        successes: list[ScopeRef] = []
-        errors: list[ScopeMemberCreationError] = []
-        if not members:
-            return ScopeMembersResultWithFailures(successes=successes, errors=errors)
-        scope_virtual_scope_id = await self._resolve_virtual_scope_id(scope)
-        member_virtual_scope_ids = await self._find_virtual_scope_ids(members)
-        for index, member in enumerate(members):
-            if member not in member_virtual_scope_ids:
-                errors.append(
-                    ScopeMemberCreationError(
-                        member=member,
-                        exception=VirtualScopeNotFound(
-                            f"No virtual scope for scope {member.scope_type}:{member.scope_id}"
-                        ),
-                        index=index,
-                    )
-                )
-                continue
-            # The handler stays outside the savepoint — see bulk_create_scoped_partial.
-            try:
-                async with self.savepoint():
-                    await self._add_entity_member(
-                        scope, scope_virtual_scope_id, self._scope_member_entity_ref(member)
-                    )
-                    await self._bulk_create_dependent_ignore_conflicts(
-                        [
-                            ScopeBindingCreatorSpec(
-                                owner=member, scope=scope, permission_cap=permission_cap
-                            )
-                        ],
-                        member_virtual_scope_ids,
-                    )
-                successes.append(member)
-            except Exception as e:
-                errors.append(ScopeMemberCreationError(member=member, exception=e, index=index))
-        return ScopeMembersResultWithFailures(successes=successes, errors=errors)
-
-    @staticmethod
-    def _scope_member_entity_ref(member: ScopeRef) -> EntityRef:
-        return EntityRef(
-            entity_type=EntityType(member.scope_type),
-            entity_id=member.scope_id,
-        )
-
-    # -- Virtual scope: outbound edges (entity_memberships) -----------------------
+    # -- Virtual scope: member edges (entity_memberships + scope_bindings) --------
 
     async def _grant_auto_assign_roles(
         self,
@@ -1220,34 +1068,38 @@ class RBACWriteOps(WriteOps):
     async def add_bulk_members(
         self,
         addition: EntityMembersAddition,
+        permission_cap: Permission | None = None,
     ) -> None:
-        """Write each member's virtual-scope membership and scope association, and grant the
-        scope's auto_assign roles to members whose ``assign_role_on`` returns a user id."""
+        """Attach each member under the scope: membership in the scope's virtual scope,
+        the legacy scope association, and the scope's binding into the member's own
+        virtual scope — never the reverse binding, which would widen every
+        member-scoped role at once. Grants the scope's auto_assign roles to members
+        whose ``assign_role_on`` returns a user id.
+
+        Raises :class:`VirtualScopeNotFound` for any missing virtual scope. Idempotent:
+        existing rows keep their ``permission_cap``.
+        """
         members = list(addition.members)
         if not members:
             return
         scope = addition.scope
         virtual_scope_id = await self._resolve_virtual_scope_id(scope)
         entity_refs = [member.entity_ref() for member in members]
-        await self._bulk_create_dependent_ignore_conflicts(
-            [EntityMembershipCreatorSpec(entity_ref=ref) for ref in entity_refs],
-            virtual_scope_id,
-        )
-        await self._bulk_create_ignore_conflicts([
-            self._association_spec(scope, ref) for ref in entity_refs
-        ])
+        member_scopes = [self._member_scope_ref(ref) for ref in entity_refs]
+        await self._enroll_members_in_scope_vs(virtual_scope_id, entity_refs, permission_cap)
+        await self._associate_entities_with_scope(scope, entity_refs)
+        await self._bind_scope_to_member_vs(scope, member_scopes, permission_cap)
         await self._grant_member_auto_assign_roles(scope, members)
 
     async def add_bulk_members_partial(
         self,
         addition: EntityMembersAddition,
+        permission_cap: Permission | None = None,
     ) -> EntityMembersResultWithFailures:
-        """Add members as :meth:`add_bulk_members` does, isolating each member
-        for partial success.
-
-        A member's membership and association share one savepoint, so a failed member
-        rolls back only its own rows and leaves the rest added. The scope's
-        ``auto_assign`` roles are granted only to the successful members.
+        """Add members as :meth:`add_bulk_members` does, isolating each member in its
+        own savepoint: a failed member — including one without a virtual scope — lands
+        in ``errors`` while the rest are added. Roles are granted only to the
+        successful members.
         """
         successes: list[ScopeMember] = []
         errors: list[EntityMemberCreationError] = []
@@ -1260,25 +1112,66 @@ class RBACWriteOps(WriteOps):
             # The handler stays outside the savepoint — see bulk_create_scoped_partial.
             try:
                 async with self.savepoint():
-                    await self._add_entity_member(scope, virtual_scope_id, member.entity_ref())
+                    ref = member.entity_ref()
+                    await self._enroll_members_in_scope_vs(virtual_scope_id, [ref], permission_cap)
+                    await self._associate_entities_with_scope(scope, [ref])
+                    await self._bind_scope_to_member_vs(
+                        scope, [self._member_scope_ref(ref)], permission_cap
+                    )
                 successes.append(member)
             except Exception as e:
                 errors.append(EntityMemberCreationError(member=member, exception=e, index=index))
         await self._grant_member_auto_assign_roles(scope, successes)
         return EntityMembersResultWithFailures(successes=successes, errors=errors)
 
-    async def _add_entity_member(
+    async def _enroll_members_in_scope_vs(
         self,
-        scope: ScopeRef,
         virtual_scope_id: VirtualScopeID,
-        ref: EntityRef,
+        refs: Sequence[EntityRef],
+        permission_cap: Permission | None,
     ) -> None:
-        """Write one member's virtual-scope membership and scope association."""
+        """Enroll each entity in the scope's virtual scope."""
         await self._bulk_create_dependent_ignore_conflicts(
-            [EntityMembershipCreatorSpec(entity_ref=ref)],
+            [
+                EntityMembershipCreatorSpec(entity_ref=ref, permission_cap=permission_cap)
+                for ref in refs
+            ],
             virtual_scope_id,
         )
-        await self._bulk_create_ignore_conflicts([self._association_spec(scope, ref)])
+
+    async def _associate_entities_with_scope(
+        self,
+        scope: ScopeRef,
+        refs: Sequence[EntityRef],
+    ) -> None:
+        """Write each entity's legacy scope association."""
+        await self._bulk_create_ignore_conflicts([
+            self._association_spec(scope, ref) for ref in refs
+        ])
+
+    async def _bind_scope_to_member_vs(
+        self,
+        scope: ScopeRef,
+        member_scopes: Sequence[ScopeRef],
+        permission_cap: Permission | None,
+    ) -> None:
+        """Bind the scope into each member's own virtual scope; raises
+        :class:`VirtualScopeNotFound` for members without one."""
+        member_virtual_scope_ids = await self._resolve_virtual_scope_ids(member_scopes)
+        await self._bulk_create_dependent_ignore_conflicts(
+            [
+                ScopeBindingCreatorSpec(
+                    owner=member_scope, scope=scope, permission_cap=permission_cap
+                )
+                for member_scope in member_scopes
+            ],
+            member_virtual_scope_ids,
+        )
+
+    @staticmethod
+    def _member_scope_ref(ref: EntityRef) -> ScopeRef:
+        """The member's own scope identity — every entity doubles as a scope."""
+        return ScopeRef(scope_type=ScopeType(ref.entity_type), scope_id=ref.entity_id)
 
     @staticmethod
     def _association_spec(scope: ScopeRef, ref: EntityRef) -> AssociationScopesEntitiesCreatorSpec:
@@ -1310,15 +1203,14 @@ class RBACWriteOps(WriteOps):
                 role_user_ids,
             )
 
-    async def remove_entity_members(
+    async def remove_bulk_members(
         self,
         scope: ScopeRef,
         entities: Collection[EntityRef],
     ) -> None:
-        """Delete each entity's virtual-scope membership and scope association; role mappings
-        are left untouched.
-
-        A scope without a virtual scope (legacy data) only has its associations deleted.
+        """Delete each member's membership, association, and the scope's binding in the
+        member's own virtual scope; role mappings are left untouched. Missing virtual
+        scopes (legacy data) never raise — whatever exists is deleted.
         """
         entity_refs = list(entities)
         if not entity_refs:
@@ -1345,20 +1237,23 @@ class RBACWriteOps(WriteOps):
                 ]),
             )
         )
+        member_virtual_scope_ids = await self._find_virtual_scope_ids([
+            self._member_scope_ref(ref) for ref in entity_refs
+        ])
+        if member_virtual_scope_ids:
+            await self._sess.execute(
+                sa.delete(ScopeBindingRow).where(
+                    ScopeBindingRow.virtual_scope_id.in_(member_virtual_scope_ids.values()),
+                    ScopeBindingRow.scope_type == scope.scope_type,
+                    ScopeBindingRow.scope_id == scope.scope_id,
+                )
+            )
 
     # -- Virtual scope: ensure compatibility for externally-created rows ----------
 
-    async def ensure_scope(
-        self,
-        scope: ScopeRef,
-        bound_scope: ScopeRef | None = None,
-    ) -> None:
-        """Ensure the virtual scope node for an already-created ``scope``. When ``bound_scope``
-        is given, it is bound to this scope's virtual scope. Idempotent.
-        """
+    async def ensure_scope(self, scope: ScopeRef) -> None:
+        """Ensure the virtual scope node for an already-created ``scope``. Idempotent."""
         await self._insert_virtual_scopes([scope])
-        if bound_scope is not None:
-            await self.bind_scope(bound_scope, scope, permission_cap=None)
 
 
 class RBACOpsProvider(DBOpsProvider):

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -969,7 +969,7 @@ class RBACWriteOps(WriteOps):
         )
         await self._sess.execute(stmt)
 
-    async def bulk_add_scope_members(
+    async def add_bulk_scope_members(
         self,
         scope: ScopeRef,
         members: Sequence[ScopeRef],
@@ -990,7 +990,7 @@ class RBACWriteOps(WriteOps):
         if not members:
             return
         virtual_scope_ids = await self._resolve_virtual_scope_ids(members)
-        await self.bulk_add_entity_members(
+        await self.add_bulk_members(
             EntityMembersAddition(
                 scope=scope,
                 members=[
@@ -1007,13 +1007,13 @@ class RBACWriteOps(WriteOps):
             virtual_scope_ids,
         )
 
-    async def bulk_add_scope_members_partial(
+    async def add_bulk_scope_members_partial(
         self,
         scope: ScopeRef,
         members: Sequence[ScopeRef],
         permission_cap: Permission | None = None,
     ) -> ScopeMembersResultWithFailures:
-        """Attach member scopes as :meth:`bulk_add_scope_members` does, isolating each
+        """Attach member scopes as :meth:`add_bulk_scope_members` does, isolating each
         member for partial success.
 
         A member's membership, association, and binding share one savepoint, so a
@@ -1184,15 +1184,13 @@ class RBACWriteOps(WriteOps):
         member = ScopeUserMember(user_id=user_id)
         domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=full_creation.domain_id)
         await self.ensure_scope(domain_scope)
-        await self.bulk_add_entity_members(
-            EntityMembersAddition(scope=domain_scope, members=[member])
-        )
+        await self.add_bulk_members(EntityMembersAddition(scope=domain_scope, members=[member]))
         for project_id in await self._domain_member_project_ids(
             full_creation.domain_id, full_creation.project_ids
         ):
             project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
             await self.ensure_scope(project_scope)
-            await self.bulk_add_entity_members(
+            await self.add_bulk_members(
                 EntityMembersAddition(scope=project_scope, members=[member])
             )
 
@@ -1219,7 +1217,7 @@ class RBACWriteOps(WriteOps):
         )
         return [ProjectID(row) for row in (await self._sess.scalars(stmt)).all()]
 
-    async def bulk_add_entity_members(
+    async def add_bulk_members(
         self,
         addition: EntityMembersAddition,
     ) -> None:
@@ -1240,11 +1238,11 @@ class RBACWriteOps(WriteOps):
         ])
         await self._grant_member_auto_assign_roles(scope, members)
 
-    async def bulk_add_entity_members_partial(
+    async def add_bulk_members_partial(
         self,
         addition: EntityMembersAddition,
     ) -> EntityMembersResultWithFailures:
-        """Add members as :meth:`bulk_add_entity_members` does, isolating each member
+        """Add members as :meth:`add_bulk_members` does, isolating each member
         for partial success.
 
         A member's membership and association share one savepoint, so a failed member

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -237,7 +237,7 @@ class EntityMembersAddition:
 
 
 @dataclass
-class EntityMemberError:
+class EntityMemberCreationError:
     """A member whose addition failed, with the exception that rolled it back."""
 
     member: ScopeMember
@@ -248,11 +248,11 @@ class EntityMemberError:
 @dataclass
 class EntityMembersResultWithFailures:
     successes: list[ScopeMember]
-    errors: list[EntityMemberError]
+    errors: list[EntityMemberCreationError]
 
 
 @dataclass
-class ScopeMemberError:
+class ScopeMemberCreationError:
     """A member scope whose attachment failed, with the exception that rolled it back."""
 
     member: ScopeRef
@@ -263,7 +263,7 @@ class ScopeMemberError:
 @dataclass
 class ScopeMembersResultWithFailures:
     successes: list[ScopeRef]
-    errors: list[ScopeMemberError]
+    errors: list[ScopeMemberCreationError]
 
 
 @dataclass
@@ -1021,7 +1021,7 @@ class RBACWriteOps(WriteOps):
         ``errors`` and leaves the rest attached.
         """
         successes: list[ScopeRef] = []
-        errors: list[ScopeMemberError] = []
+        errors: list[ScopeMemberCreationError] = []
         if not members:
             return ScopeMembersResultWithFailures(successes=successes, errors=errors)
         scope_virtual_scope_id = await self._resolve_virtual_scope_id(scope)
@@ -1029,7 +1029,7 @@ class RBACWriteOps(WriteOps):
         for index, member in enumerate(members):
             if member not in member_virtual_scope_ids:
                 errors.append(
-                    ScopeMemberError(
+                    ScopeMemberCreationError(
                         member=member,
                         exception=VirtualScopeNotFound(
                             f"No virtual scope for scope {member.scope_type}:{member.scope_id}"
@@ -1054,7 +1054,7 @@ class RBACWriteOps(WriteOps):
                     )
                 successes.append(member)
             except Exception as e:
-                errors.append(ScopeMemberError(member=member, exception=e, index=index))
+                errors.append(ScopeMemberCreationError(member=member, exception=e, index=index))
         return ScopeMembersResultWithFailures(successes=successes, errors=errors)
 
     @staticmethod
@@ -1250,7 +1250,7 @@ class RBACWriteOps(WriteOps):
         ``auto_assign`` roles are granted only to the successful members.
         """
         successes: list[ScopeMember] = []
-        errors: list[EntityMemberError] = []
+        errors: list[EntityMemberCreationError] = []
         members = list(addition.members)
         if not members:
             return EntityMembersResultWithFailures(successes=successes, errors=errors)
@@ -1263,7 +1263,7 @@ class RBACWriteOps(WriteOps):
                     await self._add_entity_member(scope, virtual_scope_id, member.entity_ref())
                 successes.append(member)
             except Exception as e:
-                errors.append(EntityMemberError(member=member, exception=e, index=index))
+                errors.append(EntityMemberCreationError(member=member, exception=e, index=index))
         await self._grant_member_auto_assign_roles(scope, successes)
         return EntityMembersResultWithFailures(successes=successes, errors=errors)
 

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -25,12 +25,11 @@ from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
 from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE
-from ai.backend.common.data.entity.types import EntityRef, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityRef, EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE
 from ai.backend.common.data.permission.types import (
     Permission,
     RBACElementType,
-    RelationType,
 )
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.exception import RBACTypeConversionError, UnreachableError
@@ -42,11 +41,13 @@ from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.virtual_scope import VirtualScopeID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.keypair.types import KeyPairCreator, KeyPairSecrets
-from ai.backend.manager.data.permission.id import ScopeId
+from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
-    EntityType,
+    EntityType as LegacyEntityType,
+)
+from ai.backend.manager.data.permission.types import (
     OperationType,
     RBACElementRef,
     RoleSource,
@@ -78,6 +79,8 @@ from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRo
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base import (
     BulkCreator,
+    CreatorSpec,
+    DependentCreatorSpec,
 )
 from ai.backend.manager.repositories.base.creator import BulkCreatorError
 from ai.backend.manager.repositories.base.integrity import (
@@ -112,8 +115,11 @@ from ai.backend.manager.repositories.base.rbac.utils import bulk_insert_on_confl
 from ai.backend.manager.repositories.keypair.creators import KeyPairCreatorSpec
 from ai.backend.manager.repositories.ops.base.provider import DBOpsProvider, WriteOps
 from ai.backend.manager.repositories.permission_controller.creators import (
+    AssociationScopesEntitiesCreatorSpec,
+    EntityMembershipCreatorSpec,
     PermissionCreatorSpec,
     RoleCreatorSpec,
+    ScopeBindingCreatorSpec,
     UserRoleCreatorSpec,
 )
 from ai.backend.manager.repositories.permission_controller.role_manager import (
@@ -228,6 +234,36 @@ class ScopeEntityMember(ScopeMember):
 class EntityMembersAddition:
     scope: ScopeRef
     members: Collection[ScopeMember]
+
+
+@dataclass
+class EntityMemberError:
+    """A member whose addition failed, with the exception that rolled it back."""
+
+    member: ScopeMember
+    exception: Exception
+    index: int
+
+
+@dataclass
+class EntityMembersResultWithFailures:
+    successes: list[ScopeMember]
+    errors: list[EntityMemberError]
+
+
+@dataclass
+class ScopeMemberError:
+    """A member scope whose attachment failed, with the exception that rolled it back."""
+
+    member: ScopeRef
+    exception: Exception
+    index: int
+
+
+@dataclass
+class ScopeMembersResultWithFailures:
+    successes: list[ScopeRef]
+    errors: list[ScopeMemberError]
 
 
 @dataclass
@@ -353,6 +389,26 @@ class RBACWriteOps(WriteOps):
         )
         self._render_role_name(template, dummy)
 
+    # -- Spec-based idempotent inserts --------------------------------------------
+
+    async def _bulk_create_ignore_conflicts[TRow: Base](
+        self, specs: Sequence[CreatorSpec[TRow]]
+    ) -> None:
+        """Insert rows from ``specs`` in one statement, skipping rows that conflict
+        with existing ones (``ON CONFLICT DO NOTHING``); existing rows are kept as-is."""
+        await bulk_insert_on_conflict_do_nothing(self._sess, [spec.build_row() for spec in specs])
+
+    async def _bulk_create_dependent_ignore_conflicts[TDependency, TRow: Base](
+        self,
+        specs: Sequence[DependentCreatorSpec[TDependency, TRow]],
+        dependency: TDependency,
+    ) -> None:
+        """Insert dependency-resolved rows from ``specs``, skipping rows that conflict
+        with existing ones (``ON CONFLICT DO NOTHING``); existing rows are kept as-is."""
+        await bulk_insert_on_conflict_do_nothing(
+            self._sess, [spec.build_row(dependency) for spec in specs]
+        )
+
     # -- Virtual-scope helpers ----------------------------------------------------
 
     async def _find_virtual_scope_id(self, scope: ScopeRef) -> VirtualScopeID | None:
@@ -375,6 +431,44 @@ class RBACWriteOps(WriteOps):
                 f"No virtual scope for scope {scope.scope_type}:{scope.scope_id}"
             )
         return virtual_scope_id
+
+    async def _find_virtual_scope_ids(
+        self, scopes: Sequence[ScopeRef]
+    ) -> dict[ScopeRef, VirtualScopeID]:
+        """Return the virtual scope ids backing ``scopes`` in one query; scopes
+        without one are absent from the result."""
+        if not scopes:
+            return {}
+        stmt = sa.select(
+            VirtualScopeRow.scope_type,
+            VirtualScopeRow.scope_id,
+            VirtualScopeRow.id,
+        ).where(
+            sa.tuple_(VirtualScopeRow.scope_type, VirtualScopeRow.scope_id).in_([
+                (s.scope_type, s.scope_id) for s in scopes
+            ])
+        )
+        return {
+            ScopeRef(scope_type=ScopeType(row.scope_type), scope_id=row.scope_id): row.id
+            for row in (await self._sess.execute(stmt)).all()
+        }
+
+    async def _resolve_virtual_scope_ids(
+        self, scopes: Sequence[ScopeRef]
+    ) -> dict[ScopeRef, VirtualScopeID]:
+        """Return the virtual scope id backing each of ``scopes`` in one query.
+
+        As with :meth:`_resolve_virtual_scope_id`, a scope without a virtual scope is
+        an invariant violation: raises :class:`VirtualScopeNotFound` naming them all.
+        """
+        resolved = await self._find_virtual_scope_ids(scopes)
+        missing = [s for s in scopes if s not in resolved]
+        if missing:
+            raise VirtualScopeNotFound(
+                "No virtual scope for scopes: "
+                + ", ".join(f"{s.scope_type}:{s.scope_id}" for s in missing)
+            )
+        return resolved
 
     async def _insert_virtual_scopes(self, scopes: Sequence[ScopeRef]) -> None:
         """Create each scope's virtual scope node with its self entity-membership and self
@@ -425,15 +519,30 @@ class RBACWriteOps(WriteOps):
         await self._sess.execute(binding_stmt)
 
     async def _delete_virtual_scopes(self, scopes: Sequence[ScopeRef]) -> None:
-        """Delete the virtual scope nodes for ``scopes`` (FK CASCADE removes their edges)."""
+        """Delete the virtual scope nodes for ``scopes`` (FK CASCADE removes the edges
+        inside them), plus the edges the scopes left in other virtual scopes — bindings
+        where a deleted scope is the reaching side and memberships where it is enrolled
+        as an entity — which no FK covers."""
         if not scopes:
             return
-        stmt = sa.delete(VirtualScopeRow).where(
-            sa.tuple_(VirtualScopeRow.scope_type, VirtualScopeRow.scope_id).in_([
-                (s.scope_type, s.scope_id) for s in scopes
-            ])
+        scope_keys = [(s.scope_type, s.scope_id) for s in scopes]
+        await self._sess.execute(
+            sa.delete(VirtualScopeRow).where(
+                sa.tuple_(VirtualScopeRow.scope_type, VirtualScopeRow.scope_id).in_(scope_keys)
+            )
         )
-        await self._sess.execute(stmt)
+        await self._sess.execute(
+            sa.delete(ScopeBindingRow).where(
+                sa.tuple_(ScopeBindingRow.scope_type, ScopeBindingRow.scope_id).in_(scope_keys)
+            )
+        )
+        await self._sess.execute(
+            sa.delete(EntityMembershipRow).where(
+                sa.tuple_(EntityMembershipRow.entity_type, EntityMembershipRow.entity_id).in_(
+                    scope_keys
+                )
+            )
+        )
 
     async def create_scoped[TRow: Base](
         self,
@@ -799,8 +908,9 @@ class RBACWriteOps(WriteOps):
         scope associations in both directions) and its virtual scope node.
 
         Deleting the virtual scope cascades to its scope bindings and entity
-        memberships (FK ``ON DELETE CASCADE``). Returns ``None`` if the row is
-        already gone.
+        memberships (FK ``ON DELETE CASCADE``); the scope's own bindings and
+        memberships in other virtual scopes are deleted explicitly. Returns ``None``
+        if the row is already gone.
         """
         result = await self.purge_scoped(deletion.purger)
         await self._delete_virtual_scopes([deletion.scope])
@@ -815,7 +925,8 @@ class RBACWriteOps(WriteOps):
 
         The real scope rows are purged in batches with their RBAC entries, then the
         virtual scope nodes for ``deletion.scopes`` are dropped (FK ``ON DELETE CASCADE``
-        removes their edges).
+        removes their edges) along with the scopes' bindings and memberships in other
+        virtual scopes.
         """
         result = await execute_rbac_entity_batch_purger(self._sess, deletion.purger)
         await self._delete_virtual_scopes(deletion.scopes)
@@ -858,6 +969,101 @@ class RBACWriteOps(WriteOps):
         )
         await self._sess.execute(stmt)
 
+    async def bulk_add_scope_members(
+        self,
+        scope: ScopeRef,
+        members: Sequence[ScopeRef],
+        permission_cap: Permission | None = None,
+    ) -> None:
+        """Attach each member scope under ``scope``, wiring both sides: the member is
+        enrolled as an entity member of ``scope``'s virtual scope (with its legacy
+        scope association), and ``scope`` is bound into the member's virtual scope so
+        ``scope``'s permissions reach the member's entities.
+
+        The reverse binding — a member reaching ``scope``'s entities — is deliberately
+        not written: member access to the containing scope flows through roles granted
+        on that scope, and a blanket reverse binding would widen every member-scoped
+        role at once. Every virtual scope involved must already exist; missing ones
+        raise :class:`VirtualScopeNotFound`. Idempotent: existing rows are kept as-is,
+        including their ``permission_cap``, which applies to the new bindings only.
+        """
+        if not members:
+            return
+        virtual_scope_ids = await self._resolve_virtual_scope_ids(members)
+        await self.bulk_add_entity_members(
+            EntityMembersAddition(
+                scope=scope,
+                members=[
+                    ScopeEntityMember(ref=self._scope_member_entity_ref(member))
+                    for member in members
+                ],
+            )
+        )
+        await self._bulk_create_dependent_ignore_conflicts(
+            [
+                ScopeBindingCreatorSpec(owner=member, scope=scope, permission_cap=permission_cap)
+                for member in members
+            ],
+            virtual_scope_ids,
+        )
+
+    async def bulk_add_scope_members_partial(
+        self,
+        scope: ScopeRef,
+        members: Sequence[ScopeRef],
+        permission_cap: Permission | None = None,
+    ) -> ScopeMembersResultWithFailures:
+        """Attach member scopes as :meth:`bulk_add_scope_members` does, isolating each
+        member for partial success.
+
+        A member's membership, association, and binding share one savepoint, so a
+        failed member — including one without a virtual scope — is reported in
+        ``errors`` and leaves the rest attached.
+        """
+        successes: list[ScopeRef] = []
+        errors: list[ScopeMemberError] = []
+        if not members:
+            return ScopeMembersResultWithFailures(successes=successes, errors=errors)
+        scope_virtual_scope_id = await self._resolve_virtual_scope_id(scope)
+        member_virtual_scope_ids = await self._find_virtual_scope_ids(members)
+        for index, member in enumerate(members):
+            if member not in member_virtual_scope_ids:
+                errors.append(
+                    ScopeMemberError(
+                        member=member,
+                        exception=VirtualScopeNotFound(
+                            f"No virtual scope for scope {member.scope_type}:{member.scope_id}"
+                        ),
+                        index=index,
+                    )
+                )
+                continue
+            # The handler stays outside the savepoint — see bulk_create_scoped_partial.
+            try:
+                async with self.savepoint():
+                    await self._add_entity_member(
+                        scope, scope_virtual_scope_id, self._scope_member_entity_ref(member)
+                    )
+                    await self._bulk_create_dependent_ignore_conflicts(
+                        [
+                            ScopeBindingCreatorSpec(
+                                owner=member, scope=scope, permission_cap=permission_cap
+                            )
+                        ],
+                        member_virtual_scope_ids,
+                    )
+                successes.append(member)
+            except Exception as e:
+                errors.append(ScopeMemberError(member=member, exception=e, index=index))
+        return ScopeMembersResultWithFailures(successes=successes, errors=errors)
+
+    @staticmethod
+    def _scope_member_entity_ref(member: ScopeRef) -> EntityRef:
+        return EntityRef(
+            entity_type=EntityType(member.scope_type),
+            entity_id=member.scope_id,
+        )
+
     # -- Virtual scope: outbound edges (entity_memberships) -----------------------
 
     async def _grant_auto_assign_roles(
@@ -894,7 +1100,7 @@ class RBACWriteOps(WriteOps):
                 .where(
                     AssociationScopesEntitiesRow.scope_type == scope_id.scope_type,
                     AssociationScopesEntitiesRow.scope_id == scope_id.scope_id,
-                    AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                    AssociationScopesEntitiesRow.entity_type == LegacyEntityType.ROLE,
                     RoleRow.auto_assign.is_(True),
                     RoleRow.status == RoleStatus.ACTIVE,
                 )
@@ -978,13 +1184,15 @@ class RBACWriteOps(WriteOps):
         member = ScopeUserMember(user_id=user_id)
         domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=full_creation.domain_id)
         await self.ensure_scope(domain_scope)
-        await self.add_entity_members(EntityMembersAddition(scope=domain_scope, members=[member]))
+        await self.bulk_add_entity_members(
+            EntityMembersAddition(scope=domain_scope, members=[member])
+        )
         for project_id in await self._domain_member_project_ids(
             full_creation.domain_id, full_creation.project_ids
         ):
             project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
             await self.ensure_scope(project_scope)
-            await self.add_entity_members(
+            await self.bulk_add_entity_members(
                 EntityMembersAddition(scope=project_scope, members=[member])
             )
 
@@ -1011,7 +1219,7 @@ class RBACWriteOps(WriteOps):
         )
         return [ProjectID(row) for row in (await self._sess.scalars(stmt)).all()]
 
-    async def add_entity_members(
+    async def bulk_add_entity_members(
         self,
         addition: EntityMembersAddition,
     ) -> None:
@@ -1023,34 +1231,75 @@ class RBACWriteOps(WriteOps):
         scope = addition.scope
         virtual_scope_id = await self._resolve_virtual_scope_id(scope)
         entity_refs = [member.entity_ref() for member in members]
-        membership_values = [
-            {
-                "virtual_scope_id": virtual_scope_id,
-                "entity_type": ref.entity_type,
-                "entity_id": ref.entity_id,
-                "permission_cap": None,
-            }
-            for ref in entity_refs
-        ]
-        await self._sess.execute(
-            pg_insert(EntityMembershipRow).values(membership_values).on_conflict_do_nothing()
+        await self._bulk_create_dependent_ignore_conflicts(
+            [EntityMembershipCreatorSpec(entity_ref=ref) for ref in entity_refs],
+            virtual_scope_id,
         )
-        association_values = [
-            {
-                "scope_type": LegacyScopeType(scope.scope_type),
-                "scope_id": str(scope.scope_id),
-                "entity_type": EntityType(ref.entity_type),
-                "entity_id": str(ref.entity_id),
-                "relation_type": RelationType.AUTO,
-                "permission_cap": None,
-            }
-            for ref in entity_refs
-        ]
-        await self._sess.execute(
-            pg_insert(AssociationScopesEntitiesRow)
-            .values(association_values)
-            .on_conflict_do_nothing()
+        await self._bulk_create_ignore_conflicts([
+            self._association_spec(scope, ref) for ref in entity_refs
+        ])
+        await self._grant_member_auto_assign_roles(scope, members)
+
+    async def bulk_add_entity_members_partial(
+        self,
+        addition: EntityMembersAddition,
+    ) -> EntityMembersResultWithFailures:
+        """Add members as :meth:`bulk_add_entity_members` does, isolating each member
+        for partial success.
+
+        A member's membership and association share one savepoint, so a failed member
+        rolls back only its own rows and leaves the rest added. The scope's
+        ``auto_assign`` roles are granted only to the successful members.
+        """
+        successes: list[ScopeMember] = []
+        errors: list[EntityMemberError] = []
+        members = list(addition.members)
+        if not members:
+            return EntityMembersResultWithFailures(successes=successes, errors=errors)
+        scope = addition.scope
+        virtual_scope_id = await self._resolve_virtual_scope_id(scope)
+        for index, member in enumerate(members):
+            # The handler stays outside the savepoint — see bulk_create_scoped_partial.
+            try:
+                async with self.savepoint():
+                    await self._add_entity_member(scope, virtual_scope_id, member.entity_ref())
+                successes.append(member)
+            except Exception as e:
+                errors.append(EntityMemberError(member=member, exception=e, index=index))
+        await self._grant_member_auto_assign_roles(scope, successes)
+        return EntityMembersResultWithFailures(successes=successes, errors=errors)
+
+    async def _add_entity_member(
+        self,
+        scope: ScopeRef,
+        virtual_scope_id: VirtualScopeID,
+        ref: EntityRef,
+    ) -> None:
+        """Write one member's virtual-scope membership and scope association."""
+        await self._bulk_create_dependent_ignore_conflicts(
+            [EntityMembershipCreatorSpec(entity_ref=ref)],
+            virtual_scope_id,
         )
+        await self._bulk_create_ignore_conflicts([self._association_spec(scope, ref)])
+
+    @staticmethod
+    def _association_spec(scope: ScopeRef, ref: EntityRef) -> AssociationScopesEntitiesCreatorSpec:
+        return AssociationScopesEntitiesCreatorSpec(
+            scope_id=ScopeId(
+                scope_type=LegacyScopeType(scope.scope_type),
+                scope_id=str(scope.scope_id),
+            ),
+            object_id=ObjectId(
+                entity_type=LegacyEntityType(ref.entity_type),
+                entity_id=str(ref.entity_id),
+            ),
+        )
+
+    async def _grant_member_auto_assign_roles(
+        self,
+        scope: ScopeRef,
+        members: Sequence[ScopeMember],
+    ) -> None:
         role_user_ids = [
             user_id for member in members if (user_id := member.assign_role_on()) is not None
         ]
@@ -1093,7 +1342,9 @@ class RBACWriteOps(WriteOps):
                 sa.tuple_(
                     AssociationScopesEntitiesRow.entity_type,
                     AssociationScopesEntitiesRow.entity_id,
-                ).in_([(EntityType(ref.entity_type), str(ref.entity_id)) for ref in entity_refs]),
+                ).in_([
+                    (LegacyEntityType(ref.entity_type), str(ref.entity_id)) for ref in entity_refs
+                ]),
             )
         )
 

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.data.entity.types import EntityRef, ScopeRef
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.identifier.virtual_scope import VirtualScopeID
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.status import PermissionStatus, RoleStatus
 from ai.backend.manager.data.permission.types import (
@@ -24,7 +26,9 @@ from ai.backend.manager.models.rbac_models.permission.object_permission import O
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
-from ai.backend.manager.repositories.base.creator import CreatorSpec
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
+from ai.backend.manager.repositories.base.creator import CreatorSpec, DependentCreatorSpec
 from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
 
 
@@ -140,4 +144,43 @@ class AssociationScopesEntitiesCreatorSpec(CreatorSpec[AssociationScopesEntities
             scope_id=self.scope_id.scope_id,
             entity_type=self.object_id.entity_type,
             entity_id=self.object_id.entity_id,
+        )
+
+
+@dataclass
+class EntityMembershipCreatorSpec(DependentCreatorSpec[VirtualScopeID, EntityMembershipRow]):
+    """Membership of an entity in a virtual scope; the virtual scope id is resolved
+    by the caller at execution time and passed as the dependency."""
+
+    entity_ref: EntityRef
+    permission_cap: Permission | None = None
+
+    @override
+    def build_row(self, dependency: VirtualScopeID) -> EntityMembershipRow:
+        return EntityMembershipRow(
+            virtual_scope_id=dependency,
+            entity_type=self.entity_ref.entity_type,
+            entity_id=self.entity_ref.entity_id,
+            permission_cap=self.permission_cap,
+        )
+
+
+@dataclass
+class ScopeBindingCreatorSpec(
+    DependentCreatorSpec[Mapping[ScopeRef, VirtualScopeID], ScopeBindingRow]
+):
+    """Binding of ``scope`` into ``owner``'s virtual scope; the owner→virtual-scope-id
+    mapping is resolved by the caller at execution time and passed as the dependency."""
+
+    owner: ScopeRef
+    scope: ScopeRef
+    permission_cap: Permission | None = None
+
+    @override
+    def build_row(self, dependency: Mapping[ScopeRef, VirtualScopeID]) -> ScopeBindingRow:
+        return ScopeBindingRow(
+            virtual_scope_id=dependency[self.owner],
+            scope_type=self.scope.scope_type,
+            scope_id=self.scope.scope_id,
+            permission_cap=self.permission_cap,
         )

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -149,8 +149,7 @@ class AssociationScopesEntitiesCreatorSpec(CreatorSpec[AssociationScopesEntities
 
 @dataclass
 class EntityMembershipCreatorSpec(DependentCreatorSpec[VirtualScopeID, EntityMembershipRow]):
-    """Membership of an entity in a virtual scope; the virtual scope id is resolved
-    by the caller at execution time and passed as the dependency."""
+    """Membership of an entity in the virtual scope given as the dependency."""
 
     entity_ref: EntityRef
     permission_cap: Permission | None = None
@@ -169,18 +168,17 @@ class EntityMembershipCreatorSpec(DependentCreatorSpec[VirtualScopeID, EntityMem
 class ScopeBindingCreatorSpec(
     DependentCreatorSpec[Mapping[ScopeRef, VirtualScopeID], ScopeBindingRow]
 ):
-    """Binding of ``scope`` into ``owner``'s virtual scope; the owner→virtual-scope-id
-    mapping is resolved by the caller at execution time and passed as the dependency."""
+    """Binding of ``bound_scope`` into ``anchor_scope``'s virtual scope."""
 
-    owner: ScopeRef
-    scope: ScopeRef
+    anchor_scope: ScopeRef
+    bound_scope: ScopeRef
     permission_cap: Permission | None = None
 
     @override
     def build_row(self, dependency: Mapping[ScopeRef, VirtualScopeID]) -> ScopeBindingRow:
         return ScopeBindingRow(
-            virtual_scope_id=dependency[self.owner],
-            scope_type=self.scope.scope_type,
-            scope_id=self.scope.scope_id,
+            virtual_scope_id=dependency[self.anchor_scope],
+            scope_type=self.bound_scope.scope_type,
+            scope_id=self.bound_scope.scope_id,
             permission_cap=self.permission_cap,
         )

--- a/src/ai/backend/manager/repositories/user/creators.py
+++ b/src/ai/backend/manager/repositories/user/creators.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class UserScopeCreation(ScopeCreation[UserRow]):
     """Creates a user row and the scope the user becomes; the user is granted its own
     scope's roles. Domain/project scope associations are written by the enrollment
-    step (``bulk_add_entity_members``), not by this creator."""
+    step (``add_bulk_members``), not by this creator."""
 
     spec: CreatorSpec[UserRow]
 

--- a/src/ai/backend/manager/repositories/user/creators.py
+++ b/src/ai/backend/manager/repositories/user/creators.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class UserScopeCreation(ScopeCreation[UserRow]):
     """Creates a user row and the scope the user becomes; the user is granted its own
     scope's roles. Domain/project scope associations are written by the enrollment
-    step (``add_entity_members``), not by this creator."""
+    step (``bulk_add_entity_members``), not by this creator."""
 
     spec: CreatorSpec[UserRow]
 

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -121,11 +121,9 @@ _ORM_CLUSTER = (
     UserRow,
 )
 
-# A scope that carries roles must name a type the permission layer knows; a scope merely
-# bound to a virtual scope is free-form, which _TEST_BOUND_SCOPE_TYPE exercises.
+# A scope that carries roles must name a type the permission layer knows.
 _TEST_SCOPE_TYPE = ScopeType(PermissionScopeType.PROJECT.value)
 _TEST_ENTITY_TYPE = VirtualScopeEntityType(PermissionScopeType.PROJECT.value)
-_TEST_BOUND_SCOPE_TYPE = ScopeType("test-bound-scope")
 _TEST_MEMBER_ENTITY_TYPE = VirtualScopeEntityType(RBACElementType.USER.value)
 _TEST_MEMBER_SCOPE_TYPE = ScopeType(RBACElementType.USER.value)
 
@@ -358,7 +356,7 @@ def bulk_scopes() -> BulkScopeContext:
 
 class TestScopeCreationVirtualScope:
     """create_scope / bulk_create_scopes materialize the VS node, self-membership, and
-    self scope_binding (plus a bound-scope binding when a bound_scope is given)."""
+    self scope_binding."""
 
     async def test_create_scope_adds_virtual_scope_membership_and_self_binding(
         self,
@@ -407,42 +405,6 @@ class TestScopeCreationVirtualScope:
         assert binding.scope_type == _TEST_SCOPE_TYPE
         assert binding.scope_id == scope_id
         assert binding.permission_cap is None
-
-    async def test_create_scope_with_bound_scope_binds_it_to_its_virtual_scope(
-        self,
-        database_connection: ExtendedAsyncSAEngine,
-        provider: RBACOpsProvider,
-        scope_tables: None,
-        single_scope: SingleScopeContext,
-    ) -> None:
-        """create_scope(bound_scope=...) binds that scope to the new scope's VS on top of
-        the self binding, so it reaches this scope's entities in one hop."""
-        scope_id = single_scope.scope_id
-        bound_scope = ScopeRef(scope_type=_TEST_BOUND_SCOPE_TYPE, scope_id=uuid.uuid4())
-
-        async with provider.write_ops() as w:
-            await w.create_scope(single_scope.creation, bound_scope=bound_scope)
-
-        async with database_connection.begin_session_read_committed() as sess:
-            vs = (
-                await sess.execute(
-                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
-                )
-            ).scalar_one()
-            binding_rows = (
-                (
-                    await sess.execute(
-                        sa.select(ScopeBindingRow).where(ScopeBindingRow.virtual_scope_id == vs.id)
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
-        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
-            (_TEST_SCOPE_TYPE, scope_id),  # self binding
-            (_TEST_BOUND_SCOPE_TYPE, bound_scope.scope_id),  # bound-scope binding
-        }
 
     async def test_bulk_create_scopes_adds_vs_membership_and_self_binding_per_scope(
         self,
@@ -547,42 +509,6 @@ class TestEnsureScope:
         assert vs_count == 1
         assert membership_count == 1
         assert binding_count == 1
-
-    async def test_ensure_scope_with_bound_scope_adds_binding(
-        self,
-        database_connection: ExtendedAsyncSAEngine,
-        provider: RBACOpsProvider,
-        scope_tables: None,
-    ) -> None:
-        """ensure_scope(scope, bound_scope) binds both the scope itself and the bound scope
-        to the scope's VS."""
-        scope_id = uuid.uuid4()
-        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
-        bound_scope = ScopeRef(scope_type=_TEST_BOUND_SCOPE_TYPE, scope_id=uuid.uuid4())
-
-        async with provider.write_ops() as w:
-            await w.ensure_scope(scope, bound_scope=bound_scope)
-
-        async with database_connection.begin_session_read_committed() as sess:
-            vs = (
-                await sess.execute(
-                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
-                )
-            ).scalar_one()
-            binding_rows = (
-                (
-                    await sess.execute(
-                        sa.select(ScopeBindingRow).where(ScopeBindingRow.virtual_scope_id == vs.id)
-                    )
-                )
-                .scalars()
-                .all()
-            )
-
-        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
-            (_TEST_SCOPE_TYPE, scope_id),  # self binding
-            (_TEST_BOUND_SCOPE_TYPE, bound_scope.scope_id),  # bound-scope binding
-        }
 
 
 @pytest.fixture
@@ -804,39 +730,43 @@ class TestBulkPurgeScopedPartial:
 
 
 class TestAddBulkMembers:
-    """add_bulk_members writes both the VS membership and the scope association."""
+    """add_bulk_members enrolls each member into the scope's VS (with its scope
+    association) and binds the scope into the member's own VS — never the reverse
+    binding."""
 
-    async def test_add_bulk_members_writes_membership_and_association(
+    async def test_writes_membership_association_and_binding(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """Each member gets a VS membership row and a scope association row."""
+        """Each member gets membership, association, and the scope's binding (with cap)
+        in its own VS — and no reverse binding in the scope's VS."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
         member_ids = [uuid.uuid4(), uuid.uuid4()]
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
+            for mid in member_ids:
+                await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=mid) for mid in member_ids],
-                )
+                ),
+                permission_cap=Permission.READ,
             )
 
         async with database_connection.begin_session_read_committed() as sess:
-            vs = (
-                await sess.execute(
-                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
-                )
-            ).scalar_one()
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            vs_by_scope = {vs.scope_id: vs.id for vs in vs_rows}
             membership_ids = set(
                 (
                     await sess.scalars(
                         sa.select(EntityMembershipRow.entity_id).where(
-                            EntityMembershipRow.virtual_scope_id == vs.id,
+                            EntityMembershipRow.virtual_scope_id == vs_by_scope[scope_id],
                             EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
                         )
                     )
@@ -856,71 +786,187 @@ class TestAddBulkMembers:
         assert membership_ids == set(member_ids)
         assert assoc_ids == {str(mid) for mid in member_ids}
 
-    async def test_add_bulk_members_is_idempotent(
+        for mid in member_ids:
+            member_bindings = {
+                (b.scope_type, b.scope_id): b.permission_cap
+                for b in binding_rows
+                if b.virtual_scope_id == vs_by_scope[mid]
+            }
+            assert member_bindings == {
+                (_TEST_MEMBER_SCOPE_TYPE, mid): None,  # self binding
+                (_TEST_SCOPE_TYPE, scope_id): Permission.READ,
+            }
+        scope_vs_bindings = {
+            (b.scope_type, b.scope_id)
+            for b in binding_rows
+            if b.virtual_scope_id == vs_by_scope[scope_id]
+        }
+        assert scope_vs_bindings == {(_TEST_SCOPE_TYPE, scope_id)}  # self binding only
+
+    async def test_readd_is_idempotent_and_keeps_binding_cap(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """Re-adding the same member is a no-op — no duplicate membership or association."""
+        """Re-adding the same member with a different cap is a no-op — no duplicate
+        membership or association, and the original binding cap is kept."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
         member_id = uuid.uuid4()
+        member_scope = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=member_id)
         addition = EntityMembersAddition(scope=scope, members=[StubMember(member_id=member_id)])
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.add_bulk_members(addition)
-            await w.add_bulk_members(addition)
+            await w.ensure_scope(member_scope)
+            await w.add_bulk_members(addition, permission_cap=Permission.READ)
+            await w.add_bulk_members(addition, permission_cap=Permission.full())
 
         async with database_connection.begin_session_read_committed() as sess:
+            scope_vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
+                )
+            ).scalar_one()
+            member_vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == member_id)
+                )
+            ).scalar_one()
             membership_count = await sess.scalar(
                 sa.select(sa.func.count())
                 .select_from(EntityMembershipRow)
-                .where(EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE)
+                .where(EntityMembershipRow.virtual_scope_id == scope_vs.id)
             )
             assoc_count = await sess.scalar(
                 sa.select(sa.func.count())
                 .select_from(AssociationScopesEntitiesRow)
                 .where(AssociationScopesEntitiesRow.entity_id == str(member_id))
             )
+            binding_rows = (
+                (
+                    await sess.execute(
+                        sa.select(ScopeBindingRow).where(
+                            ScopeBindingRow.virtual_scope_id == member_vs.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
 
-        assert membership_count == 1
+        # the scope's self membership and the member's
+        assert membership_count == 2
         assert assoc_count == 1
+        caps_by_scope = {(b.scope_type, b.scope_id): b.permission_cap for b in binding_rows}
+        assert caps_by_scope == {
+            (_TEST_MEMBER_SCOPE_TYPE, member_id): None,  # self binding
+            (_TEST_SCOPE_TYPE, scope_id): Permission.READ,
+        }
 
-
-class TestRemoveEntityMembers:
-    """remove_entity_members deletes both the VS membership and the scope association."""
-
-    async def test_remove_entity_members_deletes_membership_and_association(
+    async def test_missing_member_vs_fails_the_whole_call(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """The removed member loses both rows; the other member keeps both."""
+        """One member without a VS raises VirtualScopeNotFound and nothing is written —
+        no membership and no binding, not even for the members whose VS exists."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+        present_id, missing_id = uuid.uuid4(), uuid.uuid4()
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=present_id))
+
+        with pytest.raises(VirtualScopeNotFound):
+            async with provider.write_ops() as w:
+                await w.add_bulk_members(
+                    EntityMembersAddition(
+                        scope=scope,
+                        members=[
+                            StubMember(member_id=present_id),
+                            StubMember(member_id=missing_id),
+                        ],
+                    )
+                )
+
+        async with database_connection.begin_session_read_committed() as sess:
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+
+        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
+            (_TEST_SCOPE_TYPE, scope.scope_id),  # self bindings only
+            (_TEST_MEMBER_SCOPE_TYPE, present_id),
+        }
+        assert {(m.entity_type, m.entity_id) for m in membership_rows} == {
+            (_TEST_ENTITY_TYPE, scope.scope_id),  # self memberships only
+            (_TEST_MEMBER_ENTITY_TYPE, present_id),
+        }
+
+    async def test_empty_members_is_noop(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """An empty member collection writes nothing."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.add_bulk_members(EntityMembersAddition(scope=scope, members=[]))
+
+        async with database_connection.begin_session_read_committed() as sess:
+            binding_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(ScopeBindingRow)
+            )
+
+        assert binding_count == 1  # the self binding from ensure_scope
+
+
+class TestRemoveBulkMembers:
+    """remove_bulk_members deletes the VS membership, the scope association, and the
+    scope's binding in the member's own VS — and never raises for missing virtual
+    scopes."""
+
+    async def test_remove_deletes_membership_association_and_binding(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """The removed member loses all three rows — its own VS keeps only the self
+        binding — while the other member keeps all of them."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
         removed_id, kept_id = uuid.uuid4(), uuid.uuid4()
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
+            for mid in (removed_id, kept_id):
+                await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=removed_id), StubMember(member_id=kept_id)],
                 )
             )
-            await w.remove_entity_members(
+            await w.remove_bulk_members(
                 scope,
                 [EntityRef(entity_type=_TEST_MEMBER_ENTITY_TYPE, entity_id=removed_id)],
             )
 
         async with database_connection.begin_session_read_committed() as sess:
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            vs_by_scope = {vs.scope_id: vs.id for vs in vs_rows}
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
             membership_ids = set(
                 (
                     await sess.scalars(
                         sa.select(EntityMembershipRow.entity_id).where(
+                            EntityMembershipRow.virtual_scope_id == vs_by_scope[scope_id],
                             EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
                         )
                     )
@@ -938,195 +984,91 @@ class TestRemoveEntityMembers:
 
         assert membership_ids == {kept_id}
         assert assoc_ids == {str(kept_id)}
-
-
-# =============================================================================
-# add_bulk_scope_members
-# =============================================================================
-
-
-class TestAddBulkScopeMembers:
-    """add_bulk_scope_members enrolls each member scope into the containing scope's VS and
-    binds the containing scope into each member's VS — never the reverse binding."""
-
-    async def test_enrolls_members_and_binds_scope_without_reverse(
-        self,
-        database_connection: ExtendedAsyncSAEngine,
-        provider: RBACOpsProvider,
-        entity_member_tables: None,
-    ) -> None:
-        """Each member joins the scope's VS as an entity member (with its scope
-        association) and its own VS gains the scope's binding with the given cap; the
-        scope's own VS gains no binding for any member."""
-        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-        members = [
-            ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4()) for _ in range(2)
-        ]
-
-        async with provider.write_ops() as w:
-            await w.ensure_scope(scope)
-            for member in members:
-                await w.ensure_scope(member)
-            await w.add_bulk_scope_members(scope, members, permission_cap=Permission.READ)
-
-        async with database_connection.begin_session_read_committed() as sess:
-            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
-            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
-            vs_by_scope = {vs.scope_id: vs.id for vs in vs_rows}
-            membership_ids = set(
-                (
-                    await sess.scalars(
-                        sa.select(EntityMembershipRow.entity_id).where(
-                            EntityMembershipRow.virtual_scope_id == vs_by_scope[scope.scope_id],
-                            EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
-                        )
-                    )
-                ).all()
-            )
-            assoc_ids = set(
-                (
-                    await sess.scalars(
-                        sa.select(AssociationScopesEntitiesRow.entity_id).where(
-                            AssociationScopesEntitiesRow.scope_id == str(scope.scope_id),
-                            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
-                        )
-                    )
-                ).all()
-            )
-
-        assert membership_ids == {member.scope_id for member in members}
-        assert assoc_ids == {str(member.scope_id) for member in members}
-
-        for member in members:
-            member_bindings = {
-                (b.scope_type, b.scope_id): b.permission_cap
-                for b in binding_rows
-                if b.virtual_scope_id == vs_by_scope[member.scope_id]
-            }
-            assert member_bindings == {
-                (_TEST_MEMBER_SCOPE_TYPE, member.scope_id): None,  # self binding
-                (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
-            }
-        scope_vs_bindings = {
+        removed_bindings = {
             (b.scope_type, b.scope_id)
             for b in binding_rows
-            if b.virtual_scope_id == vs_by_scope[scope.scope_id]
+            if b.virtual_scope_id == vs_by_scope[removed_id]
         }
-        assert scope_vs_bindings == {(_TEST_SCOPE_TYPE, scope.scope_id)}  # self binding only
+        assert removed_bindings == {(_TEST_MEMBER_SCOPE_TYPE, removed_id)}  # self binding only
+        kept_bindings = {
+            (b.scope_type, b.scope_id)
+            for b in binding_rows
+            if b.virtual_scope_id == vs_by_scope[kept_id]
+        }
+        assert kept_bindings == {
+            (_TEST_MEMBER_SCOPE_TYPE, kept_id),
+            (_TEST_SCOPE_TYPE, scope_id),
+        }
 
-    async def test_readd_keeps_existing_binding_and_cap(
+    async def test_remove_without_member_vs_still_deletes(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """Re-adding the same member with a different cap is a no-op — no duplicate
-        membership or binding, and the original binding cap is kept."""
-        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-        member = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+        """A member without a VS (legacy data) still loses its membership and
+        association — the removal does not raise."""
+        scope_id = uuid.uuid4()
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+        member_id = uuid.uuid4()
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.ensure_scope(member)
-            await w.add_bulk_scope_members(scope, [member], permission_cap=Permission.READ)
-            await w.add_bulk_scope_members(scope, [member], permission_cap=Permission.full())
 
-        async with database_connection.begin_session_read_committed() as sess:
-            member_vs = (
+        async with database_connection.begin_session() as sess:
+            scope_vs = (
                 await sess.execute(
-                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == member.scope_id)
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
                 )
             ).scalar_one()
-            binding_rows = (
-                (
-                    await sess.execute(
-                        sa.select(ScopeBindingRow).where(
-                            ScopeBindingRow.virtual_scope_id == member_vs.id
-                        )
-                    )
+            sess.add(
+                EntityMembershipRow(
+                    virtual_scope_id=scope_vs.id,
+                    entity_type=_TEST_MEMBER_ENTITY_TYPE,
+                    entity_id=member_id,
+                    permission_cap=None,
                 )
-                .scalars()
-                .all()
             )
+            sess.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=PermissionScopeType(_TEST_SCOPE_TYPE),
+                    scope_id=str(scope_id),
+                    entity_type=EntityType.USER,
+                    entity_id=str(member_id),
+                    relation_type=RelationType.AUTO,
+                )
+            )
+
+        async with provider.write_ops() as w:
+            await w.remove_bulk_members(
+                scope,
+                [EntityRef(entity_type=_TEST_MEMBER_ENTITY_TYPE, entity_id=member_id)],
+            )
+
+        async with database_connection.begin_session_read_committed() as sess:
             membership_count = await sess.scalar(
                 sa.select(sa.func.count())
                 .select_from(EntityMembershipRow)
-                .where(
-                    EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
-                    EntityMembershipRow.entity_id == member.scope_id,
-                )
+                .where(EntityMembershipRow.entity_id == member_id)
+            )
+            assoc_count = await sess.scalar(
+                sa.select(sa.func.count())
+                .select_from(AssociationScopesEntitiesRow)
+                .where(AssociationScopesEntitiesRow.entity_id == str(member_id))
             )
 
-        caps_by_scope = {(b.scope_type, b.scope_id): b.permission_cap for b in binding_rows}
-        assert caps_by_scope == {
-            (_TEST_MEMBER_SCOPE_TYPE, member.scope_id): None,  # self binding
-            (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
-        }
-        # one in its own VS (self) and one in the containing scope's VS
-        assert membership_count == 2
-
-    async def test_missing_member_vs_fails_the_whole_call(
-        self,
-        database_connection: ExtendedAsyncSAEngine,
-        provider: RBACOpsProvider,
-        entity_member_tables: None,
-    ) -> None:
-        """One member without a VS raises VirtualScopeNotFound and nothing is written —
-        no membership and no binding, not even for the members whose VS exists."""
-        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-        present = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
-        missing = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
-
-        async with provider.write_ops() as w:
-            await w.ensure_scope(scope)
-            await w.ensure_scope(present)
-
-        with pytest.raises(VirtualScopeNotFound):
-            async with provider.write_ops() as w:
-                await w.add_bulk_scope_members(scope, [present, missing])
-
-        async with database_connection.begin_session_read_committed() as sess:
-            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
-            membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
-
-        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
-            (_TEST_SCOPE_TYPE, scope.scope_id),  # self bindings only
-            (_TEST_MEMBER_SCOPE_TYPE, present.scope_id),
-        }
-        assert {(m.entity_type, m.entity_id) for m in membership_rows} == {
-            (_TEST_ENTITY_TYPE, scope.scope_id),  # self memberships only
-            (_TEST_MEMBER_ENTITY_TYPE, present.scope_id),
-        }
-
-    async def test_empty_members_is_noop(
-        self,
-        database_connection: ExtendedAsyncSAEngine,
-        provider: RBACOpsProvider,
-        entity_member_tables: None,
-    ) -> None:
-        """An empty member collection writes nothing."""
-        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-
-        async with provider.write_ops() as w:
-            await w.ensure_scope(scope)
-            await w.add_bulk_scope_members(scope, [])
-
-        async with database_connection.begin_session_read_committed() as sess:
-            binding_count = await sess.scalar(
-                sa.select(sa.func.count()).select_from(ScopeBindingRow)
-            )
-
-        assert binding_count == 1  # the self binding from ensure_scope
+        assert membership_count == 0
+        assert assoc_count == 0
 
 
 # =============================================================================
-# add_bulk_members_partial / add_bulk_scope_members_partial
+# add_bulk_members_partial
 # =============================================================================
 
 
 class TestAddBulkMembersPartial:
     """add_bulk_members_partial isolates each member: a failed member is reported and
-    rolled back while the rest are added."""
+    rolled back while the rest are fully attached."""
 
     async def test_failed_member_is_isolated(
         self,
@@ -1135,7 +1077,7 @@ class TestAddBulkMembersPartial:
         entity_member_tables: None,
     ) -> None:
         """A member whose entity type has no legacy counterpart fails alone — its
-        membership is rolled back with it — while the valid member keeps both rows."""
+        membership is rolled back with it — while the valid member keeps all rows."""
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
         valid = StubMember(member_id=uuid.uuid4())
         invalid = StubMember(
@@ -1145,6 +1087,12 @@ class TestAddBulkMembersPartial:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
+            await w.ensure_scope(
+                ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=valid.member_id)
+            )
+            await w.ensure_scope(
+                ScopeRef(scope_type=ScopeType("unregistered-type"), scope_id=invalid.member_id)
+            )
             result = await w.add_bulk_members_partial(
                 EntityMembersAddition(scope=scope, members=[valid, invalid])
             )
@@ -1186,11 +1134,6 @@ class TestAddBulkMembersPartial:
         }
         assert assoc_ids == {str(valid.member_id)}
 
-
-class TestAddBulkScopeMembersPartial:
-    """add_bulk_scope_members_partial isolates each member: a member without a virtual scope
-    is reported in errors while the rest are fully attached."""
-
     async def test_missing_member_vs_is_isolated(
         self,
         database_connection: ExtendedAsyncSAEngine,
@@ -1200,14 +1143,17 @@ class TestAddBulkScopeMembersPartial:
         """The member without a VS lands in errors with nothing written for it; the
         valid member gets its membership, association, and binding."""
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-        valid = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
-        missing = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+        valid = StubMember(member_id=uuid.uuid4())
+        missing = StubMember(member_id=uuid.uuid4())
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.ensure_scope(valid)
-            result = await w.add_bulk_scope_members_partial(
-                scope, [valid, missing], permission_cap=Permission.READ
+            await w.ensure_scope(
+                ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=valid.member_id)
+            )
+            result = await w.add_bulk_members_partial(
+                EntityMembersAddition(scope=scope, members=[valid, missing]),
+                permission_cap=Permission.READ,
             )
 
         assert result.successes == [valid]
@@ -1229,15 +1175,15 @@ class TestAddBulkScopeMembersPartial:
                 ).all()
             )
 
-        assert missing.scope_id not in vs_by_scope
-        assert membership_ids == {valid.scope_id}
+        assert missing.member_id not in vs_by_scope
+        assert membership_ids == {valid.member_id}
         valid_bindings = {
             (b.scope_type, b.scope_id): b.permission_cap
             for b in binding_rows
-            if b.virtual_scope_id == vs_by_scope[valid.scope_id]
+            if b.virtual_scope_id == vs_by_scope[valid.member_id]
         }
         assert valid_bindings == {
-            (_TEST_MEMBER_SCOPE_TYPE, valid.scope_id): None,  # self binding
+            (_TEST_MEMBER_SCOPE_TYPE, valid.member_id): None,  # self binding
             (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
         }
 
@@ -1330,7 +1276,17 @@ class TestScopeDeletionVirtualScopeCleanup:
         async with provider.write_ops() as w:
             await w.create_scope(single_scope.creation)
             await w.ensure_scope(other)
-            await w.bind_scope(scope, other, permission_cap=None)
+            # Two-way membership leaves scope's binding and membership in other's VS.
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=scope,
+                    members=[
+                        ScopeEntityMember(
+                            ref=EntityRef(entity_type=_TEST_ENTITY_TYPE, entity_id=other.scope_id)
+                        )
+                    ],
+                )
+            )
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=other,
@@ -1381,8 +1337,20 @@ class TestScopeDeletionVirtualScopeCleanup:
         async with provider.write_ops() as w:
             await w.bulk_create_scopes(bulk_scopes.creations)
             await w.ensure_scope(other)
+            # Two-way membership leaves each scope's binding and membership in other's VS.
             for scope in scopes:
-                await w.bind_scope(scope, other, permission_cap=None)
+                await w.add_bulk_members(
+                    EntityMembersAddition(
+                        scope=scope,
+                        members=[
+                            ScopeEntityMember(
+                                ref=EntityRef(
+                                    entity_type=_TEST_ENTITY_TYPE, entity_id=other.scope_id
+                                )
+                            )
+                        ],
+                    )
+                )
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=other,

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -803,10 +803,10 @@ class TestBulkPurgeScopedPartial:
             assert list(blocked_scope_ids) == [_USER_SCOPE_ID]
 
 
-class TestBulkAddEntityMembers:
-    """bulk_add_entity_members writes both the VS membership and the scope association."""
+class TestAddBulkMembers:
+    """add_bulk_members writes both the VS membership and the scope association."""
 
-    async def test_bulk_add_entity_members_writes_membership_and_association(
+    async def test_add_bulk_members_writes_membership_and_association(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
@@ -819,7 +819,7 @@ class TestBulkAddEntityMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.bulk_add_entity_members(
+            await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=mid) for mid in member_ids],
@@ -856,7 +856,7 @@ class TestBulkAddEntityMembers:
         assert membership_ids == set(member_ids)
         assert assoc_ids == {str(mid) for mid in member_ids}
 
-    async def test_bulk_add_entity_members_is_idempotent(
+    async def test_add_bulk_members_is_idempotent(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
@@ -870,8 +870,8 @@ class TestBulkAddEntityMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.bulk_add_entity_members(addition)
-            await w.bulk_add_entity_members(addition)
+            await w.add_bulk_members(addition)
+            await w.add_bulk_members(addition)
 
         async with database_connection.begin_session_read_committed() as sess:
             membership_count = await sess.scalar(
@@ -905,7 +905,7 @@ class TestRemoveEntityMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.bulk_add_entity_members(
+            await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=removed_id), StubMember(member_id=kept_id)],
@@ -941,12 +941,12 @@ class TestRemoveEntityMembers:
 
 
 # =============================================================================
-# bulk_add_scope_members
+# add_bulk_scope_members
 # =============================================================================
 
 
-class TestBulkAddScopeMembers:
-    """bulk_add_scope_members enrolls each member scope into the containing scope's VS and
+class TestAddBulkScopeMembers:
+    """add_bulk_scope_members enrolls each member scope into the containing scope's VS and
     binds the containing scope into each member's VS — never the reverse binding."""
 
     async def test_enrolls_members_and_binds_scope_without_reverse(
@@ -967,7 +967,7 @@ class TestBulkAddScopeMembers:
             await w.ensure_scope(scope)
             for member in members:
                 await w.ensure_scope(member)
-            await w.bulk_add_scope_members(scope, members, permission_cap=Permission.READ)
+            await w.add_bulk_scope_members(scope, members, permission_cap=Permission.READ)
 
         async with database_connection.begin_session_read_committed() as sess:
             vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
@@ -1028,8 +1028,8 @@ class TestBulkAddScopeMembers:
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(member)
-            await w.bulk_add_scope_members(scope, [member], permission_cap=Permission.READ)
-            await w.bulk_add_scope_members(scope, [member], permission_cap=Permission.full())
+            await w.add_bulk_scope_members(scope, [member], permission_cap=Permission.READ)
+            await w.add_bulk_scope_members(scope, [member], permission_cap=Permission.full())
 
         async with database_connection.begin_session_read_committed() as sess:
             member_vs = (
@@ -1083,7 +1083,7 @@ class TestBulkAddScopeMembers:
 
         with pytest.raises(VirtualScopeNotFound):
             async with provider.write_ops() as w:
-                await w.bulk_add_scope_members(scope, [present, missing])
+                await w.add_bulk_scope_members(scope, [present, missing])
 
         async with database_connection.begin_session_read_committed() as sess:
             binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
@@ -1109,7 +1109,7 @@ class TestBulkAddScopeMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.bulk_add_scope_members(scope, [])
+            await w.add_bulk_scope_members(scope, [])
 
         async with database_connection.begin_session_read_committed() as sess:
             binding_count = await sess.scalar(
@@ -1120,12 +1120,12 @@ class TestBulkAddScopeMembers:
 
 
 # =============================================================================
-# bulk_add_entity_members_partial / bulk_add_scope_members_partial
+# add_bulk_members_partial / add_bulk_scope_members_partial
 # =============================================================================
 
 
-class TestBulkAddEntityMembersPartial:
-    """bulk_add_entity_members_partial isolates each member: a failed member is reported and
+class TestAddBulkMembersPartial:
+    """add_bulk_members_partial isolates each member: a failed member is reported and
     rolled back while the rest are added."""
 
     async def test_failed_member_is_isolated(
@@ -1145,7 +1145,7 @@ class TestBulkAddEntityMembersPartial:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            result = await w.bulk_add_entity_members_partial(
+            result = await w.add_bulk_members_partial(
                 EntityMembersAddition(scope=scope, members=[valid, invalid])
             )
 
@@ -1187,8 +1187,8 @@ class TestBulkAddEntityMembersPartial:
         assert assoc_ids == {str(valid.member_id)}
 
 
-class TestBulkAddScopeMembersPartial:
-    """bulk_add_scope_members_partial isolates each member: a member without a virtual scope
+class TestAddBulkScopeMembersPartial:
+    """add_bulk_scope_members_partial isolates each member: a member without a virtual scope
     is reported in errors while the rest are fully attached."""
 
     async def test_missing_member_vs_is_isolated(
@@ -1206,7 +1206,7 @@ class TestBulkAddScopeMembersPartial:
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(valid)
-            result = await w.bulk_add_scope_members_partial(
+            result = await w.add_bulk_scope_members_partial(
                 scope, [valid, missing], permission_cap=Permission.READ
             )
 
@@ -1331,7 +1331,7 @@ class TestScopeDeletionVirtualScopeCleanup:
             await w.create_scope(single_scope.creation)
             await w.ensure_scope(other)
             await w.bind_scope(scope, other, permission_cap=None)
-            await w.bulk_add_entity_members(
+            await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=other,
                     members=[
@@ -1383,7 +1383,7 @@ class TestScopeDeletionVirtualScopeCleanup:
             await w.ensure_scope(other)
             for scope in scopes:
                 await w.bind_scope(scope, other, permission_cap=None)
-            await w.bulk_add_entity_members(
+            await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=other,
                     members=[

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -25,7 +25,12 @@ from ai.backend.common.data.entity.types import (
     EntityType as VirtualScopeEntityType,
 )
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
-from ai.backend.common.data.permission.types import EntityType, RBACElementType, RelationType
+from ai.backend.common.data.permission.types import (
+    EntityType,
+    Permission,
+    RBACElementType,
+    RelationType,
+)
 from ai.backend.common.data.permission.types import ScopeType as PermissionScopeType
 from ai.backend.common.exception import (
     BackendAIError,
@@ -38,6 +43,7 @@ from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.errors.permission import VirtualScopeNotFound
 from ai.backend.manager.errors.repository import (
     ForeignKeyViolationError,
     UnsupportedCompositePrimaryKeyError,
@@ -72,6 +78,8 @@ from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRo
 from ai.backend.manager.repositories.base import CreatorSpec, IntegrityErrorCheck
 from ai.backend.manager.repositories.base.rbac.entity_creator import RBACEntityCreator
 from ai.backend.manager.repositories.base.rbac.entity_purger import (
+    RBACEntityBatchPurger,
+    RBACEntityBatchPurgerSpec,
     RBACEntityPurger,
     RBACEntityPurgerSpec,
 )
@@ -84,7 +92,10 @@ from ai.backend.manager.repositories.base.upserter import UpserterSpec
 from ai.backend.manager.repositories.ops.rbac.provider import (
     EntityMembersAddition,
     RBACOpsProvider,
+    ScopeBatchDeletion,
     ScopeCreation,
+    ScopeDeletion,
+    ScopeEntityMember,
     ScopeMember,
 )
 from ai.backend.manager.repositories.permission_controller.role_manager import (
@@ -180,10 +191,11 @@ def make_scope_creation(scope_id: UUID, name: str) -> ScopeCreation[OpsRBACScope
 class StubMember(ScopeMember):
     member_id: UUID
     role_user: UserID | None = None
+    entity_type: VirtualScopeEntityType = _TEST_MEMBER_ENTITY_TYPE
 
     @override
     def entity_ref(self) -> EntityRef:
-        return EntityRef(entity_type=_TEST_MEMBER_ENTITY_TYPE, entity_id=self.member_id)
+        return EntityRef(entity_type=self.entity_type, entity_id=self.member_id)
 
     @override
     def assign_role_on(self) -> UserID | None:
@@ -791,10 +803,10 @@ class TestBulkPurgeScopedPartial:
             assert list(blocked_scope_ids) == [_USER_SCOPE_ID]
 
 
-class TestAddEntityMembers:
-    """add_entity_members writes both the virtual-scope membership and the scope association."""
+class TestBulkAddEntityMembers:
+    """bulk_add_entity_members writes both the VS membership and the scope association."""
 
-    async def test_add_entity_members_writes_membership_and_association(
+    async def test_bulk_add_entity_members_writes_membership_and_association(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
@@ -807,7 +819,7 @@ class TestAddEntityMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.add_entity_members(
+            await w.bulk_add_entity_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=mid) for mid in member_ids],
@@ -844,7 +856,7 @@ class TestAddEntityMembers:
         assert membership_ids == set(member_ids)
         assert assoc_ids == {str(mid) for mid in member_ids}
 
-    async def test_add_entity_members_is_idempotent(
+    async def test_bulk_add_entity_members_is_idempotent(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
@@ -858,8 +870,8 @@ class TestAddEntityMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.add_entity_members(addition)
-            await w.add_entity_members(addition)
+            await w.bulk_add_entity_members(addition)
+            await w.bulk_add_entity_members(addition)
 
         async with database_connection.begin_session_read_committed() as sess:
             membership_count = await sess.scalar(
@@ -893,7 +905,7 @@ class TestRemoveEntityMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.add_entity_members(
+            await w.bulk_add_entity_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=removed_id), StubMember(member_id=kept_id)],
@@ -926,6 +938,489 @@ class TestRemoveEntityMembers:
 
         assert membership_ids == {kept_id}
         assert assoc_ids == {str(kept_id)}
+
+
+# =============================================================================
+# bulk_add_scope_members
+# =============================================================================
+
+
+class TestBulkAddScopeMembers:
+    """bulk_add_scope_members enrolls each member scope into the containing scope's VS and
+    binds the containing scope into each member's VS — never the reverse binding."""
+
+    async def test_enrolls_members_and_binds_scope_without_reverse(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """Each member joins the scope's VS as an entity member (with its scope
+        association) and its own VS gains the scope's binding with the given cap; the
+        scope's own VS gains no binding for any member."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+        members = [
+            ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4()) for _ in range(2)
+        ]
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            for member in members:
+                await w.ensure_scope(member)
+            await w.bulk_add_scope_members(scope, members, permission_cap=Permission.READ)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            vs_by_scope = {vs.scope_id: vs.id for vs in vs_rows}
+            membership_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(EntityMembershipRow.entity_id).where(
+                            EntityMembershipRow.virtual_scope_id == vs_by_scope[scope.scope_id],
+                            EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
+                        )
+                    )
+                ).all()
+            )
+            assoc_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                            AssociationScopesEntitiesRow.scope_id == str(scope.scope_id),
+                            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        )
+                    )
+                ).all()
+            )
+
+        assert membership_ids == {member.scope_id for member in members}
+        assert assoc_ids == {str(member.scope_id) for member in members}
+
+        for member in members:
+            member_bindings = {
+                (b.scope_type, b.scope_id): b.permission_cap
+                for b in binding_rows
+                if b.virtual_scope_id == vs_by_scope[member.scope_id]
+            }
+            assert member_bindings == {
+                (_TEST_MEMBER_SCOPE_TYPE, member.scope_id): None,  # self binding
+                (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
+            }
+        scope_vs_bindings = {
+            (b.scope_type, b.scope_id)
+            for b in binding_rows
+            if b.virtual_scope_id == vs_by_scope[scope.scope_id]
+        }
+        assert scope_vs_bindings == {(_TEST_SCOPE_TYPE, scope.scope_id)}  # self binding only
+
+    async def test_readd_keeps_existing_binding_and_cap(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """Re-adding the same member with a different cap is a no-op — no duplicate
+        membership or binding, and the original binding cap is kept."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+        member = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(member)
+            await w.bulk_add_scope_members(scope, [member], permission_cap=Permission.READ)
+            await w.bulk_add_scope_members(scope, [member], permission_cap=Permission.full())
+
+        async with database_connection.begin_session_read_committed() as sess:
+            member_vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == member.scope_id)
+                )
+            ).scalar_one()
+            binding_rows = (
+                (
+                    await sess.execute(
+                        sa.select(ScopeBindingRow).where(
+                            ScopeBindingRow.virtual_scope_id == member_vs.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            membership_count = await sess.scalar(
+                sa.select(sa.func.count())
+                .select_from(EntityMembershipRow)
+                .where(
+                    EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
+                    EntityMembershipRow.entity_id == member.scope_id,
+                )
+            )
+
+        caps_by_scope = {(b.scope_type, b.scope_id): b.permission_cap for b in binding_rows}
+        assert caps_by_scope == {
+            (_TEST_MEMBER_SCOPE_TYPE, member.scope_id): None,  # self binding
+            (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
+        }
+        # one in its own VS (self) and one in the containing scope's VS
+        assert membership_count == 2
+
+    async def test_missing_member_vs_fails_the_whole_call(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """One member without a VS raises VirtualScopeNotFound and nothing is written —
+        no membership and no binding, not even for the members whose VS exists."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+        present = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+        missing = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(present)
+
+        with pytest.raises(VirtualScopeNotFound):
+            async with provider.write_ops() as w:
+                await w.bulk_add_scope_members(scope, [present, missing])
+
+        async with database_connection.begin_session_read_committed() as sess:
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+
+        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
+            (_TEST_SCOPE_TYPE, scope.scope_id),  # self bindings only
+            (_TEST_MEMBER_SCOPE_TYPE, present.scope_id),
+        }
+        assert {(m.entity_type, m.entity_id) for m in membership_rows} == {
+            (_TEST_ENTITY_TYPE, scope.scope_id),  # self memberships only
+            (_TEST_MEMBER_ENTITY_TYPE, present.scope_id),
+        }
+
+    async def test_empty_members_is_noop(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """An empty member collection writes nothing."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.bulk_add_scope_members(scope, [])
+
+        async with database_connection.begin_session_read_committed() as sess:
+            binding_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(ScopeBindingRow)
+            )
+
+        assert binding_count == 1  # the self binding from ensure_scope
+
+
+# =============================================================================
+# bulk_add_entity_members_partial / bulk_add_scope_members_partial
+# =============================================================================
+
+
+class TestBulkAddEntityMembersPartial:
+    """bulk_add_entity_members_partial isolates each member: a failed member is reported and
+    rolled back while the rest are added."""
+
+    async def test_failed_member_is_isolated(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """A member whose entity type has no legacy counterpart fails alone — its
+        membership is rolled back with it — while the valid member keeps both rows."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+        valid = StubMember(member_id=uuid.uuid4())
+        invalid = StubMember(
+            member_id=uuid.uuid4(),
+            entity_type=VirtualScopeEntityType("unregistered-type"),
+        )
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            result = await w.bulk_add_entity_members_partial(
+                EntityMembersAddition(scope=scope, members=[valid, invalid])
+            )
+
+        assert result.successes == [valid]
+        assert [error.member for error in result.errors] == [invalid]
+        assert result.errors[0].index == 1
+
+        async with database_connection.begin_session_read_committed() as sess:
+            scope_vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope.scope_id)
+                )
+            ).scalar_one()
+            membership_rows = (
+                (
+                    await sess.execute(
+                        sa.select(EntityMembershipRow).where(
+                            EntityMembershipRow.virtual_scope_id == scope_vs.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assoc_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                            AssociationScopesEntitiesRow.scope_id == str(scope.scope_id)
+                        )
+                    )
+                ).all()
+            )
+
+        assert {(m.entity_type, m.entity_id) for m in membership_rows} == {
+            (_TEST_ENTITY_TYPE, scope.scope_id),  # self membership
+            (_TEST_MEMBER_ENTITY_TYPE, valid.member_id),
+        }
+        assert assoc_ids == {str(valid.member_id)}
+
+
+class TestBulkAddScopeMembersPartial:
+    """bulk_add_scope_members_partial isolates each member: a member without a virtual scope
+    is reported in errors while the rest are fully attached."""
+
+    async def test_missing_member_vs_is_isolated(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """The member without a VS lands in errors with nothing written for it; the
+        valid member gets its membership, association, and binding."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+        valid = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+        missing = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(valid)
+            result = await w.bulk_add_scope_members_partial(
+                scope, [valid, missing], permission_cap=Permission.READ
+            )
+
+        assert result.successes == [valid]
+        assert [error.member for error in result.errors] == [missing]
+        assert isinstance(result.errors[0].exception, VirtualScopeNotFound)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            vs_by_scope = {vs.scope_id: vs.id for vs in vs_rows}
+            membership_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(EntityMembershipRow.entity_id).where(
+                            EntityMembershipRow.virtual_scope_id == vs_by_scope[scope.scope_id],
+                            EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
+                        )
+                    )
+                ).all()
+            )
+
+        assert missing.scope_id not in vs_by_scope
+        assert membership_ids == {valid.scope_id}
+        valid_bindings = {
+            (b.scope_type, b.scope_id): b.permission_cap
+            for b in binding_rows
+            if b.virtual_scope_id == vs_by_scope[valid.scope_id]
+        }
+        assert valid_bindings == {
+            (_TEST_MEMBER_SCOPE_TYPE, valid.scope_id): None,  # self binding
+            (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
+        }
+
+
+# =============================================================================
+# Scope deletion: virtual-scope edge cleanup
+# =============================================================================
+
+
+@dataclass
+class ScopeRowPurgerSpec(RBACEntityPurgerSpec[OpsRBACScopeRow]):
+    scope_id: UUID
+
+    @override
+    def row_class(self) -> type[OpsRBACScopeRow]:
+        return OpsRBACScopeRow
+
+    @override
+    def pk_value(self) -> UUID:
+        return self.scope_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.PROJECT
+
+    @override
+    def entity_ref(self) -> RBACElementRef:
+        return RBACElementRef(RBACElementType.PROJECT, str(self.scope_id))
+
+
+@dataclass
+class ScopeRowBatchPurgerSpec(RBACEntityBatchPurgerSpec[OpsRBACScopeRow]):
+    scope_ids: Sequence[UUID]
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[OpsRBACScopeRow]]:
+        return sa.select(OpsRBACScopeRow).where(OpsRBACScopeRow.id.in_(self.scope_ids))
+
+    @override
+    def element_type(self) -> RBACElementType:
+        return RBACElementType.PROJECT
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+
+_SCOPE_DELETE_TABLES = [
+    OpsRBACScopeRow,
+    VirtualScopeRow,
+    EntityMembershipRow,
+    ScopeBindingRow,
+    RolePresetRow,
+    RolePermissionPresetRow,
+    AssociationScopesEntitiesRow,
+    PermissionRow,
+]
+
+
+@pytest.fixture
+async def scope_delete_tables(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[None, None]:
+    async with with_tables(database_connection, _SCOPE_DELETE_TABLES):  # type: ignore[arg-type]
+        yield
+
+
+class TestScopeDeletionVirtualScopeCleanup:
+    """delete_scope / batch_delete_scopes remove not only the scope's own VS node but
+    also the edges the scope left in other virtual scopes: its bindings as the reaching
+    side and its entity memberships."""
+
+    async def test_delete_scope_removes_edges_in_other_virtual_scopes(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        scope_delete_tables: None,
+        single_scope: SingleScopeContext,
+    ) -> None:
+        """The deleted scope's binding and membership in another VS are removed; the
+        other VS keeps its node and self edges."""
+        scope_id = single_scope.scope_id
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+        other = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.create_scope(single_scope.creation)
+            await w.ensure_scope(other)
+            await w.bind_scope(scope, other, permission_cap=None)
+            await w.bulk_add_entity_members(
+                EntityMembersAddition(
+                    scope=other,
+                    members=[
+                        ScopeEntityMember(
+                            ref=EntityRef(entity_type=_TEST_ENTITY_TYPE, entity_id=scope_id)
+                        )
+                    ],
+                )
+            )
+
+        async with provider.write_ops() as w:
+            result = await w.delete_scope(
+                ScopeDeletion(
+                    purger=RBACEntityPurger(spec=ScopeRowPurgerSpec(scope_id=scope_id)),
+                    scope=scope,
+                )
+            )
+
+        assert result is not None
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+
+        assert {vs.scope_id for vs in vs_rows} == {other.scope_id}
+        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
+            (_TEST_SCOPE_TYPE, other.scope_id),  # the other VS keeps only its self binding
+        }
+        assert {(m.entity_type, m.entity_id) for m in membership_rows} == {
+            (_TEST_ENTITY_TYPE, other.scope_id),  # and only its self membership
+        }
+
+    async def test_batch_delete_scopes_removes_edges_in_other_virtual_scopes(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        scope_delete_tables: None,
+        bulk_scopes: BulkScopeContext,
+    ) -> None:
+        """Every batch-deleted scope's binding and membership in the surviving VS are
+        removed along with the real rows."""
+        scope_ids = bulk_scopes.scope_ids
+        scopes = [ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=sid) for sid in scope_ids]
+        other = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.bulk_create_scopes(bulk_scopes.creations)
+            await w.ensure_scope(other)
+            for scope in scopes:
+                await w.bind_scope(scope, other, permission_cap=None)
+            await w.bulk_add_entity_members(
+                EntityMembersAddition(
+                    scope=other,
+                    members=[
+                        ScopeEntityMember(
+                            ref=EntityRef(entity_type=_TEST_ENTITY_TYPE, entity_id=sid)
+                        )
+                        for sid in scope_ids
+                    ],
+                )
+            )
+
+        async with provider.write_ops() as w:
+            result = await w.batch_delete_scopes(
+                ScopeBatchDeletion(
+                    purger=RBACEntityBatchPurger(spec=ScopeRowBatchPurgerSpec(scope_ids=scope_ids)),
+                    scopes=scopes,
+                )
+            )
+
+        assert result.deleted_count == len(scope_ids)
+
+        async with database_connection.begin_session_read_committed() as sess:
+            real_row_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(OpsRBACScopeRow)
+            )
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            membership_rows = (await sess.execute(sa.select(EntityMembershipRow))).scalars().all()
+
+        assert real_row_count == 0
+        assert {vs.scope_id for vs in vs_rows} == {other.scope_id}
+        assert {(b.scope_type, b.scope_id) for b in binding_rows} == {
+            (_TEST_SCOPE_TYPE, other.scope_id),
+        }
+        assert {(m.entity_type, m.entity_id) for m in membership_rows} == {
+            (_TEST_ENTITY_TYPE, other.scope_id),
+        }
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- `add_bulk_members(_partial)` now wires every member fully: membership in the containing scope's virtual scope, the legacy scope association, and the containing scope's binding into the member's own virtual scope (`permission_cap` applies to both edges; the reverse binding is never written). Every entity doubles as a scope backed by its own virtual scope, so the separate scope-member ops are no longer needed. The three writes live in dedicated helpers shared by the bulk and partial variants.
- `remove_bulk_members` (née `remove_entity_members`) deletes the same three edges — including the binding previously leaked in the member's virtual scope — and never raises for missing virtual scopes, so legacy rows stay removable.
- Delete `bind_scope` / `unbind_scope` / `add_bulk_scope_members(_partial)` and the `bound_scope` parameter of `create_scope` / `ensure_scope`, all absorbed by the unified ops; project creation now joins its domain scope via `add_bulk_members`.
- Fix virtual-scope purge leaks: `delete_scope` / `batch_delete_scopes` also remove the edges a deleted scope left in other virtual scopes (its bindings as the reaching side and its entity memberships), which FK CASCADE on the scope's own node never covered.
- Express the edge writes as creator specs (`EntityMembershipCreatorSpec`, `ScopeBindingCreatorSpec`) inserted through spec-based `ON CONFLICT DO NOTHING` helpers.

## Test plan
- [x] `add_bulk_members` writes membership, association, and per-member binding with the given cap — never a reverse binding
- [x] Re-adding a member with a different cap is a no-op that keeps the original cap; an empty member collection is a no-op
- [x] A member without a virtual scope fails the bulk call with nothing written; the partial variant isolates it in `errors` while fully attaching the rest
- [x] `remove_bulk_members` deletes all three edges and still deletes membership/association when the member has no virtual scope
- [x] `delete_scope` / `batch_delete_scopes` remove the deleted scopes' bindings and memberships in surviving virtual scopes

Resolves BA-7174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
