### PR TITLE
fix(BA-7254): use UserNode.from_row in legacy group_node.user_nodes resolver (#13570)

### DIFF
--- a/changes/13570.fix.md
+++ b/changes/13570.fix.md
@@ -1,0 +1,1 @@
+Fix the legacy GraphQL `group_node.user_nodes` field always failing with an internal error by constructing the connection items as `UserNode` instead of `GroupNode`

--- a/src/ai/backend/manager/api/gql_legacy/group.py
+++ b/src/ai/backend/manager/api/gql_legacy/group.py
@@ -183,7 +183,7 @@ class GroupNode(graphene.ObjectType):  # type: ignore[misc]
         first: int | None = None,
         before: str | None = None,
         last: int | None = None,
-    ) -> ConnectionResolverResult[Self]:
+    ) -> ConnectionResolverResult[UserNode]:
         from ai.backend.manager.models.user import UserRow
 
         graph_ctx: GraphQueryContext = info.context
@@ -235,7 +235,7 @@ class GroupNode(graphene.ObjectType):  # type: ignore[misc]
             cnt_query = cnt_query.where(cond)
         async with graph_ctx.db.begin_readonly_session() as db_session:
             user_rows = (await db_session.scalars(user_query)).all()
-            result = [type(self).from_row(graph_ctx, row) for row in user_rows]
+            result = [UserNode.from_row(graph_ctx, row) for row in user_rows]
             total_cnt = await db_session.scalar(cnt_query) or 0
             return ConnectionResolverResult(result, cursor, pagination_order, page_size, total_cnt)
 


### PR DESCRIPTION
This is an auto-generated backport of #13570 to the 26.4 release.