### PR TITLE
fix: render set-typed config examples as TOML arrays in generated samples

### DIFF
--- a/changes/13498.fix.md
+++ b/changes/13498.fix.md
@@ -1,0 +1,1 @@
+Render set-typed config examples (e.g. `allow-compute-plugins`) as TOML arrays instead of quoted JSON strings in the generated sample.toml files.

--- a/configs/agent/sample.toml
+++ b/configs/agent/sample.toml
@@ -176,21 +176,21 @@
   # are loaded except those in block_compute_plugins. Plugin names use Python
   # package notation (e.g., 'ai.backend.accelerator.cuda').
   # Added in 25.12.0
-  ## allow-compute-plugins = "[\"ai.backend.accelerator.cuda\", \"ai.backend.accelerator.rocm\"]"
+  ## allow-compute-plugins = ["ai.backend.accelerator.cuda", "ai.backend.accelerator.rocm"]
   # Blocklist of compute plugin names that should not be loaded by this agent.
   # Plugins in this list are excluded even if discovered. Use to disable
   # specific accelerators or features on certain nodes.
   # Added in 25.12.0
-  ## block-compute-plugins = "[\"ai.backend.accelerator.mock\"]"
+  ## block-compute-plugins = ["ai.backend.accelerator.mock"]
   # Allowlist of network plugin names that can be loaded by this agent. Network
   # plugins provide custom networking configurations for containers. If set,
   # only plugins in this list are loaded.
   # Added in 25.12.0
-  ## allow-network-plugins = "[\"ai.backend.network.overlay\"]"
+  ## allow-network-plugins = ["ai.backend.network.overlay"]
   # Blocklist of network plugin names that should not be loaded by this agent.
   # Use to disable specific network configurations on certain nodes.
   # Added in 25.12.0
-  ## block-network-plugins = "[\"ai.backend.network.legacy\"]"
+  ## block-network-plugins = ["ai.backend.network.legacy"]
   # Directory path for storing temporary image commit data. Used when users
   # commit their running containers as new images. Requires sufficient disk
   # space for container filesystem layers.

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -252,12 +252,12 @@
   # exactly which plugins are active in production. Leave as None to load all
   # available plugins except disabled_plugins.
   # Added in 25.8.0
-  ## allowed-plugins = "[\"example.plugin.what.you.want\"]"
+  ## allowed-plugins = ["example.plugin.what.you.want"]
   # List of plugins to explicitly disable (blacklist). These plugins won't be
   # loaded even if they're installed. Useful for disabling problematic or
   # unwanted plugins without uninstalling.
   # Added in 25.8.0
-  ## disabled-plugins = "[\"example.plugin.what.you.want\"]"
+  ## disabled-plugins = ["example.plugin.what.you.want"]
   # Whether to hide detailed agent information in API responses. When enabled,
   # agent details are obscured in user-facing APIs. Recommended for multi-tenant
   # environments to improve security and privacy.

--- a/src/ai/backend/common/configs/generator/toml.py
+++ b/src/ai/backend/common/configs/generator/toml.py
@@ -388,8 +388,13 @@ class TOMLGenerator:
         """
         type_lower = type_name.lower()
 
-        # List/tuple conversion - parse JSON array string like '["a", "b"]'
-        if "list" in type_lower or "sequence" in type_lower or "tuple" in type_lower:
+        # List/tuple/set conversion - parse JSON array string like '["a", "b"]'
+        if (
+            "list" in type_lower
+            or "sequence" in type_lower
+            or "tuple" in type_lower
+            or "set" in type_lower  # set[str], frozenset[str]
+        ):
             if example.startswith("["):
                 try:
                     return json.loads(example)

--- a/tests/unit/common/configs/test_generator.py
+++ b/tests/unit/common/configs/test_generator.py
@@ -263,6 +263,37 @@ class TestTOMLGenerator:
         assert "local-name" in result
         assert "# The configuration name" in result
 
+    def test_generate_collection_examples_as_arrays(self) -> None:
+        """Collection-typed examples render as TOML arrays, not quoted strings."""
+
+        class CollectionConfig(BackendAISchema):
+            allowed: Annotated[
+                set[str] | None,
+                Field(default=None),
+                BackendAIConfigMeta(
+                    description="Allowlist of plugin names",
+                    added_version="25.1.0",
+                    example=ConfigExample(local="", prod='["pkg.one", "pkg.two"]'),
+                ),
+            ]
+            ordering: Annotated[
+                list[str] | None,
+                Field(default=None),
+                BackendAIConfigMeta(
+                    description="Ordered preferences",
+                    added_version="25.1.0",
+                    example=ConfigExample(local="", prod='["first", "second"]'),
+                ),
+            ]
+
+        generator = TOMLGenerator(env=ConfigEnvironment.PROD)
+        result = generator.generate(CollectionConfig)
+
+        assert 'allowed = ["pkg.one", "pkg.two"]' in result
+        assert 'ordering = ["first", "second"]' in result
+        # A quoted JSON string would fail validation against set[str] / list[str]
+        assert '"[\\"pkg.one\\"' not in result
+
     def test_generate_uses_prod_example(self) -> None:
         """PROD environment uses prod example value."""
 


### PR DESCRIPTION
Follow-up to #12747, which fixed the same class of bug for tuple-typed examples.

## Problem

`ConfigExample.local` / `.prod` are typed `str`, so collection examples are written as JSON arrays and converted back by `_convert_example_to_type()` based on the field's type name. `set` / `frozenset` were missing from that check:

```python
if "list" in type_lower or "sequence" in type_lower or "tuple" in type_lower:
```

A field typed `set[str] | None` has `type_name == "set[str] | None"`, so the example was never parsed and got rendered as a quoted string:

```toml
## allow-compute-plugins = "[\"ai.backend.accelerator.cuda\", \"ai.backend.accelerator.rocm\"]"
```

Copying that line does not work — the field is `set[str] | None` and pydantic does not coerce `str` to `set`. Every other place in the tree already uses the array form:

- `configs/agent/halfstack.toml:23` — `# allow-compute-plugins = []`
- `configs/agent/halfstack-sftp.toml:33` — `allow-compute-plugins = []`
- `src/ai/backend/install/context.py:863` — `f"allow-compute-plugins = [{', '.join(plugin_list)}]"`

## Changes

- Add `set` to the collection check in `_convert_example_to_type()` (covers `set[...]` and `frozenset[...]`).
- Regenerate the six affected options:
  - `configs/agent/sample.toml` — `allow-compute-plugins`, `block-compute-plugins`, `allow-network-plugins`, `block-network-plugins`
  - `configs/manager/sample.toml` — `allowed-plugins`, `disabled-plugins`
- Add a generator test covering a `set[str]` example alongside a `list[str]` one.

## Verification

Local `pants export` was not available, so the tests were not run here — CI will. What was checked directly:

- Ran the patched `_convert_example_to_type()` standalone: `set[str] | None` and `frozenset[str]` now return a list, `list[str] | None` is unchanged, and a plain `str` field still returns the string (no false positives from the substring check).
- Parsed each regenerated line with `tomllib`: all six yield the intended arrays.
- Note: `configs/agent/sample.toml` does not parse as a whole either before or after this change — it contains documentation placeholders such as `[service-discovery.extra-labels.<name>]`. Unchanged behaviour, just flagging it so the check is not mistaken for a regression.

Found while configuring `allow-compute-plugins` from an external installer, where copying the sample verbatim produced a config the agent rejects.