### PR TITLE
fix(BA-7249): report GraphQL input validation as a client error

### DIFF
--- a/changes/13558.doc.md
+++ b/changes/13558.doc.md
@@ -1,0 +1,1 @@
+Document on the runtime variant preset schema that the `flag` value type is accepted only with the `args` preset target, so clients can read the constraint off the GraphQL and REST v2 schemas instead of discovering it from a rejected request.

--- a/changes/13558.doc.md
+++ b/changes/13558.doc.md
@@ -1,1 +1,0 @@
-Document on the runtime variant preset schema that the `flag` value type is accepted only with the `args` preset target, so clients can read the constraint off the GraphQL and REST v2 schemas instead of discovering it from a rejected request.

--- a/changes/13558.fix.md
+++ b/changes/13558.fix.md
@@ -1,0 +1,1 @@
+Report a GraphQL mutation input that fails a DTO constraint as a client error carrying the offending fields in `extensions.data`, instead of an internal server error with a raw validation string, and state on the runtime variant preset schema that the `flag` value type is accepted only with the `args` preset target.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4770,12 +4770,12 @@ input CreateRuntimeVariantPresetInput
   description: String = null
 
   """
-  How the value is applied: 'env' for environment variable, 'args' for command-line argument.
+  How the value is applied: 'env' for environment variable, 'args' for command-line argument. Must be 'args' when valueType is 'flag'.
   """
   presetTarget: PresetTarget!
 
   """
-  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag').
+  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). 'flag' requires presetTarget 'args'.
   """
   valueType: PresetValueType!
 
@@ -13909,7 +13909,7 @@ type PresetResourceAllocation
 }
 
 """
-Added in 26.4.2. Target for applying a preset value: environment variable or command-line argument.
+Added in 26.4.2. Target for applying a preset value: environment variable or command-line argument. ARGS is the only target that accepts the FLAG value type.
 """
 enum PresetTarget
   @join__type(graph: STRAWBERRY)
@@ -13924,10 +13924,12 @@ Added in 26.4.2. Specifies how a runtime variant preset value is applied to the 
 type PresetTargetSpec
   @join__type(graph: STRAWBERRY)
 {
-  """Target: env or args."""
+  """Target: env or args. Only args accepts the flag value type."""
   presetTarget: PresetTarget!
 
-  """Value type: str, int, float, bool, flag."""
+  """
+  Value type: str, int, float, bool, flag. flag appears only on presets targeting args.
+  """
   valueType: PresetValueType!
 
   """Default value."""
@@ -13937,7 +13939,9 @@ type PresetTargetSpec
   key: String!
 }
 
-"""Added in 26.4.2. Data type for preset value validation."""
+"""
+Added in 26.4.2. Data type for preset value validation. FLAG is accepted only when presetTarget is ARGS; pairing it with presetTarget ENV is rejected.
+"""
 enum PresetValueType
   @join__type(graph: STRAWBERRY)
 {
@@ -21637,10 +21641,14 @@ input UpdateRuntimeVariantPresetInput
   """New rank."""
   rank: Int = null
 
-  """New target."""
+  """
+  New target. Must be 'args' when the preset ends up with valueType 'flag', whether 'flag' comes from this input or from the stored preset.
+  """
   presetTarget: PresetTarget = null
 
-  """New value type."""
+  """
+  New value type. 'flag' requires the preset to end up with presetTarget 'args', whether 'args' comes from this input or from the stored preset.
+  """
   valueType: PresetValueType = null
 
   """New default value."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3228,12 +3228,12 @@ input CreateRuntimeVariantPresetInput {
   description: String = null
 
   """
-  How the value is applied: 'env' for environment variable, 'args' for command-line argument.
+  How the value is applied: 'env' for environment variable, 'args' for command-line argument. Must be 'args' when valueType is 'flag'.
   """
   presetTarget: PresetTarget!
 
   """
-  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag').
+  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). 'flag' requires presetTarget 'args'.
   """
   valueType: PresetValueType!
 
@@ -9497,7 +9497,7 @@ type PresetResourceAllocation {
 }
 
 """
-Added in 26.4.2. Target for applying a preset value: environment variable or command-line argument.
+Added in 26.4.2. Target for applying a preset value: environment variable or command-line argument. ARGS is the only target that accepts the FLAG value type.
 """
 enum PresetTarget {
   ENV
@@ -9508,10 +9508,12 @@ enum PresetTarget {
 Added in 26.4.2. Specifies how a runtime variant preset value is applied to the inference container, either as an environment variable or a command-line argument.
 """
 type PresetTargetSpec {
-  """Target: env or args."""
+  """Target: env or args. Only args accepts the flag value type."""
   presetTarget: PresetTarget!
 
-  """Value type: str, int, float, bool, flag."""
+  """
+  Value type: str, int, float, bool, flag. flag appears only on presets targeting args.
+  """
   valueType: PresetValueType!
 
   """Default value."""
@@ -9521,7 +9523,9 @@ type PresetTargetSpec {
   key: String!
 }
 
-"""Added in 26.4.2. Data type for preset value validation."""
+"""
+Added in 26.4.2. Data type for preset value validation. FLAG is accepted only when presetTarget is ARGS; pairing it with presetTarget ENV is rejected.
+"""
 enum PresetValueType {
   STR
   INT
@@ -15512,10 +15516,14 @@ input UpdateRuntimeVariantPresetInput {
   """New rank."""
   rank: Int = null
 
-  """New target."""
+  """
+  New target. Must be 'args' when the preset ends up with valueType 'flag', whether 'flag' comes from this input or from the stored preset.
+  """
   presetTarget: PresetTarget = null
 
-  """New value type."""
+  """
+  New value type. 'flag' requires the preset to end up with presetTarget 'args', whether 'args' comes from this input or from the stored preset.
+  """
   valueType: PresetValueType = null
 
   """New default value."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -24921,11 +24921,11 @@
           },
           "preset_target": {
             "$ref": "#/components/schemas/PresetTarget",
-            "description": "Target: env or args."
+            "description": "Target: env or args. Must be args when value_type is flag."
           },
           "value_type": {
             "$ref": "#/components/schemas/PresetValueType",
-            "description": "Value type: str, int, float, bool, flag."
+            "description": "Value type: str, int, float, bool, flag. flag requires preset_target args."
           },
           "default_value": {
             "anyOf": [
@@ -25064,7 +25064,8 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "default": null,
+            "description": "New target. Must be args when the preset ends up with value_type flag, whether flag comes from this input or from the stored preset."
           },
           "value_type": {
             "anyOf": [
@@ -25075,7 +25076,8 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "default": null,
+            "description": "New value type. flag requires the preset to end up with preset_target args, whether args comes from this input or from the stored preset."
           },
           "default_value": {
             "anyOf": [

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
@@ -46,8 +46,12 @@ class CreateRuntimeVariantPresetInput(BaseRequestModel):
     )
     name: str = Field(min_length=1, max_length=256, description="Preset name.")
     description: str | None = Field(default=None, description="Description.")
-    preset_target: PresetTarget = Field(description="Target: env or args.")
-    value_type: PresetValueType = Field(description="Value type: str, int, float, bool, flag.")
+    preset_target: PresetTarget = Field(
+        description="Target: env or args. Must be args when value_type is flag."
+    )
+    value_type: PresetValueType = Field(
+        description="Value type: str, int, float, bool, flag. flag requires preset_target args."
+    )
     default_value: str | None = Field(default=None, max_length=512, description="Default value.")
     key: str = Field(min_length=1, max_length=256, description="Env key or args flag.")
     required: bool = Field(
@@ -87,8 +91,20 @@ class UpdateRuntimeVariantPresetInput(BaseRequestModel):
     name: str | None = Field(default=None, min_length=1, max_length=256)
     description: str | Sentinel | None = Field(default=SENTINEL)
     rank: int | None = Field(default=None, ge=0)
-    preset_target: PresetTarget | None = Field(default=None)
-    value_type: PresetValueType | None = Field(default=None)
+    preset_target: PresetTarget | None = Field(
+        default=None,
+        description=(
+            "New target. Must be args when the preset ends up with value_type flag, "
+            "whether flag comes from this input or from the stored preset."
+        ),
+    )
+    value_type: PresetValueType | None = Field(
+        default=None,
+        description=(
+            "New value type. flag requires the preset to end up with preset_target args, "
+            "whether args comes from this input or from the stored preset."
+        ),
+    )
     default_value: str | Sentinel | None = Field(default=SENTINEL)
     key: str | None = Field(default=None, min_length=1, max_length=256)
     required: bool | None = Field(

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
@@ -4,7 +4,8 @@ from collections.abc import Callable
 from typing import Self
 from uuid import UUID
 
-from pydantic import Field, model_validator
+from pydantic import Field, ValidationError, model_validator
+from pydantic_core import InitErrorDetails, PydanticCustomError
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
@@ -29,6 +30,30 @@ def _validate_flag(v: str) -> bool:
     if v.lower() not in _VALID_BOOL_VALUES:
         raise ValueError(f"expected one of {_VALID_BOOL_VALUES}, got '{v}'")
     return v.lower() in ("true", "1")
+
+
+FLAG_REQUIRES_ARGS_MSG = "value_type 'flag' is only valid with preset_target 'args'."
+FLAG_REQUIRES_ARGS_TYPE = "flag_requires_args"
+
+
+def _flag_requires_args_error(
+    title: str, preset_target: PresetTarget | None, value_type: PresetValueType | None
+) -> ValidationError:
+    """Report the flag/args rule against both fields it constrains.
+
+    A ``model_validator`` raising ``ValueError`` lands on the model with an empty ``loc``,
+    which leaves a client no way to tell which of the two inputs it has to correct.
+    """
+    line_errors: list[InitErrorDetails] = []
+    for field, value in (("preset_target", preset_target), ("value_type", value_type)):
+        line_errors.append(
+            InitErrorDetails(
+                type=PydanticCustomError(FLAG_REQUIRES_ARGS_TYPE, FLAG_REQUIRES_ARGS_MSG),
+                loc=(field,),
+                input=value,
+            )
+        )
+    return ValidationError.from_exception_data(title, line_errors)
 
 
 VALUE_TYPE_VALIDATORS: dict[PresetValueType, Callable[[str], object]] = {
@@ -67,7 +92,9 @@ class CreateRuntimeVariantPresetInput(BaseRequestModel):
     @model_validator(mode="after")
     def validate_flag_requires_args(self) -> Self:
         if self.value_type == PresetValueType.FLAG and self.preset_target != PresetTarget.ARGS:
-            raise ValueError("value_type 'flag' is only valid with preset_target 'args'.")
+            raise _flag_requires_args_error(
+                type(self).__name__, self.preset_target, self.value_type
+            )
         return self
 
     @model_validator(mode="after")
@@ -121,7 +148,9 @@ class UpdateRuntimeVariantPresetInput(BaseRequestModel):
             and self.preset_target is not None
             and self.preset_target != PresetTarget.ARGS
         ):
-            raise ValueError("value_type 'flag' is only valid with preset_target 'args'.")
+            raise _flag_requires_args_error(
+                type(self).__name__, self.preset_target, self.value_type
+            )
         return self
 
 

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/response.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/response.py
@@ -11,8 +11,12 @@ from .types import PresetTarget, PresetValueType, UIOption
 
 
 class PresetTargetSpec(BaseResponseModel):
-    preset_target: PresetTarget = Field(description="Target: env or args.")
-    value_type: PresetValueType = Field(description="Value type: str, int, float, bool, flag.")
+    preset_target: PresetTarget = Field(
+        description="Target: env or args. Only args accepts the flag value type."
+    )
+    value_type: PresetValueType = Field(
+        description="Value type: str, int, float, bool, flag. flag appears only on presets targeting args."
+    )
     default_value: str | None = Field(default=None, description="Default value.")
     key: str = Field(description="Env key or args flag.")
 

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -352,6 +352,7 @@ class BackendAIError(web.HTTPError, ABC):
     error_type: str = "https://api.backend.ai/probs/general-error"
     error_title: str = "General Backend API Error."
     extra_msg: str | None
+    extra_data: Any | None
     body_dict: dict[str, Any]
 
     def __init__(

--- a/src/ai/backend/manager/api/gql/extensions/exception_handler.py
+++ b/src/ai/backend/manager/api/gql/extensions/exception_handler.py
@@ -15,6 +15,34 @@ from ai.backend.logging.utils import BraceStyleAdapter
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
+def to_graphql_error(e: Exception) -> GraphQLError:
+    """Render an exception as the GraphQL error a client receives."""
+    if isinstance(e, BackendAIError):
+        if e.status_code // 100 == 4:
+            log.debug("GraphQL client error: {}", e)
+        elif e.status_code // 100 == 5:
+            log.exception("GraphQL server error: {}", e)
+        extensions: dict[str, Any] = {"code": str(e.error_code())}
+        if e.extra_data is not None:
+            extensions["data"] = e.extra_data
+        # Not ``str(e)``: it appends a repr of extra_data, which travels in extensions.
+        message = f"{e.error_title} ({e.extra_msg})" if e.extra_msg else e.error_title
+    else:
+        log.exception("GraphQL unexpected error: {}", e)
+        extensions = {"code": str(ErrorCode.default())}
+        message = str(e)
+    return GraphQLError(message=message, extensions=extensions)
+
+
+async def await_and_convert_errors(coro: Awaitable[object]) -> object:
+    """Await an async resolver's result, converting whatever it raises."""
+    try:
+        result = await coro
+    except Exception as e:
+        raise to_graphql_error(e) from e
+    return result
+
+
 class GQLExceptionHandlerExtension(SchemaExtension):
     """Transforms internal exceptions into client-safe GraphQL errors with error codes."""
 
@@ -29,40 +57,8 @@ class GQLExceptionHandlerExtension(SchemaExtension):
     ) -> AwaitableOrValue[object]:
         try:
             result: object = _next(root, info, *args, **kwargs)
-        except BackendAIError as e:
-            if e.status_code // 100 == 4:
-                log.debug("GraphQL client error: {}", e)
-            elif e.status_code // 100 == 5:
-                log.exception("GraphQL server error: {}", e)
-            raise GraphQLError(
-                message=str(e),
-                extensions={"code": str(e.error_code())},
-            ) from e
         except Exception as e:
-            log.exception("GraphQL unexpected error: {}", e)
-            raise GraphQLError(
-                message=str(e),
-                extensions={"code": str(ErrorCode.default())},
-            ) from e
+            raise to_graphql_error(e) from e
         if asyncio.iscoroutine(result):
-            return self._handle_async(result)
+            return await_and_convert_errors(result)
         return result
-
-    async def _handle_async(self, coro: Awaitable[object]) -> object:
-        try:
-            return await coro
-        except BackendAIError as e:
-            if e.status_code // 100 == 4:
-                log.debug("GraphQL client error: {}", e)
-            elif e.status_code // 100 == 5:
-                log.exception("GraphQL server error: {}", e)
-            raise GraphQLError(
-                message=str(e),
-                extensions={"code": str(e.error_code())},
-            ) from e
-        except Exception as e:
-            log.exception("GraphQL unexpected error: {}", e)
-            raise GraphQLError(
-                message=str(e),
-                extensions={"code": str(ErrorCode.default())},
-            ) from e

--- a/src/ai/backend/manager/api/gql/pydantic_compat.py
+++ b/src/ai/backend/manager/api/gql/pydantic_compat.py
@@ -54,11 +54,41 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from strawberry import ID as StrawberryID
 from strawberry import UNSET
 from strawberry.relay import Node
 from strawberry.types.base import StrawberryObjectDefinition
+
+from ai.backend.common.exception import InvalidAPIParameters
+
+
+def _client_safe_details(error: ValidationError) -> list[dict[str, Any]]:
+    """Reduce pydantic error entries to the parts that may leave the server.
+
+    ``input`` echoes the submitted value back — for a model-level validator that is the
+    whole input object, credentials included — and ``ctx`` can hold a live exception
+    instance that no JSON encoder accepts.
+    """
+    details: list[dict[str, Any]] = []
+    for entry in error.errors():
+        details.append({
+            "type": entry["type"],
+            "loc": [str(part) for part in entry["loc"]],
+            "msg": entry["msg"],
+        })
+    return details
+
+
+def _summarize_details(details: list[dict[str, Any]]) -> str:
+    locations_by_message: dict[str, list[str]] = {}
+    for detail in details:
+        locations_by_message.setdefault(detail["msg"], []).append(".".join(detail["loc"]))
+    parts: list[str] = []
+    for message, locations in locations_by_message.items():
+        named = ", ".join(location for location in locations if location)
+        parts.append(f"{named}: {message}" if named else message)
+    return " ".join(parts)
 
 
 def _from_pydantic_kwargs(
@@ -257,10 +287,20 @@ class PydanticInputMixin[T_DTO: BaseModel]:
 
         This method is ``@final``: subclasses must NOT override it.
         The DTO type is inferred from the generic parameter ``T_DTO``.
+
+        A DTO constraint the GraphQL schema cannot express (a cross-field rule, a length
+        bound) fails here rather than during query validation, so the resulting
+        ``ValidationError`` is translated into the client error it actually is. Left
+        unconverted it reaches the schema's exception handler as an unrecognized
+        exception and is reported as an internal server error.
         """
         dto_cls = self.__class__.__dto_type__
         kwargs = _to_pydantic_kwargs(self, dto_cls)
-        return cast(T_DTO, dto_cls(**kwargs))
+        try:
+            return cast(T_DTO, dto_cls(**kwargs))
+        except ValidationError as e:
+            details = _client_safe_details(e)
+            raise InvalidAPIParameters(_summarize_details(details), extra_data=details) from e
 
 
 def _convert_value(value: Any, type_hint: Any) -> Any:

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
 @gql_enum(
     BackendAIGQLMeta(
         added_version="26.4.2",
-        description="Target for applying a preset value: environment variable or command-line argument.",
+        description="Target for applying a preset value: environment variable or command-line argument. ARGS is the only target that accepts the FLAG value type.",
     ),
     name="PresetTarget",
 )
@@ -89,7 +89,7 @@ class PresetTargetGQL(StrEnum):
 @gql_enum(
     BackendAIGQLMeta(
         added_version="26.4.2",
-        description="Data type for preset value validation.",
+        description="Data type for preset value validation. FLAG is accepted only when presetTarget is ARGS; pairing it with presetTarget ENV is rejected.",
     ),
     name="PresetValueType",
 )
@@ -186,10 +186,10 @@ class UIOptionGQL(PydanticOutputMixin[UIOptionDTO]):
 )
 class PresetTargetSpecGQL(PydanticOutputMixin[PresetTargetSpecDTO]):
     preset_target: PresetTargetGQL = gql_field(
-        description="How the value is applied to the container: 'env' sets it as an environment variable, 'args' appends it as a command-line argument."
+        description="How the value is applied to the container: 'env' sets it as an environment variable, 'args' appends it as a command-line argument. Only 'args' accepts the 'flag' value type."
     )
     value_type: PresetValueTypeGQL = gql_field(
-        description="Data type used for input validation (e.g., 'str', 'int', 'float', 'bool', 'flag')."
+        description="Data type used for input validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). 'flag' appears only on presets whose target is 'args'."
     )
     default_value: str | None = gql_field(
         description="The default value shown to users when they create a deployment using this preset."
@@ -314,10 +314,10 @@ class CreateRuntimeVariantPresetInputGQL(PydanticInputMixin[CreateInputDTO]):
         default=None, description="Detailed explanation of what this parameter controls."
     )
     preset_target: PresetTargetGQL = gql_field(
-        description="How the value is applied: 'env' for environment variable, 'args' for command-line argument."
+        description="How the value is applied: 'env' for environment variable, 'args' for command-line argument. Must be 'args' when valueType is 'flag'."
     )
     value_type: PresetValueTypeGQL = gql_field(
-        description="Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag')."
+        description="Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). 'flag' requires presetTarget 'args'."
     )
     default_value: str | None = gql_field(
         default=None, description="The default value shown to users when creating a deployment."
@@ -343,8 +343,14 @@ class UpdateRuntimeVariantPresetInputGQL(PydanticInputMixin[UpdateInputDTO]):
     name: str | None = gql_field(default=None, description="New name.")
     description: str | None = gql_field(default=None, description="New description.")
     rank: int | None = gql_field(default=None, description="New rank.")
-    preset_target: PresetTargetGQL | None = gql_field(default=None, description="New target.")
-    value_type: PresetValueTypeGQL | None = gql_field(default=None, description="New value type.")
+    preset_target: PresetTargetGQL | None = gql_field(
+        default=None,
+        description="New target. Must be 'args' when the preset ends up with valueType 'flag', whether 'flag' comes from this input or from the stored preset.",
+    )
+    value_type: PresetValueTypeGQL | None = gql_field(
+        default=None,
+        description="New value type. 'flag' requires the preset to end up with presetTarget 'args', whether 'args' comes from this input or from the stored preset.",
+    )
     default_value: str | None = gql_field(default=None, description="New default value.")
     key: str | None = gql_field(default=None, description="New key.")
     required: bool | None = gql_added_field(

--- a/src/ai/backend/manager/services/runtime_variant_preset/service.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/service.py
@@ -1,6 +1,10 @@
 import logging
 from typing import cast
 
+from ai.backend.common.dto.manager.v2.runtime_variant_preset.request import (
+    FLAG_REQUIRES_ARGS_MSG,
+    FLAG_REQUIRES_ARGS_TYPE,
+)
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
     PresetValueType,
@@ -63,7 +67,13 @@ class RuntimeVariantPresetService:
             effective_value_type == PresetValueType.FLAG
             and effective_preset_target != PresetTarget.ARGS
         ):
-            raise InvalidAPIParameters("value_type 'flag' is only valid with preset_target 'args'.")
+            raise InvalidAPIParameters(
+                FLAG_REQUIRES_ARGS_MSG,
+                extra_data=[
+                    {"type": FLAG_REQUIRES_ARGS_TYPE, "loc": [field], "msg": FLAG_REQUIRES_ARGS_MSG}
+                    for field in ("preset_target", "value_type")
+                ],
+            )
 
         action.updater.pk_value = action.id
         data = await self._repository.update(action.updater)

--- a/tests/unit/common/dto/manager/v2/runtime_variant_preset/test_request.py
+++ b/tests/unit/common/dto/manager/v2/runtime_variant_preset/test_request.py
@@ -46,6 +46,18 @@ class TestCreateRuntimeVariantPresetInputFlagValidation:
                 preset_target=PresetTarget.ENV,
             )
 
+    def test_flag_with_env_names_both_offending_fields(self, base_fields: dict[str, Any]) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            CreateRuntimeVariantPresetInput(
+                **base_fields,
+                value_type=PresetValueType.FLAG,
+                preset_target=PresetTarget.ENV,
+            )
+        assert [error["loc"] for error in exc_info.value.errors()] == [
+            ("preset_target",),
+            ("value_type",),
+        ]
+
     def test_bool_with_env_is_valid(self, base_fields: dict[str, Any]) -> None:
         result = CreateRuntimeVariantPresetInput(
             **base_fields,
@@ -70,6 +82,18 @@ class TestUpdateRuntimeVariantPresetInputFlagValidation:
                 value_type=PresetValueType.FLAG,
                 preset_target=PresetTarget.ENV,
             )
+
+    def test_flag_with_env_names_both_offending_fields(self, preset_id: UUID) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            UpdateRuntimeVariantPresetInput(
+                id=preset_id,
+                value_type=PresetValueType.FLAG,
+                preset_target=PresetTarget.ENV,
+            )
+        assert [error["loc"] for error in exc_info.value.errors()] == [
+            ("preset_target",),
+            ("value_type",),
+        ]
 
     def test_flag_without_preset_target_is_valid(self, preset_id: UUID) -> None:
         """When preset_target is not provided, DTO cannot validate (needs DB state)."""

--- a/tests/unit/manager/api/gql/extensions/BUILD
+++ b/tests/unit/manager/api/gql/extensions/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/gql/extensions/test_exception_handler.py
+++ b/tests/unit/manager/api/gql/extensions/test_exception_handler.py
@@ -1,0 +1,65 @@
+"""Tests for the GraphQL error shape produced from a raised exception."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.manager.api.gql.extensions.exception_handler import to_graphql_error
+
+_FIELD_DETAILS: list[dict[str, Any]] = [
+    {"type": "flag_requires_args", "loc": ["value_type"], "msg": "only valid with 'args'."}
+]
+
+
+@dataclass(frozen=True)
+class _ErrorCase:
+    label: str
+    error: Exception
+    expected_code: str
+    expected_message: str
+    expected_data: list[dict[str, Any]] | None
+
+
+class TestToGraphQLError:
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _ErrorCase(
+                label="client-error",
+                error=InvalidAPIParameters("rank: must be >= 0"),
+                expected_code="api_parsing_invalid-parameters",
+                expected_message="Invalid or Missing API Parameters. (rank: must be >= 0)",
+                expected_data=None,
+            ),
+            _ErrorCase(
+                label="client-error-with-details",
+                error=InvalidAPIParameters(
+                    "value_type: only valid with 'args'.", extra_data=_FIELD_DETAILS
+                ),
+                expected_code="api_parsing_invalid-parameters",
+                expected_message=(
+                    "Invalid or Missing API Parameters. (value_type: only valid with 'args'.)"
+                ),
+                expected_data=_FIELD_DETAILS,
+            ),
+            _ErrorCase(
+                label="unexpected-error",
+                error=RuntimeError("boom"),
+                expected_code="backendai_generic_internal-error",
+                expected_message="boom",
+                expected_data=None,
+            ),
+        ],
+        ids=lambda case: case.label,
+    )
+    def test_error_is_rendered_for_the_client(self, case: _ErrorCase) -> None:
+        error = to_graphql_error(case.error)
+
+        assert error.message == case.expected_message
+        assert error.extensions is not None
+        assert error.extensions["code"] == case.expected_code
+        assert error.extensions.get("data") == case.expected_data

--- a/tests/unit/manager/api/gql/test_pydantic_compat.py
+++ b/tests/unit/manager/api/gql/test_pydantic_compat.py
@@ -10,26 +10,34 @@ Verifies:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, Self, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
 import strawberry
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from strawberry.relay import Node, NodeID
 
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.dto.manager.v2.container_registry.response import (
     ContainerRegistryNode,
 )
+from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.manager.api.adapters.container_registry.adapter import ContainerRegistryAdapter
 from ai.backend.manager.api.adapters.registry import Adapters
 from ai.backend.manager.api.gql.container_registry.types import (
     ContainerRegistryGQL,
     ContainerRegistryTypeGQL,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin, PydanticNodeMixin
 from ai.backend.manager.defs import PASSWORD_PLACEHOLDER
 
 # ---- Test fixtures: Pydantic DTOs ----
@@ -370,3 +378,80 @@ class TestAdaptersRegistry:
             schedule_coordinator=MagicMock(),
         )
         assert isinstance(adapters.container_registry, ContainerRegistryAdapter)
+
+
+class GuardedInput(BaseModel):
+    name: str = Field(min_length=1, description="Name")
+    token: str = Field(description="Credential the client submitted")
+
+    @model_validator(mode="after")
+    def reject_reserved_name(self) -> Self:
+        if self.name == "reserved":
+            raise ValueError("name 'reserved' is not allowed")
+        return self
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(added_version="1.0.0", description="Input used by the mixin tests."),
+    name="GuardedInput",
+)
+class GuardedInputGQL(PydanticInputMixin[GuardedInput]):
+    name: str = gql_field(description="Name")
+    token: str = gql_field(description="Credential the client submitted")
+
+
+@dataclass(frozen=True)
+class _RejectedInputCase:
+    label: str
+    name: str
+    expected_details: list[dict[str, Any]]
+
+
+class TestPydanticInputMixinValidation:
+    """to_pydantic() reports DTO validation failures as client errors."""
+
+    def test_valid_input_converts(self) -> None:
+        dto = GuardedInputGQL(name="ok", token="s3cret").to_pydantic()
+
+        assert dto.name == "ok"
+        assert dto.token == "s3cret"
+
+    @pytest.mark.parametrize(
+        "case",
+        [
+            _RejectedInputCase(
+                label="field-constraint",
+                name="",
+                expected_details=[
+                    {
+                        "type": "string_too_short",
+                        "loc": ["name"],
+                        "msg": "String should have at least 1 character",
+                    }
+                ],
+            ),
+            _RejectedInputCase(
+                label="model-validator",
+                name="reserved",
+                expected_details=[
+                    {
+                        "type": "value_error",
+                        "loc": [],
+                        "msg": "Value error, name 'reserved' is not allowed",
+                    }
+                ],
+            ),
+        ],
+        ids=lambda case: case.label,
+    )
+    def test_rejected_input_raises_client_error(self, case: _RejectedInputCase) -> None:
+        with pytest.raises(InvalidAPIParameters) as exc_info:
+            GuardedInputGQL(name=case.name, token="s3cret").to_pydantic()
+
+        assert exc_info.value.extra_data == case.expected_details
+
+    def test_details_never_echo_submitted_values(self) -> None:
+        with pytest.raises(InvalidAPIParameters) as exc_info:
+            GuardedInputGQL(name="reserved", token="s3cret").to_pydantic()
+
+        assert "s3cret" not in repr(exc_info.value.extra_data)


### PR DESCRIPTION
Resolves BA-7249.

## Summary
- `adminUpdateRuntimeVariantPreset` rejected `presetTarget: ENV` + `valueType: FLAG` with `backendai_generic_internal-error` and a raw pydantic string. The rule lives in a DTO `model_validator`, and the resolver converts its input outside any handler that recognizes a `ValidationError`, so a client input mistake was reported as a server fault.
- Convert at `PydanticInputMixin.to_pydantic()` — the `@final` chokepoint every DTO-backed GraphQL input passes through — so any constraint the schema cannot express (cross-field rules, length bounds, ranges) now yields `api_parsing_invalid-parameters` and a readable message. This matches what REST v2 already does via `convert_validation_error`.
- Carry the offending fields as structured `extensions.data`, reusing the `extra_data` slot that REST v2 already returns as `data` in its problem+json body. Entries are reduced to `type`/`loc`/`msg`: pydantic's `input` echoes the submitted value back — for a model-level validator that is the whole input object, credentials included — and `ctx` can hold a live exception instance.
- A `model_validator` raising `ValueError` reports an empty `loc`, so the flag/args rule now names both fields it constrains. The service-side check that covers partial updates (where the stored preset supplies the other half of the pair) reports the same shape.
- Also state the rule in the schema descriptions clients read — both enums, the create/update input fields, and the `PresetTargetSpec` output fields — so it is visible before a request is sent. The same wording reaches the REST v2 OpenAPI schema, since both surfaces share the v2 DTOs.

Reported response for the ticket's mutation, before and after:

```
- "code": "backendai_generic_internal-error"
- "message": "1 validation error for UpdateRuntimeVariantPresetInput\n  Value error, ..."

+ "code": "api_parsing_invalid-parameters"
+ "message": "Invalid or Missing API Parameters. (preset_target, value_type: value_type 'flag' is only valid with preset_target 'args'.)"
+ "data": [
+   {"type": "flag_requires_args", "loc": ["preset_target"], "msg": "value_type 'flag' is only valid with preset_target 'args'."},
+   {"type": "flag_requires_args", "loc": ["value_type"],    "msg": "value_type 'flag' is only valid with preset_target 'args'."}
+ ]
```

Note for clients: this changes the error code and message of **every** GraphQL mutation whose DTO-backed input fails validation, not just this one. Error codes for errors raised below the input boundary are unchanged, and messages change only for errors that carry `extra_data` — that payload now travels in `extensions.data` instead of being appended to the message as a repr.

## Test plan
- [x] `tests/unit/manager/api/gql/test_pydantic_compat.py` — valid input converts; a field constraint and a model-level validator each raise `InvalidAPIParameters` with the expected details; details never echo a submitted credential
- [x] `tests/unit/manager/api/gql/extensions/test_exception_handler.py` — client error, client error with details, and an unexpected exception each render the expected code/message/data
- [x] `tests/unit/common/dto/manager/v2/runtime_variant_preset/test_request.py` — the flag/args rejection names both fields on the create and update inputs
- [x] Existing GQL and DTO unit tests pass unchanged (4574 tests)
- [ ] CI lint / type / unit-test jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
