### PR TITLE
test: give the component user fixtures their RBAC virtual scope

### DIFF
--- a/changes/13519.test.md
+++ b/changes/13519.test.md
@@ -1,0 +1,1 @@
+Create the RBAC virtual scope for users inserted by the component test fixtures, so that project member binding works against them

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -59,6 +59,7 @@ from ai.backend.common.defs import (
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.message_queue.redis_queue.queue import RedisMQArgs, RedisQueue
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
@@ -181,7 +182,7 @@ class KeypairFixtureData:
 
 @dataclass
 class UserFixtureData:
-    user_uuid: uuid.UUID
+    user_uuid: UserID
     keypair: KeypairFixtureData
     email: str = ""
 
@@ -810,7 +811,7 @@ async def group_fixture(
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
-async def _insert_user_virtual_scope(conn: AsyncConnection, user_uuid: uuid.UUID) -> None:
+async def _insert_user_virtual_scope(conn: AsyncConnection, user_uuid: UserID) -> None:
     """Give a directly-inserted user the RBAC rows ``create_full_user`` would have made.
 
     Without them the member-binding paths cannot resolve the user's virtual scope.
@@ -852,7 +853,7 @@ async def admin_user_fixture(
     unique_id = secrets.token_hex(4)
     email = f"admin-{unique_id}@test.local"
     data = UserFixtureData(
-        user_uuid=uuid.uuid4(),
+        user_uuid=UserID(uuid.uuid4()),
         keypair=KeypairFixtureData(
             access_key=f"AKTEST{secrets.token_hex(7).upper()}",
             secret_key=secrets.token_hex(20),
@@ -960,7 +961,7 @@ async def regular_user_fixture(
     unique_id = secrets.token_hex(4)
     email = f"user-{unique_id}@test.local"
     data = UserFixtureData(
-        user_uuid=uuid.uuid4(),
+        user_uuid=UserID(uuid.uuid4()),
         keypair=KeypairFixtureData(
             access_key=f"AKTEST{secrets.token_hex(7).upper()}",
             secret_key=secrets.token_hex(20),

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -21,6 +21,7 @@ import sqlalchemy as sa
 import yarl
 from aiohttp import web
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.auth import HMACAuth
@@ -809,6 +810,37 @@ async def group_fixture(
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
+async def _insert_user_virtual_scope(conn: AsyncConnection, user_uuid: uuid.UUID) -> None:
+    """Give a directly-inserted user the RBAC rows ``create_full_user`` would have made.
+
+    Without them the member-binding paths cannot resolve the user's virtual scope.
+    """
+    virtual_scope_id = uuid.uuid4()
+    await conn.execute(
+        sa.insert(VirtualScopeRow.__table__).values(
+            id=virtual_scope_id,
+            scope_type=ScopeType.USER,
+            scope_id=str(user_uuid),
+        )
+    )
+    await conn.execute(
+        sa.insert(EntityMembershipRow.__table__).values(
+            virtual_scope_id=virtual_scope_id,
+            entity_type=EntityType.USER,
+            entity_id=str(user_uuid),
+            permission_cap=None,
+        )
+    )
+    await conn.execute(
+        sa.insert(ScopeBindingRow.__table__).values(
+            virtual_scope_id=virtual_scope_id,
+            scope_type=ScopeType.USER,
+            scope_id=str(user_uuid),
+            permission_cap=None,
+        )
+    )
+
+
 @pytest.fixture()
 async def admin_user_fixture(
     db_engine: SAEngine,
@@ -862,6 +894,7 @@ async def admin_user_fixture(
                 user=str(data.user_uuid),
             )
         )
+        await _insert_user_virtual_scope(conn, data.user_uuid)
         await conn.execute(
             users.update()
             .where(users.c.uuid == str(data.user_uuid))
@@ -906,6 +939,12 @@ async def admin_user_fixture(
         )
         await conn.execute(
             keypairs.delete().where(keypairs.c.access_key == data.keypair.access_key)
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,
+                VirtualScopeRow.__table__.c.scope_id == str(data.user_uuid),
+            )
         )
         await conn.execute(users.delete().where(users.c.uuid == str(data.user_uuid)))
 
@@ -963,6 +1002,7 @@ async def regular_user_fixture(
                 user=str(data.user_uuid),
             )
         )
+        await _insert_user_virtual_scope(conn, data.user_uuid)
         await conn.execute(
             users.update()
             .where(users.c.uuid == str(data.user_uuid))
@@ -1004,6 +1044,12 @@ async def regular_user_fixture(
         )
         await conn.execute(
             keypairs.delete().where(keypairs.c.access_key == data.keypair.access_key)
+        )
+        await conn.execute(
+            VirtualScopeRow.__table__.delete().where(
+                VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,
+                VirtualScopeRow.__table__.c.scope_id == str(data.user_uuid),
+            )
         )
         await conn.execute(users.delete().where(users.c.uuid == str(data.user_uuid)))
 

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -941,6 +941,7 @@ async def admin_user_fixture(
         await conn.execute(
             keypairs.delete().where(keypairs.c.access_key == data.keypair.access_key)
         )
+        # The entity-membership and scope-binding rows cascade from the virtual scope.
         await conn.execute(
             VirtualScopeRow.__table__.delete().where(
                 VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,
@@ -1046,6 +1047,7 @@ async def regular_user_fixture(
         await conn.execute(
             keypairs.delete().where(keypairs.c.access_key == data.keypair.access_key)
         )
+        # The entity-membership and scope-binding rows cascade from the virtual scope.
         await conn.execute(
             VirtualScopeRow.__table__.delete().where(
                 VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,


### PR DESCRIPTION
## Summary

`tests/component/project/test_user_search_via_role_assign.py` and `tests/component/model_card/test_model_card_project_assign.py` have been failing since #13444, with

```
500 virtual-scope-not-found
No virtual scope for scopes: user:<uuid>
```

from `bind_user_to_project` → `add_bulk_members` → `_bind_scope_to_member_vs` → `_resolve_virtual_scope_ids`.

#13444 rewrote the member-binding paths to resolve the **user's** virtual scope. `create_full_user` creates one for every user it provisions; `admin_user_fixture` and `regular_user_fixture` insert their user rows directly and never did. That commit changed `src/` only.

This adds the missing rows next to the user — the virtual scope, its self entity-membership and its self scope-binding — mirroring what `domain_fixture` and the project fixtures already do.

## Why nobody noticed

CI's `detect-changes` gate skips the component suite for changes that touch neither models nor repositories. #13444 touched `repositories/`, but the two failing files sit in shards that its run did not reach; on `main` the most recent component job ran exactly **one** file (`rbac/test_rbac_permission.py`), and other open PRs show the same. The failure only surfaces on a branch that runs the full suite.

## Proof

#13483 temporarily carries a copy of this commit. With it applied, both component shards on that branch go green — [run 31064867672](https://github.com/lablup/backend.ai/actions/runs/31064867672) — and the six failures above disappear. Those commits are dropped from that branch once this lands.

## Test plan

- [x] `pants fmt lint check tests/component::` — clean
- [ ] Component suite in CI — the two files above should pass

Worth a look separately: a deployment upgraded from before the virtual-scope work has users without one, and those users would hit the same 500 on project member binding. That is a product question, not a test one, so it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

