### PR TITLE
test: provision user virtual scopes in group fixture

### DIFF
--- a/changes/13555.test.md
+++ b/changes/13555.test.md
@@ -1,0 +1,1 @@
+Provision user virtual scopes in group repository test fixtures.

--- a/tests/unit/manager/repositories/group/test_group_repository.py
+++ b/tests/unit/manager/repositories/group/test_group_repository.py
@@ -416,6 +416,7 @@ class TestGroupRepository:
                     resource_policy=default_user_resource_policy,
                 )
                 session.add(user)
+                session.add(VirtualScopeRow(scope_type=ScopeType.USER.value, scope_id=user_uuid))
                 user_uuids.append(user_uuid)
             await session.commit()
 


### PR DESCRIPTION
## Summary
- provision a user virtual scope for each user created by the group repository fixture
- align the fixture with the runtime user-creation invariant introduced by BA-7174
- restore the add/remove user repository scenarios that failed with `VirtualScopeNotFound`

## Test plan
- [x] `pants test tests/unit/manager/repositories/group/test_group_repository.py`
- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] pre-push lint, mypy, and changed test suite
