### PR TITLE
feat(BA-7185): add the SDK and CLI for the name-addressed fragment purge

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, update, purge, bulk-purge, bulk-purge-by-names) · my(get, update, purge) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-purge, purge-by-names) · my(get, update, purge) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, update, purge, bulk-purge, purge-by-names) · my(get, update, purge) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-purge, bulk-purge-by-names) · my(get, update, purge) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -107,7 +107,7 @@ Check options with `--help`.
 - **app-config**: user(get-domain, get-user, get-merged, delete-domain, delete-user)
 - **app-config-definition**: admin(create, get, search, purge)
 - **app-config-allow-list**: admin(create, get, search, update, purge)
-- **app-config-fragment**: user(get, update, purge, bulk-purge) · my(get, update) · admin(search)
+- **app-config-fragment**: user(get, update, purge, bulk-purge, purge-by-names) · my(get, update, purge) · admin(search)
 - **idle-checker**: admin(create, search, update, purge)
 - **export**: admin(list-reports, get-report, audit-logs, keypairs, projects, sessions, sessions-by-project, users, users-by-domain) · my(keypairs, sessions)
 

--- a/changes/13462.feature.md
+++ b/changes/13462.feature.md
@@ -1,1 +1,1 @@
-Add `./bai my app-config-fragment purge` and `./bai app-config-fragment purge-by-names`, which purge app config fragments by config name without resolving a fragment id first.
+Add `./bai my app-config-fragment purge` and `./bai app-config-fragment bulk-purge-by-names`, which purge app config fragments by config name without resolving a fragment id first.

--- a/changes/13462.feature.md
+++ b/changes/13462.feature.md
@@ -1,1 +1,1 @@
-Add `./bai my app-config-fragment purge` and `./bai app-config-fragment bulk-purge-by-names`, which purge app config fragments by config name without resolving a fragment id first.
+Add `./bai my app-config-fragment purge` and `./bai app-config-fragment purge-by-names`, which purge app config fragments by config name without resolving a fragment id first.

--- a/changes/13462.feature.md
+++ b/changes/13462.feature.md
@@ -1,0 +1,1 @@
+Add `./bai my app-config-fragment purge` and `./bai app-config-fragment purge-by-names`, which purge app config fragments by config name without resolving a fragment id first.

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -137,6 +137,50 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     run_async(_run)
 
 
+@app_config_fragment.command(name="purge-by-names")
+@click.option(
+    "--scope-type",
+    required=True,
+    type=click.Choice([scope_type.value for scope_type in AppConfigScopeType]),
+    help="Scope whose fragments to purge (public | domain | user).",
+)
+@click.option(
+    "--scope-id",
+    default=None,
+    type=click.UUID,
+    help="Domain id or user id; omit for the public scope.",
+)
+@click.argument("config_names", nargs=-1, required=True)
+def purge_by_names(
+    scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]
+) -> None:
+    """Purge one scope's fragments for CONFIG_NAMES, all-or-nothing.
+
+    A name the scope holds no fragment for purges nothing, so a typo cannot quietly destroy
+    a neighbouring config. Addresses the same (scope, config_name) pair that `get` and
+    `update` do, so no fragment id has to be resolved first.
+    """
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        ScopedPurgeAppConfigFragmentsByNamesInput,
+    )
+
+    scope = _resolve_scope(scope_type, scope_id)
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.scoped_purge_app_config_fragments_by_names(
+                ScopedPurgeAppConfigFragmentsByNamesInput(
+                    scope=scope, config_names=list(config_names)
+                )
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)
+
+
 @app_config_fragment.command()
 @click.option(
     "--id",

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -161,7 +161,7 @@ def purge_by_names(
     `update` do, so no fragment id has to be resolved first.
     """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
-        ScopedPurgeAppConfigFragmentsByNamesInput,
+        ScopedBulkPurgeAppConfigFragmentsByNamesInput,
     )
 
     scope = _resolve_scope(scope_type, scope_id)
@@ -169,9 +169,11 @@ def purge_by_names(
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.app_config_fragment.scoped_purge_app_config_fragments_by_names(
-                ScopedPurgeAppConfigFragmentsByNamesInput(
-                    scope=scope, config_names=list(config_names)
+            result = (
+                await registry.app_config_fragment.scoped_bulk_purge_app_config_fragments_by_names(
+                    ScopedBulkPurgeAppConfigFragmentsByNamesInput(
+                        scope=scope, config_names=list(config_names)
+                    )
                 )
             )
             print_result(result)

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -137,7 +137,7 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     run_async(_run)
 
 
-@app_config_fragment.command(name="bulk-purge-by-names")
+@app_config_fragment.command(name="purge-by-names")
 @click.option(
     "--scope-type",
     required=True,
@@ -151,7 +151,7 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     help="Domain id or user id; omit for the public scope.",
 )
 @click.argument("config_names", nargs=-1, required=True)
-def bulk_purge_by_names(
+def purge_by_names(
     scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]
 ) -> None:
     """Purge one scope's fragments for CONFIG_NAMES, all-or-nothing.

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -137,7 +137,7 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     run_async(_run)
 
 
-@app_config_fragment.command(name="purge-by-names")
+@app_config_fragment.command(name="bulk-purge-by-names")
 @click.option(
     "--scope-type",
     required=True,
@@ -151,7 +151,7 @@ def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
     help="Domain id or user id; omit for the public scope.",
 )
 @click.argument("config_names", nargs=-1, required=True)
-def purge_by_names(
+def bulk_purge_by_names(
     scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ...]
 ) -> None:
     """Purge one scope's fragments for CONFIG_NAMES, all-or-nothing.

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -78,3 +78,28 @@ def update(items: str) -> None:
             await registry.close()
 
     run_async(_run)
+
+
+@app_config_fragment.command()
+@click.argument("config_names", nargs=-1, required=True)
+def purge(config_names: tuple[str, ...]) -> None:
+    """Purge my user-scope fragments for CONFIG_NAMES, all-or-nothing.
+
+    A name I hold no fragment for purges nothing, so a typo cannot quietly destroy a
+    neighbouring config.
+    """
+    from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
+        MyPurgeAppConfigFragmentsByNamesInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.app_config_fragment.my_purge_app_config_fragments_by_names(
+                MyPurgeAppConfigFragmentsByNamesInput(config_names=list(config_names))
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    run_async(_run)

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -89,14 +89,14 @@ def purge(config_names: tuple[str, ...]) -> None:
     neighbouring config.
     """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
-        MyPurgeAppConfigFragmentsByNamesInput,
+        MyBulkPurgeAppConfigFragmentsByNamesInput,
     )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            result = await registry.app_config_fragment.my_purge_app_config_fragments_by_names(
-                MyPurgeAppConfigFragmentsByNamesInput(config_names=list(config_names))
+            result = await registry.app_config_fragment.my_bulk_purge_app_config_fragments_by_names(
+                MyBulkPurgeAppConfigFragmentsByNamesInput(config_names=list(config_names))
             )
             print_result(result)
         finally:

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -9,8 +9,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -18,6 +20,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -51,6 +54,21 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             f"{_PATH}/scoped/by-names",
             request=request,
             response_model=AppConfigFragmentsByNamesPayload,
+        )
+
+    async def scoped_purge_app_config_fragments_by_names(
+        self,
+        request: ScopedPurgeAppConfigFragmentsByNamesInput,
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge one scope's fragments for the given config names, all-or-nothing.
+
+        A name the scope holds no fragment for purges nothing and is reported as not found.
+        """
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/scoped/by-names/bulk-delete",
+            request=request,
+            response_model=PurgeAppConfigFragmentsByNamesPayload,
         )
 
     async def scoped_bulk_upsert_app_config_fragments(
@@ -89,6 +107,22 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             f"{_PATH}/my/bulk-upsert",
             request=request,
             response_model=UpsertAppConfigFragmentsPayload,
+        )
+
+    async def my_purge_app_config_fragments_by_names(
+        self,
+        request: MyPurgeAppConfigFragmentsByNamesInput,
+    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        """Purge the caller's own user-scope fragments for the given config names.
+
+        All-or-nothing: a name the caller holds no fragment for purges nothing and is
+        reported as not found.
+        """
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/my/by-names/bulk-delete",
+            request=request,
+            response_model=PurgeAppConfigFragmentsByNamesPayload,
         )
 
     # --- By id ---

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -9,18 +9,18 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AdminSearchAppConfigFragmentInput,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
-    MyPurgeAppConfigFragmentsByNamesInput,
+    MyBulkPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
-    ScopedPurgeAppConfigFragmentsByNamesInput,
+    ScopedBulkPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
     AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
+    BulkPurgeAppConfigFragmentsByNamesPayload,
     PurgeAppConfigFragmentPayload,
-    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -56,10 +56,10 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=AppConfigFragmentsByNamesPayload,
         )
 
-    async def scoped_purge_app_config_fragments_by_names(
+    async def scoped_bulk_purge_app_config_fragments_by_names(
         self,
-        request: ScopedPurgeAppConfigFragmentsByNamesInput,
-    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        request: ScopedBulkPurgeAppConfigFragmentsByNamesInput,
+    ) -> BulkPurgeAppConfigFragmentsByNamesPayload:
         """Purge one scope's fragments for the given config names, all-or-nothing.
 
         A name the scope holds no fragment for purges nothing and is reported as not found.
@@ -68,7 +68,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             "POST",
             f"{_PATH}/scoped/by-names/bulk-delete",
             request=request,
-            response_model=PurgeAppConfigFragmentsByNamesPayload,
+            response_model=BulkPurgeAppConfigFragmentsByNamesPayload,
         )
 
     async def scoped_bulk_upsert_app_config_fragments(
@@ -109,10 +109,10 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             response_model=UpsertAppConfigFragmentsPayload,
         )
 
-    async def my_purge_app_config_fragments_by_names(
+    async def my_bulk_purge_app_config_fragments_by_names(
         self,
-        request: MyPurgeAppConfigFragmentsByNamesInput,
-    ) -> PurgeAppConfigFragmentsByNamesPayload:
+        request: MyBulkPurgeAppConfigFragmentsByNamesInput,
+    ) -> BulkPurgeAppConfigFragmentsByNamesPayload:
         """Purge the caller's own user-scope fragments for the given config names.
 
         All-or-nothing: a name the caller holds no fragment for purges nothing and is
@@ -122,7 +122,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
             "POST",
             f"{_PATH}/my/by-names/bulk-delete",
             request=request,
-            response_model=PurgeAppConfigFragmentsByNamesPayload,
+            response_model=BulkPurgeAppConfigFragmentsByNamesPayload,
         )
 
     # --- By id ---

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -17,18 +17,18 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigScopeRef,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
-    MyPurgeAppConfigFragmentsByNamesInput,
+    MyBulkPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
-    ScopedPurgeAppConfigFragmentsByNamesInput,
+    ScopedBulkPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
     AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
+    BulkPurgeAppConfigFragmentsByNamesPayload,
     PurgeAppConfigFragmentPayload,
-    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -155,8 +155,8 @@ class TestScopedPurgeByNames:
     ) -> None:
         mock_response.json = AsyncMock(return_value={"items": [str(fragment_id)]})
 
-        result = await client.scoped_purge_app_config_fragments_by_names(
-            ScopedPurgeAppConfigFragmentsByNamesInput(
+        result = await client.scoped_bulk_purge_app_config_fragments_by_names(
+            ScopedBulkPurgeAppConfigFragmentsByNamesInput(
                 scope=AppConfigScopeRef(
                     scope_type=AppConfigScopeType.USER,
                     scope_id=AppConfigScopeID(_USER_SCOPE_ID),
@@ -168,7 +168,7 @@ class TestScopedPurgeByNames:
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/by-names/bulk-delete")
-        assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
+        assert isinstance(result, BulkPurgeAppConfigFragmentsByNamesPayload)
         assert result.items == [fragment_id]
 
 
@@ -227,14 +227,14 @@ class TestMyPurgeByNames:
     ) -> None:
         mock_response.json = AsyncMock(return_value={"items": [str(fragment_id)]})
 
-        result = await client.my_purge_app_config_fragments_by_names(
-            MyPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
+        result = await client.my_bulk_purge_app_config_fragments_by_names(
+            MyBulkPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
         )
 
         call_args = mock_session.request.call_args
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/by-names/bulk-delete")
-        assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
+        assert isinstance(result, BulkPurgeAppConfigFragmentsByNamesPayload)
         assert result.items == [fragment_id]
 
 

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -17,8 +17,10 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigScopeRef,
     BulkPurgeAppConfigFragmentInput,
     MyAppConfigFragmentsByNamesInput,
+    MyPurgeAppConfigFragmentsByNamesInput,
     MyUpsertAppConfigFragmentsInput,
     ScopedAppConfigFragmentsByNamesInput,
+    ScopedPurgeAppConfigFragmentsByNamesInput,
     ScopedUpsertAppConfigFragmentsInput,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
@@ -26,6 +28,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentsByNamesPayload,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
+    PurgeAppConfigFragmentsByNamesPayload,
     SearchAppConfigFragmentPayload,
     UpsertAppConfigFragmentsPayload,
 )
@@ -142,6 +145,33 @@ class TestScopedBulkUpsert:
         assert [item.config_name for item in result.items] == ["theme"]
 
 
+class TestScopedPurgeByNames:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        fragment_id: AppConfigFragmentID,
+    ) -> None:
+        mock_response.json = AsyncMock(return_value={"items": [str(fragment_id)]})
+
+        result = await client.scoped_purge_app_config_fragments_by_names(
+            ScopedPurgeAppConfigFragmentsByNamesInput(
+                scope=AppConfigScopeRef(
+                    scope_type=AppConfigScopeType.USER,
+                    scope_id=AppConfigScopeID(_USER_SCOPE_ID),
+                ),
+                config_names=["theme"],
+            )
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/by-names/bulk-delete")
+        assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
+        assert result.items == [fragment_id]
+
+
 class TestMyByNames:
     async def test_happy_path(
         self,
@@ -185,6 +215,27 @@ class TestMyBulkUpsert:
         assert call_args[0][0] == "POST"
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/bulk-upsert")
         assert isinstance(result, UpsertAppConfigFragmentsPayload)
+
+
+class TestMyPurgeByNames:
+    async def test_happy_path(
+        self,
+        client: V2AppConfigFragmentClient,
+        mock_session: MagicMock,
+        mock_response: AsyncMock,
+        fragment_id: AppConfigFragmentID,
+    ) -> None:
+        mock_response.json = AsyncMock(return_value={"items": [str(fragment_id)]})
+
+        result = await client.my_purge_app_config_fragments_by_names(
+            MyPurgeAppConfigFragmentsByNamesInput(config_names=["theme"])
+        )
+
+        call_args = mock_session.request.call_args
+        assert call_args[0][0] == "POST"
+        assert str(call_args[0][1]).endswith("/v2/app-config-fragments/my/by-names/bulk-delete")
+        assert isinstance(result, PurgeAppConfigFragmentsByNamesPayload)
+        assert result.items == [fragment_id]
 
 
 class TestGet:


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the name-addressed app config fragment purge stack. **Merge in order (bottom-up):**

1. #13460 — `feat(BA-7183)`: purge app config fragments by config name at one scope
2. #13461 — `feat(BA-7184)`: expose the name-addressed fragment purge on REST v2
3. 👉 **#13462 — `feat(BA-7185)`: add the SDK and CLI for the name-addressed fragment purge** ← you are here

Resolves #13459 (BA-7185)

## Summary

- Two typed SDK v2 calls on the `my` and scoped `by-names/bulk-delete` routes, and the CLI over them: `./bai my app-config-fragment purge theme menu` and `./bai app-config-fragment purge-by-names --scope-type domain --scope-id <id> theme` are each a single call.
- The `my app-config-fragment` group read and wrote by config name but offered no delete, so removing one of my own fragments meant resolving its id and then leaving the group for the top-level `purge --id`. Both commands now address the same `(scope, config_name)` pair that `get` and `update` already do.

## Test plan

- [x] SDK: the calls land on `POST /{my,scoped}/by-names/bulk-delete` and parse the payload.
- [ ] Live verification of both commands against a local manager, as a regular (non-admin) user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
