### PR TITLE
doc(BA-7249): document the value_type flag constraint in RuntimeVariantPreset inputs

### DIFF
--- a/changes/13564.doc.md
+++ b/changes/13564.doc.md
@@ -1,0 +1,1 @@
+Document the "`value_type` 'flag' requires `preset_target` 'args'" constraint in the RuntimeVariantPreset create/update input descriptions

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4775,7 +4775,7 @@ input CreateRuntimeVariantPresetInput
   presetTarget: PresetTarget!
 
   """
-  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag').
+  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). 'flag' is only valid when preset_target is 'args'.
   """
   valueType: PresetValueType!
 
@@ -21732,7 +21732,9 @@ input UpdateRuntimeVariantPresetInput
   """New target."""
   presetTarget: PresetTarget = null
 
-  """New value type."""
+  """
+  New value type. 'flag' is only valid when the effective preset_target is 'args' (the stored target applies when preset_target is omitted).
+  """
   valueType: PresetValueType = null
 
   """New default value."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3233,7 +3233,7 @@ input CreateRuntimeVariantPresetInput {
   presetTarget: PresetTarget!
 
   """
-  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag').
+  Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). 'flag' is only valid when preset_target is 'args'.
   """
   valueType: PresetValueType!
 
@@ -15593,7 +15593,9 @@ input UpdateRuntimeVariantPresetInput {
   """New target."""
   presetTarget: PresetTarget = null
 
-  """New value type."""
+  """
+  New value type. 'flag' is only valid when the effective preset_target is 'args' (the stored target applies when preset_target is omitted).
+  """
   valueType: PresetValueType = null
 
   """New default value."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -24925,7 +24925,7 @@
           },
           "value_type": {
             "$ref": "#/components/schemas/PresetValueType",
-            "description": "Value type: str, int, float, bool, flag."
+            "description": "Value type: str, int, float, bool, flag. 'flag' is only valid with preset_target 'args'."
           },
           "default_value": {
             "anyOf": [
@@ -25075,7 +25075,8 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "default": null,
+            "description": "New value type. 'flag' is only valid when the effective preset_target is 'args' (the stored target applies when preset_target is omitted)."
           },
           "default_value": {
             "anyOf": [

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
@@ -47,7 +47,12 @@ class CreateRuntimeVariantPresetInput(BaseRequestModel):
     name: str = Field(min_length=1, max_length=256, description="Preset name.")
     description: str | None = Field(default=None, description="Description.")
     preset_target: PresetTarget = Field(description="Target: env or args.")
-    value_type: PresetValueType = Field(description="Value type: str, int, float, bool, flag.")
+    value_type: PresetValueType = Field(
+        description=(
+            "Value type: str, int, float, bool, flag. "
+            "'flag' is only valid with preset_target 'args'."
+        )
+    )
     default_value: str | None = Field(default=None, max_length=512, description="Default value.")
     key: str = Field(min_length=1, max_length=256, description="Env key or args flag.")
     required: bool = Field(
@@ -88,7 +93,13 @@ class UpdateRuntimeVariantPresetInput(BaseRequestModel):
     description: str | Sentinel | None = Field(default=SENTINEL)
     rank: int | None = Field(default=None, ge=0)
     preset_target: PresetTarget | None = Field(default=None)
-    value_type: PresetValueType | None = Field(default=None)
+    value_type: PresetValueType | None = Field(
+        default=None,
+        description=(
+            "New value type. 'flag' is only valid when the effective preset_target is 'args' "
+            "(the stored target applies when preset_target is omitted)."
+        ),
+    )
     default_value: str | Sentinel | None = Field(default=SENTINEL)
     key: str | None = Field(default=None, min_length=1, max_length=256)
     required: bool | None = Field(

--- a/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
+++ b/src/ai/backend/manager/api/gql/runtime_variant_preset/types.py
@@ -403,7 +403,10 @@ class CreateRuntimeVariantPresetInputGQL(PydanticInputMixin[CreateInputDTO]):
         description="How the value is applied: 'env' for environment variable, 'args' for command-line argument."
     )
     value_type: PresetValueTypeGQL = gql_field(
-        description="Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag')."
+        description=(
+            "Data type for validation (e.g., 'str', 'int', 'float', 'bool', 'flag'). "
+            "'flag' is only valid when preset_target is 'args'."
+        )
     )
     default_value: str | None = gql_field(
         default=None, description="The default value shown to users when creating a deployment."
@@ -448,7 +451,13 @@ class UpdateRuntimeVariantPresetInputGQL(PydanticInputMixin[UpdateInputDTO]):
     description: str | None = gql_field(default=None, description="New description.")
     rank: int | None = gql_field(default=None, description="New rank.")
     preset_target: PresetTargetGQL | None = gql_field(default=None, description="New target.")
-    value_type: PresetValueTypeGQL | None = gql_field(default=None, description="New value type.")
+    value_type: PresetValueTypeGQL | None = gql_field(
+        default=None,
+        description=(
+            "New value type. 'flag' is only valid when the effective preset_target is 'args' "
+            "(the stored target applies when preset_target is omitted)."
+        ),
+    )
     default_value: str | None = gql_field(default=None, description="New default value.")
     key: str | None = gql_field(default=None, description="New key.")
     required: bool | None = gql_added_field(


### PR DESCRIPTION
Backport: 26.4

## Summary
- Document the cross-field constraint "`value_type` 'flag' is only valid with `preset_target` 'args'" in the create/update input field descriptions of `RuntimeVariantPreset` (REST DTO + GQL input), so clients can discover it from the schema (reported via the `adminUpdateRuntimeVariantPreset` ENV+FLAG case).
- Regenerate the checked-in GraphQL/OpenAPI schema dumps for the description changes.

The structured-400 GQL validation error mapping that was originally bundled here has been split into a separate PR.

## Test plan
- [x] `pants lint/check` green; schema dumps regenerated via `generate-graphql-schema.sh` and `mgr api dump-openapi`

Resolves BA-7249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13564.org.readthedocs.build/en/13564/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13564.org.readthedocs.build/ko/13564/

<!-- readthedocs-preview sorna-ko end -->