### PR TITLE
fix(BA-7262): grant a project's auto_assign roles on every membership write

### DIFF
--- a/changes/13579.fix.md
+++ b/changes/13579.fix.md
@@ -1,0 +1,1 @@
+Grant a project's `auto_assign` roles when a user is added to the project through the assign/bind paths, which registered the membership but left the role mappings untouched.

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -108,7 +108,7 @@ from ai.backend.manager.repositories.ops.rbac.provider import (
     ScopeCreation,
     ScopeDeletion,
     ScopeEntityMember,
-    ScopeMember,
+    ScopeUserMember,
 )
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
 from ai.backend.manager.repositories.permission_controller.role_manager import (
@@ -117,23 +117,6 @@ from ai.backend.manager.repositories.permission_controller.role_manager import (
 from ai.backend.manager.repositories.vfolder.deletion import initiate_vfolder_deletion
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-@dataclass
-class ProjectUserMember(ScopeMember):
-    """A user joining or leaving a project scope; ``manage_roles`` controls whether the
-    membership change also grants/revokes the user's roles at the project scope."""
-
-    user_id: UserID
-    manage_roles: bool = True
-
-    @override
-    def entity_ref(self) -> EntityRef:
-        return EntityRef(entity_type=USER_ENTITY_TYPE, entity_id=self.user_id)
-
-    @override
-    def assign_role_on(self) -> UserID | None:
-        return self.user_id if self.manage_roles else None
 
 
 @dataclass
@@ -278,7 +261,7 @@ class GroupDBSource:
         await w.add_bulk_members(
             EntityMembersAddition(
                 scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
-                members=[ProjectUserMember(user_id=UserID(row.uuid)) for row in new_user_rows],
+                members=[ScopeUserMember(user_id=UserID(row.uuid)) for row in new_user_rows],
             )
         )
 
@@ -633,7 +616,8 @@ class GroupDBSource:
         Validates that the role exists, filters to users in the project's domain
         that are not already assigned, writes each new member's virtual-scope
         membership and scope association, and creates user-role mappings for the
-        specified role.
+        specified role. Membership grants the project's ``auto_assign`` roles on
+        top of that role.
 
         Returns the list of newly assigned users.
         """
@@ -653,10 +637,7 @@ class GroupDBSource:
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
-                    members=[
-                        ProjectUserMember(user_id=UserID(row.uuid), manage_roles=False)
-                        for row in new_user_rows
-                    ],
+                    members=[ScopeUserMember(user_id=UserID(row.uuid)) for row in new_user_rows],
                 )
             )
             user_role_specs = [
@@ -731,7 +712,7 @@ class GroupDBSource:
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
-                    members=[ProjectUserMember(user_id=user_id, manage_roles=False)],
+                    members=[ScopeUserMember(user_id=user_id)],
                 )
             )
 


### PR DESCRIPTION
## Summary

**Scope reduced.** This PR originally introduced a parallel `EntityCreator`/`EntityUpserter`/`EntityPurger` family under `repositories/base/rbac/entity/`. That work is dropped: `models/specs/` (BA-7288/BA-7289) landed the same abstraction as the canonical v2 lineage, and `repositories/AGENTS.md` now declares `repositories/base/rbac/` transition-only with no new specs allowed there. Migrating the legacy domains onto the v2 family is tracked separately by BA-7296 (user/group/domain/scaling_group) and BA-7301 (container_registry).

What remains is the behavior fix the refactor was carrying:

- Delete `ProjectUserMember` and use `ScopeUserMember` at its three call sites. The class predates the BA-7074 enrollment consolidation and was left behind by it.
- Its `manage_roles` flag let a caller register a project membership without the scope's `auto_assign` roles, so membership and role state drifted apart depending on which entry point wrote the membership. Both call sites passed `manage_roles=False`, so the flag only ever turned the grant off.
- `bind_user_to_project` documented that it grants the project's `auto_assign` roles but granted none; `assign_users_to_project` wrote only the caller-supplied `role_id`. Both now grant the project's `auto_assign` roles.

With the flag gone the class is identical to `ScopeUserMember`, which already grants unconditionally — `user/db_source.py` and `RBACWriteOps` were both already on it, so `group/db_source.py` was the only outlier.

## Behavior change

Users added to a project through `assign_users_to_project` / `bind_user_to_project` now receive the project's `auto_assign` roles. For `assign_users_to_project` these are granted on top of the explicitly requested role.

## Test plan

- [x] `pants check` / `pants lint` / `pants fmt`
- [x] `tests/unit/manager/repositories/group` — includes `test_assign_users_to_project.py` and `test_unassign_users_from_project.py`, which cover both changed paths
- [x] `tests/unit/manager/repositories/auth`
- [x] `tests/unit/manager/repositories/ops/rbac`
- [x] `tests/unit/manager/repositories/permission_controller`, `tests/unit/manager/services/permission_controller`, `tests/unit/manager/services/group`

## Backport

Backport: 26.8

Narrowing the default, which for a `fix:` title would be every maintained version.

- **26.8** carries the identical defect: the same `ProjectUserMember` with `manage_roles: bool = True`, the same two call sites passing `manage_roles=False`, the same `assign_auto_assign_roles` path behind `ScopeMember.assign_role_on()`, and the same `preset_project_member` (`scope_type: project`, `auto_assign: true`) in the shipped role fixture.
- **26.4** does not carry the code at all — project membership still goes through `ProjectUserMembershipCreatorSpec` against the association row, with no `ScopeMember` family on that path.

The cherry-pick will not apply cleanly to 26.8: `ScopeUserMember` arrived after that branch was cut (BA-7074), so there is nothing to consolidate into and the backport has to be re-authored as a bare removal of the `manage_roles` field and its two `manage_roles=False` arguments. Expect the conflict-marker pull request the backport workflow opens for that case.

Resolves BA-7262

🤖 Generated with [Claude Code](https://claude.com/claude-code)
