### PR TITLE
refactor(BA-7223): remove unreferenced ORM relationships from row classes

### DIFF
--- a/changes/13530.enhance.md
+++ b/changes/13530.enhance.md
@@ -1,0 +1,1 @@
+Remove unreferenced SQLAlchemy ORM relationships from usage history, fair share, scaling group, domain, and notification row models

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -12,6 +12,7 @@ The single-file shorthand (`models/{domain}.py`) is legacy — do not add new on
 
 - Inherit `Base` (defined in `manager/models/base.py`).
 - Every Row class requires a `__tablename__`.
+- Do NOT add new `relationship()` definitions — use explicit joins in `repositories/db_source/` queries. Existing relationships are being phased out; remove them (with their `back_populates` pair) once nothing references them.
 - Inter-entity relationships: keep related Row imports inside a `TYPE_CHECKING` block only.
 
 ## No logic in Row classes

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -12,7 +12,7 @@ The single-file shorthand (`models/{domain}.py`) is legacy — do not add new on
 
 - Inherit `Base` (defined in `manager/models/base.py`).
 - Every Row class requires a `__tablename__`.
-- Do NOT add new `relationship()` definitions — use explicit joins in `repositories/db_source/` queries. Existing relationships are being phased out; remove them (with their `back_populates` pair) once nothing references them.
+- Do NOT add new `relationship()` definitions — fetch related rows in `repositories/db_source/` queries. Existing relationships are being phased out; remove them (with their `back_populates` pair) once nothing references them.
 - Inter-entity relationships: keep related Row imports inside a `TYPE_CHECKING` block only.
 
 ## No logic in Row classes

--- a/src/ai/backend/manager/models/README.md
+++ b/src/ai/backend/manager/models/README.md
@@ -26,7 +26,7 @@ Query-related methods (`get_by_id`, `list_by_condition`, etc.) should be impleme
 ### Reference Columns
 
 - Use ID(UUID) columns without DB-level Foreign Key constraints
-- Relationships are defined via SQLAlchemy `relationship()` with `primaryjoin`
+- Related rows are fetched via explicit joins in repositories, not via `relationship()`
 
 ### Enum
 
@@ -82,8 +82,8 @@ Sets default at Python level. Applied only when creating via ORM.
 
 ## Relationship Definition
 
-- `back_populates` is required for bidirectional relationships
-- Specify `primaryjoin`, `foreign_keys` for complex join conditions
+- Do not define new `relationship()` attributes on Row classes — fetch related rows with explicit joins in repositories
+- Existing relationships are being removed; when the last reference to one disappears, delete it together with its `back_populates` pair on the other side
 - Association table naming: `association_{tableA}_{tableB}`
 
 ## Index Design
@@ -92,7 +92,7 @@ Consider indexes for the following columns:
 
 - **WHERE clause**: Frequently filtered columns like `status`, `domain_name`, `scaling_group_name`
 - **ORDER BY clause**: Columns used for sorting like `created_at`, `priority`
-- **Reference columns**: Improves relationship query performance
+- **Reference columns**: Improves join query performance
 - **Compound conditions**: Column combinations frequently used together
 
 Index types:
@@ -107,7 +107,6 @@ Implement `to_data()` method to convert ORM Row to dataclass.
 
 - Convert Enum values to appropriate types
 - Convert JSONB data to structured models using Pydantic `model_validate()`
-- Extract only necessary fields from relationship data
 
 ## Naming Conventions
 
@@ -132,6 +131,6 @@ When adding a new model:
 - [ ] Set `server_default` or `default` (only one)
 - [ ] Include `created_at` column (cursor pagination)
 - [ ] Add necessary indexes (consider WHERE, ORDER BY)
-- [ ] Set `back_populates` for bidirectional relationships
+- [ ] No `relationship()` attributes — related rows come from repository joins
 - [ ] Implement `to_data()` conversion method
 - [ ] Generate Alembic migration

--- a/src/ai/backend/manager/models/README.md
+++ b/src/ai/backend/manager/models/README.md
@@ -26,7 +26,7 @@ Query-related methods (`get_by_id`, `list_by_condition`, etc.) should be impleme
 ### Reference Columns
 
 - Use ID(UUID) columns without DB-level Foreign Key constraints
-- Related rows are fetched via explicit joins in repositories, not via `relationship()`
+- Related rows are fetched by repository queries, not via `relationship()`
 
 ### Enum
 
@@ -82,7 +82,7 @@ Sets default at Python level. Applied only when creating via ORM.
 
 ## Relationship Definition
 
-- Do not define new `relationship()` attributes on Row classes — fetch related rows with explicit joins in repositories
+- Do not define new `relationship()` attributes on Row classes — fetch related rows with repository queries
 - Existing relationships are being removed; when the last reference to one disappears, delete it together with its `back_populates` pair on the other side
 - Association table naming: `association_{tableA}_{tableB}`
 
@@ -92,7 +92,7 @@ Consider indexes for the following columns:
 
 - **WHERE clause**: Frequently filtered columns like `status`, `domain_name`, `scaling_group_name`
 - **ORDER BY clause**: Columns used for sorting like `created_at`, `priority`
-- **Reference columns**: Improves join query performance
+- **Reference columns**: Improves lookup performance for queries on referenced rows
 - **Compound conditions**: Column combinations frequently used together
 
 Index types:
@@ -131,6 +131,6 @@ When adding a new model:
 - [ ] Set `server_default` or `default` (only one)
 - [ ] Include `created_at` column (cursor pagination)
 - [ ] Add necessary indexes (consider WHERE, ORDER BY)
-- [ ] No `relationship()` attributes — related rows come from repository joins
+- [ ] No `relationship()` attributes — related rows come from repository queries
 - [ ] Implement `to_data()` conversion method
 - [ ] Generate Alembic migration

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -17,7 +17,7 @@ from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
-from sqlalchemy.orm import Mapped, foreign, load_only, mapped_column, relationship
+from sqlalchemy.orm import Mapped, load_only, mapped_column, relationship
 from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common import msgpack
@@ -50,11 +50,7 @@ from ai.backend.manager.models.rbac import (
 from ai.backend.manager.models.rbac.context import ClientContext
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.group import GroupRow
-    from ai.backend.manager.models.network import NetworkRow
     from ai.backend.manager.models.scaling_group import ScalingGroupForDomainRow
-    from ai.backend.manager.models.session import SessionRow
-    from ai.backend.manager.models.user import UserRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -85,12 +81,6 @@ def row_to_data(row: DomainRow | Row[Any]) -> DomainData:
         integration_name=row.integration_id,  # DB column is integration_id
         dotfiles=row.dotfiles,
     )
-
-
-def _get_network_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.network import NetworkRow
-
-    return DomainRow.name == foreign(NetworkRow.domain_name)
 
 
 class DomainRow(CreatedAtMixin, Base):  # type: ignore[misc]
@@ -135,25 +125,8 @@ class DomainRow(CreatedAtMixin, Base):  # type: ignore[misc]
         "dotfiles", sa.LargeBinary(length=MAXIMUM_DOTFILE_SIZE), nullable=False, default=b"\x90"
     )
 
-    sessions: Mapped[list[SessionRow]] = relationship(
-        "SessionRow",
-        back_populates="domain",
-        foreign_keys="[SessionRow.domain_name]",
-    )
-    users: Mapped[list[UserRow]] = relationship(
-        "UserRow",
-        back_populates="domain",
-        foreign_keys="[UserRow.domain_name]",
-    )
-    groups: Mapped[list[GroupRow]] = relationship("GroupRow", back_populates="domain")
     sgroup_for_domains_rows: Mapped[list[ScalingGroupForDomainRow]] = relationship(
         "ScalingGroupForDomainRow",
-        back_populates="domain_row",
-    )
-    networks: Mapped[list[NetworkRow]] = relationship(
-        "NetworkRow",
-        back_populates="domain_row",
-        primaryjoin=_get_network_join_condition,
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/fair_share/row.py
+++ b/src/ai/backend/manager/models/fair_share/row.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotQuantity
@@ -33,12 +32,6 @@ from ai.backend.manager.models.base import (
     ResourceSlotColumn,
 )
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.domain import DomainRow
-    from ai.backend.manager.models.group import GroupRow
-    from ai.backend.manager.models.user import UserRow
-
 
 __all__ = (
     "DomainFairShareRow",
@@ -88,12 +81,6 @@ def _merge_resource_weights(
 def _resource_slot_to_slot_quantities(slot: ResourceSlot) -> list[SlotQuantity]:
     """Convert a ResourceSlot to list[SlotQuantity] (unordered)."""
     return [SlotQuantity(slot_name=k, quantity=Decimal(str(v))) for k, v in slot.items()]
-
-
-def _get_domain_fair_share_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return DomainFairShareRow.domain_name == foreign(DomainRow.name)
 
 
 class DomainFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
@@ -226,14 +213,6 @@ class DomainFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         "Example: 1 means daily aggregation, 7 means weekly aggregation.",
     )
 
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_domain_fair_share_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
-    )
-
     __table_args__ = (
         sa.UniqueConstraint("resource_group_id", "domain_name", name="uq_domain_fair_share_rg_id"),
         sa.Index("ix_domain_fair_share_lookup", "resource_group", "domain_name"),
@@ -298,18 +277,6 @@ class DomainFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
                 uses_default_resources=uses_default_resources,  # New field
             ),
         )
-
-
-def _get_project_fair_share_project_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.group import GroupRow
-
-    return ProjectFairShareRow.project_id == foreign(GroupRow.id)
-
-
-def _get_project_fair_share_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return ProjectFairShareRow.domain_name == foreign(DomainRow.name)
 
 
 class ProjectFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
@@ -427,21 +394,6 @@ class ProjectFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         comment="Aggregation period for usage buckets in days.",
     )
 
-    project: Mapped[GroupRow | None] = relationship(
-        "GroupRow",
-        primaryjoin=_get_project_fair_share_project_join_condition,
-        foreign_keys=[project_id],
-        uselist=False,
-        viewonly=True,
-    )
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_project_fair_share_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
-    )
-
     __table_args__ = (
         sa.UniqueConstraint("resource_group_id", "project_id", name="uq_project_fair_share_rg_id"),
         sa.Index("ix_project_fair_share_lookup", "resource_group", "project_id"),
@@ -507,24 +459,6 @@ class ProjectFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
                 uses_default_resources=uses_default_resources,  # New field
             ),
         )
-
-
-def _get_user_fair_share_user_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.user import UserRow
-
-    return UserFairShareRow.user_uuid == foreign(UserRow.uuid)
-
-
-def _get_user_fair_share_project_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.group import GroupRow
-
-    return UserFairShareRow.project_id == foreign(GroupRow.id)
-
-
-def _get_user_fair_share_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return UserFairShareRow.domain_name == foreign(DomainRow.name)
 
 
 class UserFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
@@ -652,28 +586,6 @@ class UserFairShareRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         nullable=False,
         default=DEFAULT_DECAY_UNIT_DAYS,
         comment="Aggregation period for usage buckets in days.",
-    )
-
-    user: Mapped[UserRow | None] = relationship(
-        "UserRow",
-        primaryjoin=_get_user_fair_share_user_join_condition,
-        foreign_keys=[user_uuid],
-        uselist=False,
-        viewonly=True,
-    )
-    project: Mapped[GroupRow | None] = relationship(
-        "GroupRow",
-        primaryjoin=_get_user_fair_share_project_join_condition,
-        foreign_keys=[project_id],
-        uselist=False,
-        viewonly=True,
-    )
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_user_fair_share_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
     )
 
     __table_args__ = (

--- a/src/ai/backend/manager/models/group/row.py
+++ b/src/ai/backend/manager/models/group/row.py
@@ -229,9 +229,9 @@ class GroupRow(Base):  # type: ignore[misc]
 
     # Relationships (defined with deferred join conditions to avoid circular imports)
     sessions: Mapped[list[SessionRow]] = relationship("SessionRow", back_populates="group")
-    domain: Mapped[DomainRow] = relationship("DomainRow", back_populates="groups")
+    domain: Mapped[DomainRow] = relationship("DomainRow")
     sgroup_for_groups_rows: Mapped[list[ScalingGroupForProjectRow]] = relationship(
-        "ScalingGroupForProjectRow", back_populates="project_row"
+        "ScalingGroupForProjectRow"
     )
     users: Mapped[list[AssocGroupUserRow]] = relationship(
         "AssocGroupUserRow", back_populates="group"

--- a/src/ai/backend/manager/models/keypair/row.py
+++ b/src/ai/backend/manager/models/keypair/row.py
@@ -107,7 +107,6 @@ class KeyPairRow(Base):  # type: ignore[misc]
     )
     sgroup_for_keypairs_rows: Mapped[list[ScalingGroupForKeypairsRow]] = relationship(
         "ScalingGroupForKeypairsRow",
-        back_populates="keypair_row",
     )
     user_row: Mapped[UserRow] = relationship(
         "UserRow", back_populates="keypairs", foreign_keys=[user]

--- a/src/ai/backend/manager/models/network/row.py
+++ b/src/ai/backend/manager/models/network/row.py
@@ -88,7 +88,6 @@ class NetworkRow(Base):  # type: ignore[misc]
     )
     domain_row: Mapped[DomainRow] = relationship(
         "DomainRow",
-        back_populates="networks",
         primaryjoin=_get_domain_join_condition,
     )
 

--- a/src/ai/backend/manager/models/notification/row.py
+++ b/src/ai/backend/manager/models/notification/row.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
@@ -22,10 +22,6 @@ from ai.backend.manager.models.base import (
     Base,
 )
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.user import UserRow
-
-
 __all__ = (
     "NotificationChannelRow",
     "NotificationRuleRow",
@@ -33,18 +29,6 @@ __all__ = (
 
 
 # ========== ORM Models ==========
-
-
-def _get_notification_channel_rules_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.notification import NotificationRuleRow
-
-    return NotificationChannelRow.id == foreign(NotificationRuleRow.channel_id)
-
-
-def _get_notification_channel_creator_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.user import UserRow
-
-    return foreign(NotificationChannelRow.created_by) == UserRow.uuid
 
 
 class NotificationChannelRow(Base):  # type: ignore[misc]
@@ -83,20 +67,6 @@ class NotificationChannelRow(Base):  # type: ignore[misc]
         onupdate=sa.func.now(),
     )
 
-    # Relationships
-    rules: Mapped[list[NotificationRuleRow]] = relationship(
-        "NotificationRuleRow",
-        back_populates="channel",
-        primaryjoin=_get_notification_channel_rules_join_condition,
-        foreign_keys=[id],
-    )
-    creator: Mapped[UserRow] = relationship(
-        "UserRow",
-        primaryjoin=_get_notification_channel_creator_join_condition,
-        foreign_keys=[created_by],
-        uselist=False,
-    )
-
     def to_data(self) -> NotificationChannelData:
         """Convert Row to domain model data."""
         # Parse channel_type string to enum
@@ -127,12 +97,6 @@ def _get_notification_rule_channel_join_condition() -> sa.ColumnElement[bool]:
     from ai.backend.manager.models.notification import NotificationChannelRow
 
     return foreign(NotificationRuleRow.channel_id) == NotificationChannelRow.id
-
-
-def _get_notification_rule_creator_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.user import UserRow
-
-    return foreign(NotificationRuleRow.created_by) == UserRow.uuid
 
 
 class NotificationRuleRow(Base):  # type: ignore[misc]
@@ -169,15 +133,8 @@ class NotificationRuleRow(Base):  # type: ignore[misc]
     # Relationships
     channel: Mapped[NotificationChannelRow] = relationship(
         "NotificationChannelRow",
-        back_populates="rules",
         primaryjoin=_get_notification_rule_channel_join_condition,
         foreign_keys=[channel_id],
-    )
-    creator: Mapped[UserRow] = relationship(
-        "UserRow",
-        primaryjoin=_get_notification_rule_creator_join_condition,
-        foreign_keys=[created_by],
-        uselist=False,
     )
 
     def to_data(self) -> NotificationRuleData:

--- a/src/ai/backend/manager/models/resource_preset/row.py
+++ b/src/ai/backend/manager/models/resource_preset/row.py
@@ -70,7 +70,6 @@ class ResourcePresetRow(Base):  # type: ignore[misc]
     )
     scaling_group_row: Mapped[ScalingGroupRow | None] = relationship(
         "ScalingGroupRow",
-        back_populates="resource_preset_rows",
         primaryjoin=_get_scaling_group_join_condition,
     )
 

--- a/src/ai/backend/manager/models/resource_usage_history/row.py
+++ b/src/ai/backend/manager/models/resource_usage_history/row.py
@@ -19,10 +19,9 @@ from __future__ import annotations
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot
@@ -33,14 +32,6 @@ from ai.backend.manager.models.base import (
 )
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.domain import DomainRow
-    from ai.backend.manager.models.group import GroupRow
-    from ai.backend.manager.models.kernel import KernelRow
-    from ai.backend.manager.models.session import SessionRow
-    from ai.backend.manager.models.user import UserRow
-
-
 __all__ = (
     "KernelUsageRecordRow",
     "DomainUsageBucketRow",
@@ -48,36 +39,6 @@ __all__ = (
     "UserUsageBucketRow",
     "UsageBucketEntryRow",
 )
-
-
-def _get_kernel_usage_record_kernel_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.kernel import KernelRow
-
-    return KernelUsageRecordRow.kernel_id == foreign(KernelRow.id)
-
-
-def _get_kernel_usage_record_session_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.session import SessionRow
-
-    return KernelUsageRecordRow.session_id == foreign(SessionRow.id)
-
-
-def _get_kernel_usage_record_user_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.user import UserRow
-
-    return KernelUsageRecordRow.user_uuid == foreign(UserRow.uuid)
-
-
-def _get_kernel_usage_record_project_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.group import GroupRow
-
-    return KernelUsageRecordRow.project_id == foreign(GroupRow.id)
-
-
-def _get_kernel_usage_record_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return KernelUsageRecordRow.domain_name == foreign(DomainRow.name)
 
 
 class KernelUsageRecordRow(Base):  # type: ignore[misc]
@@ -126,54 +87,11 @@ class KernelUsageRecordRow(Base):  # type: ignore[misc]
         "resource_usage", ResourceSlotColumn(), nullable=False, default=ResourceSlot
     )
 
-    # Relationships (Optional since referenced entities can be deleted)
-    kernel: Mapped[KernelRow | None] = relationship(
-        "KernelRow",
-        primaryjoin=_get_kernel_usage_record_kernel_join_condition,
-        foreign_keys=[kernel_id],
-        uselist=False,
-        viewonly=True,
-    )
-    session: Mapped[SessionRow | None] = relationship(
-        "SessionRow",
-        primaryjoin=_get_kernel_usage_record_session_join_condition,
-        foreign_keys=[session_id],
-        uselist=False,
-        viewonly=True,
-    )
-    user: Mapped[UserRow | None] = relationship(
-        "UserRow",
-        primaryjoin=_get_kernel_usage_record_user_join_condition,
-        foreign_keys=[user_uuid],
-        uselist=False,
-        viewonly=True,
-    )
-    project: Mapped[GroupRow | None] = relationship(
-        "GroupRow",
-        primaryjoin=_get_kernel_usage_record_project_join_condition,
-        foreign_keys=[project_id],
-        uselist=False,
-        viewonly=True,
-    )
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_kernel_usage_record_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
-    )
-
     __table_args__ = (
         sa.Index("ix_kernel_usage_rg_period", "resource_group", "period_start"),
         sa.Index("ix_kernel_usage_rg_id_period", "resource_group_id", "period_start"),
         sa.Index("ix_kernel_usage_user_period", "user_uuid", "period_start"),
     )
-
-
-def _get_domain_usage_bucket_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return DomainUsageBucketRow.domain_name == foreign(DomainRow.name)
 
 
 class DomainUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
@@ -222,15 +140,6 @@ class DomainUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc
         "Sum of agent.available_slots for calculating usage ratio.",
     )
 
-    # Relationships
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_domain_usage_bucket_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
-    )
-
     __table_args__ = (
         sa.UniqueConstraint(
             "domain_name",
@@ -240,18 +149,6 @@ class DomainUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc
         ),
         sa.Index("ix_domain_usage_bucket_lookup", "domain_name", "resource_group", "period_start"),
     )
-
-
-def _get_project_usage_bucket_project_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.group import GroupRow
-
-    return ProjectUsageBucketRow.project_id == foreign(GroupRow.id)
-
-
-def _get_project_usage_bucket_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return ProjectUsageBucketRow.domain_name == foreign(DomainRow.name)
 
 
 class ProjectUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
@@ -301,22 +198,6 @@ class ProjectUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[mis
         "Sum of agent.available_slots for calculating usage ratio.",
     )
 
-    # Relationships
-    project: Mapped[GroupRow | None] = relationship(
-        "GroupRow",
-        primaryjoin=_get_project_usage_bucket_project_join_condition,
-        foreign_keys=[project_id],
-        uselist=False,
-        viewonly=True,
-    )
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_project_usage_bucket_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
-    )
-
     __table_args__ = (
         sa.UniqueConstraint(
             "project_id",
@@ -326,24 +207,6 @@ class ProjectUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[mis
         ),
         sa.Index("ix_project_usage_bucket_lookup", "project_id", "resource_group", "period_start"),
     )
-
-
-def _get_user_usage_bucket_user_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.user import UserRow
-
-    return UserUsageBucketRow.user_uuid == foreign(UserRow.uuid)
-
-
-def _get_user_usage_bucket_project_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.group import GroupRow
-
-    return UserUsageBucketRow.project_id == foreign(GroupRow.id)
-
-
-def _get_user_usage_bucket_domain_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.domain import DomainRow
-
-    return UserUsageBucketRow.domain_name == foreign(DomainRow.name)
 
 
 class UserUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
@@ -397,29 +260,6 @@ class UserUsageBucketRow(LifecycleTimestampsMixin, Base):  # type: ignore[misc]
         default=ResourceSlot,
         comment="Scaling group capacity at bucket period. "
         "Sum of agent.available_slots for calculating usage ratio.",
-    )
-
-    # Relationships
-    user: Mapped[UserRow | None] = relationship(
-        "UserRow",
-        primaryjoin=_get_user_usage_bucket_user_join_condition,
-        foreign_keys=[user_uuid],
-        uselist=False,
-        viewonly=True,
-    )
-    project: Mapped[GroupRow | None] = relationship(
-        "GroupRow",
-        primaryjoin=_get_user_usage_bucket_project_join_condition,
-        foreign_keys=[project_id],
-        uselist=False,
-        viewonly=True,
-    )
-    domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow",
-        primaryjoin=_get_user_usage_bucket_domain_join_condition,
-        foreign_keys=[domain_name],
-        uselist=False,
-        viewonly=True,
     )
 
     __table_args__ = (

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -21,7 +21,6 @@ from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import (
     Mapped,
-    foreign,
     joinedload,
     load_only,
     mapped_column,
@@ -67,11 +66,6 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.agent import AgentRow
-    from ai.backend.manager.models.domain import DomainRow
-    from ai.backend.manager.models.group import GroupRow
-    from ai.backend.manager.models.keypair import KeyPairRow
-    from ai.backend.manager.models.resource_preset import ResourcePresetRow
-    from ai.backend.manager.models.session import SessionRow
 
 __all__: Sequence[str] = (
     # table defs
@@ -163,11 +157,6 @@ class ScalingGroupForDomainRow(Base):  # type: ignore[misc]
     )
     sgroup_row: Mapped[ScalingGroupRow] = relationship(
         "ScalingGroupRow",
-        back_populates="sgroup_for_domains_rows",
-    )
-    domain_row: Mapped[DomainRow] = relationship(
-        "DomainRow",
-        back_populates="sgroup_for_domains_rows",
     )
 
 
@@ -199,11 +188,6 @@ class ScalingGroupForProjectRow(Base):  # type: ignore[misc]
     )
     sgroup_row: Mapped[ScalingGroupRow] = relationship(
         "ScalingGroupRow",
-        back_populates="sgroup_for_groups_rows",
-    )
-    project_row: Mapped[GroupRow] = relationship(
-        "GroupRow",
-        back_populates="sgroup_for_groups_rows",
     )
 
 
@@ -234,22 +218,11 @@ class ScalingGroupForKeypairsRow(Base):  # type: ignore[misc]
     )
     sgroup_row: Mapped[ScalingGroupRow] = relationship(
         "ScalingGroupRow",
-        back_populates="sgroup_for_keypairs_rows",
-    )
-    keypair_row: Mapped[KeyPairRow] = relationship(
-        "KeyPairRow",
-        back_populates="sgroup_for_keypairs_rows",
     )
 
 
 # For compatibility
 sgroups_for_keypairs = ScalingGroupForKeypairsRow.__table__
-
-
-def _get_resource_preset_join_condition() -> Any:
-    from ai.backend.manager.models.resource_preset import ResourcePresetRow
-
-    return ScalingGroupRow.name == foreign(ResourcePresetRow.scaling_group_name)
 
 
 class ScalingGroupRow(Base):  # type: ignore[misc]
@@ -332,33 +305,10 @@ class ScalingGroupRow(Base):  # type: ignore[misc]
         default=DefaultSessionOptions,
     )
 
-    sessions: Mapped[list[SessionRow]] = relationship(
-        "SessionRow",
-        back_populates="scaling_group",
-        foreign_keys="[SessionRow.scaling_group_name]",
-    )
     agents: Mapped[list[AgentRow]] = relationship(
         "AgentRow",
         back_populates="scaling_group_row",
         foreign_keys="[AgentRow.scaling_group]",
-    )
-
-    sgroup_for_domains_rows: Mapped[list[ScalingGroupForDomainRow]] = relationship(
-        "ScalingGroupForDomainRow",
-        back_populates="sgroup_row",
-    )
-    sgroup_for_groups_rows: Mapped[list[ScalingGroupForProjectRow]] = relationship(
-        "ScalingGroupForProjectRow",
-        back_populates="sgroup_row",
-    )
-    sgroup_for_keypairs_rows: Mapped[list[ScalingGroupForKeypairsRow]] = relationship(
-        "ScalingGroupForKeypairsRow",
-        back_populates="sgroup_row",
-    )
-    resource_preset_rows: Mapped[list[ResourcePresetRow]] = relationship(
-        "ResourcePresetRow",
-        back_populates="scaling_group_row",
-        primaryjoin=_get_resource_preset_join_condition,
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -467,7 +467,6 @@ class SessionRow(Base):  # type: ignore[misc]
     )
     scaling_group: Mapped[ScalingGroupRow] = relationship(
         "ScalingGroupRow",
-        back_populates="sessions",
         foreign_keys=[scaling_group_name],
     )
     target_sgroup_names: Mapped[list[str] | None] = mapped_column(
@@ -489,7 +488,6 @@ class SessionRow(Base):  # type: ignore[misc]
     )
     domain: Mapped[DomainRow] = relationship(
         "DomainRow",
-        back_populates="sessions",
         foreign_keys=[domain_name],
     )
     group_id: Mapped[UUID] = mapped_column(

--- a/src/ai/backend/manager/models/user/row.py
+++ b/src/ai/backend/manager/models/user/row.py
@@ -263,7 +263,7 @@ class UserRow(Base):  # type: ignore[misc]
         foreign_keys="KernelRow.user_uuid",
     )
     domain: Mapped[DomainRow | None] = relationship(
-        "DomainRow", back_populates="users", primaryjoin=_get_domain_join_condition
+        "DomainRow", primaryjoin=_get_domain_join_condition
     )
     groups: Mapped[list[AssocGroupUserRow]] = relationship(
         "AssocGroupUserRow", back_populates="user", primaryjoin=_get_groups_join_condition


### PR DESCRIPTION
## Summary
- Remove zero-reference `relationship()` definitions (and their join-condition helpers) from the `resource_usage_history`, `fair_share`, `scaling_group`, `domain`, and `notification` row modules.
- Drop the paired `back_populates` arguments on the surviving side (`session`, `user`, `group`, `network`, `keypair`, `resource_preset` rows).
- Update `models/AGENTS.md` and `models/README.md`: no new `relationship()` definitions — fetch related rows via explicit repository joins.

## Test plan
- [x] `sqlalchemy.orm.configure_mappers()` succeeds after the removals
- [x] `pants lint` / `pants check` pass on changed files
- [x] CI test suite

Resolves BA-7223

🤖 Generated with [Claude Code](https://claude.com/claude-code)