### PR TITLE
fix: merge the two alembic heads on main

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/c04f8b1a6e37_merge_default_keypair_and_service_ports.py
+++ b/src/ai/backend/manager/models/alembic/versions/c04f8b1a6e37_merge_default_keypair_and_service_ports.py
@@ -1,0 +1,26 @@
+"""merge the default keypair and service port backfill heads
+
+``a2f6b90c41d7`` and ``55e0c3669e2e`` both branch off ``2dccb3069031`` and were
+merged in parallel, leaving two heads. Empty merge so that later migrations
+chain onto a single one.
+
+Revision ID: c04f8b1a6e37
+Revises: a2f6b90c41d7, 55e0c3669e2e
+Create Date: 2026-08-06 17:55:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "c04f8b1a6e37"
+down_revision = ("a2f6b90c41d7", "55e0c3669e2e")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

`main` has two alembic heads, so `check-multiple-alembic-migrations` fails on every branch off it:

```
Detected head revisions: a2f6b90c41d7, 55e0c3669e2e
```

| Head | From |
|---|---|
| `a2f6b90c41d7` | #13483 — add `is_default` to keypairs |
| `55e0c3669e2e` | backfill missing service ports in runtime_variants |

Both declare `down_revision = "2dccb3069031"` and were merged in parallel, so neither is wrong on its own — they simply never saw each other.

This adds the empty merge the migration guardrails prescribe for exactly this case. Their `down_revision` values are left alone: both are already on `main`, and relinearising a released migration is what the guardrails forbid.

## Verification

- [x] `python scripts/check-multiple-alembic-heads.py` — `Detected head revisions: c04f8b1a6e37`, exit 0
- [x] `alembic upgrade head` against a copy of the dev database: applies `55e0c3669e2e`, then the merge, landing on `c04f8b1a6e37`
- [ ] CI

Nothing else changes — the migration's `upgrade()` and `downgrade()` are both `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
