### PR TITLE
fix(BA-7254): use UserNode.from_row in legacy group_node.user_nodes resolver

### DIFF
--- a/changes/13570.fix.md
+++ b/changes/13570.fix.md
@@ -1,0 +1,1 @@
+Fix the legacy GraphQL `group_node.user_nodes` field always failing with an internal error by constructing the connection items as `UserNode` instead of `GroupNode`

--- a/src/ai/backend/manager/api/gql_legacy/group.py
+++ b/src/ai/backend/manager/api/gql_legacy/group.py
@@ -185,7 +185,7 @@ class GroupNode(graphene.ObjectType):  # type: ignore[misc]
         first: int | None = None,
         before: str | None = None,
         last: int | None = None,
-    ) -> ConnectionResolverResult[Self]:
+    ) -> ConnectionResolverResult[UserNode]:
         from ai.backend.manager.models.user import UserRow
 
         graph_ctx: GraphQueryContext = info.context
@@ -237,7 +237,7 @@ class GroupNode(graphene.ObjectType):  # type: ignore[misc]
             cnt_query = cnt_query.where(cond)
         async with graph_ctx.db.begin_readonly_session() as db_session:
             user_rows = (await db_session.scalars(user_query)).all()
-            result = [type(self).from_row(graph_ctx, row) for row in user_rows]
+            result = [UserNode.from_row(graph_ctx, row) for row in user_rows]
             total_cnt = await db_session.scalar(cnt_query) or 0
             return ConnectionResolverResult(result, cursor, pagination_order, page_size, total_cnt)
 


### PR DESCRIPTION
## Summary
- Fix the legacy GraphQL `group_node { user_nodes { ... } }` query always failing with a 500 internal error (`'UserRow' object has no attribute 'id'`).
- `GroupNode.resolve_user_nodes` built result items with `type(self).from_row(...)`, passing each `UserRow` to `GroupNode.from_row`, which reads `row.id` — a column that does not exist on `UserRow` (its PK is `uuid`). Use `UserNode.from_row` instead and fix the return type annotation accordingly.

## Test plan
- [x] Verified against a live local manager: `{ group_node(id: ...) { user_nodes(first: 5) { count edges { node { email } } } } }` now returns the member list (`count: 8`) with `errors: null` instead of a 500.
- [x] Verified the `filter` argument path: `user_nodes(filter: "email contains \"admin\"")` returns the filtered members.

Resolves BA-7254

🤖 Generated with [Claude Code](https://claude.com/claude-code)