### PR TITLE
feat(BA-7157): seed --enable-prompt-tokens-details preset for the vllm runtime variant

### DIFF
--- a/changes/13455.feature.md
+++ b/changes/13455.feature.md
@@ -1,0 +1,1 @@
+Add the `--enable-prompt-tokens-details` flag to the vLLM runtime variant preset seed so it can be toggled from the model service runtime parameter form.

--- a/changes/13455.feature.md
+++ b/changes/13455.feature.md
@@ -1,1 +1,1 @@
-Add the `--enable-prompt-tokens-details` flag to the vLLM runtime variant preset seed so it can be toggled from the model service runtime parameter form.
+Add the `--enable-prompt-tokens-details` preset to the vLLM runtime variant.

--- a/fixtures/manager/example-runtime-variant-presets.json
+++ b/fixtures/manager/example-runtime-variant-presets.json
@@ -780,6 +780,21 @@
       }
     },
     {
+      "runtime_variant_name": "vllm",
+      "name": "enable-prompt-tokens-details",
+      "description": "Report prompt token details (e.g. cached tokens) in usage responses.",
+      "rank": 3000,
+      "preset_target": "args",
+      "value_type": "flag",
+      "default_value": null,
+      "key": "--enable-prompt-tokens-details",
+      "category": "monitoring",
+      "display_name": "Enable Prompt Tokens Details",
+      "ui_option": {
+        "ui_type": "checkbox"
+      }
+    },
+    {
       "runtime_variant_name": "sglang",
       "name": "model",
       "description": "HuggingFace model name or local path.",

--- a/src/ai/backend/install/fixtures/example-runtime-variant-presets.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variant-presets.json
@@ -780,6 +780,21 @@
       }
     },
     {
+      "runtime_variant_name": "vllm",
+      "name": "enable-prompt-tokens-details",
+      "description": "Report prompt token details (e.g. cached tokens) in usage responses.",
+      "rank": 3000,
+      "preset_target": "args",
+      "value_type": "flag",
+      "default_value": null,
+      "key": "--enable-prompt-tokens-details",
+      "category": "monitoring",
+      "display_name": "Enable Prompt Tokens Details",
+      "ui_option": {
+        "ui_type": "checkbox"
+      }
+    },
+    {
       "runtime_variant_name": "sglang",
       "name": "model",
       "description": "HuggingFace model name or local path.",

--- a/src/ai/backend/manager/models/alembic/versions/fb5befb44035_seed_enable_prompt_tokens_details_preset.py
+++ b/src/ai/backend/manager/models/alembic/versions/fb5befb44035_seed_enable_prompt_tokens_details_preset.py
@@ -1,0 +1,99 @@
+"""seed enable-prompt-tokens-details preset for vllm
+
+Adds vLLM's ``--enable-prompt-tokens-details`` flag as a runtime variant
+preset so it can be toggled from the model service form instead of the
+free-form ``VLLM_EXTRA_ARGS`` escape hatch. With the flag on, vLLM
+reports ``usage.prompt_tokens_details`` (notably ``cached_tokens``) in
+its OpenAI-compatible responses, which is the only way to observe
+whether ``--enable-prefix-caching`` is actually hitting.
+
+The seed migration ``e7b3a1f9c2d4`` already shipped, so the row is added
+in a new revision using the same idempotent insert/delete pattern.
+
+Revision ID: fb5befb44035
+Revises: c1a7d3f05e28
+Create Date: 2026-08-05
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "fb5befb44035"
+down_revision = "c1a7d3f05e28"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+_PRESET_ROW = {
+    "runtime_variant_name": "vllm",
+    "name": "enable-prompt-tokens-details",
+    "description": "Report prompt token details (e.g. cached tokens) in usage responses.",
+    "rank": 2450,
+    "preset_target": "args",
+    "value_type": "flag",
+    "default_value": None,
+    "key": "--enable-prompt-tokens-details",
+    "category": "monitoring",
+    "display_name": "Enable Prompt Tokens Details",
+    "ui_option": {
+        "ui_type": "checkbox",
+    },
+}
+
+_INSERT_SQL = sa.text(
+    """
+    INSERT INTO runtime_variant_presets
+        (runtime_variant, name, description, rank, preset_target, value_type,
+         default_value, key, category, display_name, ui_option)
+    SELECT
+        rv.id, :name, :description, :rank, :preset_target, :value_type,
+        :default_value, :key, :category, :display_name, CAST(:ui_option AS JSONB)
+    FROM runtime_variants rv
+    WHERE rv.name = :variant_name
+    ON CONFLICT ON CONSTRAINT uq_runtime_variant_presets_variant_name DO NOTHING
+    """
+)
+
+_DELETE_SQL = sa.text(
+    """
+    DELETE FROM runtime_variant_presets
+    WHERE name = :name
+      AND runtime_variant = (SELECT id FROM runtime_variants WHERE name = :variant_name)
+    """
+)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        _INSERT_SQL,
+        {
+            "variant_name": _PRESET_ROW["runtime_variant_name"],
+            "name": _PRESET_ROW["name"],
+            "description": _PRESET_ROW["description"],
+            "rank": _PRESET_ROW["rank"],
+            "preset_target": _PRESET_ROW["preset_target"],
+            "value_type": _PRESET_ROW["value_type"],
+            "default_value": _PRESET_ROW["default_value"],
+            "key": _PRESET_ROW["key"],
+            "category": _PRESET_ROW["category"],
+            "display_name": _PRESET_ROW["display_name"],
+            "ui_option": json.dumps(_PRESET_ROW["ui_option"]),
+        },
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        _DELETE_SQL,
+        {
+            "name": _PRESET_ROW["name"],
+            "variant_name": _PRESET_ROW["runtime_variant_name"],
+        },
+    )

--- a/src/ai/backend/manager/models/alembic/versions/fb5befb44035_seed_enable_prompt_tokens_details_preset.py
+++ b/src/ai/backend/manager/models/alembic/versions/fb5befb44035_seed_enable_prompt_tokens_details_preset.py
@@ -8,32 +8,35 @@ its OpenAI-compatible responses, which is the only way to observe
 whether ``--enable-prefix-caching`` is actually hitting.
 
 The seed migration ``e7b3a1f9c2d4`` already shipped, so the row is added
-in a new revision using the same idempotent insert/delete pattern.
+in a new revision using the same idempotent insert pattern.
 
 Revision ID: fb5befb44035
-Revises: c1a7d3f05e28
+Revises: c8d51e7a3b62
 Create Date: 2026-08-05
 
 """
 
 import json
+import logging
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "fb5befb44035"
-down_revision = "c1a7d3f05e28"
+down_revision = "c8d51e7a3b62"
 # Part of: NEXT_RELEASE_VERSION
 branch_labels = None
 depends_on = None
 
+log = logging.getLogger("alembic.runtime.migration")
+
+_VARIANT_NAME = "vllm"
 
 _PRESET_ROW = {
-    "runtime_variant_name": "vllm",
     "name": "enable-prompt-tokens-details",
     "description": "Report prompt token details (e.g. cached tokens) in usage responses.",
-    "rank": 2450,
+    "rank": 3000,
     "preset_target": "args",
     "value_type": "flag",
     "default_value": None,
@@ -44,6 +47,14 @@ _PRESET_ROW = {
         "ui_type": "checkbox",
     },
 }
+
+_BIND_PARAMS = {
+    **_PRESET_ROW,
+    "variant_name": _VARIANT_NAME,
+    "ui_option": json.dumps(_PRESET_ROW["ui_option"]),
+}
+
+_VARIANT_ID_SQL = sa.text("SELECT id FROM runtime_variants WHERE name = :variant_name")
 
 _INSERT_SQL = sa.text(
     """
@@ -59,41 +70,60 @@ _INSERT_SQL = sa.text(
     """
 )
 
+# Deployment revisions reference presets through a ``preset_values`` JSONB array
+# with no foreign key, so an unguarded delete leaves the reference dangling and
+# the argument is dropped without an error at the next reconcile. Matching every
+# seeded column additionally keeps a same-named row an operator created out of
+# the delete.
 _DELETE_SQL = sa.text(
     """
-    DELETE FROM runtime_variant_presets
-    WHERE name = :name
-      AND runtime_variant = (SELECT id FROM runtime_variants WHERE name = :variant_name)
+    DELETE FROM runtime_variant_presets rvp
+    USING runtime_variants rv
+    WHERE rvp.runtime_variant = rv.id
+      AND rv.name = :variant_name
+      AND rvp.name = :name
+      AND rvp.description = :description
+      AND rvp.rank = :rank
+      AND rvp.preset_target = :preset_target
+      AND rvp.value_type = :value_type
+      AND rvp.default_value IS NOT DISTINCT FROM CAST(:default_value AS VARCHAR)
+      AND rvp.key = :key
+      AND rvp.category = :category
+      AND rvp.display_name = :display_name
+      AND rvp.ui_option = CAST(:ui_option AS JSONB)
+      AND NOT EXISTS (
+          SELECT 1 FROM deployment_revisions dr
+          WHERE dr.preset_values
+                @> jsonb_build_array(jsonb_build_object('preset_id', rvp.id::text))
+      )
+      AND NOT EXISTS (
+          SELECT 1 FROM deployment_revision_presets drp
+          WHERE drp.preset_values
+                @> jsonb_build_array(jsonb_build_object('preset_id', rvp.id::text))
+      )
     """
 )
 
 
 def upgrade() -> None:
     conn = op.get_bind()
-    conn.execute(
-        _INSERT_SQL,
-        {
-            "variant_name": _PRESET_ROW["runtime_variant_name"],
-            "name": _PRESET_ROW["name"],
-            "description": _PRESET_ROW["description"],
-            "rank": _PRESET_ROW["rank"],
-            "preset_target": _PRESET_ROW["preset_target"],
-            "value_type": _PRESET_ROW["value_type"],
-            "default_value": _PRESET_ROW["default_value"],
-            "key": _PRESET_ROW["key"],
-            "category": _PRESET_ROW["category"],
-            "display_name": _PRESET_ROW["display_name"],
-            "ui_option": json.dumps(_PRESET_ROW["ui_option"]),
-        },
-    )
+    if conn.scalar(_VARIANT_ID_SQL, {"variant_name": _VARIANT_NAME}) is None:
+        log.warning(
+            "runtime variant %r not found; skipped seeding the %r preset",
+            _VARIANT_NAME,
+            _PRESET_ROW["name"],
+        )
+        return
+    conn.execute(_INSERT_SQL, _BIND_PARAMS)
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-    conn.execute(
-        _DELETE_SQL,
-        {
-            "name": _PRESET_ROW["name"],
-            "variant_name": _PRESET_ROW["runtime_variant_name"],
-        },
-    )
+    result = conn.execute(_DELETE_SQL, _BIND_PARAMS)
+    if result.rowcount == 0:
+        log.warning(
+            "kept the %r preset of runtime variant %r: absent, locally modified,"
+            " or still referenced by a deployment revision",
+            _PRESET_ROW["name"],
+            _VARIANT_NAME,
+        )

--- a/tests/unit/manager/models/runtime_variant_preset/BUILD
+++ b/tests/unit/manager/models/runtime_variant_preset/BUILD
@@ -1,0 +1,10 @@
+python_tests(
+    name="tests",
+    # The seed sources are read as data rather than imported, so the
+    # dependencies cannot be inferred.
+    dependencies=[
+        "fixtures/manager:json",
+        "src/ai/backend/manager/models/alembic/versions/e7b3a1f9c2d4_seed_runtime_variant_presets_data.py:../../../src",
+        "src/ai/backend/manager/models/alembic/versions/fb5befb44035_seed_enable_prompt_tokens_details_preset.py:../../../src",
+    ],
+)

--- a/tests/unit/manager/models/runtime_variant_preset/BUILD
+++ b/tests/unit/manager/models/runtime_variant_preset/BUILD
@@ -1,10 +1,5 @@
 python_tests(
     name="tests",
-    # The seed sources are read as data rather than imported, so the
-    # dependencies cannot be inferred.
-    dependencies=[
-        "fixtures/manager:json",
-        "src/ai/backend/manager/models/alembic/versions/e7b3a1f9c2d4_seed_runtime_variant_presets_data.py:../../../src",
-        "src/ai/backend/manager/models/alembic/versions/fb5befb44035_seed_enable_prompt_tokens_details_preset.py:../../../src",
-    ],
+    # The fixture is read as data rather than imported.
+    dependencies=["fixtures/manager:json"],
 )

--- a/tests/unit/manager/models/runtime_variant_preset/test_preset_seed_sources.py
+++ b/tests/unit/manager/models/runtime_variant_preset/test_preset_seed_sources.py
@@ -1,0 +1,110 @@
+"""The runtime variant preset seed sources must not drift apart.
+
+A fresh install seeds ``runtime_variant_presets`` from the manager fixture, the
+installer ships its own copy of that fixture, and an upgraded deployment gets
+the same rows from the seed migrations. Nothing in the schema ties the three
+together, so a preset added to one of them alone leaves the table holding a
+different set depending on how the database was created.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import ai.backend.install
+import ai.backend.manager.models
+
+_MANAGER_FIXTURE_PATH = Path("fixtures/manager/example-runtime-variant-presets.json")
+_INSTALLER_FIXTURE_PATH = (
+    Path(ai.backend.install.__file__).parent / "fixtures" / "example-runtime-variant-presets.json"
+)
+_VERSIONS_DIR = Path(ai.backend.manager.models.__file__).parent / "alembic" / "versions"
+
+# A seed migration embeds its rows as literals, so a new one has to be listed
+# here to stay covered. Until it is, the tests below report it as drift.
+_SNAPSHOT_MIGRATION = _VERSIONS_DIR / "e7b3a1f9c2d4_seed_runtime_variant_presets_data.py"
+_SINGLE_ROW_MIGRATIONS = (
+    _VERSIONS_DIR / "fb5befb44035_seed_enable_prompt_tokens_details_preset.py",
+)
+
+
+@dataclass(frozen=True, order=True)
+class _PresetKey:
+    runtime_variant_name: str
+    name: str
+
+
+def _module_literals(path: Path) -> dict[str, Any]:
+    """Module-level literal assignments of a revision, read without importing it."""
+    literals: dict[str, Any] = {}
+    for node in ast.parse(path.read_text()).body:
+        if not isinstance(node, ast.Assign):
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        try:
+            literals[target.id] = ast.literal_eval(node.value)
+        except ValueError:
+            continue
+    return literals
+
+
+class TestPresetSeedSources:
+    @pytest.fixture
+    def fixture_presets(self) -> dict[_PresetKey, dict[str, Any]]:
+        rows = json.loads(_MANAGER_FIXTURE_PATH.read_text())["runtime_variant_presets"]
+        return {_PresetKey(row["runtime_variant_name"], row["name"]): row for row in rows}
+
+    @pytest.fixture
+    def installer_fixture_presets(self) -> dict[_PresetKey, dict[str, Any]]:
+        rows = json.loads(_INSTALLER_FIXTURE_PATH.read_text())["runtime_variant_presets"]
+        return {_PresetKey(row["runtime_variant_name"], row["name"]): row for row in rows}
+
+    @pytest.fixture
+    def seeded_presets(self) -> dict[_PresetKey, dict[str, Any]]:
+        rows: list[dict[str, Any]] = json.loads(
+            _module_literals(_SNAPSHOT_MIGRATION)["_SEED_DATA_JSON"]
+        )
+        for path in _SINGLE_ROW_MIGRATIONS:
+            literals = _module_literals(path)
+            rows.append({
+                "runtime_variant_name": literals["_VARIANT_NAME"],
+                **literals["_PRESET_ROW"],
+            })
+        return {_PresetKey(row["runtime_variant_name"], row["name"]): row for row in rows}
+
+    def test_installer_fixture_mirrors_the_manager_fixture(
+        self,
+        fixture_presets: dict[_PresetKey, dict[str, Any]],
+        installer_fixture_presets: dict[_PresetKey, dict[str, Any]],
+    ) -> None:
+        assert installer_fixture_presets == fixture_presets
+
+    def test_seed_migrations_describe_the_same_presets(
+        self,
+        fixture_presets: dict[_PresetKey, dict[str, Any]],
+        seeded_presets: dict[_PresetKey, dict[str, Any]],
+    ) -> None:
+        unseeded = sorted(set(fixture_presets) - set(seeded_presets))
+        unfixtured = sorted(set(seeded_presets) - set(fixture_presets))
+        assert not unseeded, f"presets in the fixture but not in any seed migration: {unseeded}"
+        assert not unfixtured, f"presets in a seed migration but not in the fixture: {unfixtured}"
+
+    def test_seeded_values_match_the_fixture(
+        self,
+        fixture_presets: dict[_PresetKey, dict[str, Any]],
+        seeded_presets: dict[_PresetKey, dict[str, Any]],
+    ) -> None:
+        mismatched = sorted(
+            key
+            for key, row in seeded_presets.items()
+            if key in fixture_presets and row != fixture_presets[key]
+        )
+        assert not mismatched, f"presets whose seeded values differ from the fixture: {mismatched}"

--- a/tests/unit/manager/models/runtime_variant_preset/test_preset_seed_sources.py
+++ b/tests/unit/manager/models/runtime_variant_preset/test_preset_seed_sources.py
@@ -9,7 +9,6 @@ different set depending on how the database was created.
 
 from __future__ import annotations
 
-import ast
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -18,19 +17,16 @@ from typing import Any
 import pytest
 
 import ai.backend.install
-import ai.backend.manager.models
+from ai.backend.manager.models.alembic.versions import (
+    e7b3a1f9c2d4_seed_runtime_variant_presets_data as snapshot_seed,
+)
+from ai.backend.manager.models.alembic.versions import (
+    fb5befb44035_seed_enable_prompt_tokens_details_preset as prompt_tokens_seed,
+)
 
 _MANAGER_FIXTURE_PATH = Path("fixtures/manager/example-runtime-variant-presets.json")
 _INSTALLER_FIXTURE_PATH = (
     Path(ai.backend.install.__file__).parent / "fixtures" / "example-runtime-variant-presets.json"
-)
-_VERSIONS_DIR = Path(ai.backend.manager.models.__file__).parent / "alembic" / "versions"
-
-# A seed migration embeds its rows as literals, so a new one has to be listed
-# here to stay covered. Until it is, the tests below report it as drift.
-_SNAPSHOT_MIGRATION = _VERSIONS_DIR / "e7b3a1f9c2d4_seed_runtime_variant_presets_data.py"
-_SINGLE_ROW_MIGRATIONS = (
-    _VERSIONS_DIR / "fb5befb44035_seed_enable_prompt_tokens_details_preset.py",
 )
 
 
@@ -38,22 +34,6 @@ _SINGLE_ROW_MIGRATIONS = (
 class _PresetKey:
     runtime_variant_name: str
     name: str
-
-
-def _module_literals(path: Path) -> dict[str, Any]:
-    """Module-level literal assignments of a revision, read without importing it."""
-    literals: dict[str, Any] = {}
-    for node in ast.parse(path.read_text()).body:
-        if not isinstance(node, ast.Assign):
-            continue
-        target = node.targets[0]
-        if not isinstance(target, ast.Name):
-            continue
-        try:
-            literals[target.id] = ast.literal_eval(node.value)
-        except ValueError:
-            continue
-    return literals
 
 
 class TestPresetSeedSources:
@@ -69,15 +49,13 @@ class TestPresetSeedSources:
 
     @pytest.fixture
     def seeded_presets(self) -> dict[_PresetKey, dict[str, Any]]:
-        rows: list[dict[str, Any]] = json.loads(
-            _module_literals(_SNAPSHOT_MIGRATION)["_SEED_DATA_JSON"]
-        )
-        for path in _SINGLE_ROW_MIGRATIONS:
-            literals = _module_literals(path)
-            rows.append({
-                "runtime_variant_name": literals["_VARIANT_NAME"],
-                **literals["_PRESET_ROW"],
-            })
+        # A seed migration keeps its rows as module literals, so a new one has to
+        # be added here to stay covered. Until it is, the tests report it as drift.
+        rows: list[dict[str, Any]] = list(snapshot_seed._SEED_DATA)
+        rows.append({
+            "runtime_variant_name": prompt_tokens_seed._VARIANT_NAME,
+            **prompt_tokens_seed._PRESET_ROW,
+        })
         return {_PresetKey(row["runtime_variant_name"], row["name"]): row for row in rows}
 
     def test_installer_fixture_mirrors_the_manager_fixture(


### PR DESCRIPTION
Resolves BA-7157

## Summary

- Add a new alembic migration (`fb5befb44035`) that inserts vLLM's `--enable-prompt-tokens-details` flag as a `RuntimeVariantPreset` row for the `vllm` runtime variant, so it appears as a checkbox in the WebUI model service runtime parameter form.
- With this flag on, vLLM reports `usage.prompt_tokens_details` (notably `cached_tokens`) in its OpenAI-compatible responses — the only way to observe whether `--enable-prefix-caching` is actually hitting. Previously the flag could only be set via the free-form `VLLM_EXTRA_ARGS` legacy path.
- The row reuses the idempotent insert pattern from the shipped seed migration `e7b3a1f9c2d4`, which cannot be edited because it is already stamped on existing installs. No WebUI change is required; the `flag` value type and checkbox UI type are already wired on the frontend.
- The same row is added to both fixture copies (`fixtures/manager/` and `src/ai/backend/install/fixtures/`), which is where a fresh install seeds the table from.

### Migration behavior

| Case | Behavior |
|---|---|
| `vllm` variant present | Row inserted; re-running the migration is a no-op (`ON CONFLICT DO NOTHING`) |
| `vllm` variant absent | Insert skipped with a warning instead of stamping the revision on a silent no-op |
| Downgrade, row untouched and unreferenced | Row deleted |
| Downgrade, row referenced by a deployment revision | Row kept — the reference lives in a `preset_values` JSONB array with no FK, so deleting it would drop the argument at the next reconcile with no error |
| Downgrade, row locally modified | Row kept — the delete matches every seeded column, so an operator-created row of the same name is not clobbered |

The preset takes rank 3000, continuing the 100-step ladder that the seeded rows and the API-side allocator (`RANK_GAP`) both follow.

## Test plan

- [x] `fb5befb44035` chains off `c8d51e7a3b62`, main's current head; the chain resolves to a single head.
- [x] Verified the insert/delete SQL against PostgreSQL 16: insert applies, re-running is idempotent, the downgrade removes the seeded row, and the downgrade keeps the row when it is referenced from `deployment_revisions.preset_values`, referenced from `deployment_revision_presets.preset_values`, or locally modified. Verified the insert is a no-op when the `vllm` variant is absent.
- [x] `tests/unit/manager/models/runtime_variant_preset/test_preset_seed_sources.py` fails if the two fixture copies and the seed migrations ever describe different preset sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
