### PR TITLE
test: fix pre-existing repository test fixture failures

### DIFF
--- a/tests/unit/manager/repositories/domain/test_domain_repository.py
+++ b/tests/unit/manager/repositories/domain/test_domain_repository.py
@@ -219,7 +219,7 @@ class TestDomainRepository:
                 "domain_name": "sample-domain",
                 "is_active": True,
                 "created_at": datetime.now(tz=UTC),
-                "modified_at": datetime.now(tz=UTC),
+                "updated_at": datetime.now(tz=UTC),
                 "type": ProjectType.GENERAL,
                 "total_resource_slots": ResourceSlot(),
                 "allowed_vfolder_hosts": VFolderHostPermissionMap(),

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -47,6 +47,7 @@ from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.group.db_source import GroupDBSource
 from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
@@ -100,6 +101,7 @@ class TestRoleAssignment:
                 ResourcePresetRow,
                 VirtualScopeRow,
                 EntityMembershipRow,
+                ScopeBindingRow,
             ],
         ):
             yield database_connection
@@ -202,6 +204,7 @@ class TestRoleAssignment:
                     resource_policy=policy_name,
                 )
             )
+            session.add(VirtualScopeRow(scope_type=ScopeType.USER.value, scope_id=user_uuid))
             await session.commit()
         return user_uuid
 


### PR DESCRIPTION
## Summary
- Fix the domain repository fixture inserting a nonexistent `modified_at` column into `groups` (the actual column is `updated_at`), which failed every dependent test with `CompileError: Unconsumed column names`.
- Provision the USER virtual scope in the role assignment user fixture so `bind/unbind_user_to_project` no longer raises `VirtualScopeNotFound`, and add `ScopeBindingRow` to `with_tables`.

## Test plan
- [x] `pants test tests/unit/manager/repositories/domain/test_domain_repository.py` passes
- [x] `pants test tests/unit/manager/repositories/permission_controller/test_role_assignment.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)