### PR TITLE
fix(BA-7247): declare the endpoint rows the idle-check test's mappers need (#13553)

### DIFF
--- a/changes/13553.fix.md
+++ b/changes/13553.fix.md
@@ -1,0 +1,1 @@
+Restore the idle-check host unit tests, which stopped running when the mapper registry lost the endpoint rows their session relationships resolve against.

--- a/tests/unit/manager/test_idle_check_host.py
+++ b/tests/unit/manager/test_idle_check_host.py
@@ -52,7 +52,12 @@ from ai.backend.manager.idle import (
 )
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
+from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
+from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
+from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision_preset import DeploymentRevisionPresetRow
 from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -61,15 +66,19 @@ from ai.backend.manager.models.rbac_models import RoleRow, UserRoleRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
+from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
+from ai.backend.manager.models.routing import RoutingRow
+from ai.backend.manager.models.runtime_variant import RuntimeVariantRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.db.engine import create_async_engine
 from ai.backend.testutils.db import with_tables
 
@@ -87,11 +96,20 @@ _IDLE_ROWS = [
     KeyPairRow,
     GroupRow,
     AssociationScopesEntitiesRow,
-    AgentRow,
     ContainerRegistryRow,
     ImageRow,
+    VFolderRow,
+    EndpointRow,
+    DeploymentPolicyRow,
+    DeploymentAutoScalingPolicyRow,
+    RuntimeVariantRow,
+    DeploymentRevisionPresetRow,
+    DeploymentRevisionRow,
     SessionRow,
+    AgentRow,
     KernelRow,
+    ReplicaGroupRow,
+    RoutingRow,
 ]
 
 


### PR DESCRIPTION
This is an auto-generated backport of #13553 to the 26.8 release.