### PR TITLE
feat(BA-7233): require service port in runtime variant default model definition

### DIFF
--- a/changes/13539.enhance.md
+++ b/changes/13539.enhance.md
@@ -1,0 +1,1 @@
+Require a service port in runtime variant default model definitions so revisions always resolve a port, with an idempotent backfill for legacy rows

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -39727,6 +39727,7 @@
           "port": {
             "anyOf": [
               {
+                "exclusiveMinimum": 1,
                 "type": "integer"
               },
               {

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -753,8 +753,6 @@ class DefaultModelServiceConfig(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
     start_command: str | None = None
     shell: str | None = None
-    # Mirrors the resolved ModelServiceConfig.port constraint so invalid ports
-    # fail at the DB boundary instead of at to_resolved().
     port: int = Field(gt=1)
     health_check: ModelHealthCheckDraft | None = None
 

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -5,7 +5,7 @@ import shlex
 import sys
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import Annotated, Any, override
+from typing import Any, override
 
 import humps
 import tomli
@@ -146,10 +146,6 @@ agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 
 DEFAULT_SHELL = "/bin/bash"
 
-# Shared port constraint for every model-service config variant (strict,
-# draft, baseline) so the same range is enforced at every boundary.
-ModelServicePort = Annotated[int, Field(gt=1)]
-
 
 class PreStartAction(BaseConfigModel):
     action: str = Field(
@@ -260,9 +256,10 @@ class ModelServiceConfig(BaseConfigModel):
         ),
         examples=[DEFAULT_SHELL],
     )
-    port: ModelServicePort = Field(
+    port: int = Field(
         description="Port number for the model service. Must be greater than 1.",
         examples=[8080],
+        gt=1,
     )
     health_check: ModelHealthCheck | None = Field(
         default=None,
@@ -561,7 +558,7 @@ class ModelServiceConfigDraft(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
     start_command: str | None = None
     shell: str | None = None
-    port: ModelServicePort | None = None
+    port: int | None = Field(default=None, gt=1)
     health_check: ModelHealthCheckDraft | None = None
 
     @model_validator(mode="before")
@@ -756,7 +753,7 @@ class DefaultModelServiceConfig(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
     start_command: str | None = None
     shell: str | None = None
-    port: ModelServicePort
+    port: int = Field(gt=1)
     health_check: ModelHealthCheckDraft | None = None
 
     @model_validator(mode="before")

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -753,7 +753,9 @@ class DefaultModelServiceConfig(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
     start_command: str | None = None
     shell: str | None = None
-    port: int
+    # Mirrors the resolved ModelServiceConfig.port constraint so invalid ports
+    # fail at the DB boundary instead of at to_resolved().
+    port: int = Field(gt=1)
     health_check: ModelHealthCheckDraft | None = None
 
     @model_validator(mode="before")

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -746,15 +746,32 @@ class ModelDefinitionDraft(BaseConfigModel):
         return cls.model_validate(data)
 
 
+class DefaultModelServiceConfig(BaseConfigModel):
+    """Baseline model service config; ``port`` stays required so the baseline
+    guarantees every revision resolves a service port."""
+
+    pre_start_actions: list[PreStartAction] | None = None
+    start_command: str | None = None
+    shell: str | None = None
+    port: int
+    health_check: ModelHealthCheckDraft | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_start_command(cls, data: Any) -> Any:
+        return resolve_model_service_start_command(data)
+
+
 class DefaultModelConfig(BaseConfigModel):
-    """Baseline model config stored on a runtime variant. ``name`` is required
-    so the always-present baseline layer guarantees every revision a model name;
-    ``model_path`` keeps its dynamic mount-destination default in the reader.
+    """Baseline model config stored on a runtime variant. ``name`` and
+    ``service.port`` are required so the always-present baseline layer
+    guarantees them to every revision; ``model_path`` keeps its dynamic
+    mount-destination default in the reader.
     """
 
     name: str
     model_path: str | None = None
-    service: ModelServiceConfigDraft | None = None
+    service: DefaultModelServiceConfig
     metadata: ModelMetadata | None = None
 
 

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -5,7 +5,7 @@ import shlex
 import sys
 from collections.abc import Mapping, MutableMapping
 from pathlib import Path
-from typing import Any, override
+from typing import Annotated, Any, override
 
 import humps
 import tomli
@@ -146,6 +146,10 @@ agent_selector_config_iv = t.Dict({}) | agent_selector_globalconfig_iv
 
 DEFAULT_SHELL = "/bin/bash"
 
+# Shared port constraint for every model-service config variant (strict,
+# draft, baseline) so the same range is enforced at every boundary.
+ModelServicePort = Annotated[int, Field(gt=1)]
+
 
 class PreStartAction(BaseConfigModel):
     action: str = Field(
@@ -256,10 +260,9 @@ class ModelServiceConfig(BaseConfigModel):
         ),
         examples=[DEFAULT_SHELL],
     )
-    port: int = Field(
+    port: ModelServicePort = Field(
         description="Port number for the model service. Must be greater than 1.",
         examples=[8080],
-        gt=1,
     )
     health_check: ModelHealthCheck | None = Field(
         default=None,
@@ -558,7 +561,7 @@ class ModelServiceConfigDraft(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
     start_command: str | None = None
     shell: str | None = None
-    port: int | None = None
+    port: ModelServicePort | None = None
     health_check: ModelHealthCheckDraft | None = None
 
     @model_validator(mode="before")
@@ -753,7 +756,7 @@ class DefaultModelServiceConfig(BaseConfigModel):
     pre_start_actions: list[PreStartAction] | None = None
     start_command: str | None = None
     shell: str | None = None
-    port: int = Field(gt=1)
+    port: ModelServicePort
     health_check: ModelHealthCheckDraft | None = None
 
     @model_validator(mode="before")

--- a/src/ai/backend/manager/models/alembic/versions/55e0c3669e2e_backfill_missing_service_ports_in_runtime_variants.py
+++ b/src/ai/backend/manager/models/alembic/versions/55e0c3669e2e_backfill_missing_service_ports_in_runtime_variants.py
@@ -1,8 +1,9 @@
 """backfill missing service ports in runtime_variants
 
-``default_model_definition`` now requires ``service.port`` on every model
-entry; create the service block and/or fill the port so pre-existing rows
-keep loading. Idempotent: only touches entries whose port is absent or null.
+``default_model_definition`` now requires ``service.port`` (> 1) on every
+model entry; create the service block and/or fill the port so pre-existing
+rows keep loading. Idempotent: only touches entries whose port is absent,
+null, or not greater than 1.
 
 Revision ID: 55e0c3669e2e
 Revises: 2dccb3069031
@@ -35,7 +36,11 @@ def upgrade() -> None:
             "WHERE jsonb_typeof(default_model_definition->'models') = 'array' "
             "AND EXISTS ("
             "  SELECT 1 FROM jsonb_array_elements(default_model_definition->'models') AS m"
-            "  WHERE jsonb_typeof(m) = 'object' AND (m->'service'->>'port') IS NULL"
+            "  WHERE jsonb_typeof(m) = 'object' AND ("
+            "    (m->'service'->>'port') IS NULL"
+            "    OR (jsonb_typeof(m->'service'->'port') = 'number'"
+            "        AND (m->'service'->>'port')::numeric <= 1)"
+            "  )"
             ")"
         )
     ).fetchall()
@@ -49,7 +54,8 @@ def upgrade() -> None:
             if not isinstance(service, dict):
                 service = {}
                 model["service"] = service
-            if service.get("port") is None:
+            port = service.get("port")
+            if port is None or (isinstance(port, (int, float)) and port <= 1):
                 service["port"] = _FALLBACK_PORT
         bind.execute(
             sa.text(

--- a/src/ai/backend/manager/models/alembic/versions/55e0c3669e2e_backfill_missing_service_ports_in_runtime_variants.py
+++ b/src/ai/backend/manager/models/alembic/versions/55e0c3669e2e_backfill_missing_service_ports_in_runtime_variants.py
@@ -1,0 +1,65 @@
+"""backfill missing service ports in runtime_variants
+
+``default_model_definition`` now requires ``service.port`` on every model
+entry; create the service block and/or fill the port so pre-existing rows
+keep loading. Idempotent: only touches entries whose port is absent or null.
+
+Revision ID: 55e0c3669e2e
+Revises: 2dccb3069031
+Create Date: 2026-08-06 13:10:00.000000
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "55e0c3669e2e"
+down_revision = "2dccb3069031"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+# Every seeded baseline ships a port, so only rows written outside the seed
+# chain can lack one; 8000 matches the most common seeded service port.
+_FALLBACK_PORT = 8000
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, default_model_definition FROM runtime_variants "
+            "WHERE jsonb_typeof(default_model_definition->'models') = 'array' "
+            "AND EXISTS ("
+            "  SELECT 1 FROM jsonb_array_elements(default_model_definition->'models') AS m"
+            "  WHERE jsonb_typeof(m) = 'object' AND (m->'service'->>'port') IS NULL"
+            ")"
+        )
+    ).fetchall()
+    for row in rows:
+        definition = dict(row.default_model_definition)
+        for model in definition["models"]:
+            # Non-object elements (JSON null, scalars) are left for app-level validation.
+            if not isinstance(model, dict):
+                continue
+            service = model.get("service")
+            if not isinstance(service, dict):
+                service = {}
+                model["service"] = service
+            if service.get("port") is None:
+                service["port"] = _FALLBACK_PORT
+        bind.execute(
+            sa.text(
+                "UPDATE runtime_variants "
+                "SET default_model_definition = CAST(:definition AS JSONB) "
+                "WHERE id = :id"
+            ).bindparams(id=row.id, definition=json.dumps(definition))
+        )
+
+
+def downgrade() -> None:
+    # Backfilled ports are indistinguishable from operator-set ones; keep them.
+    pass

--- a/tests/unit/manager/api/adapters/test_runtime_variant_adapter.py
+++ b/tests/unit/manager/api/adapters/test_runtime_variant_adapter.py
@@ -22,6 +22,7 @@ class TestRuntimeVariantDataToNode:
                         "name": "vllm-model",
                         "service": {
                             "start_command": "vllm serve '{model_path}'",
+                            "port": 8000,
                         },
                     }
                 ]


### PR DESCRIPTION
## Summary
- Add `DefaultModelServiceConfig` (required `port`) and make `DefaultModelConfig.service` mandatory, so the runtime variant baseline guarantees every revision resolves a service port the same way it guarantees the model name (BA-7209). The stored baseline is validated at the DB column boundary.
- The `command`/legacy `start_command` normalization validator carries over from `ModelServiceConfigDraft` — fixtures and raw inserts still supply list-form `start_command`.
- Alembic migration `55e0c3669e2e`: idempotent backfill that creates missing `service` blocks and fills absent/null ports with `8000` (every seeded baseline already ships a port; only rows written outside the seed chain can lack one). Non-object array elements are skipped; downgrade is a no-op.
- No fixture changes needed: all bundled runtime variants already carry `service.port`.

## Test plan
- [x] `pants lint/check` green including `--changed-dependents=direct` (pre-push scope); reader/adapter/repository test suites pass
- [x] Migration logic verified against a live DB across null shapes (missing/null service, scalar service, null port, string port, JSON-null models/elements, top-level null) — fills correctly, idempotent second pass selects nothing
- [x] Migration also executed via a real `alembic upgrade head` run on the local DB
- [x] Live: manager restart + `runtime-variant search` loads all variants through the new required-port validation

Resolves BA-7233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13539.org.readthedocs.build/en/13539/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13539.org.readthedocs.build/ko/13539/

<!-- readthedocs-preview sorna-ko end -->