### PR TITLE
feat(BA-7250): support partial success in bulk app config fragment upsert

### DIFF
--- a/changes/13563.breaking.md
+++ b/changes/13563.breaking.md
@@ -1,0 +1,1 @@
+The `scopedUpsertAppConfigFragments` and `myUpsertAppConfigFragments` GraphQL mutations now return an `UpsertAppConfigFragmentsPayload` (`items` + `failed`) instead of a list of fragments, and a batch whose items are all rejected answers with `failed` entries instead of an error.

--- a/changes/13563.breaking.md
+++ b/changes/13563.breaking.md
@@ -1,1 +1,0 @@
-The `scopedUpsertAppConfigFragments` and `myUpsertAppConfigFragments` GraphQL mutations now return an `UpsertAppConfigFragmentsPayload` (`items` + `failed`) instead of a list of fragments, and a batch whose items are all rejected answers with `failed` entries instead of an error.

--- a/changes/13563.feature.md
+++ b/changes/13563.feature.md
@@ -1,0 +1,1 @@
+Support per-item partial success in the bulk app config fragment upsert: a rejected item (e.g. a config name not allow-listed at the scope) no longer rolls back the whole batch, and the response reports the failed items with their reasons.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1225,6 +1225,19 @@ input AppConfigFragmentScopeTypeFilter
 }
 
 """
+Added in 26.9.0. One failed item of a partial bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
+"""
+type AppConfigFragmentUpsertError
+  @join__type(graph: STRAWBERRY)
+{
+  """Config name of the item that failed."""
+  configName: String!
+
+  """Reason the item failed."""
+  message: String!
+}
+
+"""
 Added in 26.8.0. One (config_name, config) pair to upsert at the request's scope.
 """
 input AppConfigFragmentUpsertItem
@@ -12254,14 +12267,14 @@ type Mutation
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), all-or-nothing. RBAC-authorized at that scope.
+  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success. RBAC-authorized at that scope.
   """
-  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, all-or-nothing.
+  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success.
   """
-  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -21873,6 +21886,17 @@ type UpdateVFSStoragePayload
 {
   """Updated VFS storage"""
   vfsStorage: VFSStorage!
+}
+
+"""Added in 26.9.0. Partial-success payload for a bulk fragment upsert."""
+type UpsertAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The upserted app config fragments."""
+  items: [AppConfigFragment!]!
+
+  """Per-item failures, each naming the config name it targeted."""
+  failed: [AppConfigFragmentUpsertError!]!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -903,6 +903,17 @@ input AppConfigFragmentScopeTypeFilter {
 }
 
 """
+Added in 26.9.0. One failed item of a partial bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
+"""
+type AppConfigFragmentUpsertError {
+  """Config name of the item that failed."""
+  configName: String!
+
+  """Reason the item failed."""
+  message: String!
+}
+
+"""
 Added in 26.8.0. One (config_name, config) pair to upsert at the request's scope.
 """
 input AppConfigFragmentUpsertItem {
@@ -8006,14 +8017,14 @@ type Mutation {
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), all-or-nothing. RBAC-authorized at that scope.
+  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success. RBAC-authorized at that scope.
   """
-  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): [AppConfigFragment!]!
+  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, all-or-nothing.
+  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success.
   """
-  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): [AppConfigFragment!]!
+  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -15720,6 +15731,15 @@ input UpdateVFSStorageInput {
 type UpdateVFSStoragePayload {
   """Updated VFS storage"""
   vfsStorage: VFSStorage!
+}
+
+"""Added in 26.9.0. Partial-success payload for a bulk fragment upsert."""
+type UpsertAppConfigFragmentsPayload {
+  """The upserted app config fragments."""
+  items: [AppConfigFragment!]!
+
+  """Per-item failures, each naming the config name it targeted."""
+  failed: [AppConfigFragmentUpsertError!]!
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -42006,7 +42006,7 @@
           }
         },
         "parameters": [],
-        "description": "Upsert many fragments at one scope, all-or-nothing (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Upsert many fragments at one scope, with per-item partial success (auth, RBAC).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/my/by-names": {
@@ -42064,7 +42064,7 @@
           }
         },
         "parameters": [],
-        "description": "Upsert many fragments at the caller's own user scope, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Upsert many fragments at the caller's own user scope, with per-item partial\nsuccess (auth).\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
+++ b/src/ai/backend/client/cli/v2/app_config_fragment/commands.py
@@ -112,10 +112,10 @@ def get(scope_type: str, scope_id: uuid.UUID | None, config_names: tuple[str, ..
     ),
 )
 def update(scope_type: str, scope_id: uuid.UUID | None, items: str) -> None:
-    """Write the given configs' fragments at one scope, all-or-nothing.
+    """Write the given configs' fragments at one scope, reporting each item's outcome.
 
     Each item replaces the scope's fragment for its config name, or creates it when the
-    scope holds none. Every item lands or none does.
+    scope holds none. A rejected item fails alone and the rest of the batch lands.
     """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
         ScopedUpsertAppConfigFragmentsInput,

--- a/src/ai/backend/client/cli/v2/my/app_config_fragment.py
+++ b/src/ai/backend/client/cli/v2/my/app_config_fragment.py
@@ -56,10 +56,10 @@ def get(config_names: tuple[str, ...]) -> None:
     ),
 )
 def update(items: str) -> None:
-    """Write the given configs' fragments at my own user scope, all-or-nothing.
+    """Write the given configs' fragments at my own user scope, reporting each item's outcome.
 
     Each item replaces my fragment for its config name, or creates it when I hold none.
-    Every item lands or none does.
+    A rejected item fails alone and the rest of the batch lands.
     """
     from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
         MyUpsertAppConfigFragmentsInput,

--- a/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
+++ b/src/ai/backend/client/v2/domains_v2/app_config_fragment.py
@@ -57,7 +57,7 @@ class V2AppConfigFragmentClient(BaseDomainClient):
         self,
         request: ScopedUpsertAppConfigFragmentsInput,
     ) -> UpsertAppConfigFragmentsPayload:
-        """Upsert many fragments at one scope, all-or-nothing."""
+        """Upsert many fragments at one scope, reporting per-item success and failure."""
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/scoped/bulk-upsert",
@@ -83,7 +83,8 @@ class V2AppConfigFragmentClient(BaseDomainClient):
         self,
         request: MyUpsertAppConfigFragmentsInput,
     ) -> UpsertAppConfigFragmentsPayload:
-        """Upsert many fragments at the caller's own user scope, all-or-nothing."""
+        """Upsert many fragments at the caller's own user scope, reporting per-item success
+        and failure."""
         return await self._client.typed_request(
             "POST",
             f"{_PATH}/my/bulk-upsert",

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -15,6 +15,7 @@ from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 __all__ = (
     "AppConfigFragmentBulkErrorInfo",
     "AppConfigFragmentNode",
+    "AppConfigFragmentUpsertErrorInfo",
     "AppConfigFragmentsByNamesPayload",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
@@ -41,10 +42,24 @@ class AppConfigFragmentsByNamesPayload(BaseRootResponseModel[list[AppConfigFragm
     """One entry per requested config name, null where the scope holds no fragment for it."""
 
 
+class AppConfigFragmentUpsertErrorInfo(BaseResponseModel):
+    """One failed item of a partial-success bulk upsert.
+
+    A rejected insert never had a fragment id, so the item is named by its config name —
+    the batch shares one scope, and a scope holds at most one fragment per name.
+    """
+
+    config_name: str = Field(description="Config name of the item that failed.")
+    message: str = Field(description="Reason the item failed.")
+
+
 class UpsertAppConfigFragmentsPayload(BaseResponseModel):
-    """Payload for a scoped upsert of many fragments (all-or-nothing)."""
+    """Partial-success payload for a scoped upsert of many fragments."""
 
     items: list[AppConfigFragmentNode] = Field(description="The upserted app config fragments.")
+    failed: list[AppConfigFragmentUpsertErrorInfo] = Field(
+        description="Per-item failures, each naming the config name it targeted."
+    )
 
 
 class PurgeAppConfigFragmentPayload(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -24,6 +24,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentBulkErrorInfo,
     AppConfigFragmentNode,
+    AppConfigFragmentUpsertErrorInfo,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
     SearchAppConfigFragmentPayload,
@@ -139,7 +140,13 @@ class AppConfigFragmentAdapter(BaseAdapter):
             BulkUpsertAppConfigFragmentsAction(scope=scope, upserter_specs=specs)
         )
         return UpsertAppConfigFragmentsPayload(
-            items=[self._fragment_to_node(fragment) for fragment in action_result.fragments],
+            items=[self._fragment_to_node(fragment) for fragment in action_result.succeeded],
+            failed=[
+                AppConfigFragmentUpsertErrorInfo(
+                    config_name=error.config_name, message=error.message
+                )
+                for error in action_result.failed
+            ],
         )
 
     async def get(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentNode:

--- a/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
@@ -15,11 +15,13 @@ from .types import (
     AppConfigFragmentGQL,
     AppConfigFragmentOrderByGQL,
     AppConfigFragmentOrderFieldGQL,
+    AppConfigFragmentUpsertErrorGQL,
     AppConfigFragmentUpsertItemGQL,
     AppConfigScopeRefGQL,
     AppConfigScopeTypeFilterGQL,
     MyUpsertAppConfigFragmentsInputGQL,
     ScopedUpsertAppConfigFragmentsInputGQL,
+    UpsertAppConfigFragmentsPayloadGQL,
 )
 
 __all__ = (
@@ -31,10 +33,12 @@ __all__ = (
     "AppConfigFragmentOrderByGQL",
     "AppConfigFragmentOrderFieldGQL",
     "AppConfigScopeRefGQL",
+    "AppConfigFragmentUpsertErrorGQL",
     "AppConfigFragmentUpsertItemGQL",
     "AppConfigScopeTypeFilterGQL",
     "MyUpsertAppConfigFragmentsInputGQL",
     "ScopedUpsertAppConfigFragmentsInputGQL",
+    "UpsertAppConfigFragmentsPayloadGQL",
     # Query resolvers
     "admin_app_config_fragments",
     "app_config_fragment",

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -36,6 +36,7 @@ from .types import (
     AppConfigScopeRefGQL,
     MyUpsertAppConfigFragmentsInputGQL,
     ScopedUpsertAppConfigFragmentsInputGQL,
+    UpsertAppConfigFragmentsPayloadGQL,
 )
 
 
@@ -107,36 +108,37 @@ async def admin_app_config_fragments(
         added_version="26.8.0",
         description=(
             "Upsert many app config fragments at one scope (insert, or replace config on "
-            "conflict), all-or-nothing. RBAC-authorized at that scope."
+            "conflict), with per-item partial success. RBAC-authorized at that scope."
         ),
     )
 )
 async def scoped_upsert_app_config_fragments(
     info: Info[StrawberryGQLContext],
     input: ScopedUpsertAppConfigFragmentsInputGQL,
-) -> list[AppConfigFragmentGQL]:
+) -> UpsertAppConfigFragmentsPayloadGQL:
     payload = await info.context.adapters.app_config_fragment.scoped_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
     BackendAIGQLMeta(
         added_version="26.8.0",
         description=(
-            "Upsert many app config fragments at the current user's own user scope, all-or-nothing."
+            "Upsert many app config fragments at the current user's own user scope, with "
+            "per-item partial success."
         ),
     )
 )
 async def my_upsert_app_config_fragments(
     info: Info[StrawberryGQLContext],
     input: MyUpsertAppConfigFragmentsInputGQL,
-) -> list[AppConfigFragmentGQL]:
+) -> UpsertAppConfigFragmentsPayloadGQL:
     payload = await info.context.adapters.app_config_fragment.my_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
 
 @gql_root_field(

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -34,10 +34,17 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
 )
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentUpsertErrorInfo as AppConfigFragmentUpsertErrorInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    UpsertAppConfigFragmentsPayload as UpsertAppConfigFragmentsPayloadDTO,
+)
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,
 )
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -47,8 +54,9 @@ from ai.backend.manager.api.gql.decorators import (
     gql_field,
     gql_node_type,
     gql_pydantic_input,
+    gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 __all__ = (
@@ -58,11 +66,13 @@ __all__ = (
     "AppConfigFragmentGQL",
     "AppConfigFragmentOrderByGQL",
     "AppConfigFragmentOrderFieldGQL",
+    "AppConfigFragmentUpsertErrorGQL",
     "AppConfigFragmentUpsertItemGQL",
     "AppConfigScopeRefGQL",
     "AppConfigScopeTypeFilterGQL",
     "MyUpsertAppConfigFragmentsInputGQL",
     "ScopedUpsertAppConfigFragmentsInputGQL",
+    "UpsertAppConfigFragmentsPayloadGQL",
 )
 
 
@@ -183,6 +193,42 @@ class AppConfigFragmentConnection(Connection[AppConfigFragmentGQL]):
     def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.count = count
+
+
+# ---------------------------------------------------------------------------
+# Mutation payloads
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "One failed item of a partial bulk fragment upsert, named by its config name — "
+            "the batch shares one scope, and a rejected insert never had a fragment id."
+        ),
+    ),
+    model=AppConfigFragmentUpsertErrorInfoDTO,
+    name="AppConfigFragmentUpsertError",
+)
+class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpsertErrorInfoDTO]):
+    config_name: str = gql_field(description="Config name of the item that failed.")
+    message: str = gql_field(description="Reason the item failed.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Partial-success payload for a bulk fragment upsert.",
+    ),
+    model=UpsertAppConfigFragmentsPayloadDTO,
+    name="UpsertAppConfigFragmentsPayload",
+)
+class UpsertAppConfigFragmentsPayloadGQL(PydanticOutputMixin[UpsertAppConfigFragmentsPayloadDTO]):
+    items: list[AppConfigFragmentGQL] = gql_field(description="The upserted app config fragments.")
+    failed: list[AppConfigFragmentUpsertErrorGQL] = gql_field(
+        description="Per-item failures, each naming the config name it targeted."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -94,7 +94,7 @@ class V2AppConfigFragmentHandler:
         self,
         body: BodyParam[ScopedUpsertAppConfigFragmentsInput],
     ) -> APIResponse:
-        """Upsert many fragments at one scope, all-or-nothing (auth, RBAC-authorized)."""
+        """Upsert many fragments at one scope, with per-item partial success (auth, RBAC)."""
         result = await self._adapter.scoped_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
@@ -102,6 +102,7 @@ class V2AppConfigFragmentHandler:
         self,
         body: BodyParam[MyUpsertAppConfigFragmentsInput],
     ) -> APIResponse:
-        """Upsert many fragments at the caller's own user scope, all-or-nothing (auth)."""
+        """Upsert many fragments at the caller's own user scope, with per-item partial
+        success (auth)."""
         result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -55,3 +55,27 @@ class AppConfigFragmentBulkResult:
 
     succeeded: list[AppConfigFragmentData]
     failed: list[AppConfigFragmentBulkItemError]
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentUpsertItemError:
+    """One failed item of a partial bulk upsert: the config name it targeted and a reason.
+
+    A rejected insert never had a fragment id, so the config name is what identifies the
+    item — the batch shares one scope, and a scope holds at most one fragment per name.
+    """
+
+    config_name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentUpsertBulkResult:
+    """Partial-success result of a bulk upsert.
+
+    ``succeeded`` are the fragments inserted or replaced; ``failed`` are the items whose
+    write was rejected (e.g. no allow-list row), each named by its config name.
+    """
+
+    succeeded: list[AppConfigFragmentData]
+    failed: list[AppConfigFragmentUpsertItemError]

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -112,7 +112,7 @@ class AppConfigFragmentDBSource:
         async with self._rbac_ops_provider.write_ops() as w:
             result = await w.bulk_upsert_scoped_partial(upserters)
             return AppConfigFragmentUpsertBulkResult(
-                succeeded=[row.to_data() for row in result.successes],
+                succeeded=[row.to_data() for row in result.items],
                 failed=[
                     AppConfigFragmentUpsertItemError(
                         config_name=specs[error.index].config_name,

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -118,7 +118,7 @@ class AppConfigFragmentDBSource:
                         config_name=specs[error.index].config_name,
                         message=str(error.exception),
                     )
-                    for error in result.errors
+                    for error in result.failed
                 ],
             )
 

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -20,6 +20,8 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
+    AppConfigFragmentUpsertBulkResult,
+    AppConfigFragmentUpsertItemError,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.app_config import (
@@ -80,20 +82,21 @@ class AppConfigFragmentDBSource:
     @app_config_fragment_db_source_resilience.apply()
     async def bulk_upsert(
         self, specs: Sequence[AppConfigFragmentUpserterSpec]
-    ) -> list[AppConfigFragmentData]:
-        """Upsert each fragment at its scope in one transaction (all-or-nothing).
+    ) -> AppConfigFragmentUpsertBulkResult:
+        """Upsert each fragment at its scope with per-item partial success.
 
         Each item inserts-or-updates; a newly inserted row binds to its scope, an updated one
-        keeps its binding. A ``public`` fragment is GLOBAL, so it binds to no scope.
+        keeps its binding. A ``public`` fragment is GLOBAL, so it binds to no scope. A
+        rejected item (e.g. no allow-list row) fails alone and the rest of the batch lands.
         """
-        async with self._rbac_ops_provider.write_ops() as w:
-            results: list[AppConfigFragmentData] = []
-            for spec in specs:
-                # A public fragment is GLOBAL — no scope element, so it binds to nothing. Its
-                # NULL scope_id still keys it like any other row (NULLS NOT DISTINCT), so one
-                # conflict target serves every scope.
-                element_type = spec.scope_type.to_rbac_element_type()
-                upserter = RBACEntityUpserter(
+        upserters = []
+        for spec in specs:
+            # A public fragment is GLOBAL — no scope element, so it binds to nothing. Its
+            # NULL scope_id still keys it like any other row (NULLS NOT DISTINCT), so one
+            # conflict target serves every scope.
+            element_type = spec.scope_type.to_rbac_element_type()
+            upserters.append(
+                RBACEntityUpserter(
                     spec=spec,
                     element_type=RBACElementType.APP_CONFIG_FRAGMENT,
                     scope_ref=(
@@ -105,8 +108,19 @@ class AppConfigFragmentDBSource:
                         columns=["config_name", "scope_type", "scope_id"]
                     ),
                 )
-                results.append((await w.upsert_scoped(upserter)).row.to_data())
-            return results
+            )
+        async with self._rbac_ops_provider.write_ops() as w:
+            result = await w.bulk_upsert_scoped_partial(upserters)
+            return AppConfigFragmentUpsertBulkResult(
+                succeeded=[row.to_data() for row in result.successes],
+                failed=[
+                    AppConfigFragmentUpsertItemError(
+                        config_name=specs[error.index].config_name,
+                        message=str(error.exception),
+                    )
+                    for error in result.errors
+                ],
+            )
 
     @app_config_fragment_db_source_resilience.apply()
     async def get_by_id(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentData:

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -14,6 +14,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
+    AppConfigFragmentUpsertBulkResult,
 )
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
@@ -63,7 +64,7 @@ class AppConfigFragmentRepository:
     @app_config_fragment_repository_resilience.apply()
     async def bulk_upsert(
         self, specs: Sequence[AppConfigFragmentUpserterSpec]
-    ) -> list[AppConfigFragmentData]:
+    ) -> AppConfigFragmentUpsertBulkResult:
         return await self._db_source.bulk_upsert(specs)
 
     @app_config_fragment_repository_resilience.apply()

--- a/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
@@ -5,7 +5,10 @@ from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentUpsertItemError,
+)
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.repositories.app_config_fragment.types import (
     AppConfigFragmentSearchScope,
@@ -55,7 +58,8 @@ class BulkUpsertAppConfigFragmentsAction(AppConfigFragmentScopeAction):
 
 @dataclass
 class BulkUpsertAppConfigFragmentsActionResult(AppConfigFragmentScopeActionResult):
-    fragments: list[AppConfigFragmentData]
+    succeeded: list[AppConfigFragmentData]
+    failed: list[AppConfigFragmentUpsertItemError]
     #: The scope the upsert ran at, carried only to report the RBAC scope.
     _scope: AppConfigFragmentSearchScope
 

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -53,8 +53,10 @@ class AppConfigFragmentService:
     async def bulk_upsert(
         self, action: BulkUpsertAppConfigFragmentsAction
     ) -> BulkUpsertAppConfigFragmentsActionResult:
-        fragments = await self._repository.bulk_upsert(action.upserter_specs)
-        return BulkUpsertAppConfigFragmentsActionResult(fragments=fragments, _scope=action.scope)
+        result = await self._repository.bulk_upsert(action.upserter_specs)
+        return BulkUpsertAppConfigFragmentsActionResult(
+            succeeded=result.succeeded, failed=result.failed, _scope=action.scope
+        )
 
     async def admin_search(
         self, action: AdminSearchAppConfigFragmentAction

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -122,7 +122,10 @@ class TestScopedBulkUpsert:
         node_payload: dict[str, Any],
     ) -> None:
         mock_response.json = AsyncMock(
-            return_value={"items": [node_payload]},
+            return_value={
+                "items": [node_payload],
+                "failed": [{"config_name": "menu", "message": "not allowed"}],
+            },
         )
 
         result = await client.scoped_bulk_upsert_app_config_fragments(
@@ -140,6 +143,9 @@ class TestScopedBulkUpsert:
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/bulk-upsert")
         assert isinstance(result, UpsertAppConfigFragmentsPayload)
         assert [item.config_name for item in result.items] == ["theme"]
+        assert [(error.config_name, error.message) for error in result.failed] == [
+            ("menu", "not allowed")
+        ]
 
 
 class TestMyByNames:
@@ -172,7 +178,7 @@ class TestMyBulkUpsert:
         node_payload: dict[str, Any],
     ) -> None:
         mock_response.json = AsyncMock(
-            return_value={"items": [node_payload]},
+            return_value={"items": [node_payload], "failed": []},
         )
 
         result = await client.my_bulk_upsert_app_config_fragments(

--- a/tests/unit/manager/api/gql/test_app_config_fragment_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_fragment_types.py
@@ -9,6 +9,8 @@ from typing import Any, cast
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
+    AppConfigFragmentUpsertErrorInfo,
+    UpsertAppConfigFragmentsPayload,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     AppConfigFragmentOrderField,
@@ -21,6 +23,7 @@ from ai.backend.manager.api.gql.app_config_fragment.types import (
     AppConfigFragmentOrderByGQL,
     AppConfigFragmentOrderFieldGQL,
     AppConfigScopeTypeFilterGQL,
+    UpsertAppConfigFragmentsPayloadGQL,
 )
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 
@@ -64,6 +67,31 @@ class TestAppConfigFragmentGQL:
 
         assert gql.scope_type == AppConfigScopeType.PUBLIC
         assert gql.scope_id is None
+
+
+class TestUpsertAppConfigFragmentsPayloadGQL:
+    def test_from_pydantic_converts_items_and_failures(self) -> None:
+        node = AppConfigFragmentNode(
+            id=AppConfigFragmentID(uuid.uuid4()),
+            config_name="theme",
+            scope_type=AppConfigScopeType.USER,
+            scope_id=AppConfigScopeID(uuid.uuid4()),
+            config={"mode": "dark"},
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        payload = UpsertAppConfigFragmentsPayload(
+            items=[node],
+            failed=[AppConfigFragmentUpsertErrorInfo(config_name="menu", message="not allowed")],
+        )
+
+        gql = UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
+
+        assert [item.config_name for item in gql.items] == ["theme"]
+        assert cast(dict[str, Any], gql.items[0].config) == {"mode": "dark"}
+        assert [(error.config_name, error.message) for error in gql.failed] == [
+            ("menu", "not allowed")
+        ]
 
 
 class TestAppConfigFragmentInputs:

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -24,7 +24,6 @@ from ai.backend.manager.data.app_config_fragment.types import (
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.errors.app_config import (
     AppConfigFragmentNotFound,
-    AppConfigFragmentWriteNotAllowed,
 )
 from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
@@ -795,7 +794,10 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        assert await self._scope_bindings(database, str(upserted[0].id)) == case.expected_bindings
+        assert (
+            await self._scope_bindings(database, str(upserted.succeeded[0].id))
+            == case.expected_bindings
+        )
 
     @pytest.mark.parametrize(
         "case",
@@ -833,7 +835,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        created = upserted[0]
+        created = upserted.succeeded[0]
         assert await self._scope_bindings(database, str(created.id)) == case.expected_bindings
         purged = await repository.purge(AppConfigFragmentPurgerSpec(fragment_id=created.id))
         assert purged.id == created.id
@@ -858,7 +860,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        created = upserted[0]
+        created = upserted.succeeded[0]
         assert await self._scope_bindings(database, str(created.id)) == [
             _ScopeBinding(scope_type=ScopeType.USER, scope_id=str(_USER_ID))
         ]
@@ -871,7 +873,7 @@ class TestRBACScopeAssociation:
 
 class TestUpsert:
     """A fragment is addressed by ``(config_name, scope_type, scope_id)``, so an upsert inserts
-    it when absent and replaces its ``config`` when present, in one all-or-nothing transaction.
+    it when absent and replaces its ``config`` when present, with per-item partial success.
     """
 
     @pytest.mark.parametrize(
@@ -903,7 +905,7 @@ class TestUpsert:
         case: _FragmentScopeCase,
     ) -> None:
         """An insert binds the new row to its RBAC scope, exactly as a create does."""
-        upserted = await repository.bulk_upsert([
+        result = await repository.bulk_upsert([
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
                 scope_type=case.scope_type,
@@ -912,6 +914,8 @@ class TestUpsert:
             )
         ])
 
+        assert result.failed == []
+        upserted = result.succeeded
         assert [(f.config_name, f.scope_type, f.scope_id) for f in upserted] == [
             ("theme", case.scope_type, case.scope_id)
         ]
@@ -963,7 +967,7 @@ class TestUpsert:
         """
         existing = fragment_at_every_scope[case.scope_type]
 
-        upserted = await repository.bulk_upsert([
+        result = await repository.bulk_upsert([
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
                 scope_type=case.scope_type,
@@ -972,6 +976,8 @@ class TestUpsert:
             )
         ])
 
+        assert result.failed == []
+        upserted = result.succeeded
         assert [f.id for f in upserted] == [existing.id]
         assert upserted[0].config == {"theme": "light"}
         async with database.begin_readonly_session() as db_sess:
@@ -1010,7 +1016,7 @@ class TestUpsert:
             )
         ])
 
-        upserted = await repository.bulk_upsert([
+        result = await repository.bulk_upsert([
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
                 scope_type=AppConfigScopeType.PUBLIC,
@@ -1025,7 +1031,8 @@ class TestUpsert:
             ),
         ])
 
-        assert [(f.scope_type, f.config) for f in upserted] == [
+        assert result.failed == []
+        assert [(f.scope_type, f.config) for f in result.succeeded] == [
             (AppConfigScopeType.PUBLIC, {"theme": "light"}),
             (AppConfigScopeType.USER, {"theme": "solarized"}),
         ]
@@ -1036,38 +1043,46 @@ class TestUpsert:
         theme_defined_not_allow_listed: None,
     ) -> None:
         """The FK to the allow list gates an upsert as it gates a create."""
-        with pytest.raises(AppConfigFragmentWriteNotAllowed):
-            await repository.bulk_upsert([
-                AppConfigFragmentUpserterSpec(
-                    config_name="theme",
-                    scope_type=AppConfigScopeType.PUBLIC,
-                    scope_id=None,
-                    config={"theme": "dark"},
-                )
-            ])
+        result = await repository.bulk_upsert([
+            AppConfigFragmentUpserterSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id=None,
+                config={"theme": "dark"},
+            )
+        ])
 
-    async def test_upsert_persists_nothing_when_one_item_is_rejected(
+        assert result.succeeded == []
+        assert [error.config_name for error in result.failed] == ["theme"]
+        assert "not allowed" in result.failed[0].message
+
+    async def test_upsert_rejected_item_fails_alone_and_the_rest_land(
         self,
         repository: AppConfigFragmentRepository,
         database: ExtendedAsyncSAEngine,
         theme_registered: None,
     ) -> None:
-        """The batch shares one transaction, so a rejected item rolls the whole call back."""
-        with pytest.raises(AppConfigFragmentWriteNotAllowed):
-            await repository.bulk_upsert([
-                AppConfigFragmentUpserterSpec(
-                    config_name="theme",
-                    scope_type=AppConfigScopeType.PUBLIC,
-                    scope_id=None,
-                    config={"theme": "dark"},
-                ),
-                AppConfigFragmentUpserterSpec(
-                    config_name="menu",  # registered nowhere, so its FK gate rejects it
-                    scope_type=AppConfigScopeType.PUBLIC,
-                    scope_id=None,
-                    config={"menu": "compact"},
-                ),
-            ])
+        """Each item has its own savepoint, so a rejected item leaves the rest upserted."""
+        result = await repository.bulk_upsert([
+            AppConfigFragmentUpserterSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id=None,
+                config={"theme": "dark"},
+            ),
+            AppConfigFragmentUpserterSpec(
+                config_name="menu",  # registered nowhere, so its FK gate rejects it
+                scope_type=AppConfigScopeType.PUBLIC,
+                scope_id=None,
+                config={"menu": "compact"},
+            ),
+        ])
+
+        assert [(f.config_name, f.config) for f in result.succeeded] == [
+            ("theme", {"theme": "dark"})
+        ]
+        assert [error.config_name for error in result.failed] == ["menu"]
+        assert "not allowed" in result.failed[0].message
 
         async with database.begin_readonly_session() as db_sess:
             stored = (
@@ -1077,9 +1092,11 @@ class TestUpsert:
                     )
                 )
             ).all()
-        assert stored == []
+        assert [row.config_name for row in stored] == ["theme"]
 
     async def test_upsert_of_no_items_writes_nothing(
         self, repository: AppConfigFragmentRepository, theme_registered: None
     ) -> None:
-        assert await repository.bulk_upsert([]) == []
+        result = await repository.bulk_upsert([])
+        assert result.succeeded == []
+        assert result.failed == []

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -19,6 +19,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
+    AppConfigFragmentUpsertBulkResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
@@ -145,7 +146,9 @@ class TestAppConfigFragmentService:
         scoped_fragment: AppConfigFragmentData,
         case: _RBACScopeCase,
     ) -> None:
-        mock_repository.bulk_upsert = AsyncMock(return_value=[scoped_fragment])
+        mock_repository.bulk_upsert = AsyncMock(
+            return_value=AppConfigFragmentUpsertBulkResult(succeeded=[scoped_fragment], failed=[])
+        )
         specs = [
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
@@ -160,7 +163,8 @@ class TestAppConfigFragmentService:
             BulkUpsertAppConfigFragmentsAction(scope=scope, upserter_specs=specs)
         )
 
-        assert result.fragments == [scoped_fragment]
+        assert result.succeeded == [scoped_fragment]
+        assert result.failed == []
         # The result reports the RBAC scope the upsert was authorized at.
         assert result.scope_type() == case.expected_scope_type
         assert result.scope_id() == case.expected_scope_id


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 2-PR stack. **Merge in order:**

1. ⬇️ #13572 — `feat(BA-7256): add a partial bulk upsert primitive to the RBAC write ops`
2. 👉 **#13563** — `feat(BA-7250): support partial success in bulk app config fragment upsert` ← you are here

Both PRs build and pass CI independently.

## Summary
- The fragment bulk upsert (`scopedUpsertAppConfigFragments` / `myUpsertAppConfigFragments`, REST v2 `bulk-upsert`) was all-or-nothing: the db source looped the single-item `upsert_scoped` op inside one transaction, so one rejected item (e.g. a config name not allow-listed at the scope) rolled back the whole batch.
- Switch the fragment upsert path to `bulk_upsert_scoped_partial` (added in #13572) end-to-end (db source → repository → action result → DTO → adapter → GraphQL/REST/SDK/CLI). `UpsertAppConfigFragmentsPayload` now carries `failed` alongside `items`; a failed item is named by its `config_name`, since a rejected insert never had a fragment id and the batch shares one scope.
- RBAC is unchanged: the action stays scope-level, one CREATE check covers the batch.
- **BREAKING**: the two upsert mutations now return `UpsertAppConfigFragmentsPayload!` instead of `[AppConfigFragment!]!`, and an all-items-rejected batch answers 200 with `failed` entries instead of an error. Both mutations and both REST `bulk-upsert` routes shipped in **26.8.0** (`f4be60f690`), so a 26.8 client is affected on both counts. The `approved-breaking-change` label stays so graphql-inspector accepts the schema diff against `main`.

**Changelog**: the response-shape half of the break is carried by #13580, which lands the payload type on its own with `changes/13580.breaking.md`. This PR will be rebased onto it, after which its own diff is the behavior — whether the all-rejected batch answering 200 instead of an error warrants a second breaking entry here is still open.

Resolves BA-7250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13563.org.readthedocs.build/en/13563/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13563.org.readthedocs.build/ko/13563/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13563.org.readthedocs.build/en/13563/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13563.org.readthedocs.build/ko/13563/

<!-- readthedocs-preview sorna-ko end -->


