### PR TITLE
fix: add empty merge migration to reconcile diverged alembic heads

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/e3f2ff64863f_merge_heads_13f4b8bc37f2_and_.py
+++ b/src/ai/backend/manager/models/alembic/versions/e3f2ff64863f_merge_heads_13f4b8bc37f2_and_.py
@@ -1,0 +1,22 @@
+"""merge heads 13f4b8bc37f2 and d366a4c96f75
+
+Revision ID: e3f2ff64863f
+Revises: 13f4b8bc37f2, d366a4c96f75
+Create Date: 2026-08-06 11:24:15.708997
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e3f2ff64863f"
+down_revision = ("13f4b8bc37f2", "d366a4c96f75")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary
- main ended up with two alembic heads: `13f4b8bc37f2` (#13504, add uuid column to agents) and `d366a4c96f75` (#13497, backfill model names in runtime_variants) both revise `c1a7d3f05e28`
- Add an empty merge migration `e3f2ff64863f` per `models/alembic/AGENTS.md` — the two released migrations are left untouched

## Test plan
- [x] `alembic heads` reports a single head (`e3f2ff64863f`)
- [x] `pants lint` / `pants check` and pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)