### PR TITLE
fix: add empty merge migration to reconcile diverged alembic heads (#13527)

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/e3f2ff64863f_merge_heads_13f4b8bc37f2_and_.py
+++ b/src/ai/backend/manager/models/alembic/versions/e3f2ff64863f_merge_heads_13f4b8bc37f2_and_.py
@@ -1,0 +1,22 @@
+"""merge heads 13f4b8bc37f2 and d366a4c96f75
+
+Revision ID: e3f2ff64863f
+Revises: 13f4b8bc37f2, d366a4c96f75
+Create Date: 2026-08-06 11:24:15.708997
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e3f2ff64863f"
+down_revision = ("13f4b8bc37f2", "d366a4c96f75")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
This is an auto-generated backport of #13527 to the 26.4 release.