### PR TITLE
fix: merge the two alembic heads on main (#13567)

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/c04f8b1a6e37_merge_default_keypair_and_service_ports.py
+++ b/src/ai/backend/manager/models/alembic/versions/c04f8b1a6e37_merge_default_keypair_and_service_ports.py
@@ -1,0 +1,26 @@
+"""merge the default keypair and service port backfill heads
+
+``a2f6b90c41d7`` and ``55e0c3669e2e`` both branch off ``2dccb3069031`` and were
+merged in parallel, leaving two heads. Empty merge so that later migrations
+chain onto a single one.
+
+Revision ID: c04f8b1a6e37
+Revises: a2f6b90c41d7, 55e0c3669e2e
+Create Date: 2026-08-06 17:55:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "c04f8b1a6e37"
+down_revision = ("a2f6b90c41d7", "55e0c3669e2e")
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
This is an auto-generated backport of #13567 to the 26.4 release.