### PR TITLE
feat(BA-7250): carry rejected items in the bulk fragment upsert payload

### DIFF
--- a/changes/13580.breaking.md
+++ b/changes/13580.breaking.md
@@ -1,1 +1,0 @@
-Answer the app config fragment bulk upsert with an `UpsertAppConfigFragmentsPayload` instead of a bare list of fragments, over both GraphQL and REST v2.

--- a/changes/13580.breaking.md
+++ b/changes/13580.breaking.md
@@ -1,1 +1,1 @@
-The `scopedUpsertAppConfigFragments` and `myUpsertAppConfigFragments` GraphQL mutations and the REST v2 fragment `bulk-upsert` endpoints now answer with an `UpsertAppConfigFragmentsPayload` (`items` + `failed`) instead of a bare list of fragments; `failed` is always empty until per-item partial success lands.
+Answer the app config fragment bulk upsert with an `UpsertAppConfigFragmentsPayload` (`items` + `failed`) instead of a bare list of fragments, over both GraphQL and REST v2.

--- a/changes/13580.breaking.md
+++ b/changes/13580.breaking.md
@@ -1,1 +1,1 @@
-Answer the app config fragment bulk upsert with an `UpsertAppConfigFragmentsPayload` (`items` + `failed`) instead of a bare list of fragments, over both GraphQL and REST v2.
+Answer the app config fragment bulk upsert with an `UpsertAppConfigFragmentsPayload` instead of a bare list of fragments, over both GraphQL and REST v2.

--- a/changes/13580.breaking.md
+++ b/changes/13580.breaking.md
@@ -1,0 +1,1 @@
+The `scopedUpsertAppConfigFragments` and `myUpsertAppConfigFragments` GraphQL mutations and the REST v2 fragment `bulk-upsert` endpoints now answer with an `UpsertAppConfigFragmentsPayload` (`items` + `failed`) instead of a bare list of fragments; `failed` is always empty until per-item partial success lands.

--- a/changes/13580.feature.md
+++ b/changes/13580.feature.md
@@ -1,1 +1,1 @@
-Report the bulk app config fragment upsert as a payload of the fragments written plus the items whose write was rejected, each named by its config name, instead of a bare list of fragments.
+Report the bulk app config fragment upsert as a payload of the fragments written plus the items whose write was rejected, each named by its config name, instead of a bare list of fragments (the upsert is still all-or-nothing, so no item is reported failed yet).

--- a/changes/13580.feature.md
+++ b/changes/13580.feature.md
@@ -1,1 +1,0 @@
-Report the bulk app config fragment upsert as a payload of the fragments written plus the items whose write was rejected, each named by its config name, instead of a bare list of fragments (the upsert is still all-or-nothing, so no item is reported failed yet).

--- a/changes/13580.feature.md
+++ b/changes/13580.feature.md
@@ -1,0 +1,1 @@
+Add the app config fragment bulk upsert over GraphQL and REST v2, answering with an `UpsertAppConfigFragmentsPayload`.

--- a/changes/13580.feature.md
+++ b/changes/13580.feature.md
@@ -1,0 +1,1 @@
+Report the bulk app config fragment upsert as a payload of the fragments written plus the items whose write was rejected, each named by its config name, instead of a bare list of fragments.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12267,12 +12267,12 @@ type Mutation
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing).
+  Added in 26.9.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing).
   """
   scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing).
+  Added in 26.9.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing).
   """
   myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1225,7 +1225,7 @@ input AppConfigFragmentScopeTypeFilter
 }
 
 """
-Added in 26.9.0. One rejected item of a bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
+Added in 26.9.0. One failed item of a partial bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
 """
 type AppConfigFragmentUpsertError
   @join__type(graph: STRAWBERRY)
@@ -12267,12 +12267,12 @@ type Mutation
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), all-or-nothing. RBAC-authorized at that scope.
+  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing, to be fixed). RBAC-authorized at that scope.
   """
   scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, all-or-nothing.
+  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing, to be fixed).
   """
   myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
@@ -21889,7 +21889,7 @@ type UpdateVFSStoragePayload
 }
 
 """
-Added in 26.9.0. Payload of a bulk fragment upsert: the fragments written, and the rejected items.
+Added in 26.9.0. Partial-success payload for a bulk fragment upsert (not in effect yet: still all-or-nothing, so failed is always empty, to be fixed).
 """
 type UpsertAppConfigFragmentsPayload
   @join__type(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1238,7 +1238,7 @@ type AppConfigFragmentUpsertError
 }
 
 """
-Added in 26.8.0. One (config_name, config) pair to upsert at the request's scope.
+Added in 26.9.0. One (config_name, config) pair to upsert at the request's scope.
 """
 input AppConfigFragmentUpsertItem
   @join__type(graph: STRAWBERRY)
@@ -13064,7 +13064,7 @@ type MyStorageHostPermissionsPayload
 }
 
 """
-Added in 26.8.0. Upsert many fragments at the current user's own user scope.
+Added in 26.9.0. Upsert many fragments at the current user's own user scope.
 """
 input MyUpsertAppConfigFragmentsInput
   @join__type(graph: STRAWBERRY)
@@ -19458,7 +19458,7 @@ enum SchedulingStatus
 }
 
 """
-Added in 26.8.0. Upsert many fragments at one scope; the scope is named once for all items.
+Added in 26.9.0. Upsert many fragments at one scope; the scope is named once for all items.
 """
 input ScopedUpsertAppConfigFragmentsInput
   @join__type(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -12267,12 +12267,12 @@ type Mutation
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing, to be fixed). RBAC-authorized at that scope.
+  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing).
   """
   scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing, to be fixed).
+  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing).
   """
   myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
@@ -15470,7 +15470,7 @@ type Query
   scopedIdleCheckerAssignments(scope: IdleCheckerAssignmentScope!, filter: IdleCheckerAssignmentFilter = null, orderBy: [IdleCheckerAssignmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): IdleCheckerAssignmentConnection! @join__field(graph: STRAWBERRY)
 
   """
-  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered position by position, null where the scope holds no fragment for that name. RBAC-authorized at that scope.
+  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered position by position, null where the scope holds no fragment for that name.
   """
   scopedAppConfigFragmentsByNames(scope: AppConfigScopeRef!, configNames: [String!]!): [AppConfigFragment]! @join__field(graph: STRAWBERRY)
 
@@ -21889,7 +21889,7 @@ type UpdateVFSStoragePayload
 }
 
 """
-Added in 26.9.0. Partial-success payload for a bulk fragment upsert (not in effect yet: still all-or-nothing, so failed is always empty, to be fixed).
+Added in 26.9.0. Partial-success payload for a bulk fragment upsert (not in effect yet: still all-or-nothing).
 """
 type UpsertAppConfigFragmentsPayload
   @join__type(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1225,6 +1225,19 @@ input AppConfigFragmentScopeTypeFilter
 }
 
 """
+Added in 26.9.0. One rejected item of a bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
+"""
+type AppConfigFragmentUpsertError
+  @join__type(graph: STRAWBERRY)
+{
+  """Config name of the item that failed."""
+  configName: String!
+
+  """Reason the item failed."""
+  message: String!
+}
+
+"""
 Added in 26.8.0. One (config_name, config) pair to upsert at the request's scope.
 """
 input AppConfigFragmentUpsertItem
@@ -12256,12 +12269,12 @@ type Mutation
   """
   Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), all-or-nothing. RBAC-authorized at that scope.
   """
-  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, all-or-nothing.
   """
-  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): [AppConfigFragment!]! @join__field(graph: STRAWBERRY)
+  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -21873,6 +21886,19 @@ type UpdateVFSStoragePayload
 {
   """Updated VFS storage"""
   vfsStorage: VFSStorage!
+}
+
+"""
+Added in 26.9.0. Payload of a bulk fragment upsert: the fragments written, and the rejected items.
+"""
+type UpsertAppConfigFragmentsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The upserted app config fragments."""
+  items: [AppConfigFragment!]!
+
+  """Per-item failures, each naming the config name it targeted."""
+  failed: [AppConfigFragmentUpsertError!]!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8017,12 +8017,12 @@ type Mutation {
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing).
+  Added in 26.9.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing).
   """
   scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing).
+  Added in 26.9.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing).
   """
   myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -903,6 +903,17 @@ input AppConfigFragmentScopeTypeFilter {
 }
 
 """
+Added in 26.9.0. One rejected item of a bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
+"""
+type AppConfigFragmentUpsertError {
+  """Config name of the item that failed."""
+  configName: String!
+
+  """Reason the item failed."""
+  message: String!
+}
+
+"""
 Added in 26.8.0. One (config_name, config) pair to upsert at the request's scope.
 """
 input AppConfigFragmentUpsertItem {
@@ -8008,12 +8019,12 @@ type Mutation {
   """
   Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), all-or-nothing. RBAC-authorized at that scope.
   """
-  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): [AppConfigFragment!]!
+  scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
   Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, all-or-nothing.
   """
-  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): [AppConfigFragment!]!
+  myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
@@ -15720,6 +15731,17 @@ input UpdateVFSStorageInput {
 type UpdateVFSStoragePayload {
   """Updated VFS storage"""
   vfsStorage: VFSStorage!
+}
+
+"""
+Added in 26.9.0. Payload of a bulk fragment upsert: the fragments written, and the rejected items.
+"""
+type UpsertAppConfigFragmentsPayload {
+  """The upserted app config fragments."""
+  items: [AppConfigFragment!]!
+
+  """Per-item failures, each naming the config name it targeted."""
+  failed: [AppConfigFragmentUpsertError!]!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -914,7 +914,7 @@ type AppConfigFragmentUpsertError {
 }
 
 """
-Added in 26.8.0. One (config_name, config) pair to upsert at the request's scope.
+Added in 26.9.0. One (config_name, config) pair to upsert at the request's scope.
 """
 input AppConfigFragmentUpsertItem {
   """Registered config name."""
@@ -8810,7 +8810,7 @@ type MyStorageHostPermissionsPayload {
 }
 
 """
-Added in 26.8.0. Upsert many fragments at the current user's own user scope.
+Added in 26.9.0. Upsert many fragments at the current user's own user scope.
 """
 input MyUpsertAppConfigFragmentsInput {
   """The (config_name, config) pairs to upsert."""
@@ -13817,7 +13817,7 @@ type ScopeResourceUsageV2 {
 }
 
 """
-Added in 26.8.0. Upsert many fragments at one scope; the scope is named once for all items.
+Added in 26.9.0. Upsert many fragments at one scope; the scope is named once for all items.
 """
 input ScopedUpsertAppConfigFragmentsInput {
   """Scope the fragments are written at."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -8017,12 +8017,12 @@ type Mutation {
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing, to be fixed). RBAC-authorized at that scope.
+  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing).
   """
   scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing, to be fixed).
+  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing).
   """
   myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
@@ -10391,7 +10391,7 @@ type Query {
   scopedIdleCheckerAssignments(scope: IdleCheckerAssignmentScope!, filter: IdleCheckerAssignmentFilter = null, orderBy: [IdleCheckerAssignmentOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): IdleCheckerAssignmentConnection!
 
   """
-  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered position by position, null where the scope holds no fragment for that name. RBAC-authorized at that scope.
+  Added in 26.8.0. Read the fragments written at one scope for the given config names — the current values, to inspect before editing them. Answered position by position, null where the scope holds no fragment for that name.
   """
   scopedAppConfigFragmentsByNames(scope: AppConfigScopeRef!, configNames: [String!]!): [AppConfigFragment]!
 
@@ -15734,7 +15734,7 @@ type UpdateVFSStoragePayload {
 }
 
 """
-Added in 26.9.0. Partial-success payload for a bulk fragment upsert (not in effect yet: still all-or-nothing, so failed is always empty, to be fixed).
+Added in 26.9.0. Partial-success payload for a bulk fragment upsert (not in effect yet: still all-or-nothing).
 """
 type UpsertAppConfigFragmentsPayload {
   """The upserted app config fragments."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -903,7 +903,7 @@ input AppConfigFragmentScopeTypeFilter {
 }
 
 """
-Added in 26.9.0. One rejected item of a bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
+Added in 26.9.0. One failed item of a partial bulk fragment upsert, named by its config name — the batch shares one scope, and a rejected insert never had a fragment id.
 """
 type AppConfigFragmentUpsertError {
   """Config name of the item that failed."""
@@ -8017,12 +8017,12 @@ type Mutation {
   adminUpdateAppConfigAllowList(input: UpdateAppConfigAllowListInput!): UpdateAppConfigAllowListPayload
 
   """
-  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), all-or-nothing. RBAC-authorized at that scope.
+  Added in 26.8.0. Upsert many app config fragments at one scope (insert, or replace config on conflict), with per-item partial success (not in effect yet: still all-or-nothing, to be fixed). RBAC-authorized at that scope.
   """
   scopedUpsertAppConfigFragments(input: ScopedUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
   """
-  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, all-or-nothing.
+  Added in 26.8.0. Upsert many app config fragments at the current user's own user scope, with per-item partial success (not in effect yet: still all-or-nothing, to be fixed).
   """
   myUpsertAppConfigFragments(input: MyUpsertAppConfigFragmentsInput!): UpsertAppConfigFragmentsPayload!
 
@@ -15734,7 +15734,7 @@ type UpdateVFSStoragePayload {
 }
 
 """
-Added in 26.9.0. Payload of a bulk fragment upsert: the fragments written, and the rejected items.
+Added in 26.9.0. Partial-success payload for a bulk fragment upsert (not in effect yet: still all-or-nothing, so failed is always empty, to be fixed).
 """
 type UpsertAppConfigFragmentsPayload {
   """The upserted app config fragments."""

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -42006,7 +42006,7 @@
           }
         },
         "parameters": [],
-        "description": "Upsert many fragments at one scope, all-or-nothing (auth, RBAC-authorized).\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Upsert many fragments at one scope, with per-item partial success (auth, RBAC).\n\n(Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)\n\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/my/by-names": {
@@ -42064,7 +42064,7 @@
           }
         },
         "parameters": [],
-        "description": "Upsert many fragments at the caller's own user scope, all-or-nothing (auth).\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Upsert many fragments at the caller's own user scope, with per-item partial\nsuccess (auth).\n\n(Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)\n\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -42006,7 +42006,7 @@
           }
         },
         "parameters": [],
-        "description": "Upsert many fragments at one scope, with per-item partial success (auth, RBAC).\n\n(Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)\n\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Upsert many fragments at one scope, with per-item partial success (auth, RBAC).\n\nNot in effect yet: still all-or-nothing.\n\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/my/by-names": {
@@ -42064,7 +42064,7 @@
           }
         },
         "parameters": [],
-        "description": "Upsert many fragments at the caller's own user scope, with per-item partial\nsuccess (auth).\n\n(Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)\n\n\n**Preconditions:**\n* User privilege required.\n"
+        "description": "Upsert many fragments at the caller's own user scope, with per-item partial\nsuccess (auth).\n\nNot in effect yet: still all-or-nothing.\n\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/app-config-fragments/{fragment_id}": {

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -43,7 +43,7 @@ class AppConfigFragmentsByNamesPayload(BaseRootResponseModel[list[AppConfigFragm
 
 
 class AppConfigFragmentUpsertErrorInfo(BaseResponseModel):
-    """One rejected item of a bulk upsert.
+    """One failed item of a partial-success bulk upsert.
 
     A rejected insert never had a fragment id, so the item is named by its config name —
     the batch shares one scope, and a scope holds at most one fragment per name.
@@ -54,7 +54,11 @@ class AppConfigFragmentUpsertErrorInfo(BaseResponseModel):
 
 
 class UpsertAppConfigFragmentsPayload(BaseResponseModel):
-    """Payload for a scoped upsert of many fragments: the ones written, and the rejected ones."""
+    """Partial-success payload for a scoped upsert of many fragments.
+
+    (Not in effect yet: the upsert is still all-or-nothing, so ``failed`` is always empty.
+    To be fixed.)
+    """
 
     items: list[AppConfigFragmentNode] = Field(description="The upserted app config fragments.")
     failed: list[AppConfigFragmentUpsertErrorInfo] = Field(

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -15,6 +15,7 @@ from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 __all__ = (
     "AppConfigFragmentBulkErrorInfo",
     "AppConfigFragmentNode",
+    "AppConfigFragmentUpsertErrorInfo",
     "AppConfigFragmentsByNamesPayload",
     "BulkPurgeAppConfigFragmentPayload",
     "PurgeAppConfigFragmentPayload",
@@ -41,10 +42,24 @@ class AppConfigFragmentsByNamesPayload(BaseRootResponseModel[list[AppConfigFragm
     """One entry per requested config name, null where the scope holds no fragment for it."""
 
 
+class AppConfigFragmentUpsertErrorInfo(BaseResponseModel):
+    """One rejected item of a bulk upsert.
+
+    A rejected insert never had a fragment id, so the item is named by its config name —
+    the batch shares one scope, and a scope holds at most one fragment per name.
+    """
+
+    config_name: str = Field(description="Config name of the item that failed.")
+    message: str = Field(description="Reason the item failed.")
+
+
 class UpsertAppConfigFragmentsPayload(BaseResponseModel):
-    """Payload for a scoped upsert of many fragments (all-or-nothing)."""
+    """Payload for a scoped upsert of many fragments: the ones written, and the rejected ones."""
 
     items: list[AppConfigFragmentNode] = Field(description="The upserted app config fragments.")
+    failed: list[AppConfigFragmentUpsertErrorInfo] = Field(
+        description="Per-item failures, each naming the config name it targeted."
+    )
 
 
 class PurgeAppConfigFragmentPayload(BaseResponseModel):

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/response.py
@@ -56,8 +56,7 @@ class AppConfigFragmentUpsertErrorInfo(BaseResponseModel):
 class UpsertAppConfigFragmentsPayload(BaseResponseModel):
     """Partial-success payload for a scoped upsert of many fragments.
 
-    (Not in effect yet: the upsert is still all-or-nothing, so ``failed`` is always empty.
-    To be fixed.)
+    Not in effect yet: the upsert is still all-or-nothing.
     """
 
     items: list[AppConfigFragmentNode] = Field(description="The upserted app config fragments.")

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -216,8 +216,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     ) -> list[AppConfigFragmentNode | None]:
         """The fragments written at one scope for the given config names.
 
-        RBAC-authorized at that scope, so a caller reads only a scope they may read. Meant for
-        fetching the current fragment values before editing them.
+        Meant for fetching the current fragment values before editing them.
         """
         return await self._fragments_by_names(
             AppConfigFragmentSearchScope(

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -24,6 +24,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentBulkErrorInfo,
     AppConfigFragmentNode,
+    AppConfigFragmentUpsertErrorInfo,
     BulkPurgeAppConfigFragmentPayload,
     PurgeAppConfigFragmentPayload,
     SearchAppConfigFragmentPayload,
@@ -139,7 +140,13 @@ class AppConfigFragmentAdapter(BaseAdapter):
             BulkUpsertAppConfigFragmentsAction(scope=scope, upserter_specs=specs)
         )
         return UpsertAppConfigFragmentsPayload(
-            items=[self._fragment_to_node(fragment) for fragment in action_result.fragments],
+            items=[self._fragment_to_node(fragment) for fragment in action_result.succeeded],
+            failed=[
+                AppConfigFragmentUpsertErrorInfo(
+                    config_name=error.config_name, message=error.message
+                )
+                for error in action_result.failed
+            ],
         )
 
     async def get(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentNode:

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -140,7 +140,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             BulkUpsertAppConfigFragmentsAction(scope=scope, upserter_specs=specs)
         )
         return UpsertAppConfigFragmentsPayload(
-            items=[self._fragment_to_node(fragment) for fragment in action_result.succeeded],
+            items=[self._fragment_to_node(fragment) for fragment in action_result.items],
             failed=[
                 AppConfigFragmentUpsertErrorInfo(
                     config_name=error.config_name, message=error.message

--- a/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/__init__.py
@@ -15,11 +15,13 @@ from .types import (
     AppConfigFragmentGQL,
     AppConfigFragmentOrderByGQL,
     AppConfigFragmentOrderFieldGQL,
+    AppConfigFragmentUpsertErrorGQL,
     AppConfigFragmentUpsertItemGQL,
     AppConfigScopeRefGQL,
     AppConfigScopeTypeFilterGQL,
     MyUpsertAppConfigFragmentsInputGQL,
     ScopedUpsertAppConfigFragmentsInputGQL,
+    UpsertAppConfigFragmentsPayloadGQL,
 )
 
 __all__ = (
@@ -31,10 +33,12 @@ __all__ = (
     "AppConfigFragmentOrderByGQL",
     "AppConfigFragmentOrderFieldGQL",
     "AppConfigScopeRefGQL",
+    "AppConfigFragmentUpsertErrorGQL",
     "AppConfigFragmentUpsertItemGQL",
     "AppConfigScopeTypeFilterGQL",
     "MyUpsertAppConfigFragmentsInputGQL",
     "ScopedUpsertAppConfigFragmentsInputGQL",
+    "UpsertAppConfigFragmentsPayloadGQL",
     # Query resolvers
     "admin_app_config_fragments",
     "app_config_fragment",

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -108,8 +108,8 @@ async def admin_app_config_fragments(
         added_version="26.8.0",
         description=(
             "Upsert many app config fragments at one scope (insert, or replace config on "
-            "conflict), with per-item partial success (not in effect yet: still "
-            "all-or-nothing). RBAC-authorized at that scope."
+            "conflict), with per-item partial success "
+            "(not in effect yet: still all-or-nothing)."
         ),
     )
 )
@@ -148,7 +148,7 @@ async def my_upsert_app_config_fragments(
         description=(
             "Read the fragments written at one scope for the given config names — the current "
             "values, to inspect before editing them. Answered position by position, null "
-            "where the scope holds no fragment for that name. RBAC-authorized at that scope."
+            "where the scope holds no fragment for that name."
         ),
     )
 )  # type: ignore[misc]

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -108,7 +108,8 @@ async def admin_app_config_fragments(
         added_version="26.8.0",
         description=(
             "Upsert many app config fragments at one scope (insert, or replace config on "
-            "conflict), all-or-nothing. RBAC-authorized at that scope."
+            "conflict), with per-item partial success (not in effect yet: still "
+            "all-or-nothing, to be fixed). RBAC-authorized at that scope."
         ),
     )
 )
@@ -126,7 +127,8 @@ async def scoped_upsert_app_config_fragments(
     BackendAIGQLMeta(
         added_version="26.8.0",
         description=(
-            "Upsert many app config fragments at the current user's own user scope, all-or-nothing."
+            "Upsert many app config fragments at the current user's own user scope, with "
+            "per-item partial success (not in effect yet: still all-or-nothing, to be fixed)."
         ),
     )
 )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -109,7 +109,7 @@ async def admin_app_config_fragments(
         description=(
             "Upsert many app config fragments at one scope (insert, or replace config on "
             "conflict), with per-item partial success (not in effect yet: still "
-            "all-or-nothing, to be fixed). RBAC-authorized at that scope."
+            "all-or-nothing). RBAC-authorized at that scope."
         ),
     )
 )
@@ -128,7 +128,7 @@ async def scoped_upsert_app_config_fragments(
         added_version="26.8.0",
         description=(
             "Upsert many app config fragments at the current user's own user scope, with "
-            "per-item partial success (not in effect yet: still all-or-nothing, to be fixed)."
+            "per-item partial success (not in effect yet: still all-or-nothing)."
         ),
     )
 )

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -120,7 +120,7 @@ async def scoped_upsert_app_config_fragments(
     payload = await info.context.adapters.app_config_fragment.scoped_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
+    return UpsertAppConfigFragmentsPayloadGQL.from_payload(payload)
 
 
 @gql_mutation(
@@ -139,7 +139,7 @@ async def my_upsert_app_config_fragments(
     payload = await info.context.adapters.app_config_fragment.my_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
+    return UpsertAppConfigFragmentsPayloadGQL.from_payload(payload)
 
 
 @gql_root_field(

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -36,6 +36,7 @@ from .types import (
     AppConfigScopeRefGQL,
     MyUpsertAppConfigFragmentsInputGQL,
     ScopedUpsertAppConfigFragmentsInputGQL,
+    UpsertAppConfigFragmentsPayloadGQL,
 )
 
 
@@ -114,11 +115,11 @@ async def admin_app_config_fragments(
 async def scoped_upsert_app_config_fragments(
     info: Info[StrawberryGQLContext],
     input: ScopedUpsertAppConfigFragmentsInputGQL,
-) -> list[AppConfigFragmentGQL]:
+) -> UpsertAppConfigFragmentsPayloadGQL:
     payload = await info.context.adapters.app_config_fragment.scoped_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -132,11 +133,11 @@ async def scoped_upsert_app_config_fragments(
 async def my_upsert_app_config_fragments(
     info: Info[StrawberryGQLContext],
     input: MyUpsertAppConfigFragmentsInputGQL,
-) -> list[AppConfigFragmentGQL]:
+) -> UpsertAppConfigFragmentsPayloadGQL:
     payload = await info.context.adapters.app_config_fragment.my_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return [AppConfigFragmentGQL.from_pydantic(node) for node in payload.items]
+    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
 
 @gql_root_field(

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     ScopedAppConfigFragmentsByNamesInput,
 )
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import encode_cursor
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -105,7 +106,7 @@ async def admin_app_config_fragments(
 
 @gql_mutation(
     BackendAIGQLMeta(
-        added_version="26.8.0",
+        added_version=NEXT_RELEASE_VERSION,
         description=(
             "Upsert many app config fragments at one scope (insert, or replace config on "
             "conflict), with per-item partial success "
@@ -125,7 +126,7 @@ async def scoped_upsert_app_config_fragments(
 
 @gql_mutation(
     BackendAIGQLMeta(
-        added_version="26.8.0",
+        added_version=NEXT_RELEASE_VERSION,
         description=(
             "Upsert many app config fragments at the current user's own user scope, with "
             "per-item partial success (not in effect yet: still all-or-nothing)."

--- a/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/resolver.py
@@ -120,7 +120,7 @@ async def scoped_upsert_app_config_fragments(
     payload = await info.context.adapters.app_config_fragment.scoped_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return UpsertAppConfigFragmentsPayloadGQL.from_payload(payload)
+    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
 
 @gql_mutation(
@@ -139,7 +139,7 @@ async def my_upsert_app_config_fragments(
     payload = await info.context.adapters.app_config_fragment.my_upsert_app_config_fragments(
         input.to_pydantic()
     )
-    return UpsertAppConfigFragmentsPayloadGQL.from_payload(payload)
+    return UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
 
 @gql_root_field(

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -56,7 +56,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 __all__ = (
@@ -211,7 +211,7 @@ class AppConfigFragmentConnection(Connection[AppConfigFragmentGQL]):
     model=AppConfigFragmentUpsertErrorInfoDTO,
     name="AppConfigFragmentUpsertError",
 )
-class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpsertErrorInfoDTO]):
+class AppConfigFragmentUpsertErrorGQL:
     config_name: str = gql_field(description="Config name of the item that failed.")
     message: str = gql_field(description="Reason the item failed.")
 
@@ -227,11 +227,23 @@ class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpser
     model=UpsertAppConfigFragmentsPayloadDTO,
     name="UpsertAppConfigFragmentsPayload",
 )
-class UpsertAppConfigFragmentsPayloadGQL(PydanticOutputMixin[UpsertAppConfigFragmentsPayloadDTO]):
+class UpsertAppConfigFragmentsPayloadGQL:
     items: list[AppConfigFragmentGQL] = gql_field(description="The upserted app config fragments.")
     failed: list[AppConfigFragmentUpsertErrorGQL] = gql_field(
         description="Per-item failures, each naming the config name it targeted."
     )
+
+    @classmethod
+    def from_payload(cls, payload: UpsertAppConfigFragmentsPayloadDTO) -> Self:
+        return cls(
+            items=[AppConfigFragmentGQL.from_pydantic(node) for node in payload.items],
+            failed=[
+                AppConfigFragmentUpsertErrorGQL(
+                    config_name=error.config_name, message=error.message
+                )
+                for error in payload.failed
+            ],
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -78,7 +78,7 @@ __all__ = (
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
-        added_version="26.8.0",
+        added_version=NEXT_RELEASE_VERSION,
         description="One (config_name, config) pair to upsert at the request's scope.",
     ),
     name="AppConfigFragmentUpsertItem",
@@ -107,7 +107,7 @@ class AppConfigScopeRefGQL(PydanticInputMixin[AppConfigScopeRefDTO]):
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
-        added_version="26.8.0",
+        added_version=NEXT_RELEASE_VERSION,
         description="Upsert many fragments at one scope; the scope is named once for all items.",
     ),
     name="ScopedUpsertAppConfigFragmentsInput",
@@ -123,7 +123,7 @@ class ScopedUpsertAppConfigFragmentsInputGQL(
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
-        added_version="26.8.0",
+        added_version=NEXT_RELEASE_VERSION,
         description="Upsert many fragments at the current user's own user scope.",
     ),
     name="MyUpsertAppConfigFragmentsInput",

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -56,7 +56,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 __all__ = (
@@ -211,7 +211,7 @@ class AppConfigFragmentConnection(Connection[AppConfigFragmentGQL]):
     model=AppConfigFragmentUpsertErrorInfoDTO,
     name="AppConfigFragmentUpsertError",
 )
-class AppConfigFragmentUpsertErrorGQL:
+class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpsertErrorInfoDTO]):
     config_name: str = gql_field(description="Config name of the item that failed.")
     message: str = gql_field(description="Reason the item failed.")
 
@@ -227,23 +227,11 @@ class AppConfigFragmentUpsertErrorGQL:
     model=UpsertAppConfigFragmentsPayloadDTO,
     name="UpsertAppConfigFragmentsPayload",
 )
-class UpsertAppConfigFragmentsPayloadGQL:
+class UpsertAppConfigFragmentsPayloadGQL(PydanticOutputMixin[UpsertAppConfigFragmentsPayloadDTO]):
     items: list[AppConfigFragmentGQL] = gql_field(description="The upserted app config fragments.")
     failed: list[AppConfigFragmentUpsertErrorGQL] = gql_field(
         description="Per-item failures, each naming the config name it targeted."
     )
-
-    @classmethod
-    def from_payload(cls, payload: UpsertAppConfigFragmentsPayloadDTO) -> Self:
-        return cls(
-            items=[AppConfigFragmentGQL.from_pydantic(node) for node in payload.items],
-            failed=[
-                AppConfigFragmentUpsertErrorGQL(
-                    config_name=error.config_name, message=error.message
-                )
-                for error in payload.failed
-            ],
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -220,8 +220,8 @@ class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpser
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "Partial-success payload for a bulk fragment upsert (not in effect yet: still "
-            "all-or-nothing, so failed is always empty, to be fixed)."
+            "Partial-success payload for a bulk fragment upsert "
+            "(not in effect yet: still all-or-nothing)."
         ),
     ),
     model=UpsertAppConfigFragmentsPayloadDTO,

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -34,10 +34,17 @@ from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
 )
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    AppConfigFragmentUpsertErrorInfo as AppConfigFragmentUpsertErrorInfoDTO,
+)
+from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
+    UpsertAppConfigFragmentsPayload as UpsertAppConfigFragmentsPayloadDTO,
+)
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     AppConfigScopeTypeFilter as AppConfigScopeTypeFilterDTO,
 )
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -47,8 +54,9 @@ from ai.backend.manager.api.gql.decorators import (
     gql_field,
     gql_node_type,
     gql_pydantic_input,
+    gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 __all__ = (
@@ -58,11 +66,13 @@ __all__ = (
     "AppConfigFragmentGQL",
     "AppConfigFragmentOrderByGQL",
     "AppConfigFragmentOrderFieldGQL",
+    "AppConfigFragmentUpsertErrorGQL",
     "AppConfigFragmentUpsertItemGQL",
     "AppConfigScopeRefGQL",
     "AppConfigScopeTypeFilterGQL",
     "MyUpsertAppConfigFragmentsInputGQL",
     "ScopedUpsertAppConfigFragmentsInputGQL",
+    "UpsertAppConfigFragmentsPayloadGQL",
 )
 
 
@@ -183,6 +193,42 @@ class AppConfigFragmentConnection(Connection[AppConfigFragmentGQL]):
     def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.count = count
+
+
+# ---------------------------------------------------------------------------
+# Mutation payloads
+# ---------------------------------------------------------------------------
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "One rejected item of a bulk fragment upsert, named by its config name — "
+            "the batch shares one scope, and a rejected insert never had a fragment id."
+        ),
+    ),
+    model=AppConfigFragmentUpsertErrorInfoDTO,
+    name="AppConfigFragmentUpsertError",
+)
+class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpsertErrorInfoDTO]):
+    config_name: str = gql_field(description="Config name of the item that failed.")
+    message: str = gql_field(description="Reason the item failed.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload of a bulk fragment upsert: the fragments written, and the rejected items.",
+    ),
+    model=UpsertAppConfigFragmentsPayloadDTO,
+    name="UpsertAppConfigFragmentsPayload",
+)
+class UpsertAppConfigFragmentsPayloadGQL(PydanticOutputMixin[UpsertAppConfigFragmentsPayloadDTO]):
+    items: list[AppConfigFragmentGQL] = gql_field(description="The upserted app config fragments.")
+    failed: list[AppConfigFragmentUpsertErrorGQL] = gql_field(
+        description="Per-item failures, each naming the config name it targeted."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -204,7 +204,7 @@ class AppConfigFragmentConnection(Connection[AppConfigFragmentGQL]):
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
         description=(
-            "One rejected item of a bulk fragment upsert, named by its config name — "
+            "One failed item of a partial bulk fragment upsert, named by its config name — "
             "the batch shares one scope, and a rejected insert never had a fragment id."
         ),
     ),
@@ -219,7 +219,10 @@ class AppConfigFragmentUpsertErrorGQL(PydanticOutputMixin[AppConfigFragmentUpser
 @gql_pydantic_type(
     BackendAIGQLMeta(
         added_version=NEXT_RELEASE_VERSION,
-        description="Payload of a bulk fragment upsert: the fragments written, and the rejected items.",
+        description=(
+            "Partial-success payload for a bulk fragment upsert (not in effect yet: still "
+            "all-or-nothing, so failed is always empty, to be fixed)."
+        ),
     ),
     model=UpsertAppConfigFragmentsPayloadDTO,
     name="UpsertAppConfigFragmentsPayload",

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -96,7 +96,7 @@ class V2AppConfigFragmentHandler:
     ) -> APIResponse:
         """Upsert many fragments at one scope, with per-item partial success (auth, RBAC).
 
-        (Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)
+        Not in effect yet: still all-or-nothing.
         """
         result = await self._adapter.scoped_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
@@ -108,7 +108,7 @@ class V2AppConfigFragmentHandler:
         """Upsert many fragments at the caller's own user scope, with per-item partial
         success (auth).
 
-        (Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)
+        Not in effect yet: still all-or-nothing.
         """
         result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/app_config_fragment/handler.py
@@ -94,7 +94,10 @@ class V2AppConfigFragmentHandler:
         self,
         body: BodyParam[ScopedUpsertAppConfigFragmentsInput],
     ) -> APIResponse:
-        """Upsert many fragments at one scope, all-or-nothing (auth, RBAC-authorized)."""
+        """Upsert many fragments at one scope, with per-item partial success (auth, RBAC).
+
+        (Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)
+        """
         result = await self._adapter.scoped_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
@@ -102,6 +105,10 @@ class V2AppConfigFragmentHandler:
         self,
         body: BodyParam[MyUpsertAppConfigFragmentsInput],
     ) -> APIResponse:
-        """Upsert many fragments at the caller's own user scope, all-or-nothing (auth)."""
+        """Upsert many fragments at the caller's own user scope, with per-item partial
+        success (auth).
+
+        (Partial success is not in effect yet: the upsert is still all-or-nothing. To be fixed.)
+        """
         result = await self._adapter.my_upsert_app_config_fragments(body.parsed)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -76,8 +76,7 @@ class AppConfigFragmentUpsertBulkResult:
     ``items`` are the fragments inserted or replaced; ``failed`` are the items whose
     write was rejected (e.g. no allow-list row), each named by its config name.
 
-    (Not in effect yet: the upsert is still all-or-nothing, so ``failed`` is always empty.
-    To be fixed.)
+    Not in effect yet: the upsert is still all-or-nothing.
     """
 
     items: list[AppConfigFragmentData]

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -55,3 +55,27 @@ class AppConfigFragmentBulkResult:
 
     succeeded: list[AppConfigFragmentData]
     failed: list[AppConfigFragmentBulkItemError]
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentUpsertItemError:
+    """One rejected item of a bulk upsert: the config name it targeted and a reason.
+
+    A rejected insert never had a fragment id, so the config name is what identifies the
+    item — the batch shares one scope, and a scope holds at most one fragment per name.
+    """
+
+    config_name: str
+    message: str
+
+
+@dataclass(frozen=True)
+class AppConfigFragmentUpsertBulkResult:
+    """Result of a bulk upsert.
+
+    ``succeeded`` are the fragments inserted or replaced; ``failed`` are the items whose
+    write was rejected (e.g. no allow-list row), each named by its config name.
+    """
+
+    succeeded: list[AppConfigFragmentData]
+    failed: list[AppConfigFragmentUpsertItemError]

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -73,12 +73,12 @@ class AppConfigFragmentUpsertItemError:
 class AppConfigFragmentUpsertBulkResult:
     """Partial-success result of a bulk upsert.
 
-    ``succeeded`` are the fragments inserted or replaced; ``failed`` are the items whose
+    ``items`` are the fragments inserted or replaced; ``failed`` are the items whose
     write was rejected (e.g. no allow-list row), each named by its config name.
 
     (Not in effect yet: the upsert is still all-or-nothing, so ``failed`` is always empty.
     To be fixed.)
     """
 
-    succeeded: list[AppConfigFragmentData]
+    items: list[AppConfigFragmentData]
     failed: list[AppConfigFragmentUpsertItemError]

--- a/src/ai/backend/manager/data/app_config_fragment/types.py
+++ b/src/ai/backend/manager/data/app_config_fragment/types.py
@@ -59,7 +59,7 @@ class AppConfigFragmentBulkResult:
 
 @dataclass(frozen=True)
 class AppConfigFragmentUpsertItemError:
-    """One rejected item of a bulk upsert: the config name it targeted and a reason.
+    """One failed item of a partial bulk upsert: the config name it targeted and a reason.
 
     A rejected insert never had a fragment id, so the config name is what identifies the
     item — the batch shares one scope, and a scope holds at most one fragment per name.
@@ -71,10 +71,13 @@ class AppConfigFragmentUpsertItemError:
 
 @dataclass(frozen=True)
 class AppConfigFragmentUpsertBulkResult:
-    """Result of a bulk upsert.
+    """Partial-success result of a bulk upsert.
 
     ``succeeded`` are the fragments inserted or replaced; ``failed`` are the items whose
     write was rejected (e.g. no allow-list row), each named by its config name.
+
+    (Not in effect yet: the upsert is still all-or-nothing, so ``failed`` is always empty.
+    To be fixed.)
     """
 
     succeeded: list[AppConfigFragmentData]

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -108,7 +108,7 @@ class AppConfigFragmentDBSource:
                     ),
                 )
                 results.append((await w.upsert_scoped(upserter)).row.to_data())
-            return AppConfigFragmentUpsertBulkResult(succeeded=results, failed=[])
+            return AppConfigFragmentUpsertBulkResult(items=results, failed=[])
 
     @app_config_fragment_db_source_resilience.apply()
     async def get_by_id(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentData:

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -85,8 +85,7 @@ class AppConfigFragmentDBSource:
         """Upsert each fragment at its scope in one transaction (all-or-nothing).
 
         Each item inserts-or-updates; a newly inserted row binds to its scope, an updated one
-        keeps its binding. A ``public`` fragment is GLOBAL, so it binds to no scope. One
-        transaction covers the batch, so a rejected item raises and no item is reported failed.
+        keeps its binding. A ``public`` fragment is GLOBAL, so it binds to no scope.
         """
         async with self._rbac_ops_provider.write_ops() as w:
             results: list[AppConfigFragmentData] = []

--- a/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/db_source/db_source.py
@@ -20,6 +20,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
+    AppConfigFragmentUpsertBulkResult,
 )
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.errors.app_config import (
@@ -80,11 +81,12 @@ class AppConfigFragmentDBSource:
     @app_config_fragment_db_source_resilience.apply()
     async def bulk_upsert(
         self, specs: Sequence[AppConfigFragmentUpserterSpec]
-    ) -> list[AppConfigFragmentData]:
+    ) -> AppConfigFragmentUpsertBulkResult:
         """Upsert each fragment at its scope in one transaction (all-or-nothing).
 
         Each item inserts-or-updates; a newly inserted row binds to its scope, an updated one
-        keeps its binding. A ``public`` fragment is GLOBAL, so it binds to no scope.
+        keeps its binding. A ``public`` fragment is GLOBAL, so it binds to no scope. One
+        transaction covers the batch, so a rejected item raises and no item is reported failed.
         """
         async with self._rbac_ops_provider.write_ops() as w:
             results: list[AppConfigFragmentData] = []
@@ -106,7 +108,7 @@ class AppConfigFragmentDBSource:
                     ),
                 )
                 results.append((await w.upsert_scoped(upserter)).row.to_data())
-            return results
+            return AppConfigFragmentUpsertBulkResult(succeeded=results, failed=[])
 
     @app_config_fragment_db_source_resilience.apply()
     async def get_by_id(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentData:

--- a/src/ai/backend/manager/repositories/app_config_fragment/repository.py
+++ b/src/ai/backend/manager/repositories/app_config_fragment/repository.py
@@ -14,6 +14,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
+    AppConfigFragmentUpsertBulkResult,
 )
 from ai.backend.manager.models.scopes import SearchScope
 from ai.backend.manager.repositories.app_config_fragment.db_source import (
@@ -63,7 +64,7 @@ class AppConfigFragmentRepository:
     @app_config_fragment_repository_resilience.apply()
     async def bulk_upsert(
         self, specs: Sequence[AppConfigFragmentUpserterSpec]
-    ) -> list[AppConfigFragmentData]:
+    ) -> AppConfigFragmentUpsertBulkResult:
         return await self._db_source.bulk_upsert(specs)
 
     @app_config_fragment_repository_resilience.apply()

--- a/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
@@ -5,7 +5,10 @@ from typing import override
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.app_config_fragment.types import AppConfigFragmentData
+from ai.backend.manager.data.app_config_fragment.types import (
+    AppConfigFragmentData,
+    AppConfigFragmentUpsertItemError,
+)
 from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.repositories.app_config_fragment.types import (
     AppConfigFragmentSearchScope,
@@ -55,7 +58,8 @@ class BulkUpsertAppConfigFragmentsAction(AppConfigFragmentScopeAction):
 
 @dataclass
 class BulkUpsertAppConfigFragmentsActionResult(AppConfigFragmentScopeActionResult):
-    fragments: list[AppConfigFragmentData]
+    succeeded: list[AppConfigFragmentData]
+    failed: list[AppConfigFragmentUpsertItemError]
     #: The scope the upsert ran at, carried only to report the RBAC scope.
     _scope: AppConfigFragmentSearchScope
 

--- a/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
@@ -24,7 +24,7 @@ from ai.backend.manager.services.app_config_fragment.actions.base import (
 
 @dataclass
 class BulkUpsertAppConfigFragmentsAction(AppConfigFragmentScopeAction):
-    """Upsert many fragments at one scope (RBAC-authorized at that scope).
+    """Upsert many fragments at one scope.
 
     Every item shares ``scope``, so the RBAC gate is the write permission at that single
     scope — the same gate a create at that scope crosses.

--- a/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config_fragment/actions/bulk_upsert.py
@@ -58,7 +58,7 @@ class BulkUpsertAppConfigFragmentsAction(AppConfigFragmentScopeAction):
 
 @dataclass
 class BulkUpsertAppConfigFragmentsActionResult(AppConfigFragmentScopeActionResult):
-    succeeded: list[AppConfigFragmentData]
+    items: list[AppConfigFragmentData]
     failed: list[AppConfigFragmentUpsertItemError]
     #: The scope the upsert ran at, carried only to report the RBAC scope.
     _scope: AppConfigFragmentSearchScope

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -53,8 +53,10 @@ class AppConfigFragmentService:
     async def bulk_upsert(
         self, action: BulkUpsertAppConfigFragmentsAction
     ) -> BulkUpsertAppConfigFragmentsActionResult:
-        fragments = await self._repository.bulk_upsert(action.upserter_specs)
-        return BulkUpsertAppConfigFragmentsActionResult(fragments=fragments, _scope=action.scope)
+        result = await self._repository.bulk_upsert(action.upserter_specs)
+        return BulkUpsertAppConfigFragmentsActionResult(
+            succeeded=result.succeeded, failed=result.failed, _scope=action.scope
+        )
 
     async def admin_search(
         self, action: AdminSearchAppConfigFragmentAction

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -55,7 +55,7 @@ class AppConfigFragmentService:
     ) -> BulkUpsertAppConfigFragmentsActionResult:
         result = await self._repository.bulk_upsert(action.upserter_specs)
         return BulkUpsertAppConfigFragmentsActionResult(
-            succeeded=result.succeeded, failed=result.failed, _scope=action.scope
+            items=result.items, failed=result.failed, _scope=action.scope
         )
 
     async def admin_search(

--- a/tests/unit/client_v2/test_app_config_fragment.py
+++ b/tests/unit/client_v2/test_app_config_fragment.py
@@ -122,7 +122,10 @@ class TestScopedBulkUpsert:
         node_payload: dict[str, Any],
     ) -> None:
         mock_response.json = AsyncMock(
-            return_value={"items": [node_payload]},
+            return_value={
+                "items": [node_payload],
+                "failed": [{"config_name": "menu", "message": "not allowed"}],
+            },
         )
 
         result = await client.scoped_bulk_upsert_app_config_fragments(
@@ -140,6 +143,9 @@ class TestScopedBulkUpsert:
         assert str(call_args[0][1]).endswith("/v2/app-config-fragments/scoped/bulk-upsert")
         assert isinstance(result, UpsertAppConfigFragmentsPayload)
         assert [item.config_name for item in result.items] == ["theme"]
+        assert [(error.config_name, error.message) for error in result.failed] == [
+            ("menu", "not allowed")
+        ]
 
 
 class TestMyByNames:
@@ -172,7 +178,7 @@ class TestMyBulkUpsert:
         node_payload: dict[str, Any],
     ) -> None:
         mock_response.json = AsyncMock(
-            return_value={"items": [node_payload]},
+            return_value={"items": [node_payload], "failed": []},
         )
 
         result = await client.my_bulk_upsert_app_config_fragments(

--- a/tests/unit/manager/api/gql/test_app_config_fragment_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_fragment_types.py
@@ -85,7 +85,7 @@ class TestUpsertAppConfigFragmentsPayloadGQL:
             failed=[AppConfigFragmentUpsertErrorInfo(config_name="menu", message="not allowed")],
         )
 
-        gql = UpsertAppConfigFragmentsPayloadGQL.from_payload(payload)
+        gql = UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
 
         assert [item.config_name for item in gql.items] == ["theme"]
         assert cast(dict[str, Any], gql.items[0].config) == {"mode": "dark"}

--- a/tests/unit/manager/api/gql/test_app_config_fragment_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_fragment_types.py
@@ -9,6 +9,8 @@ from typing import Any, cast
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.dto.manager.v2.app_config_fragment.response import (
     AppConfigFragmentNode,
+    AppConfigFragmentUpsertErrorInfo,
+    UpsertAppConfigFragmentsPayload,
 )
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     AppConfigFragmentOrderField,
@@ -21,6 +23,7 @@ from ai.backend.manager.api.gql.app_config_fragment.types import (
     AppConfigFragmentOrderByGQL,
     AppConfigFragmentOrderFieldGQL,
     AppConfigScopeTypeFilterGQL,
+    UpsertAppConfigFragmentsPayloadGQL,
 )
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter
 
@@ -64,6 +67,31 @@ class TestAppConfigFragmentGQL:
 
         assert gql.scope_type == AppConfigScopeType.PUBLIC
         assert gql.scope_id is None
+
+
+class TestUpsertAppConfigFragmentsPayloadGQL:
+    def test_from_pydantic_converts_items_and_failures(self) -> None:
+        node = AppConfigFragmentNode(
+            id=AppConfigFragmentID(uuid.uuid4()),
+            config_name="theme",
+            scope_type=AppConfigScopeType.USER,
+            scope_id=AppConfigScopeID(uuid.uuid4()),
+            config={"mode": "dark"},
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        payload = UpsertAppConfigFragmentsPayload(
+            items=[node],
+            failed=[AppConfigFragmentUpsertErrorInfo(config_name="menu", message="not allowed")],
+        )
+
+        gql = UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
+
+        assert [item.config_name for item in gql.items] == ["theme"]
+        assert cast(dict[str, Any], gql.items[0].config) == {"mode": "dark"}
+        assert [(error.config_name, error.message) for error in gql.failed] == [
+            ("menu", "not allowed")
+        ]
 
 
 class TestAppConfigFragmentInputs:

--- a/tests/unit/manager/api/gql/test_app_config_fragment_types.py
+++ b/tests/unit/manager/api/gql/test_app_config_fragment_types.py
@@ -85,7 +85,7 @@ class TestUpsertAppConfigFragmentsPayloadGQL:
             failed=[AppConfigFragmentUpsertErrorInfo(config_name="menu", message="not allowed")],
         )
 
-        gql = UpsertAppConfigFragmentsPayloadGQL.from_pydantic(payload)
+        gql = UpsertAppConfigFragmentsPayloadGQL.from_payload(payload)
 
         assert [item.config_name for item in gql.items] == ["theme"]
         assert cast(dict[str, Any], gql.items[0].config) == {"mode": "dark"}

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -796,7 +796,7 @@ class TestRBACScopeAssociation:
             )
         ])
         assert (
-            await self._scope_bindings(database, str(upserted.succeeded[0].id))
+            await self._scope_bindings(database, str(upserted.items[0].id))
             == case.expected_bindings
         )
 
@@ -836,7 +836,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        created = upserted.succeeded[0]
+        created = upserted.items[0]
         assert await self._scope_bindings(database, str(created.id)) == case.expected_bindings
         purged = await repository.purge(AppConfigFragmentPurgerSpec(fragment_id=created.id))
         assert purged.id == created.id
@@ -861,7 +861,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        created = upserted.succeeded[0]
+        created = upserted.items[0]
         assert await self._scope_bindings(database, str(created.id)) == [
             _ScopeBinding(scope_type=ScopeType.USER, scope_id=str(_USER_ID))
         ]
@@ -916,7 +916,7 @@ class TestUpsert:
         ])
 
         assert result.failed == []
-        upserted = result.succeeded
+        upserted = result.items
         assert [(f.config_name, f.scope_type, f.scope_id) for f in upserted] == [
             ("theme", case.scope_type, case.scope_id)
         ]
@@ -978,7 +978,7 @@ class TestUpsert:
         ])
 
         assert result.failed == []
-        upserted = result.succeeded
+        upserted = result.items
         assert [f.id for f in upserted] == [existing.id]
         assert upserted[0].config == {"theme": "light"}
         async with database.begin_readonly_session() as db_sess:
@@ -1033,7 +1033,7 @@ class TestUpsert:
         ])
 
         assert result.failed == []
-        assert [(f.scope_type, f.config) for f in result.succeeded] == [
+        assert [(f.scope_type, f.config) for f in result.items] == [
             (AppConfigScopeType.PUBLIC, {"theme": "light"}),
             (AppConfigScopeType.USER, {"theme": "solarized"}),
         ]
@@ -1091,5 +1091,5 @@ class TestUpsert:
         self, repository: AppConfigFragmentRepository, theme_registered: None
     ) -> None:
         result = await repository.bulk_upsert([])
-        assert result.succeeded == []
+        assert result.items == []
         assert result.failed == []

--- a/tests/unit/manager/repositories/app_config_fragment/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_fragment/test_repository.py
@@ -795,7 +795,10 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        assert await self._scope_bindings(database, str(upserted[0].id)) == case.expected_bindings
+        assert (
+            await self._scope_bindings(database, str(upserted.succeeded[0].id))
+            == case.expected_bindings
+        )
 
     @pytest.mark.parametrize(
         "case",
@@ -833,7 +836,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        created = upserted[0]
+        created = upserted.succeeded[0]
         assert await self._scope_bindings(database, str(created.id)) == case.expected_bindings
         purged = await repository.purge(AppConfigFragmentPurgerSpec(fragment_id=created.id))
         assert purged.id == created.id
@@ -858,7 +861,7 @@ class TestRBACScopeAssociation:
                 config={"k": "v"},
             )
         ])
-        created = upserted[0]
+        created = upserted.succeeded[0]
         assert await self._scope_bindings(database, str(created.id)) == [
             _ScopeBinding(scope_type=ScopeType.USER, scope_id=str(_USER_ID))
         ]
@@ -903,7 +906,7 @@ class TestUpsert:
         case: _FragmentScopeCase,
     ) -> None:
         """An insert binds the new row to its RBAC scope, exactly as a create does."""
-        upserted = await repository.bulk_upsert([
+        result = await repository.bulk_upsert([
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
                 scope_type=case.scope_type,
@@ -912,6 +915,8 @@ class TestUpsert:
             )
         ])
 
+        assert result.failed == []
+        upserted = result.succeeded
         assert [(f.config_name, f.scope_type, f.scope_id) for f in upserted] == [
             ("theme", case.scope_type, case.scope_id)
         ]
@@ -963,7 +968,7 @@ class TestUpsert:
         """
         existing = fragment_at_every_scope[case.scope_type]
 
-        upserted = await repository.bulk_upsert([
+        result = await repository.bulk_upsert([
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
                 scope_type=case.scope_type,
@@ -972,6 +977,8 @@ class TestUpsert:
             )
         ])
 
+        assert result.failed == []
+        upserted = result.succeeded
         assert [f.id for f in upserted] == [existing.id]
         assert upserted[0].config == {"theme": "light"}
         async with database.begin_readonly_session() as db_sess:
@@ -1010,7 +1017,7 @@ class TestUpsert:
             )
         ])
 
-        upserted = await repository.bulk_upsert([
+        result = await repository.bulk_upsert([
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
                 scope_type=AppConfigScopeType.PUBLIC,
@@ -1025,7 +1032,8 @@ class TestUpsert:
             ),
         ])
 
-        assert [(f.scope_type, f.config) for f in upserted] == [
+        assert result.failed == []
+        assert [(f.scope_type, f.config) for f in result.succeeded] == [
             (AppConfigScopeType.PUBLIC, {"theme": "light"}),
             (AppConfigScopeType.USER, {"theme": "solarized"}),
         ]
@@ -1082,4 +1090,6 @@ class TestUpsert:
     async def test_upsert_of_no_items_writes_nothing(
         self, repository: AppConfigFragmentRepository, theme_registered: None
     ) -> None:
-        assert await repository.bulk_upsert([]) == []
+        result = await repository.bulk_upsert([])
+        assert result.succeeded == []
+        assert result.failed == []

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -19,6 +19,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
+    AppConfigFragmentUpsertBulkResult,
 )
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
@@ -145,7 +146,9 @@ class TestAppConfigFragmentService:
         scoped_fragment: AppConfigFragmentData,
         case: _RBACScopeCase,
     ) -> None:
-        mock_repository.bulk_upsert = AsyncMock(return_value=[scoped_fragment])
+        mock_repository.bulk_upsert = AsyncMock(
+            return_value=AppConfigFragmentUpsertBulkResult(succeeded=[scoped_fragment], failed=[])
+        )
         specs = [
             AppConfigFragmentUpserterSpec(
                 config_name="theme",
@@ -160,7 +163,8 @@ class TestAppConfigFragmentService:
             BulkUpsertAppConfigFragmentsAction(scope=scope, upserter_specs=specs)
         )
 
-        assert result.fragments == [scoped_fragment]
+        assert result.succeeded == [scoped_fragment]
+        assert result.failed == []
         # The result reports the RBAC scope the upsert was authorized at.
         assert result.scope_type() == case.expected_scope_type
         assert result.scope_id() == case.expected_scope_id

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -147,7 +147,7 @@ class TestAppConfigFragmentService:
         case: _RBACScopeCase,
     ) -> None:
         mock_repository.bulk_upsert = AsyncMock(
-            return_value=AppConfigFragmentUpsertBulkResult(succeeded=[scoped_fragment], failed=[])
+            return_value=AppConfigFragmentUpsertBulkResult(items=[scoped_fragment], failed=[])
         )
         specs = [
             AppConfigFragmentUpserterSpec(
@@ -163,7 +163,7 @@ class TestAppConfigFragmentService:
             BulkUpsertAppConfigFragmentsAction(scope=scope, upserter_specs=specs)
         )
 
-        assert result.succeeded == [scoped_fragment]
+        assert result.items == [scoped_fragment]
         assert result.failed == []
         # The result reports the RBAC scope the upsert was authorized at.
         assert result.scope_type() == case.expected_scope_type

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -20,6 +20,7 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentData,
     AppConfigFragmentSearchResult,
     AppConfigFragmentUpsertBulkResult,
+    AppConfigFragmentUpsertItemError,
 )
 from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
@@ -72,6 +73,12 @@ class _ScopedSearchCase:
 
     scope: AppConfigFragmentSearchScope
     expected_rbac_scope_id: str
+
+
+@pytest.fixture
+def rejected_upsert_item() -> AppConfigFragmentUpsertItemError:
+    """One rejected item for the repository mock to return alongside the written fragment."""
+    return AppConfigFragmentUpsertItemError(config_name="menu", message="not allow-listed")
 
 
 @pytest.fixture
@@ -144,10 +151,13 @@ class TestAppConfigFragmentService:
         service: AppConfigFragmentService,
         mock_repository: MagicMock,
         scoped_fragment: AppConfigFragmentData,
+        rejected_upsert_item: AppConfigFragmentUpsertItemError,
         case: _RBACScopeCase,
     ) -> None:
         mock_repository.bulk_upsert = AsyncMock(
-            return_value=AppConfigFragmentUpsertBulkResult(items=[scoped_fragment], failed=[])
+            return_value=AppConfigFragmentUpsertBulkResult(
+                items=[scoped_fragment], failed=[rejected_upsert_item]
+            )
         )
         specs = [
             AppConfigFragmentUpserterSpec(
@@ -164,7 +174,7 @@ class TestAppConfigFragmentService:
         )
 
         assert result.items == [scoped_fragment]
-        assert result.failed == []
+        assert result.failed == [rejected_upsert_item]
         # The result reports the RBAC scope the upsert was authorized at.
         assert result.scope_type() == case.expected_scope_type
         assert result.scope_id() == case.expected_scope_id


### PR DESCRIPTION
Part of #13560 (BA-7250) — the issue is closed by #13563, which adds the behavior on top of this shape.

## Summary
- The scoped and my bulk fragment upserts (`scopedUpsertAppConfigFragments` / `myUpsertAppConfigFragments`, REST v2 `bulk-upsert`) answered with a bare list of fragments, so a response had no place to name an item whose write was rejected.
- Give the upsert its own result type (`items` + `failed`) and thread it end to end: db source → repository → action result → DTO → adapter → GraphQL payload. A failed item is named by its `config_name`, since a rejected insert never had a fragment id and the batch shares one scope, which holds at most one fragment per name.
- Behavior is unchanged. The db source still upserts the batch in one transaction, so a rejected item raises and `failed` stays empty. Every description that promises partial success says so in parentheses, and the note comes out with the behavior.
- **Dated to 26.9.0, not backported.** 26.8.0 shipped these mutations answering with a bare list of fragments (`f4be60f690`). That shape is not being backported, so no release will ever carry the contract the schema claimed for 26.8.0 — the two mutations and their upsert-only input types are dated to the next release instead, and the changelog entry is a feature. The `approved-breaking-change` label stays: graphql-inspector still sees a changed return type against `main`.

## Test plan
- [x] `tests/unit/manager/api/gql/test_app_config_fragment_types.py` — payload DTO converts items and failures to GraphQL
- [x] `tests/unit/client_v2/test_app_config_fragment.py` — SDK parses the payload with and without failures
- [x] `tests/unit/manager/services/app_config_fragment/test_service.py` — the action result carries `items` and `failed`
- [x] `tests/unit/manager/repositories/app_config_fragment/test_repository.py` — the upsert result reports the fragments written, and a rejected item still raises

## Follow-up
The per-item partial success behavior itself — swapping the all-or-nothing loop for the RBAC ops partial upsert primitive — lands in #13563, on top of #13572. With this PR merged, that change touches only the db source, the caveat notes, and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13580.org.readthedocs.build/en/13580/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13580.org.readthedocs.build/ko/13580/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13580.org.readthedocs.build/en/13580/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13580.org.readthedocs.build/ko/13580/

<!-- readthedocs-preview sorna-ko end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13580.org.readthedocs.build/en/13580/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13580.org.readthedocs.build/ko/13580/

<!-- readthedocs-preview sorna-ko end -->



<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13580.org.readthedocs.build/en/13580/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13580.org.readthedocs.build/ko/13580/

<!-- readthedocs-preview sorna-ko end -->