### PR TITLE
feat(BA-7184): expose the name-addressed fragment purge on REST v2

### DIFF
--- a/changes/13461.feature.md
+++ b/changes/13461.feature.md
@@ -1,0 +1,1 @@
+Add `POST /v2/app-config-fragments/my/by-names/bulk-delete` and `POST /v2/app-config-fragments/scoped/by-names/bulk-delete`, which purge a scope's app config fragments by config name, all-or-nothing.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1085,7 +1085,7 @@
         "title": "ScopedAppConfigFragmentsByNamesInput",
         "type": "object"
       },
-      "ScopedPurgeAppConfigFragmentsByNamesInput": {
+      "ScopedBulkPurgeAppConfigFragmentsByNamesInput": {
         "description": "Purge the fragments written at one scope for the given config names.",
         "properties": {
           "scope": {
@@ -1106,7 +1106,7 @@
           "scope",
           "config_names"
         ],
-        "title": "ScopedPurgeAppConfigFragmentsByNamesInput",
+        "title": "ScopedBulkPurgeAppConfigFragmentsByNamesInput",
         "type": "object"
       },
       "AppConfigFragmentUpsertItem": {
@@ -1176,7 +1176,7 @@
         "title": "MyAppConfigFragmentsByNamesInput",
         "type": "object"
       },
-      "MyPurgeAppConfigFragmentsByNamesInput": {
+      "MyBulkPurgeAppConfigFragmentsByNamesInput": {
         "description": "Purge the current user's own user-scope fragments for the given config names.",
         "properties": {
           "config_names": {
@@ -1192,7 +1192,7 @@
         "required": [
           "config_names"
         ],
-        "title": "MyPurgeAppConfigFragmentsByNamesInput",
+        "title": "MyBulkPurgeAppConfigFragmentsByNamesInput",
         "type": "object"
       },
       "MyUpsertAppConfigFragmentsInput": {
@@ -42042,7 +42042,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ScopedPurgeAppConfigFragmentsByNamesInput"
+                "$ref": "#/components/schemas/ScopedBulkPurgeAppConfigFragmentsByNamesInput"
               }
             }
           }
@@ -42129,7 +42129,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MyPurgeAppConfigFragmentsByNamesInput"
+                "$ref": "#/components/schemas/MyBulkPurgeAppConfigFragmentsByNamesInput"
               }
             }
           }

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1085,6 +1085,30 @@
         "title": "ScopedAppConfigFragmentsByNamesInput",
         "type": "object"
       },
+      "ScopedPurgeAppConfigFragmentsByNamesInput": {
+        "description": "Purge the fragments written at one scope for the given config names.",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/AppConfigScopeRef",
+            "description": "Scope whose fragments to purge."
+          },
+          "config_names": {
+            "description": "Config names whose fragments to purge. All-or-nothing: a name the scope holds no fragment for purges nothing and is reported as not found.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "scope",
+          "config_names"
+        ],
+        "title": "ScopedPurgeAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
       "AppConfigFragmentUpsertItem": {
         "description": "One (config_name, config) pair to upsert at the request's scope.",
         "properties": {
@@ -1150,6 +1174,25 @@
           "config_names"
         ],
         "title": "MyAppConfigFragmentsByNamesInput",
+        "type": "object"
+      },
+      "MyPurgeAppConfigFragmentsByNamesInput": {
+        "description": "Purge the current user's own user-scope fragments for the given config names.",
+        "properties": {
+          "config_names": {
+            "description": "Config names whose fragments to purge. All-or-nothing: a name the scope holds no fragment for purges nothing and is reported as not found.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Config Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "config_names"
+        ],
+        "title": "MyPurgeAppConfigFragmentsByNamesInput",
         "type": "object"
       },
       "MyUpsertAppConfigFragmentsInput": {
@@ -41979,6 +42022,35 @@
         "description": "Read one scope's fragments for the given config names (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
+    "/v2/app-config-fragments/scoped/by-names/bulk-delete": {
+      "post": {
+        "operationId": "v2/app-config-fragments.scoped_bulk_purge_by_names",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScopedPurgeAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Purge one scope's fragments by config name, all-or-nothing (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
     "/v2/app-config-fragments/scoped/bulk-upsert": {
       "post": {
         "operationId": "v2/app-config-fragments.scoped_bulk_upsert",
@@ -42035,6 +42107,35 @@
         },
         "parameters": [],
         "description": "Read the caller's own user-scope fragments for the given config names (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/app-config-fragments/my/by-names/bulk-delete": {
+      "post": {
+        "operationId": "v2/app-config-fragments.my_bulk_purge_by_names",
+        "tags": [
+          "v2/app-config-fragments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MyPurgeAppConfigFragmentsByNamesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Purge the caller's own user-scope fragments by config name, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/my/bulk-upsert": {

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -27,10 +27,10 @@ __all__ = (
     "AppConfigScopeRef",
     "BulkPurgeAppConfigFragmentInput",
     "MyAppConfigFragmentsByNamesInput",
-    "MyPurgeAppConfigFragmentsByNamesInput",
+    "MyBulkPurgeAppConfigFragmentsByNamesInput",
     "MyUpsertAppConfigFragmentsInput",
     "ScopedAppConfigFragmentsByNamesInput",
-    "ScopedPurgeAppConfigFragmentsByNamesInput",
+    "ScopedBulkPurgeAppConfigFragmentsByNamesInput",
     "ScopedSearchAppConfigFragmentInput",
     "ScopedUpsertAppConfigFragmentsInput",
 )
@@ -82,7 +82,7 @@ class MyAppConfigFragmentsByNamesInput(BaseRequestModel):
     )
 
 
-class ScopedPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
+class ScopedBulkPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
     """Purge the fragments written at one scope for the given config names."""
 
     scope: AppConfigScopeRef = Field(description="Scope whose fragments to purge.")
@@ -95,7 +95,7 @@ class ScopedPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
     )
 
 
-class MyPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
+class MyBulkPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
     """Purge the current user's own user-scope fragments for the given config names."""
 
     config_names: list[str] = Field(

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -27,8 +27,10 @@ __all__ = (
     "AppConfigScopeRef",
     "BulkPurgeAppConfigFragmentInput",
     "MyAppConfigFragmentsByNamesInput",
+    "MyPurgeAppConfigFragmentsByNamesInput",
     "MyUpsertAppConfigFragmentsInput",
     "ScopedAppConfigFragmentsByNamesInput",
+    "ScopedPurgeAppConfigFragmentsByNamesInput",
     "ScopedSearchAppConfigFragmentInput",
     "ScopedUpsertAppConfigFragmentsInput",
 )
@@ -76,6 +78,31 @@ class MyAppConfigFragmentsByNamesInput(BaseRequestModel):
         description=(
             "Config names whose fragments to read. Answered position by position, null "
             "where the scope holds no fragment for that name."
+        ),
+    )
+
+
+class ScopedPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
+    """Purge the fragments written at one scope for the given config names."""
+
+    scope: AppConfigScopeRef = Field(description="Scope whose fragments to purge.")
+    config_names: list[str] = Field(
+        min_length=1,
+        description=(
+            "Config names whose fragments to purge. All-or-nothing: a name the scope holds "
+            "no fragment for purges nothing and is reported as not found."
+        ),
+    )
+
+
+class MyPurgeAppConfigFragmentsByNamesInput(BaseRequestModel):
+    """Purge the current user's own user-scope fragments for the given config names."""
+
+    config_names: list[str] = Field(
+        min_length=1,
+        description=(
+            "Config names whose fragments to purge. All-or-nothing: a name the scope holds "
+            "no fragment for purges nothing and is reported as not found."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -18,7 +18,7 @@ __all__ = (
     "AppConfigFragmentsByNamesPayload",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
-    "PurgeAppConfigFragmentsByNamesPayload",
+    "BulkPurgeAppConfigFragmentsByNamesPayload",
     "SearchAppConfigFragmentPayload",
     "UpsertAppConfigFragmentsPayload",
 )
@@ -54,7 +54,7 @@ class PurgeAppConfigFragmentPayload(BaseResponseModel):
     id: AppConfigFragmentID = Field(description="Id of the purged app config fragment.")
 
 
-class PurgeAppConfigFragmentsByNamesPayload(BaseResponseModel):
+class BulkPurgeAppConfigFragmentsByNamesPayload(BaseResponseModel):
     """Payload for an all-or-nothing purge of the fragments one scope holds for config names."""
 
     items: list[AppConfigFragmentID] = Field(

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -18,6 +18,7 @@ __all__ = (
     "AppConfigFragmentsByNamesPayload",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
+    "PurgeAppConfigFragmentsByNamesPayload",
     "SearchAppConfigFragmentPayload",
     "UpsertAppConfigFragmentsPayload",
 )
@@ -51,6 +52,14 @@ class PurgeAppConfigFragmentPayload(BaseResponseModel):
     """Payload for app config fragment purge."""
 
     id: AppConfigFragmentID = Field(description="Id of the purged app config fragment.")
+
+
+class PurgeAppConfigFragmentsByNamesPayload(BaseResponseModel):
+    """Payload for an all-or-nothing purge of the fragments one scope holds for config names."""
+
+    items: list[AppConfigFragmentID] = Field(
+        description="Ids of the purged fragments, in the order their config names were given."
+    )
 
 
 class AppConfigFragmentBulkErrorInfo(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -16,10 +16,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
-    MyPurgeAppConfigFragmentsByNamesInput,
+    MyBulkPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
-    ScopedPurgeAppConfigFragmentsByNamesInput,
+    ScopedBulkPurgeAppConfigFragmentsByNamesInput,
     ScopedSearchAppConfigFragmentInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
@@ -27,8 +27,8 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentBulkErrorInfo,
     AppConfigFragmentNode,
     BulkPurgeAppConfigFragmentPayload,
+    BulkPurgeAppConfigFragmentsByNamesPayload,
     PurgeAppConfigFragmentPayload,
-    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -68,6 +68,9 @@ from ai.backend.manager.services.app_config_fragment.actions.admin_search import
 from ai.backend.manager.services.app_config_fragment.actions.bulk_purge import (
     BulkPurgeAppConfigFragmentAction,
 )
+from ai.backend.manager.services.app_config_fragment.actions.bulk_purge_by_names import (
+    BulkPurgeAppConfigFragmentsByNamesAction,
+)
 from ai.backend.manager.services.app_config_fragment.actions.bulk_upsert import (
     BulkUpsertAppConfigFragmentsAction,
 )
@@ -76,9 +79,6 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
 )
 from ai.backend.manager.services.app_config_fragment.actions.purge import (
     PurgeAppConfigFragmentAction,
-)
-from ai.backend.manager.services.app_config_fragment.actions.purge_by_names import (
-    PurgeAppConfigFragmentsByNamesAction,
 )
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
@@ -178,9 +178,9 @@ class AppConfigFragmentAdapter(BaseAdapter):
             ],
         )
 
-    async def scoped_purge_app_config_fragments_by_names(
-        self, input: ScopedPurgeAppConfigFragmentsByNamesInput
-    ) -> PurgeAppConfigFragmentsByNamesPayload:
+    async def scoped_bulk_purge_app_config_fragments_by_names(
+        self, input: ScopedBulkPurgeAppConfigFragmentsByNamesInput
+    ) -> BulkPurgeAppConfigFragmentsByNamesPayload:
         """Purge the fragments written at the scope named in ``input`` for ``config_names``.
 
         RBAC-authorized at that scope, so a caller purges only a scope they may write.
@@ -188,16 +188,20 @@ class AppConfigFragmentAdapter(BaseAdapter):
         scope = AppConfigFragmentSearchScope(
             scope_type=input.scope.scope_type, scope_id=input.scope.scope_id
         )
-        action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
-            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
+        action_result = (
+            await self._processors.app_config_fragment.bulk_purge_by_names.wait_for_complete(
+                BulkPurgeAppConfigFragmentsByNamesAction(
+                    scope=scope, config_names=input.config_names
+                )
+            )
         )
-        return PurgeAppConfigFragmentsByNamesPayload(
+        return BulkPurgeAppConfigFragmentsByNamesPayload(
             items=[fragment.id for fragment in action_result.fragments]
         )
 
-    async def my_purge_app_config_fragments_by_names(
-        self, input: MyPurgeAppConfigFragmentsByNamesInput
-    ) -> PurgeAppConfigFragmentsByNamesPayload:
+    async def my_bulk_purge_app_config_fragments_by_names(
+        self, input: MyBulkPurgeAppConfigFragmentsByNamesInput
+    ) -> BulkPurgeAppConfigFragmentsByNamesPayload:
         """Purge the current user's own ``user``-scope fragments for ``config_names``.
 
         Calls ``current_user()`` internally — the caller does not pass a scope.
@@ -208,10 +212,14 @@ class AppConfigFragmentAdapter(BaseAdapter):
         scope = AppConfigFragmentSearchScope(
             scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(me.user_id)
         )
-        action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
-            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
+        action_result = (
+            await self._processors.app_config_fragment.bulk_purge_by_names.wait_for_complete(
+                BulkPurgeAppConfigFragmentsByNamesAction(
+                    scope=scope, config_names=input.config_names
+                )
+            )
         )
-        return PurgeAppConfigFragmentsByNamesPayload(
+        return BulkPurgeAppConfigFragmentsByNamesPayload(
             items=[fragment.id for fragment in action_result.fragments]
         )
 

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -16,8 +16,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedSearchAppConfigFragmentInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
@@ -26,6 +28,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -73,6 +76,9 @@ from ai.backend.manager.services.app_config_fragment.actions.get import (
 )
 from ai.backend.manager.services.app_config_fragment.actions.purge import (
     PurgeAppConfigFragmentAction,
+)
+from ai.backend.manager.services.app_config_fragment.actions.purge_by_names import (
+    PurgeAppConfigFragmentsByNamesAction,
 )
 from ai.backend.manager.services.app_config_fragment.actions.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
@@ -170,6 +176,43 @@ class AppConfigFragmentAdapter(BaseAdapter):
                 AppConfigFragmentBulkErrorInfo(id=error.id, message=error.message)
                 for error in action_result.failed
             ],
+        )
+
+    async def scoped_purge_app_config_fragments_by_names(
+        self, input: ScopedPurgeAppConfigFragmentsByNamesInput
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge the fragments written at the scope named in ``input`` for ``config_names``.
+
+        RBAC-authorized at that scope, so a caller purges only a scope they may write.
+        """
+        scope = AppConfigFragmentSearchScope(
+            scope_type=input.scope.scope_type, scope_id=input.scope.scope_id
+        )
+        action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
+            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
+        )
+        return PurgeAppConfigFragmentsByNamesPayload(
+            items=[fragment.id for fragment in action_result.fragments]
+        )
+
+    async def my_purge_app_config_fragments_by_names(
+        self, input: MyPurgeAppConfigFragmentsByNamesInput
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge the current user's own ``user``-scope fragments for ``config_names``.
+
+        Calls ``current_user()`` internally — the caller does not pass a scope.
+        """
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        scope = AppConfigFragmentSearchScope(
+            scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(me.user_id)
+        )
+        action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
+            PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
+        )
+        return PurgeAppConfigFragmentsByNamesPayload(
+            items=[fragment.id for fragment in action_result.fragments]
         )
 
     async def batch_load_by_ids(

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from functools import lru_cache
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.app_config.types import AppConfigScope, AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
@@ -185,7 +185,9 @@ class AppConfigFragmentAdapter(BaseAdapter):
 
         RBAC-authorized at that scope, so a caller purges only a scope they may write.
         """
-        scope = AppConfigScope(scope_type=input.scope.scope_type, scope_id=input.scope.scope_id)
+        scope = AppConfigFragmentSearchScope(
+            scope_type=input.scope.scope_type, scope_id=input.scope.scope_id
+        )
         action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
             PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
         )
@@ -203,7 +205,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        scope = AppConfigScope(
+        scope = AppConfigFragmentSearchScope(
             scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(me.user_id)
         )
         action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from functools import lru_cache
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import AppConfigScope, AppConfigScopeType
 from ai.backend.common.data.app_config.types import AppConfigScopeType as AppConfigScopeTypeDTO
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
@@ -185,9 +185,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
 
         RBAC-authorized at that scope, so a caller purges only a scope they may write.
         """
-        scope = AppConfigFragmentSearchScope(
-            scope_type=input.scope.scope_type, scope_id=input.scope.scope_id
-        )
+        scope = AppConfigScope(scope_type=input.scope.scope_type, scope_id=input.scope.scope_id)
         action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(
             PurgeAppConfigFragmentsByNamesAction(scope=scope, config_names=input.config_names)
         )
@@ -205,7 +203,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        scope = AppConfigFragmentSearchScope(
+        scope = AppConfigScope(
             scope_type=AppConfigScopeType.USER, scope_id=AppConfigScopeID(me.user_id)
         )
         action_result = await self._processors.app_config_fragment.purge_by_names.wait_for_complete(

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -11,10 +11,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
-    MyPurgeAppConfigFragmentsByNamesInput,
+    MyBulkPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
-    ScopedPurgeAppConfigFragmentsByNamesInput,
+    ScopedBulkPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -110,16 +110,16 @@ class V2AppConfigFragmentHandler:
 
     async def scoped_bulk_purge_by_names(
         self,
-        body: BodyParam[ScopedPurgeAppConfigFragmentsByNamesInput],
+        body: BodyParam[ScopedBulkPurgeAppConfigFragmentsByNamesInput],
     ) -> APIResponse:
         """Purge one scope's fragments by config name, all-or-nothing (auth, RBAC-authorized)."""
-        result = await self._adapter.scoped_purge_app_config_fragments_by_names(body.parsed)
+        result = await self._adapter.scoped_bulk_purge_app_config_fragments_by_names(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def my_bulk_purge_by_names(
         self,
-        body: BodyParam[MyPurgeAppConfigFragmentsByNamesInput],
+        body: BodyParam[MyBulkPurgeAppConfigFragmentsByNamesInput],
     ) -> APIResponse:
         """Purge the caller's own user-scope fragments by config name, all-or-nothing (auth)."""
-        result = await self._adapter.my_purge_app_config_fragments_by_names(body.parsed)
+        result = await self._adapter.my_bulk_purge_app_config_fragments_by_names(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -11,8 +11,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -104,4 +106,20 @@ class V2AppConfigFragmentHandler:
     ) -> APIResponse:
         """Upsert many fragments at the caller's own user scope, all-or-nothing (auth)."""
         result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def scoped_bulk_purge_by_names(
+        self,
+        body: BodyParam[ScopedPurgeAppConfigFragmentsByNamesInput],
+    ) -> APIResponse:
+        """Purge one scope's fragments by config name, all-or-nothing (auth, RBAC-authorized)."""
+        result = await self._adapter.scoped_purge_app_config_fragments_by_names(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def my_bulk_purge_by_names(
+        self,
+        body: BodyParam[MyPurgeAppConfigFragmentsByNamesInput],
+    ) -> APIResponse:
+        """Purge the caller's own user-scope fragments by config name, all-or-nothing (auth)."""
+        result = await self._adapter.my_purge_app_config_fragments_by_names(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/registry.py
@@ -20,22 +20,26 @@ def register_v2_app_config_fragment_routes(
     """Register all REST v2 app config fragment routes.
 
     Writes go through ``/upsert``: a fragment is addressed by ``(scope, config_name)`` rather
-    than by id, so there is no separate create or update endpoint. The paginated scoped search
-    is not exposed either — ``/by-names`` is the read a client needs before editing. Every
+    than by id, so there is no separate create or update endpoint. ``/by-names`` carries that
+    same address for the operations that share it — the read, and the delete beneath it — so a
+    caller removing a fragment never has to resolve an id first. The paginated scoped search is
+    not exposed either: ``/by-names`` is the read a client needs before editing. Every
     route but ``/admin/search`` is open to any authenticated user and gated by RBAC at the
     processor (a user acts on their own user-scope, a domain admin on their domain's, a
     superadmin on any; public is superadmin-only). Only the system-wide ``/admin/search``
     skips RBAC, being superadmin-only at the middleware.
 
     Layout:
-        POST   /bulk-delete       purge many by id               (auth, RBAC)
-        POST   /admin/search      system-wide paginated search   (superadmin)
-        POST   /scoped/by-names   read one scope's by names      (auth, RBAC)
-        POST   /scoped/bulk-upsert  upsert many at one scope     (auth, RBAC)
-        POST   /my/by-names       read own scope's by names      (auth)
-        POST   /my/bulk-upsert    upsert many at own scope       (auth)
-        GET    /{fragment_id}     get by id                      (auth, RBAC)
-        DELETE /{fragment_id}     purge by id                    (auth, RBAC)
+        POST   /bulk-delete                  purge many by id              (auth, RBAC)
+        POST   /admin/search                 system-wide paginated search  (superadmin)
+        POST   /scoped/by-names              read one scope's by names     (auth, RBAC)
+        POST   /scoped/by-names/bulk-delete  purge one scope's by names    (auth, RBAC)
+        POST   /scoped/bulk-upsert           upsert many at one scope      (auth, RBAC)
+        POST   /my/by-names                  read own scope's by names     (auth)
+        POST   /my/by-names/bulk-delete      purge own scope's by names    (auth)
+        POST   /my/bulk-upsert               upsert many at own scope      (auth)
+        GET    /{fragment_id}                get by id                     (auth, RBAC)
+        DELETE /{fragment_id}                purge by id                   (auth, RBAC)
     """
     registry = RouteRegistry.create("app-config-fragments", route_deps.cors_options)
 
@@ -45,9 +49,21 @@ def register_v2_app_config_fragment_routes(
         "POST", "/scoped/by-names", handler.scoped_fragments_by_names, middlewares=[auth_required]
     )
     registry.add(
+        "POST",
+        "/scoped/by-names/bulk-delete",
+        handler.scoped_bulk_purge_by_names,
+        middlewares=[auth_required],
+    )
+    registry.add(
         "POST", "/scoped/bulk-upsert", handler.scoped_bulk_upsert, middlewares=[auth_required]
     )
     registry.add("POST", "/my/by-names", handler.my_fragments_by_names, middlewares=[auth_required])
+    registry.add(
+        "POST",
+        "/my/by-names/bulk-delete",
+        handler.my_bulk_purge_by_names,
+        middlewares=[auth_required],
+    )
     registry.add("POST", "/my/bulk-upsert", handler.my_bulk_upsert, middlewares=[auth_required])
     registry.add("GET", "/{fragment_id}", handler.get, middlewares=[auth_required])
     registry.add("DELETE", "/{fragment_id}", handler.purge, middlewares=[auth_required])

--- a/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
@@ -13,10 +13,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
     AppConfigScopeRef,
     BulkPurgeAppConfigFragmentInput,
-    MyPurgeAppConfigFragmentsByNamesInput,
+    MyBulkPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
-    ScopedPurgeAppConfigFragmentsByNamesInput,
+    ScopedBulkPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.exception import BackendAISchemaValidationFailed
@@ -154,7 +154,7 @@ class TestAppConfigFragmentsByNamesInput:
             })
 
 
-class TestScopedPurgeAppConfigFragmentsByNamesInput:
+class TestScopedBulkPurgeAppConfigFragmentsByNamesInput:
     """The scoped purge names the scope like the by-names read does, plus the names to purge."""
 
     @pytest.mark.parametrize(
@@ -167,7 +167,7 @@ class TestScopedPurgeAppConfigFragmentsByNamesInput:
         ids=lambda case: case.scope_type.value,
     )
     def test_scope_id_matching_its_scope_type_is_accepted(self, case: _ScopeCase) -> None:
-        req = ScopedPurgeAppConfigFragmentsByNamesInput(
+        req = ScopedBulkPurgeAppConfigFragmentsByNamesInput(
             scope=AppConfigScopeRef(scope_type=case.scope_type, scope_id=case.scope_id),
             config_names=["theme"],
         )
@@ -177,31 +177,31 @@ class TestScopedPurgeAppConfigFragmentsByNamesInput:
 
     def test_scope_id_disagreeing_with_its_scope_type_is_rejected(self) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
-            ScopedPurgeAppConfigFragmentsByNamesInput.model_validate({
+            ScopedBulkPurgeAppConfigFragmentsByNamesInput.model_validate({
                 "scope": {"scope_type": AppConfigScopeType.DOMAIN, "scope_id": None},
                 "config_names": ["theme"],
             })
 
     def test_an_empty_batch_is_rejected(self) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
-            ScopedPurgeAppConfigFragmentsByNamesInput.model_validate({
+            ScopedBulkPurgeAppConfigFragmentsByNamesInput.model_validate({
                 "scope": {"scope_type": AppConfigScopeType.PUBLIC, "scope_id": None},
                 "config_names": [],
             })
 
 
-class TestMyPurgeAppConfigFragmentsByNamesInput:
+class TestMyBulkPurgeAppConfigFragmentsByNamesInput:
     """The self-service purge names configs, not ids, and carries no scope."""
 
     def test_config_names_alone_are_a_complete_body(self) -> None:
-        req = MyPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
+        req = MyBulkPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
 
         assert req.config_names == ["theme"]
         assert not hasattr(req, "scope_type")
 
     def test_an_empty_batch_is_rejected(self) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
-            MyPurgeAppConfigFragmentsByNamesInput.model_validate({"config_names": []})
+            MyBulkPurgeAppConfigFragmentsByNamesInput.model_validate({"config_names": []})
 
 
 class TestBulkPurgeAppConfigFragmentInput:

--- a/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
+++ b/tests/unit/common/dto/manager/v2/app_config_fragment/test_request.py
@@ -13,8 +13,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentUpsertItem,
     AppConfigScopeRef,
     BulkPurgeAppConfigFragmentInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.exception import BackendAISchemaValidationFailed
@@ -150,6 +152,56 @@ class TestAppConfigFragmentsByNamesInput:
                 "scope_id": None,
                 "config_names": ["theme"],
             })
+
+
+class TestScopedPurgeAppConfigFragmentsByNamesInput:
+    """The scoped purge names the scope like the by-names read does, plus the names to purge."""
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _ScopeCase(scope_type=AppConfigScopeType.PUBLIC, scope_id=None),
+            _ScopeCase(scope_type=AppConfigScopeType.DOMAIN, scope_id=_SCOPE_ID),
+            _ScopeCase(scope_type=AppConfigScopeType.USER, scope_id=_SCOPE_ID),
+        ],
+        ids=lambda case: case.scope_type.value,
+    )
+    def test_scope_id_matching_its_scope_type_is_accepted(self, case: _ScopeCase) -> None:
+        req = ScopedPurgeAppConfigFragmentsByNamesInput(
+            scope=AppConfigScopeRef(scope_type=case.scope_type, scope_id=case.scope_id),
+            config_names=["theme"],
+        )
+
+        assert req.scope.scope_type is case.scope_type
+        assert req.scope.scope_id == case.scope_id
+
+    def test_scope_id_disagreeing_with_its_scope_type_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            ScopedPurgeAppConfigFragmentsByNamesInput.model_validate({
+                "scope": {"scope_type": AppConfigScopeType.DOMAIN, "scope_id": None},
+                "config_names": ["theme"],
+            })
+
+    def test_an_empty_batch_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            ScopedPurgeAppConfigFragmentsByNamesInput.model_validate({
+                "scope": {"scope_type": AppConfigScopeType.PUBLIC, "scope_id": None},
+                "config_names": [],
+            })
+
+
+class TestMyPurgeAppConfigFragmentsByNamesInput:
+    """The self-service purge names configs, not ids, and carries no scope."""
+
+    def test_config_names_alone_are_a_complete_body(self) -> None:
+        req = MyPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
+
+        assert req.config_names == ["theme"]
+        assert not hasattr(req, "scope_type")
+
+    def test_an_empty_batch_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            MyPurgeAppConfigFragmentsByNamesInput.model_validate({"config_names": []})
 
 
 class TestBulkPurgeAppConfigFragmentInput:


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the name-addressed app config fragment purge stack. **Merge in order (bottom-up):**

1. #13460 — `feat(BA-7183)`: purge app config fragments by config name at one scope
2. 👉 **#13461 — `feat(BA-7184)`: expose the name-addressed fragment purge on REST v2** ← you are here
3. #13462 — `feat(BA-7185)`: add the SDK and CLI for the name-addressed fragment purge

Resolves #13458 (BA-7184)

## Summary

- `/by-names` already carries the `(scope, config_name)` address for the read, so the name-addressed delete goes **beneath that segment** rather than beside the id-addressed `/bulk-delete`:

  | | read | delete |
  |---|---|---|
  | scoped | `POST /scoped/by-names` | `POST /scoped/by-names/bulk-delete` |
  | my | `POST /my/by-names` | `POST /my/by-names/bulk-delete` |

- The scoped and `my` callers differ only in which scope they may name, not in behaviour, so per `api/rest/v2/AGENTS.md` they share one route pair and RBAC decides. The `my` route names no scope at all, so a regular user cannot address anyone else's.
- **No `admin_` variant.** It would carry `superadmin_required`, which locks out the domain admins that hold `APP_CONFIG_FRAGMENT` owner operations at domain scope. Purge is not exposed on GraphQL at all — neither by id nor in bulk — so this stays REST-only like its siblings.

## Test plan

- [x] DTO: `config_names` alone is a complete body for the `my` input; the scoped input accepts every scope kind with a matching id and rejects a mismatch; an empty batch is rejected on both.
- [ ] Live verification against a local manager, as a regular (non-admin) user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13461.org.readthedocs.build/en/13461/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13461.org.readthedocs.build/ko/13461/

<!-- readthedocs-preview sorna-ko end -->