### PR TITLE
feat(BA-7236): wire the session idle-check exclusion and inclusion adapters

### DIFF
--- a/changes/13557.feature.md
+++ b/changes/13557.feature.md
@@ -1,0 +1,1 @@
+Wire the session idle-check exclusion and inclusion GQL/REST endpoints to the idle-checker service instead of raising `NotImplementedError`.

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -68,8 +68,11 @@ from ai.backend.common.dto.manager.v2.session.request import (
 from ai.backend.common.dto.manager.v2.session.response import (
     AdminSearchSessionsPayload,
     EnqueueSessionPayload,
+    ExcludeSessionIdleChecksFailureInfo,
     ExcludeSessionIdleChecksPayload,
+    IncludeSessionIdleChecksFailureInfo,
     IncludeSessionIdleChecksPayload,
+    SessionIdleCheckTargetInfo,
     SessionLifecycleInfoGQLDTO,
     SessionLogsPayload,
     SessionMetadataInfoGQLDTO,
@@ -139,6 +142,13 @@ from ai.backend.manager.models.session.scopes import ProjectSessionOperationScop
 from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
+from ai.backend.manager.services.idle_checker.actions.exclude_sessions import (
+    ExcludeSessionIdleChecksAction,
+)
+from ai.backend.manager.services.idle_checker.actions.include_sessions import (
+    IncludeSessionIdleChecksAction,
+)
 from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
     BatchGetKernelResourceAllocationAction,
 )
@@ -1021,16 +1031,70 @@ class SessionAdapter(BaseAdapter):
     async def exclude_idle_checks(
         self, input: ExcludeSessionIdleChecksInput
     ) -> ExcludeSessionIdleChecksPayload:
-        """Exclude sessions from a checker's idle checks."""
-        # Wired to the idle-checker service by BA-7120 (#13328).
-        raise NotImplementedError
+        """Exclude checker-session pairs from idle checks."""
+        result = await self._processors.idle_checker.exclude_sessions.run(
+            ExcludeSessionIdleChecksAction(
+                targets=[
+                    SessionIdleCheckPair(
+                        session_id=SessionId(target.session_id),
+                        checker_id=target.checker_id,
+                    )
+                    for target in input.targets
+                ],
+                user_id=UserID(self._require_user_id()),
+            )
+        )
+        return ExcludeSessionIdleChecksPayload(
+            items=[
+                SessionIdleCheckTargetInfo(
+                    checker_id=pair.checker_id,
+                    session_id=SessionID(pair.session_id),
+                )
+                for pair in result.success
+            ],
+            failed=[
+                ExcludeSessionIdleChecksFailureInfo(
+                    checker_id=pair.checker_id,
+                    session_id=SessionID(pair.session_id),
+                    message=str(error),
+                )
+                for pair, error in result.errors.items()
+            ],
+        )
 
     async def include_idle_checks(
         self, input: IncludeSessionIdleChecksInput
     ) -> IncludeSessionIdleChecksPayload:
-        """Re-include previously excluded sessions into a checker's idle checks."""
-        # Wired to the idle-checker service by BA-7120 (#13328).
-        raise NotImplementedError
+        """Re-include previously excluded checker-session pairs into idle checks."""
+        result = await self._processors.idle_checker.include_sessions.run(
+            IncludeSessionIdleChecksAction(
+                targets=[
+                    SessionIdleCheckPair(
+                        session_id=SessionId(target.session_id),
+                        checker_id=target.checker_id,
+                    )
+                    for target in input.targets
+                ],
+                user_id=UserID(self._require_user_id()),
+            )
+        )
+        return IncludeSessionIdleChecksPayload(
+            items=[
+                SessionIdleCheckTargetInfo(
+                    checker_id=pair.checker_id,
+                    session_id=SessionID(pair.session_id),
+                )
+                for pair in result.success
+            ],
+            failed=[
+                IncludeSessionIdleChecksFailureInfo(
+                    checker_id=pair.checker_id,
+                    session_id=SessionID(pair.session_id),
+                    message=str(error),
+                )
+                for pair, error in result.errors.items()
+            ],
+        )
 
     # -------------------------------------------------------------------------
     # Service management


### PR DESCRIPTION
## Summary
- Wire the session adapter's `exclude_idle_checks` / `include_idle_checks` to the idle-checker service bulk actions — they previously raised `NotImplementedError`.
- Map the bulk action results (`success` / `errors`) to the GQL/REST payload schema (`items` / `failed`).

## Test plan
- [ ] CI passes
- [ ] Verify the exclude/include endpoints against a live server (GQL mutations / REST v2)

Resolves BA-7236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13557.org.readthedocs.build/ko/13557/

<!-- readthedocs-preview sorna-ko end -->

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13557.org.readthedocs.build/en/13557/

<!-- readthedocs-preview sorna end -->