### PR TITLE
feat(BA-7212): add a uuid column to the agents table

### DIFF
--- a/changes/13504.feature.md
+++ b/changes/13504.feature.md
@@ -1,0 +1,1 @@
+Add a `uuid` column to the `agents` table, backfilled for existing rows, while keeping the existing string primary key

--- a/src/ai/backend/common/identifier/agent.py
+++ b/src/ai/backend/common/identifier/agent.py
@@ -1,0 +1,7 @@
+from typing import NewType
+from uuid import UUID
+
+__all__ = ("AgentUUID",)
+
+
+AgentUUID = NewType("AgentUUID", UUID)

--- a/src/ai/backend/manager/models/agent/row.py
+++ b/src/ai/backend/manager/models/agent/row.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.expression import false, true
 
 from ai.backend.common.auth import PublicKey
+from ai.backend.common.identifier.agent import AgentUUID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import AccessKey, AgentId, ResourceSlot, SlotName, SlotTypes
 from ai.backend.manager.data.agent.types import (
@@ -67,6 +68,13 @@ __all__: Sequence[str] = (
 class AgentRow(Base):  # type: ignore[misc]
     __tablename__ = "agents"
 
+    uuid: Mapped[AgentUUID] = mapped_column(
+        "uuid",
+        GUID(AgentUUID),
+        unique=True,
+        nullable=False,
+        server_default=sa.text("uuid_generate_v4()"),
+    )
     id: Mapped[str] = mapped_column("id", sa.String(length=64), primary_key=True)
     status: Mapped[AgentStatus] = mapped_column(
         "status", EnumType(AgentStatus), nullable=False, index=True, default=AgentStatus.ALIVE

--- a/src/ai/backend/manager/models/agent/row.py
+++ b/src/ai/backend/manager/models/agent/row.py
@@ -75,7 +75,7 @@ class AgentRow(Base):  # type: ignore[misc]
         nullable=False,
         server_default=sa.text("uuid_generate_v4()"),
     )
-    id: Mapped[str] = mapped_column("id", sa.String(length=64), primary_key=True)
+    id: Mapped[AgentId] = mapped_column("id", sa.String(length=64), primary_key=True)
     status: Mapped[AgentStatus] = mapped_column(
         "status", EnumType(AgentStatus), nullable=False, index=True, default=AgentStatus.ALIVE
     )
@@ -349,7 +349,7 @@ class AgentPermissionContext(AbstractPermissionContext[AgentPermission, AgentRow
     @override
     async def calculate_final_permission(self, rbac_obj: AgentRow) -> frozenset[AgentPermission]:
         agent_row = rbac_obj
-        agent_id = cast(AgentId, agent_row.id)
+        agent_id = agent_row.id
         permissions: set[AgentPermission] = set()
 
         if (

--- a/src/ai/backend/manager/models/alembic/versions/13f4b8bc37f2_add_uuid_column_to_agents_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/13f4b8bc37f2_add_uuid_column_to_agents_table.py
@@ -1,0 +1,37 @@
+"""add uuid column to agents table
+
+Revision ID: 13f4b8bc37f2
+Revises: c1a7d3f05e28
+Create Date: 2026-08-06 01:43:22.390606
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "13f4b8bc37f2"
+down_revision = "c1a7d3f05e28"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column(
+            "uuid",
+            GUID(),
+            server_default=sa.text("uuid_generate_v4()"),
+            nullable=False,
+        ),
+    )
+    op.create_unique_constraint("uq_agents_uuid", "agents", ["uuid"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_agents_uuid", "agents", type_="unique")
+    op.drop_column("agents", "uuid")


### PR DESCRIPTION
## Summary
- Add a `uuid` column (UUID type, UNIQUE, `server_default uuid_generate_v4()`) to the `agents` table, keeping the existing varchar(64) primary key as-is.
- Introduce the `AgentUUID` identifier type in `common/identifier/agent.py` and map the column as `GUID(AgentUUID)` on `AgentRow`.
- Add an Alembic migration that adds the column with the volatile server default, which backfills existing rows with distinct UUIDs.

## Test plan
- [x] `alembic upgrade head` on a local DB: existing agent rows are backfilled with distinct UUIDs.
- [x] Column definition verified: `uuid` NOT NULL, default `uuid_generate_v4()`, unique constraint `uq_agents_uuid`.
- [x] `alembic downgrade -1` → `upgrade head` round trip passes.

Resolves BA-7212

🤖 Generated with [Claude Code](https://claude.com/claude-code)