### PR TITLE
feat(BA-7209): require model name in runtime variant default model definition

### DIFF
--- a/changes/13497.enhance.md
+++ b/changes/13497.enhance.md
@@ -1,0 +1,1 @@
+Require `name` in runtime variant default model definitions and backfill nameless entries so revisions created without a model name always resolve

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -746,6 +746,28 @@ class ModelDefinitionDraft(BaseConfigModel):
         return cls.model_validate(data)
 
 
+class DefaultModelConfig(BaseConfigModel):
+    """Baseline model config stored on a runtime variant. ``name`` is required
+    so the always-present baseline layer guarantees every revision a model name;
+    ``model_path`` keeps its dynamic mount-destination default in the reader.
+    """
+
+    name: str
+    model_path: str | None = None
+    service: ModelServiceConfigDraft | None = None
+    metadata: ModelMetadata | None = None
+
+
+class DefaultModelDefinition(BaseConfigModel):
+    """Stored shape of ``runtime_variants.default_model_definition``."""
+
+    models: list[DefaultModelConfig] | None = None
+
+    def to_draft(self) -> ModelDefinitionDraft:
+        # exclude_unset keeps unset fields from clobbering lower-priority merge layers.
+        return ModelDefinitionDraft.model_validate(self.model_dump(exclude_unset=True))
+
+
 def find_config_file(daemon_name: str) -> Path:
     toml_path_from_env = os.environ.get("BACKEND_CONFIG_FILE", None)
     if not toml_path_from_env:

--- a/src/ai/backend/manager/data/runtime_variant/types.py
+++ b/src/ai/backend/manager/data/runtime_variant/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 
 
@@ -13,6 +13,6 @@ class RuntimeVariantData:
     name: str
     description: str | None
     reads_vfolder_config_files: bool
-    default_model_definition: ModelDefinitionDraft
+    default_model_definition: DefaultModelDefinition
     created_at: datetime
     updated_at: datetime | None

--- a/src/ai/backend/manager/models/alembic/versions/d366a4c96f75_backfill_missing_model_names_in_runtime_variants.py
+++ b/src/ai/backend/manager/models/alembic/versions/d366a4c96f75_backfill_missing_model_names_in_runtime_variants.py
@@ -1,0 +1,56 @@
+"""backfill missing model names in runtime_variants
+
+``default_model_definition`` now loads as ``DefaultModelDefinition``, which
+requires ``name`` on every model entry; fill nameless entries from the variant
+name so pre-existing rows keep loading. Idempotent.
+
+Revision ID: d366a4c96f75
+Revises: c1a7d3f05e28
+Create Date: 2026-08-05 18:30:00.000000
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d366a4c96f75"
+down_revision = "c1a7d3f05e28"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, name, default_model_definition FROM runtime_variants "
+            "WHERE jsonb_typeof(default_model_definition->'models') = 'array' "
+            "AND EXISTS ("
+            "  SELECT 1 FROM jsonb_array_elements(default_model_definition->'models') AS m"
+            "  WHERE jsonb_typeof(m) = 'object' AND m->>'name' IS NULL"
+            ")"
+        )
+    ).fetchall()
+    for row in rows:
+        definition = dict(row.default_model_definition)
+        models = definition["models"]
+        for idx, model in enumerate(models):
+            # Non-object elements (JSON null, scalars) are left for app-level validation.
+            if isinstance(model, dict) and model.get("name") is None:
+                model["name"] = f"{row.name}-model" if idx == 0 else f"{row.name}-model-{idx}"
+        bind.execute(
+            sa.text(
+                "UPDATE runtime_variants "
+                "SET default_model_definition = CAST(:definition AS JSONB) "
+                "WHERE id = :id"
+            ).bindparams(id=row.id, definition=json.dumps(definition))
+        )
+
+
+def downgrade() -> None:
+    # Backfilled names are indistinguishable from operator-set ones; keep them.
+    pass

--- a/src/ai/backend/manager/models/runtime_variant/row.py
+++ b/src/ai/backend/manager/models/runtime_variant/row.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn
@@ -30,9 +30,9 @@ class RuntimeVariantRow(Base):  # type: ignore[misc]
         nullable=False,
         server_default=sa.false(),
     )
-    default_model_definition: Mapped[ModelDefinitionDraft] = mapped_column(
+    default_model_definition: Mapped[DefaultModelDefinition] = mapped_column(
         "default_model_definition",
-        PydanticColumn(ModelDefinitionDraft, exclude_unset=True),
+        PydanticColumn(DefaultModelDefinition, exclude_unset=True),
         nullable=False,
     )
 

--- a/src/ai/backend/manager/repositories/runtime_variant/creators.py
+++ b/src/ai/backend/manager/repositories/runtime_variant/creators.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.errors.resource import RuntimeVariantConflict
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
@@ -32,5 +32,5 @@ class RuntimeVariantCreatorSpec(CreatorSpec[RuntimeVariantRow]):
         row = RuntimeVariantRow()
         row.name = self.name
         row.description = self.description
-        row.default_model_definition = ModelDefinitionDraft()
+        row.default_model_definition = DefaultModelDefinition()
         return row

--- a/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
+++ b/src/ai/backend/manager/sokovan/deployment/revision_draft/reader.py
@@ -114,7 +114,7 @@ class RevisionDraftReader:
 
     def _variant_baseline_to_draft(self, variant: RuntimeVariantData) -> RevisionDraft:
         """Project the variant's ``default_model_definition`` into a RevisionDraft."""
-        return RevisionDraft(model_definition=variant.default_model_definition)
+        return RevisionDraft(model_definition=variant.default_model_definition.to_draft())
 
     def _preset_to_draft(
         self,

--- a/tests/unit/manager/api/adapters/test_runtime_variant_adapter.py
+++ b/tests/unit/manager/api/adapters/test_runtime_variant_adapter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from uuid import uuid4
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
 from ai.backend.manager.api.adapters.runtime_variant.adapter import RuntimeVariantAdapter
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
@@ -16,9 +16,10 @@ class TestRuntimeVariantDataToNode:
             name="vllm",
             description=None,
             reads_vfolder_config_files=False,
-            default_model_definition=ModelDefinitionDraft.model_validate({
+            default_model_definition=DefaultModelDefinition.model_validate({
                 "models": [
                     {
+                        "name": "vllm-model",
                         "service": {
                             "start_command": "vllm serve '{model_path}'",
                         },

--- a/tests/unit/manager/models/test_deployment_revision.py
+++ b/tests/unit/manager/models/test_deployment_revision.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.vfolder import VFolderUUID
@@ -309,7 +309,7 @@ class TestDeploymentRevisionRow:
             variant = RuntimeVariantRow(
                 name=f"test-variant-{uuid.uuid4().hex[:8]}",
                 description="Test runtime variant",
-                default_model_definition=ModelDefinitionDraft(),
+                default_model_definition=DefaultModelDefinition(),
             )
             db_sess.add(variant)
             await db_sess.flush()

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -14,7 +14,7 @@ import pytest
 import sqlalchemy as sa
 from dateutil.tz import tzutc
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
@@ -702,7 +702,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                     id=runtime_variant_id,
                     name=f"vllm-{runtime_variant_id.hex[:8]}",
                     description="test variant",
-                    default_model_definition=ModelDefinitionDraft(),
+                    default_model_definition=DefaultModelDefinition(),
                 )
             )
             await db_sess.flush()
@@ -938,7 +938,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                     id=runtime_variant_id,
                     name=f"vllm-{runtime_variant_id.hex[:8]}",
                     description="test variant",
-                    default_model_definition=ModelDefinitionDraft(),
+                    default_model_definition=DefaultModelDefinition(),
                 )
             )
             await db_sess.flush()
@@ -1718,7 +1718,7 @@ class TestDeploymentRevisionOperations:
                     id=variant_id,
                     name=f"test-variant-{variant_id.hex[:8]}",
                     description="test",
-                    default_model_definition=ModelDefinitionDraft(),
+                    default_model_definition=DefaultModelDefinition(),
                 )
             )
             await db_sess.commit()

--- a/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
+++ b/tests/unit/manager/repositories/deployment_revision_preset/test_repository.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import pytest
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.image import ImageID
 from ai.backend.common.identifier.runtime_variant import RuntimeVariantID
@@ -92,7 +92,7 @@ async def repository(
                 RuntimeVariantRow(
                     id=_VARIANT_ID,
                     name="rv-test",
-                    default_model_definition=ModelDefinitionDraft(),
+                    default_model_definition=DefaultModelDefinition(),
                 )
             )
             session.add_all([

--- a/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
+++ b/tests/unit/manager/repositories/model_serving/test_list_endpoints_by_owner_validated.py
@@ -21,7 +21,7 @@ from collections.abc import AsyncGenerator
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.config import ModelDefinition
+from ai.backend.common.config import DefaultModelDefinition, ModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
@@ -289,7 +289,7 @@ async def listed_endpoint(
                 id=runtime_variant_id,
                 name=f"variant-{runtime_variant_id.hex[:8]}",
                 description="test variant",
-                default_model_definition=ModelDefinition.model_validate({"models": []}),
+                default_model_definition=DefaultModelDefinition(models=[]),
             )
         )
         await sess.flush()

--- a/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
+++ b/tests/unit/manager/repositories/model_serving/test_modify_endpoint_model_definition.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.config import ModelDefinition, ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition, ModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.user.types import UserData
@@ -289,7 +289,7 @@ class TestModifyEndpointModelDefinitionRefresh:
                     id=runtime_variant_id,
                     name=f"variant-{runtime_variant_id.hex[:8]}",
                     description="test variant",
-                    default_model_definition=ModelDefinitionDraft(),
+                    default_model_definition=DefaultModelDefinition(),
                 )
             )
             await sess.flush()

--- a/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
+++ b/tests/unit/manager/repositories/model_serving/test_update_route_traffic.py
@@ -19,7 +19,7 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
-from ai.backend.common.config import ModelDefinition
+from ai.backend.common.config import DefaultModelDefinition, ModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.image import ImageID
@@ -280,7 +280,7 @@ async def endpoint_with_revision_and_route(
                 id=runtime_variant_id,
                 name=f"variant-{runtime_variant_id.hex[:8]}",
                 description="test variant",
-                default_model_definition=ModelDefinition.model_validate({"models": []}),
+                default_model_definition=DefaultModelDefinition(models=[]),
             )
         )
         await sess.flush()

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -12,7 +12,7 @@ from pathlib import PurePosixPath
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.config import ModelDefinitionDraft
+from ai.backend.common.config import DefaultModelDefinition
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.identifier.vfolder import VFolderUUID
@@ -1436,7 +1436,7 @@ class TestVfolderRepositoryDeleteForever:
             variant = RuntimeVariantRow(
                 name=f"test-variant-{uuid.uuid4().hex[:8]}",
                 description="Test runtime variant",
-                default_model_definition=ModelDefinitionDraft(),
+                default_model_definition=DefaultModelDefinition(),
             )
             db_sess.add(variant)
             await db_sess.flush()

--- a/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
+++ b/tests/unit/manager/sokovan/deployment/test_revision_draft_reader.py
@@ -14,6 +14,7 @@ import pytest
 
 from ai.backend.common.config import (
     DEFAULT_SHELL,
+    DefaultModelDefinition,
     ModelConfigDraft,
     ModelDefinitionDraft,
     ModelServiceConfigDraft,
@@ -46,14 +47,14 @@ def _mounts(model_mount_destination: str = "/models") -> MountMetadata:
 
 def _variant(
     reads_vfolder_config_files: bool = False,
-    default_model_definition: ModelDefinitionDraft | None = None,
+    default_model_definition: DefaultModelDefinition | None = None,
 ) -> RuntimeVariantData:
     return RuntimeVariantData(
         id=RuntimeVariantID(uuid4()),
         name="custom",
         description=None,
         reads_vfolder_config_files=reads_vfolder_config_files,
-        default_model_definition=default_model_definition or ModelDefinitionDraft(),
+        default_model_definition=default_model_definition or DefaultModelDefinition(),
         created_at=datetime(2026, 5, 15, tzinfo=UTC),
         updated_at=None,
     )
@@ -161,7 +162,7 @@ async def _merge_chain(
     """
     variant = _variant(
         reads_vfolder_config_files=reads_files,
-        default_model_definition=ModelDefinitionDraft.model_validate(variant_default),
+        default_model_definition=DefaultModelDefinition.model_validate(variant_default),
     )
     reader = RevisionDraftReader(deployment_repository=_repository(variant, yaml_payload))
     request = ModelDefinitionDraft.model_validate(request_payload) if request_payload else None


### PR DESCRIPTION
## Summary
- Add `DefaultModelDefinition` / `DefaultModelConfig` types for the `runtime_variants.default_model_definition` column: `models[].name` is now required, so the variant baseline (the lowest always-present merge layer) guarantees every resolved revision a model name. `model_path` semantics are unchanged — its default is still the mount destination injected by the revision-draft reader.
- `RevisionDraftReader._variant_baseline_to_draft` converts the stored baseline via `to_draft()` (exclude_unset) before entering the merge chain, preserving merge-priority behavior.
- Alembic migration `d366a4c96f75`: idempotent backfill filling nameless model entries with `<variant-name>-model` (indexed suffix for later entries); guards against JSON-null/scalar array elements; no-op downgrade.

## Test plan
- [x] `pants fmt/fix/lint/check/test --changed-since` all green (9 affected test files pass)
- [x] Migration logic verified against a live DB with representative rows: missing name, mixed multi-model, `models: null`, JSON-null top-level, `"name": null`, null/scalar array elements, empty list — fills correctly, preserves existing names, second pass selects nothing
- [x] Live e2e: revision created without any model name resolved `name` from the variant baseline (`custom-model` / `image-model`) and deployed to a healthy serving container

Resolves BA-7209

🤖 Generated with [Claude Code](https://claude.com/claude-code)