### PR TITLE
feat(BA-7253): expose runtime variant preset UI metadata in GraphQL

### DIFF
--- a/changes/13562.feature.md
+++ b/changes/13562.feature.md
@@ -1,0 +1,1 @@
+Expose runtime variant preset UI metadata in GraphQL create and update inputs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4791,6 +4791,15 @@ input CreateRuntimeVariantPresetInput
   Added in 26.4.4. Whether this preset parameter must be supplied when building a deployment revision.
   """
   required: Boolean! = false
+
+  """Added in 26.9.0. UI category group for organizing parameters."""
+  category: String
+
+  """Added in 26.9.0. Human-readable display label for the UI."""
+  displayName: String
+
+  """Added in 26.9.0. UI rendering options."""
+  uiOption: RuntimeVariantPresetUIOptionInput
 }
 
 """Added in 26.4.2. Create preset payload."""
@@ -18956,6 +18965,25 @@ type RuntimeVariantPreset implements Node
   runtimeVariant: RuntimeVariant
 }
 
+"""Added in 26.9.0. Choice item input."""
+input RuntimeVariantPresetChoiceItemInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Option value."""
+  value: String!
+
+  """Display label."""
+  label: String!
+}
+
+"""Added in 26.9.0. Select UI config input."""
+input RuntimeVariantPresetChoiceOptionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """List of choices."""
+  items: [RuntimeVariantPresetChoiceItemInput!]!
+}
+
 """Added in 26.4.2. Paginated list of runtime variant presets."""
 type RuntimeVariantPresetConnection
   @join__type(graph: STRAWBERRY)
@@ -18999,6 +19027,17 @@ input RuntimeVariantPresetFilter
   NOT: [RuntimeVariantPresetFilter!] = null
 }
 
+"""Added in 26.9.0. Number input UI config input."""
+input RuntimeVariantPresetNumberOptionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Minimum value."""
+  min: Float = null
+
+  """Maximum value."""
+  max: Float = null
+}
+
 """Added in 26.4.2. Order specification."""
 input RuntimeVariantPresetOrderBy
   @join__type(graph: STRAWBERRY)
@@ -19017,6 +19056,59 @@ enum RuntimeVariantPresetOrderField
   NAME @join__enumValue(graph: STRAWBERRY)
   RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 26.9.0. Slider UI config input."""
+input RuntimeVariantPresetSliderOptionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Minimum value."""
+  min: Float!
+
+  """Maximum value."""
+  max: Float!
+
+  """Increment step."""
+  step: Float! = 1
+}
+
+"""Added in 26.9.0. Text input UI config input."""
+input RuntimeVariantPresetTextOptionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Placeholder text."""
+  placeholder: String = null
+}
+
+"""Added in 26.9.0. UI rendering options input."""
+input RuntimeVariantPresetUIOptionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """UI render type."""
+  uiType: RuntimeVariantPresetUIType!
+
+  """Slider config."""
+  slider: RuntimeVariantPresetSliderOptionInput = null
+
+  """Number input config."""
+  number: RuntimeVariantPresetNumberOptionInput = null
+
+  """Select config."""
+  choices: RuntimeVariantPresetChoiceOptionInput = null
+
+  """Text input config."""
+  text: RuntimeVariantPresetTextOptionInput = null
+}
+
+"""Added in 26.9.0. UI control type for a runtime variant preset."""
+enum RuntimeVariantPresetUIType
+  @join__type(graph: STRAWBERRY)
+{
+  SLIDER @join__enumValue(graph: STRAWBERRY)
+  NUMBER_INPUT @join__enumValue(graph: STRAWBERRY)
+  SELECT @join__enumValue(graph: STRAWBERRY)
+  CHECKBOX @join__enumValue(graph: STRAWBERRY)
+  TEXT_INPUT @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -21651,6 +21743,15 @@ input UpdateRuntimeVariantPresetInput
 
   """Added in 26.4.4. New required flag."""
   required: Boolean = null
+
+  """Added in 26.9.0. New UI category group."""
+  category: String
+
+  """Added in 26.9.0. New human-readable display label."""
+  displayName: String
+
+  """Added in 26.9.0. New UI rendering options."""
+  uiOption: RuntimeVariantPresetUIOptionInput
 }
 
 """Added in 26.4.2. Update preset payload."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3249,6 +3249,15 @@ input CreateRuntimeVariantPresetInput {
   Added in 26.4.4. Whether this preset parameter must be supplied when building a deployment revision.
   """
   required: Boolean! = false
+
+  """Added in 26.9.0. UI category group for organizing parameters."""
+  category: String
+
+  """Added in 26.9.0. Human-readable display label for the UI."""
+  displayName: String
+
+  """Added in 26.9.0. UI rendering options."""
+  uiOption: RuntimeVariantPresetUIOptionInput
 }
 
 """Added in 26.4.2. Create preset payload."""
@@ -13397,6 +13406,21 @@ type RuntimeVariantPreset implements Node {
   runtimeVariant: RuntimeVariant
 }
 
+"""Added in 26.9.0. Choice item input."""
+input RuntimeVariantPresetChoiceItemInput {
+  """Option value."""
+  value: String!
+
+  """Display label."""
+  label: String!
+}
+
+"""Added in 26.9.0. Select UI config input."""
+input RuntimeVariantPresetChoiceOptionInput {
+  """List of choices."""
+  items: [RuntimeVariantPresetChoiceItemInput!]!
+}
+
 """Added in 26.4.2. Paginated list of runtime variant presets."""
 type RuntimeVariantPresetConnection {
   """Pagination data for this connection"""
@@ -13434,6 +13458,15 @@ input RuntimeVariantPresetFilter {
   NOT: [RuntimeVariantPresetFilter!] = null
 }
 
+"""Added in 26.9.0. Number input UI config input."""
+input RuntimeVariantPresetNumberOptionInput {
+  """Minimum value."""
+  min: Float = null
+
+  """Maximum value."""
+  max: Float = null
+}
+
 """Added in 26.4.2. Order specification."""
 input RuntimeVariantPresetOrderBy {
   """Field to order by."""
@@ -13448,6 +13481,51 @@ enum RuntimeVariantPresetOrderField {
   NAME
   RANK
   CREATED_AT
+}
+
+"""Added in 26.9.0. Slider UI config input."""
+input RuntimeVariantPresetSliderOptionInput {
+  """Minimum value."""
+  min: Float!
+
+  """Maximum value."""
+  max: Float!
+
+  """Increment step."""
+  step: Float! = 1
+}
+
+"""Added in 26.9.0. Text input UI config input."""
+input RuntimeVariantPresetTextOptionInput {
+  """Placeholder text."""
+  placeholder: String = null
+}
+
+"""Added in 26.9.0. UI rendering options input."""
+input RuntimeVariantPresetUIOptionInput {
+  """UI render type."""
+  uiType: RuntimeVariantPresetUIType!
+
+  """Slider config."""
+  slider: RuntimeVariantPresetSliderOptionInput = null
+
+  """Number input config."""
+  number: RuntimeVariantPresetNumberOptionInput = null
+
+  """Select config."""
+  choices: RuntimeVariantPresetChoiceOptionInput = null
+
+  """Text input config."""
+  text: RuntimeVariantPresetTextOptionInput = null
+}
+
+"""Added in 26.9.0. UI control type for a runtime variant preset."""
+enum RuntimeVariantPresetUIType {
+  SLIDER
+  NUMBER_INPUT
+  SELECT
+  CHECKBOX
+  TEXT_INPUT
 }
 
 """
@@ -15526,6 +15604,15 @@ input UpdateRuntimeVariantPresetInput {
 
   """Added in 26.4.4. New required flag."""
   required: Boolean = null
+
+  """Added in 26.9.0. New UI category group."""
+  category: String
+
+  """Added in 26.9.0. New human-readable display label."""
+  displayName: String
+
+  """Added in 26.9.0. New UI rendering options."""
+  uiOption: RuntimeVariantPresetUIOptionInput
 }
 
 """Added in 26.4.2. Update preset payload."""

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -54,6 +54,7 @@ from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     UIOption as UIOptionDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import StringFilter as StringFilterGQL
 from ai.backend.manager.api.gql.base import UUIDFilter as UUIDFilterGQL
 from ai.backend.manager.api.gql.decorators import (
@@ -99,6 +100,21 @@ class PresetValueTypeGQL(StrEnum):
     FLOAT = "float"
     BOOL = "bool"
     FLAG = "flag"
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="UI control type for a runtime variant preset.",
+    ),
+    name="RuntimeVariantPresetUIType",
+)
+class UITypeGQL(StrEnum):
+    SLIDER = "slider"
+    NUMBER_INPUT = "number_input"
+    SELECT = "select"
+    CHECKBOX = "checkbox"
+    TEXT_INPUT = "text_input"
 
 
 @gql_enum(
@@ -174,6 +190,76 @@ class UIOptionGQL(PydanticOutputMixin[UIOptionDTO]):
     number: NumberOptionGQL | None = gql_field(description="Number input config.")
     choices: ChoiceOptionGQL | None = gql_field(description="Select/radio config.")
     text: TextOptionGQL | None = gql_field(description="Text input config.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Slider UI config input."),
+    name="RuntimeVariantPresetSliderOptionInput",
+)
+class SliderOptionInputGQL(PydanticInputMixin[SliderOptionDTO]):
+    min: float = gql_field(description="Minimum value.")
+    max: float = gql_field(description="Maximum value.")
+    step: float = gql_field(default=1, description="Increment step.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Number input UI config input.",
+    ),
+    name="RuntimeVariantPresetNumberOptionInput",
+)
+class NumberOptionInputGQL(PydanticInputMixin[NumberOptionDTO]):
+    min: float | None = gql_field(default=None, description="Minimum value.")
+    max: float | None = gql_field(default=None, description="Maximum value.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Choice item input."),
+    name="RuntimeVariantPresetChoiceItemInput",
+)
+class ChoiceItemInputGQL(PydanticInputMixin[ChoiceItemDTO]):
+    value: str = gql_field(description="Option value.")
+    label: str = gql_field(description="Display label.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Select UI config input.",
+    ),
+    name="RuntimeVariantPresetChoiceOptionInput",
+)
+class ChoiceOptionInputGQL(PydanticInputMixin[ChoiceOptionDTO]):
+    items: list[ChoiceItemInputGQL] = gql_field(description="List of choices.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Text input UI config input.",
+    ),
+    name="RuntimeVariantPresetTextOptionInput",
+)
+class TextOptionInputGQL(PydanticInputMixin[TextOptionDTO]):
+    placeholder: str | None = gql_field(default=None, description="Placeholder text.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="UI rendering options input.",
+    ),
+    name="RuntimeVariantPresetUIOptionInput",
+)
+class UIOptionInputGQL(PydanticInputMixin[UIOptionDTO]):
+    ui_type: UITypeGQL = gql_field(description="UI render type.")
+    slider: SliderOptionInputGQL | None = gql_field(default=None, description="Slider config.")
+    number: NumberOptionInputGQL | None = gql_field(
+        default=None, description="Number input config."
+    )
+    choices: ChoiceOptionInputGQL | None = gql_field(default=None, description="Select config.")
+    text: TextOptionInputGQL | None = gql_field(default=None, description="Text input config.")
 
 
 @gql_pydantic_type(
@@ -332,6 +418,24 @@ class CreateRuntimeVariantPresetInputGQL(PydanticInputMixin[CreateInputDTO]):
         ),
         default=False,
     )
+    category: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="UI category group for organizing parameters.",
+        )
+    )
+    display_name: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Human-readable display label for the UI.",
+        )
+    )
+    ui_option: UIOptionInputGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="UI rendering options.",
+        )
+    )
 
 
 @gql_pydantic_input(
@@ -350,6 +454,24 @@ class UpdateRuntimeVariantPresetInputGQL(PydanticInputMixin[UpdateInputDTO]):
     required: bool | None = gql_added_field(
         BackendAIGQLMeta(added_version="26.4.4", description="New required flag."),
         default=None,
+    )
+    category: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="New UI category group.",
+        )
+    )
+    display_name: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="New human-readable display label.",
+        )
+    )
+    ui_option: UIOptionInputGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="New UI rendering options.",
+        )
     )
 
 


### PR DESCRIPTION
## Summary

- Expose `category`, `displayName`, and `uiOption` on runtime variant preset GraphQL create and update inputs.
- Add typed GraphQL inputs for slider, number, choice, checkbox, and text UI options.
- Regenerate the GraphQL v2 schema and federated supergraph.

## Test plan

- [x] `pants fmt ::`
- [x] `pants fix ::`
- [x] `pants lint --changed-since=origin/main`
- [x] Push-hook MyPy and affected unit tests
- [x] Localdev GraphQL create → update → get → delete verification

Resolves BA-7253


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13562.org.readthedocs.build/en/13562/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13562.org.readthedocs.build/ko/13562/

<!-- readthedocs-preview sorna-ko end -->