### PR TITLE
feat(BA-7275): replace CUDA runtime API with driver API in cuda_open plugin

### DIFF
--- a/changes/13599.enhance.md
+++ b/changes/13599.enhance.md
@@ -1,0 +1,1 @@
+Drop the CUDA toolkit (`libcudart`) requirement of the open-source CUDA plugin by querying devices through the CUDA driver API (`libcuda`) and NVML, enabling toolkit-free containerized agent deployments

--- a/docs/install/install-from-package/os-preparation.rst
+++ b/docs/install/install-from-package/os-preparation.rst
@@ -246,8 +246,12 @@ set up and working. Please refer to the vendor documentation for the details.
 
 - To integrate NVIDIA GPUs,
 
-   - Install the NVIDIA driver and CUDA toolkit.
-   - Install the NVIDIA container toolkit (nvidia-docker2).
+   - Install the NVIDIA driver. The open-source CUDA plugin talks to the
+     driver directly via the CUDA driver API, so the CUDA toolkit is *not*
+     required on the host. Install the toolkit only if you need it for other
+     purposes (e.g., compiling CUDA programs on the host).
+   - Install the NVIDIA container toolkit (nvidia-docker2) for containerized
+     deployments so that containers can access the GPUs.
 
 
 Pull container images

--- a/src/ai/backend/accelerator/cuda_open/nvidia.py
+++ b/src/ai/backend/accelerator/cuda_open/nvidia.py
@@ -3,48 +3,11 @@ from __future__ import annotations
 import ctypes
 import platform
 from abc import ABCMeta, abstractmethod
-from collections.abc import MutableMapping, Sequence
-from itertools import groupby
-from operator import itemgetter
-from typing import Any, NamedTuple, cast
+from collections.abc import MutableMapping
+from typing import Any, NamedTuple
 
-# ref: https://developer.nvidia.com/cuda-toolkit-archive
-TARGET_CUDA_VERSIONS = (
-    (13, 0),
-    (12, 9),
-    (12, 8),
-    (12, 7),
-    (12, 6),
-    (12, 5),
-    (12, 4),
-    (12, 3),
-    (12, 2),
-    (12, 1),
-    (12, 0),
-    (11, 8),
-    (11, 7),
-    (11, 6),
-    (11, 5),
-    (11, 4),
-    (11, 3),
-    (11, 2),
-    (11, 1),
-    (11, 0),
-    (10, 2),
-    (10, 1),
-    (10, 0),
-    (9, 2),
-    (9, 1),
-    (9, 0),
-    (8, 0),
-    (7, 5),
-    (7, 0),
-    (6, 5),
-    (6, 0),
-    (5, 5),
-    (5, 0),
-    # older versions are not supported
-)
+# ref: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__DEVICE.html
+CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16
 
 
 class LibraryError(RuntimeError):
@@ -64,460 +27,6 @@ class LibraryError(RuntimeError):
     def __repr__(self) -> str:
         args = ", ".join(map(repr, self.args))
         return f"LibraryError({args})"
-
-
-class cudaDeviceProp_v13(ctypes.Structure):
-    _fields_ = [
-        ("name", ctypes.c_char * 256),
-        ("uuid", ctypes.c_byte * 16),  # cudaUUID_t
-        ("luid", ctypes.c_byte * 8),
-        ("luidDeviceNodeMask", ctypes.c_uint),
-        ("totalGlobalMem", ctypes.c_size_t),
-        ("sharedMemPerBlock", ctypes.c_size_t),
-        ("regsPerBlock", ctypes.c_int),
-        ("warpSize", ctypes.c_int),
-        ("memPitch", ctypes.c_size_t),
-        ("maxThreadsPerBlock", ctypes.c_int),
-        ("maxThreadsDim", ctypes.c_int * 3),
-        ("maxGridSize", ctypes.c_int * 3),
-        ("totalConstMem", ctypes.c_size_t),
-        ("major", ctypes.c_int),
-        ("minor", ctypes.c_int),
-        ("textureAlignment", ctypes.c_size_t),
-        ("texturePitchAlignment", ctypes.c_size_t),
-        ("multiProcessorCount", ctypes.c_int),
-        ("integrated", ctypes.c_int),
-        ("canMapHostMemory", ctypes.c_int),
-        ("maxTexture1D", ctypes.c_int),
-        ("maxTexture1DMipmap", ctypes.c_int),
-        ("maxTexture2D", ctypes.c_int * 2),
-        ("maxTexture2DMipmap", ctypes.c_int * 2),
-        ("maxTexture2DLinear", ctypes.c_int * 3),
-        ("maxTexture2DGather", ctypes.c_int * 2),
-        ("maxTexture3D", ctypes.c_int * 3),
-        ("maxTexture3DAlt", ctypes.c_int * 3),
-        ("maxTextureCubemap", ctypes.c_int),
-        ("maxTexture1DLayered", ctypes.c_int * 2),
-        ("maxTexture2DLayered", ctypes.c_int * 3),
-        ("maxTextureCubemapLayered", ctypes.c_int * 2),
-        ("maxSurface1D", ctypes.c_int),
-        ("maxSurface2D", ctypes.c_int * 2),
-        ("maxSurface3D", ctypes.c_int * 3),
-        ("maxSurface1DLayered", ctypes.c_int * 2),
-        ("maxSurface2DLayered", ctypes.c_int * 3),
-        ("maxSurfaceCubemap", ctypes.c_int),
-        ("maxSurfaceCubemapLayered", ctypes.c_int * 2),
-        ("surfaceAlignment", ctypes.c_size_t),
-        ("concurrentKernels", ctypes.c_int),
-        ("ECCEnabled", ctypes.c_int),
-        ("pciBusID", ctypes.c_int),
-        ("pciDeviceID", ctypes.c_int),
-        ("pciDomainID", ctypes.c_int),
-        ("tccDriver", ctypes.c_int),
-        ("asyncEngineCount", ctypes.c_int),
-        ("unifiedAddressing", ctypes.c_int),
-        ("memoryBusWidth", ctypes.c_int),
-        ("l2CacheSize", ctypes.c_int),
-        ("persistingL2CacheMaxSize", ctypes.c_int),
-        ("maxThreadsPerMultiProcessor", ctypes.c_int),
-        ("streamPrioritiesSupported", ctypes.c_int),
-        ("globalL1CacheSupported", ctypes.c_int),
-        ("localL1CacheSupported", ctypes.c_int),
-        ("sharedMemPerMultiprocessor", ctypes.c_size_t),
-        ("regsPerMultiprocessor", ctypes.c_int),
-        ("managedMemory", ctypes.c_int),
-        ("isMultiGpuBoard", ctypes.c_int),
-        ("multiGpuBoardGroupID", ctypes.c_int),
-        ("hostNativeAtomicSupported", ctypes.c_int),
-        ("pageableMemoryAccess", ctypes.c_int),
-        ("concurrentManagedAccess", ctypes.c_int),
-        ("computePreemptionSupported", ctypes.c_int),
-        ("canUseHostPointerForRegisteredMem", ctypes.c_int),
-        ("cooperativeLaunch", ctypes.c_int),
-        ("sharedMemPerBlockOptin", ctypes.c_size_t),
-        ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
-        ("directManagedMemAccessFromHost", ctypes.c_int),
-        ("maxBlocksPerMultiProcessor", ctypes.c_int),
-        ("accessPolicyMaxWindowSize", ctypes.c_int),
-        ("reservedSharedMemPerBlock", ctypes.c_size_t),
-        ("hostRegisterSupported", ctypes.c_int),
-        ("sparseCudaArraySupported", ctypes.c_int),
-        ("hostRegisterReadOnlySupported", ctypes.c_int),
-        ("timelineSemaphoreInteropSupported", ctypes.c_int),
-        ("memoryPoolsSupported", ctypes.c_int),
-        ("gpuDirectRDMASupported", ctypes.c_int),
-        ("gpuDirectRDMAFlushWritesOptions", ctypes.c_uint),
-        ("gpuDirectRDMAWritesOrdering", ctypes.c_int),
-        ("memoryPoolSupportedHandleTypes", ctypes.c_uint),
-        ("deferredMappingCudaArraySupported", ctypes.c_int),
-        ("ipcEventSupported", ctypes.c_int),
-        ("clusterLaunch", ctypes.c_int),
-        ("unifiedFunctionPointers", ctypes.c_int),
-        ("deviceNumaConfig", ctypes.c_int),
-        ("deviceNumaId", ctypes.c_int),
-        ("mpsEnabled", ctypes.c_int),
-        ("hostNumaId", ctypes.c_int),
-        ("gpuPciDeviceID", ctypes.c_uint),
-        ("gpuPciSubsystemID", ctypes.c_uint),
-        ("hostNumaMultinodeIpcSupported", ctypes.c_int),
-        ("reserved", ctypes.c_int * 56),
-    ]
-
-
-class cudaDeviceProp_v12(ctypes.Structure):
-    _fields_ = [
-        ("name", ctypes.c_char * 256),
-        ("uuid", ctypes.c_byte * 16),  # cudaUUID_t
-        ("luid", ctypes.c_byte * 8),
-        ("luidDeviceNodeMask", ctypes.c_uint),
-        ("totalGlobalMem", ctypes.c_size_t),
-        ("sharedMemPerBlock", ctypes.c_size_t),
-        ("regsPerBlock", ctypes.c_int),
-        ("warpSize", ctypes.c_int),
-        ("memPitch", ctypes.c_size_t),
-        ("maxThreadsPerBlock", ctypes.c_int),
-        ("maxThreadsDim", ctypes.c_int * 3),
-        ("maxGridSize", ctypes.c_int * 3),
-        ("clockRate", ctypes.c_int),
-        ("totalConstMem", ctypes.c_size_t),
-        ("major", ctypes.c_int),
-        ("minor", ctypes.c_int),
-        ("textureAlignment", ctypes.c_size_t),
-        ("texturePitchAlignment", ctypes.c_size_t),
-        ("deviceOverlap", ctypes.c_int),
-        ("multiProcessorCount", ctypes.c_int),
-        ("kernelExecTimeoutEnabled", ctypes.c_int),
-        ("integrated", ctypes.c_int),
-        ("canMapHostMemory", ctypes.c_int),
-        ("computeMode", ctypes.c_int),
-        ("maxTexture1D", ctypes.c_int),
-        ("maxTexture1DMipmap", ctypes.c_int),
-        ("maxTexture1DLinear", ctypes.c_int),
-        ("maxTexture2D", ctypes.c_int * 2),
-        ("maxTexture2DMipmap", ctypes.c_int * 2),
-        ("maxTexture2DLinear", ctypes.c_int * 3),
-        ("maxTexture2DGather", ctypes.c_int * 2),
-        ("maxTexture3D", ctypes.c_int * 3),
-        ("maxTexture3DAlt", ctypes.c_int * 3),
-        ("maxTextureCubemap", ctypes.c_int),
-        ("maxTexture1DLayered", ctypes.c_int * 2),
-        ("maxTexture2DLayered", ctypes.c_int * 3),
-        ("maxTextureCubemapLayered", ctypes.c_int * 2),
-        ("maxSurface1D", ctypes.c_int),
-        ("maxSurface2D", ctypes.c_int * 2),
-        ("maxSurface3D", ctypes.c_int * 3),
-        ("maxSurface1DLayered", ctypes.c_int * 2),
-        ("maxSurface2DLayered", ctypes.c_int * 3),
-        ("maxSurfaceCubemap", ctypes.c_int),
-        ("maxSurfaceCubemapLayered", ctypes.c_int * 2),
-        ("surfaceAlignment", ctypes.c_size_t),
-        ("concurrentKernels", ctypes.c_int),
-        ("ECCEnabled", ctypes.c_int),
-        ("pciBusID", ctypes.c_int),
-        ("pciDeviceID", ctypes.c_int),
-        ("pciDomainID", ctypes.c_int),
-        ("tccDriver", ctypes.c_int),
-        ("asyncEngineCount", ctypes.c_int),
-        ("unifiedAddressing", ctypes.c_int),
-        ("memoryClockRate", ctypes.c_int),
-        ("memoryBusWidth", ctypes.c_int),
-        ("l2CacheSize", ctypes.c_int),
-        ("persistingL2CacheMaxSize", ctypes.c_int),
-        ("maxThreadsPerMultiProcessor", ctypes.c_int),
-        ("streamPrioritiesSupported", ctypes.c_int),
-        ("globalL1CacheSupported", ctypes.c_int),
-        ("localL1CacheSupported", ctypes.c_int),
-        ("sharedMemPerMultiprocessor", ctypes.c_size_t),
-        ("regsPerMultiprocessor", ctypes.c_int),
-        ("managedMemSupported", ctypes.c_int),
-        ("isMultiGpuBoard", ctypes.c_int),
-        ("multiGpuBoardGroupID", ctypes.c_int),
-        ("hostNativeAtomicSupported", ctypes.c_int),
-        ("singleToDoublePrecisionPerfRatio", ctypes.c_int),
-        ("pageableMemoryAccess", ctypes.c_int),
-        ("concurrentManagedAccess", ctypes.c_int),
-        ("computePreemptionSupported", ctypes.c_int),
-        ("canUseHostPointerForRegisteredMem", ctypes.c_int),
-        ("cooperativeLaunch", ctypes.c_int),
-        ("cooperativeMultiDeviceLaunch", ctypes.c_int),
-        ("sharedMemPerBlockOptin", ctypes.c_size_t),
-        ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
-        ("directManagedMemAccessFromHost", ctypes.c_int),
-        ("accessPolicyMaxWindowSize", ctypes.c_int),
-        ("accessPolicyMaxWindowSize", ctypes.c_int),
-        ("reservedSharedMemPerBlock", ctypes.c_size_t),
-        ("hostRegisterSupported", ctypes.c_int),  # new in CUDA 12
-        ("sparseCudaArraySupported", ctypes.c_int),  # new in CUDA 12
-        ("hostRegisterReadOnlySupported", ctypes.c_int),  # new in CUDA 12
-        ("timelineSemaphoreInteropSupported", ctypes.c_int),  # new in CUDA 12
-        ("memoryPoolsSupported", ctypes.c_int),  # new in CUDA 12
-        ("gpuDirectRDMASupported", ctypes.c_int),  # new in CUDA 12
-        ("gpuDirectRDMAFlushWritesOptions", ctypes.c_uint),  # new in CUDA 12
-        ("gpuDirectRDMAWritesOrdering", ctypes.c_int),  # new in CUDA 12
-        ("memoryPoolSupportedHandleTypes", ctypes.c_uint),  # new in CUDA 12
-        ("deferredMappingCudaArraySupported", ctypes.c_int),  # new in CUDA 12
-        ("ipcEventSupported", ctypes.c_int),  # new in CUDA 12
-        ("clusterLaunch", ctypes.c_int),  # new in CUDA 12
-        ("unifiedFunctionPointers", ctypes.c_int),  # new in CUDA 12
-        ("reserved2", ctypes.c_int * 2),
-        ("reserved", ctypes.c_int * 61),
-    ]
-
-
-class cudaDeviceProp_v11(ctypes.Structure):
-    _fields_ = [
-        ("name", ctypes.c_char * 256),
-        ("uuid", ctypes.c_byte * 16),  # cudaUUID_t
-        ("luid", ctypes.c_byte * 8),
-        ("luidDeviceNodeMask", ctypes.c_uint),
-        ("totalGlobalMem", ctypes.c_size_t),
-        ("sharedMemPerBlock", ctypes.c_size_t),
-        ("regsPerBlock", ctypes.c_int),
-        ("warpSize", ctypes.c_int),
-        ("memPitch", ctypes.c_size_t),
-        ("maxThreadsPerBlock", ctypes.c_int),
-        ("maxThreadsDim", ctypes.c_int * 3),
-        ("maxGridSize", ctypes.c_int * 3),
-        ("clockRate", ctypes.c_int),
-        ("totalConstMem", ctypes.c_size_t),
-        ("major", ctypes.c_int),
-        ("minor", ctypes.c_int),
-        ("textureAlignment", ctypes.c_size_t),
-        ("texturePitchAlignment", ctypes.c_size_t),
-        ("deviceOverlap", ctypes.c_int),
-        ("multiProcessorCount", ctypes.c_int),
-        ("kernelExecTimeoutEnabled", ctypes.c_int),
-        ("integrated", ctypes.c_int),
-        ("canMapHostMemory", ctypes.c_int),
-        ("computeMode", ctypes.c_int),
-        ("maxTexture1D", ctypes.c_int),
-        ("maxTexture1DMipmap", ctypes.c_int),
-        ("maxTexture1DLinear", ctypes.c_int),
-        ("maxTexture2D", ctypes.c_int * 2),
-        ("maxTexture2DMipmap", ctypes.c_int * 2),
-        ("maxTexture2DLinear", ctypes.c_int * 3),
-        ("maxTexture2DGather", ctypes.c_int * 2),
-        ("maxTexture3D", ctypes.c_int * 3),
-        ("maxTexture3DAlt", ctypes.c_int * 3),
-        ("maxTextureCubemap", ctypes.c_int),
-        ("maxTexture1DLayered", ctypes.c_int * 2),
-        ("maxTexture2DLayered", ctypes.c_int * 3),
-        ("maxTextureCubemapLayered", ctypes.c_int * 2),
-        ("maxSurface1D", ctypes.c_int),
-        ("maxSurface2D", ctypes.c_int * 2),
-        ("maxSurface3D", ctypes.c_int * 3),
-        ("maxSurface1DLayered", ctypes.c_int * 2),
-        ("maxSurface2DLayered", ctypes.c_int * 3),
-        ("maxSurfaceCubemap", ctypes.c_int),
-        ("maxSurfaceCubemapLayered", ctypes.c_int * 2),
-        ("surfaceAlignment", ctypes.c_size_t),
-        ("concurrentKernels", ctypes.c_int),
-        ("ECCEnabled", ctypes.c_int),
-        ("pciBusID", ctypes.c_int),
-        ("pciDeviceID", ctypes.c_int),
-        ("pciDomainID", ctypes.c_int),
-        ("tccDriver", ctypes.c_int),
-        ("asyncEngineCount", ctypes.c_int),
-        ("unifiedAddressing", ctypes.c_int),
-        ("memoryClockRate", ctypes.c_int),
-        ("memoryBusWidth", ctypes.c_int),
-        ("l2CacheSize", ctypes.c_int),
-        ("persistingL2CacheMaxSize", ctypes.c_int),  # new in CUDA 11
-        ("maxThreadsPerMultiProcessor", ctypes.c_int),
-        ("streamPrioritiesSupported", ctypes.c_int),
-        ("globalL1CacheSupported", ctypes.c_int),
-        ("localL1CacheSupported", ctypes.c_int),
-        ("sharedMemPerMultiprocessor", ctypes.c_size_t),
-        ("regsPerMultiprocessor", ctypes.c_int),
-        ("managedMemSupported", ctypes.c_int),
-        ("isMultiGpuBoard", ctypes.c_int),
-        ("multiGpuBoardGroupID", ctypes.c_int),
-        ("hostNativeAtomicSupported", ctypes.c_int),
-        ("singleToDoublePrecisionPerfRatio", ctypes.c_int),
-        ("pageableMemoryAccess", ctypes.c_int),
-        ("concurrentManagedAccess", ctypes.c_int),
-        ("computePreemptionSupported", ctypes.c_int),
-        ("canUseHostPointerForRegisteredMem", ctypes.c_int),
-        ("cooperativeLaunch", ctypes.c_int),
-        ("cooperativeMultiDeviceLaunch", ctypes.c_int),
-        ("sharedMemPerBlockOptin", ctypes.c_size_t),
-        ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
-        ("directManagedMemAccessFromHost", ctypes.c_int),
-        ("maxBlocksPerMultiProcessor", ctypes.c_int),  # new in CUDA 11
-        ("accessPolicyMaxWindowSize", ctypes.c_int),  # new in CUDA 11
-        ("reservedSharedMemPerBlock", ctypes.c_size_t),  # new in CUDA 11
-        ("_reserved", ctypes.c_char * 1024),
-    ]
-
-
-class cudaDeviceProp_v10(ctypes.Structure):
-    _fields_ = [
-        ("name", ctypes.c_char * 256),
-        ("uuid", ctypes.c_byte * 16),  # cudaUUID_t  # new in CUDA 10
-        ("luid", ctypes.c_byte * 8),  # new in CUDA 10
-        ("luidDeviceNodeMask", ctypes.c_uint),  # new in CUDA 10
-        ("totalGlobalMem", ctypes.c_size_t),
-        ("sharedMemPerBlock", ctypes.c_size_t),
-        ("regsPerBlock", ctypes.c_int),
-        ("warpSize", ctypes.c_int),
-        ("memPitch", ctypes.c_size_t),
-        ("maxThreadsPerBlock", ctypes.c_int),
-        ("maxThreadsDim", ctypes.c_int * 3),
-        ("maxGridSize", ctypes.c_int * 3),
-        ("clockRate", ctypes.c_int),
-        ("totalConstMem", ctypes.c_size_t),
-        ("major", ctypes.c_int),
-        ("minor", ctypes.c_int),
-        ("textureAlignment", ctypes.c_size_t),
-        ("texturePitchAlignment", ctypes.c_size_t),
-        ("deviceOverlap", ctypes.c_int),
-        ("multiProcessorCount", ctypes.c_int),
-        ("kernelExecTimeoutEnabled", ctypes.c_int),
-        ("integrated", ctypes.c_int),
-        ("canMapHostMemory", ctypes.c_int),
-        ("computeMode", ctypes.c_int),
-        ("maxTexture1D", ctypes.c_int),
-        ("maxTexture1DMipmap", ctypes.c_int),
-        ("maxTexture1DLinear", ctypes.c_int),
-        ("maxTexture2D", ctypes.c_int * 2),
-        ("maxTexture2DMipmap", ctypes.c_int * 2),
-        ("maxTexture2DLinear", ctypes.c_int * 3),
-        ("maxTexture2DGather", ctypes.c_int * 2),
-        ("maxTexture3D", ctypes.c_int * 3),
-        ("maxTexture3DAlt", ctypes.c_int * 3),
-        ("maxTextureCubemap", ctypes.c_int),
-        ("maxTexture1DLayered", ctypes.c_int * 2),
-        ("maxTexture2DLayered", ctypes.c_int * 3),
-        ("maxTextureCubemapLayered", ctypes.c_int * 2),
-        ("maxSurface1D", ctypes.c_int),
-        ("maxSurface2D", ctypes.c_int * 2),
-        ("maxSurface3D", ctypes.c_int * 3),
-        ("maxSurface1DLayered", ctypes.c_int * 2),
-        ("maxSurface2DLayered", ctypes.c_int * 3),
-        ("maxSurfaceCubemap", ctypes.c_int),
-        ("maxSurfaceCubemapLayered", ctypes.c_int * 2),
-        ("surfaceAlignment", ctypes.c_size_t),
-        ("concurrentKernels", ctypes.c_int),
-        ("ECCEnabled", ctypes.c_int),
-        ("pciBusID", ctypes.c_int),
-        ("pciDeviceID", ctypes.c_int),
-        ("pciDomainID", ctypes.c_int),
-        ("tccDriver", ctypes.c_int),
-        ("asyncEngineCount", ctypes.c_int),
-        ("unifiedAddressing", ctypes.c_int),
-        ("memoryClockRate", ctypes.c_int),
-        ("memoryBusWidth", ctypes.c_int),
-        ("l2CacheSize", ctypes.c_int),
-        ("maxThreadsPerMultiProcessor", ctypes.c_int),
-        ("streamPrioritiesSupported", ctypes.c_int),
-        ("globalL1CacheSupported", ctypes.c_int),
-        ("localL1CacheSupported", ctypes.c_int),
-        ("sharedMemPerMultiprocessor", ctypes.c_size_t),
-        ("regsPerMultiprocessor", ctypes.c_int),
-        ("managedMemSupported", ctypes.c_int),
-        ("isMultiGpuBoard", ctypes.c_int),
-        ("multiGpuBoardGroupID", ctypes.c_int),
-        ("hostNativeAtomicSupported", ctypes.c_int),
-        ("singleToDoublePrecisionPerfRatio", ctypes.c_int),
-        ("pageableMemoryAccess", ctypes.c_int),
-        ("concurrentManagedAccess", ctypes.c_int),
-        ("computePreemptionSupported", ctypes.c_int),
-        ("canUseHostPointerForRegisteredMem", ctypes.c_int),
-        ("cooperativeLaunch", ctypes.c_int),
-        ("cooperativeMultiDeviceLaunch", ctypes.c_int),
-        ("sharedMemPerBlockOptin", ctypes.c_size_t),
-        ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
-        ("directManagedMemAccessFromHost", ctypes.c_int),
-        ("_reserved", ctypes.c_char * 1024),
-    ]
-
-
-class cudaDeviceProp(ctypes.Structure):
-    _fields_ = [
-        ("name", ctypes.c_char * 256),
-        ("totalGlobalMem", ctypes.c_size_t),
-        ("sharedMemPerBlock", ctypes.c_size_t),
-        ("regsPerBlock", ctypes.c_int),
-        ("warpSize", ctypes.c_int),
-        ("memPitch", ctypes.c_size_t),
-        ("maxThreadsPerBlock", ctypes.c_int),
-        ("maxThreadsDim", ctypes.c_int * 3),
-        ("maxGridSize", ctypes.c_int * 3),
-        ("clockRate", ctypes.c_int),
-        ("totalConstMem", ctypes.c_size_t),
-        ("major", ctypes.c_int),
-        ("minor", ctypes.c_int),
-        ("textureAlignment", ctypes.c_size_t),
-        ("texturePitchAlignment", ctypes.c_size_t),
-        ("deviceOverlap", ctypes.c_int),
-        ("multiProcessorCount", ctypes.c_int),
-        ("kernelExecTimeoutEnabled", ctypes.c_int),
-        ("integrated", ctypes.c_int),
-        ("canMapHostMemory", ctypes.c_int),
-        ("computeMode", ctypes.c_int),
-        ("maxTexture1D", ctypes.c_int),
-        ("maxTexture1DMipmap", ctypes.c_int),
-        ("maxTexture1DLinear", ctypes.c_int),
-        ("maxTexture2D", ctypes.c_int * 2),
-        ("maxTexture2DMipmap", ctypes.c_int * 2),
-        ("maxTexture2DLinear", ctypes.c_int * 3),
-        ("maxTexture2DGather", ctypes.c_int * 2),
-        ("maxTexture3D", ctypes.c_int * 3),
-        ("maxTexture3DAlt", ctypes.c_int * 3),
-        ("maxTextureCubemap", ctypes.c_int),
-        ("maxTexture1DLayered", ctypes.c_int * 2),
-        ("maxTexture2DLayered", ctypes.c_int * 3),
-        ("maxTextureCubemapLayered", ctypes.c_int * 2),
-        ("maxSurface1D", ctypes.c_int),
-        ("maxSurface2D", ctypes.c_int * 2),
-        ("maxSurface3D", ctypes.c_int * 3),
-        ("maxSurface1DLayered", ctypes.c_int * 2),
-        ("maxSurface2DLayered", ctypes.c_int * 3),
-        ("maxSurfaceCubemap", ctypes.c_int),
-        ("maxSurfaceCubemapLayered", ctypes.c_int * 2),
-        ("surfaceAlignment", ctypes.c_size_t),
-        ("concurrentKernels", ctypes.c_int),
-        ("ECCEnabled", ctypes.c_int),
-        ("pciBusID", ctypes.c_int),
-        ("pciDeviceID", ctypes.c_int),
-        ("pciDomainID", ctypes.c_int),
-        ("tccDriver", ctypes.c_int),
-        ("asyncEngineCount", ctypes.c_int),
-        ("unifiedAddressing", ctypes.c_int),
-        ("memoryClockRate", ctypes.c_int),
-        ("memoryBusWidth", ctypes.c_int),
-        ("l2CacheSize", ctypes.c_int),
-        ("maxThreadsPerMultiProcessor", ctypes.c_int),
-        ("streamPrioritiesSupported", ctypes.c_int),
-        ("globalL1CacheSupported", ctypes.c_int),
-        ("localL1CacheSupported", ctypes.c_int),
-        ("sharedMemPerMultiprocessor", ctypes.c_size_t),
-        ("regsPerMultiprocessor", ctypes.c_int),
-        ("managedMemSupported", ctypes.c_int),
-        ("isMultiGpuBoard", ctypes.c_int),
-        ("multiGpuBoardGroupID", ctypes.c_int),
-        ("hostNativeAtomicSupported", ctypes.c_int),
-        ("singleToDoublePrecisionPerfRatio", ctypes.c_int),
-        ("pageableMemoryAccess", ctypes.c_int),
-        ("concurrentManagedAccess", ctypes.c_int),
-        ("computePreemptionSupported", ctypes.c_int),
-        ("canUseHostPointerForRegisteredMem", ctypes.c_int),
-        ("cooperativeLaunch", ctypes.c_int),
-        ("cooperativeMultiDeviceLaunch", ctypes.c_int),
-        ("sharedMemPerBlockOptin", ctypes.c_size_t),
-        ("pageableMemoryAccessUsesHostPageTables", ctypes.c_int),
-        ("directManagedMemAccessFromHost", ctypes.c_int),
-        ("_reserved", ctypes.c_char * 1024),
-    ]
-
-
-type cudaDeviceProp_t = (
-    cudaDeviceProp_v13
-    | cudaDeviceProp_v12
-    | cudaDeviceProp_v11
-    | cudaDeviceProp_v10
-    | cudaDeviceProp
-)
 
 
 def _load_library(name: str) -> ctypes.CDLL | None:
@@ -560,9 +69,10 @@ class LibraryBase(metaclass=ABCMeta):
         return rc
 
 
-class libcudart(LibraryBase):
-    name = "CUDART"
+class libcuda(LibraryBase):
+    name = "CUDA"
 
+    _initialized = False
     _version = (0, 0)
 
     @classmethod
@@ -570,83 +80,89 @@ class libcudart(LibraryBase):
         system_type = platform.system()
         match system_type:
             case "Windows":
-                arch = platform.architecture()[0]
-                for major, minor in TARGET_CUDA_VERSIONS:
-                    ver = f"{major}{minor}"
-                    cudart = _load_library(f"cudart{arch[:2]}_{ver}.dll")
-                    if cudart is not None:
-                        return cudart
+                return _load_library("nvcuda.dll")
             case "Darwin":
-                for major, _ in groupby(TARGET_CUDA_VERSIONS, key=itemgetter(0)):
-                    cudart = _load_library(f"libcudart.{major}.dylib")
-                    if cudart is not None:
-                        return cudart
-                for major, minor in TARGET_CUDA_VERSIONS:
-                    cudart = _load_library(f"libcudart.{major}.{minor}.dylib")
-                    if cudart is not None:
-                        return cudart
-                return _load_library("libcudart.dylib")
+                return _load_library("libcuda.dylib")
             case _:
-                for major, _ in groupby(TARGET_CUDA_VERSIONS, key=itemgetter(0)):
-                    cudart = _load_library(f"libcudart.so.{major}")
-                    if cudart is not None:
-                        return cudart
-                for major, minor in TARGET_CUDA_VERSIONS:
-                    cudart = _load_library(f"libcudart.so.{major}.{minor}")
-                    if cudart is not None:
-                        return cudart
-                return _load_library("libcudart.so")
-        return None
+                lib = _load_library("libcuda.so.1")
+                if lib is None:
+                    lib = _load_library("libcuda.so")
+                return lib
+
+    @classmethod
+    def ensure_init(cls) -> None:
+        if not cls._initialized:
+            cls.invoke("cuInit", 0)
+            cls._initialized = True
 
     @classmethod
     def get_version(cls) -> tuple[int, int]:
+        # This reports the maximum CUDA version supported by the installed
+        # driver, not the version of a CUDA toolkit (there is none, since we
+        # no longer link against the CUDA runtime library).
+        cls.ensure_init()
         if cls._version == (0, 0):
             raw_ver = ctypes.c_int()
-            cls.invoke("cudaRuntimeGetVersion", ctypes.byref(raw_ver))
+            cls.invoke("cuDriverGetVersion", ctypes.byref(raw_ver))
             cls._version = (raw_ver.value // 1000, (raw_ver.value % 100) // 10)
         return cls._version
 
     @classmethod
     def get_device_count(cls) -> int:
+        cls.ensure_init()
         count = ctypes.c_int()
-        cls.invoke("cudaGetDeviceCount", ctypes.byref(count))
+        cls.invoke("cuDeviceGetCount", ctypes.byref(count))
         return count.value
 
     @classmethod
     def get_device_props(cls, device_idx: int) -> MutableMapping[str, Any]:
-        props_struct: cudaDeviceProp_t
-        if cls.get_version() >= (13, 0):
-            props_struct = cudaDeviceProp_v13()
-        elif cls.get_version() >= (12, 0):
-            props_struct = cudaDeviceProp_v12()
-        elif cls.get_version() >= (11, 0):
-            props_struct = cudaDeviceProp_v11()
-        elif cls.get_version() >= (10, 0):
-            props_struct = cudaDeviceProp_v10()
-        else:
-            props_struct = cudaDeviceProp()
-        cls.invoke("cudaGetDeviceProperties", ctypes.byref(props_struct), device_idx)
-        props: MutableMapping[str, Any] = {
-            # Treat each field as two-tuple assuming that we don't have bit-fields
-            k: getattr(props_struct, k)
-            for k, _ in cast(Sequence[tuple[str, Any]], props_struct._fields_)
-        }
-        pci_bus_id = b" " * 16
-        cls.invoke("cudaDeviceGetPCIBusId", ctypes.c_char_p(pci_bus_id), 16, device_idx)
-        props["name"] = props["name"].decode()
-        props["pciBusID_str"] = pci_bus_id.split(b"\x00")[0].decode()
-        if "uuid" in props:
-            props["uuid"] = bytes(props["uuid"])
-        if "luid" in props:
-            props["luid"] = bytes(props["luid"])
-        return props
+        cls.ensure_init()
+        device = ctypes.c_int()
+        cls.invoke("cuDeviceGet", ctypes.byref(device), device_idx)
 
-    @classmethod
-    def reset(cls) -> None:
-        """
-        Releases the underlying CUDA driver context and resources occupied by it.
-        """
-        cls.invoke("cudaDeviceReset")
+        props: MutableMapping[str, Any] = {}
+
+        name_buf = (ctypes.c_char * 256)()
+        cls.invoke("cuDeviceGetName", ctypes.byref(name_buf), 256, device.value)
+        props["name"] = name_buf.value.decode()
+
+        # cuDeviceGetUuid_v2 was added in CUDA 11.4; drivers older than that
+        # only expose the legacy cuDeviceGetUuid. Both symbols may be absent
+        # on ancient drivers, in which case we simply omit the key (plugin.py
+        # falls back to an all-zero UUID).
+        uuid_buf = (ctypes.c_byte * 16)()
+        try:
+            cls.invoke("cuDeviceGetUuid_v2", ctypes.byref(uuid_buf), device.value)
+            props["uuid"] = bytes(uuid_buf)
+        except AttributeError:
+            try:
+                cls.invoke("cuDeviceGetUuid", ctypes.byref(uuid_buf), device.value)
+                props["uuid"] = bytes(uuid_buf)
+            except AttributeError:
+                pass
+
+        # cuDeviceTotalMem_v2 supersedes the legacy cuDeviceTotalMem.
+        total_mem = ctypes.c_size_t()
+        try:
+            cls.invoke("cuDeviceTotalMem_v2", ctypes.byref(total_mem), device.value)
+        except AttributeError:
+            cls.invoke("cuDeviceTotalMem", ctypes.byref(total_mem), device.value)
+        props["totalGlobalMem"] = total_mem.value
+
+        mp_count = ctypes.c_int()
+        cls.invoke(
+            "cuDeviceGetAttribute",
+            ctypes.byref(mp_count),
+            CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
+            device.value,
+        )
+        props["multiProcessorCount"] = mp_count.value
+
+        pci_bus_id = (ctypes.c_char * 16)()
+        cls.invoke("cuDeviceGetPCIBusId", ctypes.byref(pci_bus_id), 16, device.value)
+        props["pciBusID_str"] = pci_bus_id.value.decode()
+
+        return props
 
 
 class nvmlMemoryInfo_t(ctypes.Structure):

--- a/src/ai/backend/accelerator/cuda_open/nvidia.py
+++ b/src/ai/backend/accelerator/cuda_open/nvidia.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import ctypes
 import platform
 from abc import ABCMeta, abstractmethod
-from collections.abc import MutableMapping
-from typing import Any, NamedTuple
+from typing import Any, ClassVar, NamedTuple
 
 # ref: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__DEVICE.html
 CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16
@@ -42,7 +41,10 @@ def _load_library(name: str) -> ctypes.CDLL | None:
 class LibraryBase(metaclass=ABCMeta):
     name = "LIBRARY"
 
-    _lib = None
+    # The class-level caches below (_lib here; _initialized/_version/_init_error
+    # in subclasses) are mutated without locking. This is safe because all
+    # callers run on the agent's single event-loop thread.
+    _lib: ClassVar[ctypes.CDLL | None] = None
 
     @classmethod
     @abstractmethod
@@ -57,11 +59,13 @@ class LibraryBase(metaclass=ABCMeta):
             raise ImportError(f"Could not load the {cls.name} library!")
 
     @classmethod
+    def has_symbol(cls, name: str) -> bool:
+        cls._ensure_lib()
+        return hasattr(cls._lib, name)
+
+    @classmethod
     def invoke(cls, func_name: str, *args: Any, check_rc: bool = True) -> int:
-        try:
-            cls._ensure_lib()
-        except ImportError:
-            raise
+        cls._ensure_lib()
         func = getattr(cls._lib, func_name)
         rc = func(*args)
         if check_rc and rc != 0:
@@ -69,11 +73,21 @@ class LibraryBase(metaclass=ABCMeta):
         return rc
 
 
+class CudaDeviceProps(NamedTuple):
+    name: str
+    uuid: bytes | None
+    total_global_mem: int
+    multiprocessor_count: int
+    pci_bus_id: str
+
+
 class libcuda(LibraryBase):
     name = "CUDA"
 
-    _initialized = False
-    _version = (0, 0)
+    # Single-threaded caches; see the note on LibraryBase.
+    _initialized: ClassVar[bool] = False
+    _version: ClassVar[tuple[int, int]] = (0, 0)
+    _init_error: ClassVar[LibraryError | None] = None
 
     @classmethod
     def load_library(cls) -> ctypes.CDLL | None:
@@ -84,15 +98,24 @@ class libcuda(LibraryBase):
             case "Darwin":
                 return _load_library("libcuda.dylib")
             case _:
-                lib = _load_library("libcuda.so.1")
-                if lib is None:
-                    lib = _load_library("libcuda.so")
-                return lib
+                # Load only the driver SONAME (libcuda.so.1). The bare
+                # libcuda.so symlink is provided by the CUDA toolkit's
+                # link-time stub library, which would load successfully but
+                # then fail cuInit with confusing errors.
+                return _load_library("libcuda.so.1")
 
     @classmethod
     def ensure_init(cls) -> None:
+        # A failed cuInit is sticky: retrying against a broken driver is
+        # pointless and slow, so we cache the error and re-raise it as-is.
+        if cls._init_error is not None:
+            raise cls._init_error
         if not cls._initialized:
-            cls.invoke("cuInit", 0)
+            try:
+                cls.invoke("cuInit", 0)
+            except LibraryError as e:
+                cls._init_error = e
+                raise
             cls._initialized = True
 
     @classmethod
@@ -100,7 +123,9 @@ class libcuda(LibraryBase):
         # This reports the maximum CUDA version supported by the installed
         # driver, not the version of a CUDA toolkit (there is none, since we
         # no longer link against the CUDA runtime library).
-        cls.ensure_init()
+        # cuDriverGetVersion is documented to be callable before cuInit, so we
+        # deliberately skip ensure_init() to keep version reporting working on
+        # GPU-less hosts where cuInit would fail.
         if cls._version == (0, 0):
             raw_ver = ctypes.c_int()
             cls.invoke("cuDriverGetVersion", ctypes.byref(raw_ver))
@@ -115,39 +140,35 @@ class libcuda(LibraryBase):
         return count.value
 
     @classmethod
-    def get_device_props(cls, device_idx: int) -> MutableMapping[str, Any]:
+    def get_device_props(cls, device_idx: int) -> CudaDeviceProps:
         cls.ensure_init()
         device = ctypes.c_int()
         cls.invoke("cuDeviceGet", ctypes.byref(device), device_idx)
 
-        props: MutableMapping[str, Any] = {}
-
         name_buf = (ctypes.c_char * 256)()
         cls.invoke("cuDeviceGetName", ctypes.byref(name_buf), 256, device.value)
-        props["name"] = name_buf.value.decode()
+        name = name_buf.value.decode()
 
-        # cuDeviceGetUuid_v2 was added in CUDA 11.4; drivers older than that
-        # only expose the legacy cuDeviceGetUuid. Both symbols may be absent
-        # on ancient drivers, in which case we simply omit the key (plugin.py
-        # falls back to an all-zero UUID).
+        # cuDeviceGetUuid_v2 (added in CUDA 11.4) returns the MIG-instance
+        # UUID when the device is a MIG instance, while the legacy
+        # cuDeviceGetUuid returns the parent GPU's UUID. We deterministically
+        # prefer _v2 and fall back to the legacy symbol only on drivers that
+        # lack it. Both symbols may be absent on ancient drivers, in which
+        # case uuid is None (plugin.py falls back to an all-zero UUID).
+        device_uuid: bytes | None = None
         uuid_buf = (ctypes.c_byte * 16)()
-        try:
+        if cls.has_symbol("cuDeviceGetUuid_v2"):
             cls.invoke("cuDeviceGetUuid_v2", ctypes.byref(uuid_buf), device.value)
-            props["uuid"] = bytes(uuid_buf)
-        except AttributeError:
-            try:
-                cls.invoke("cuDeviceGetUuid", ctypes.byref(uuid_buf), device.value)
-                props["uuid"] = bytes(uuid_buf)
-            except AttributeError:
-                pass
+            device_uuid = bytes(uuid_buf)
+        elif cls.has_symbol("cuDeviceGetUuid"):
+            cls.invoke("cuDeviceGetUuid", ctypes.byref(uuid_buf), device.value)
+            device_uuid = bytes(uuid_buf)
 
-        # cuDeviceTotalMem_v2 supersedes the legacy cuDeviceTotalMem.
+        # cuDeviceTotalMem_v2 exists in every supported driver (CUDA >= 3.2);
+        # the legacy cuDeviceTotalMem uses the old 32-bit ABI and would
+        # truncate sizes above 4 GiB, so we never fall back to it.
         total_mem = ctypes.c_size_t()
-        try:
-            cls.invoke("cuDeviceTotalMem_v2", ctypes.byref(total_mem), device.value)
-        except AttributeError:
-            cls.invoke("cuDeviceTotalMem", ctypes.byref(total_mem), device.value)
-        props["totalGlobalMem"] = total_mem.value
+        cls.invoke("cuDeviceTotalMem_v2", ctypes.byref(total_mem), device.value)
 
         mp_count = ctypes.c_int()
         cls.invoke(
@@ -156,13 +177,17 @@ class libcuda(LibraryBase):
             CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT,
             device.value,
         )
-        props["multiProcessorCount"] = mp_count.value
 
         pci_bus_id = (ctypes.c_char * 16)()
         cls.invoke("cuDeviceGetPCIBusId", ctypes.byref(pci_bus_id), 16, device.value)
-        props["pciBusID_str"] = pci_bus_id.value.decode()
 
-        return props
+        return CudaDeviceProps(
+            name=name,
+            uuid=device_uuid,
+            total_global_mem=total_mem.value,
+            multiprocessor_count=mp_count.value,
+            pci_bus_id=pci_bus_id.value.decode(),
+        )
 
 
 class nvmlMemoryInfo_t(ctypes.Structure):
@@ -203,7 +228,8 @@ class DeviceStat(NamedTuple):
 class libnvml(LibraryBase):
     name = "NVML"
 
-    _initialized = False
+    # Single-threaded cache; see the note on LibraryBase.
+    _initialized: ClassVar[bool] = False
 
     @classmethod
     def load_library(cls) -> ctypes.CDLL | None:
@@ -216,7 +242,6 @@ class libnvml(LibraryBase):
         if lib is None:
             lib = _load_library("libnvidia-ml.so.1")
         return lib
-        return None
 
     @classmethod
     def ensure_init(cls) -> None:

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -49,7 +49,7 @@ from ai.backend.common.types import (
 )
 
 from . import __version__
-from .nvidia import LibraryError, libcudart, libnvml
+from .nvidia import LibraryError, libcuda, libnvml
 
 __all__ = (
     "PREFIX",
@@ -133,7 +133,7 @@ class CUDAPlugin(AbstractComputePlugin):
             log.info("detected devices:\n" + pformat(detected_devices))
             log.info("CUDA acceleration is enabled.")
         except ImportError:
-            log.warning("could not load the CUDA runtime library.")
+            log.warning("could not load the CUDA driver library.")
             log.info("CUDA acceleration is disabled.")
             self.enabled = False
         except RuntimeError as e:
@@ -154,9 +154,9 @@ class CUDAPlugin(AbstractComputePlugin):
         if not self.enabled:
             return []
         all_devices = []
-        num_devices = libcudart.get_device_count()
+        num_devices = libcuda.get_device_count()
         for dev_id in map(lambda idx: DeviceId(str(idx)), range(num_devices)):
-            raw_info = libcudart.get_device_props(int(dev_id))
+            raw_info = libcuda.get_device_props(int(dev_id))
             sysfs_node_path = f"/sys/bus/pci/devices/{raw_info['pciBusID_str'].lower()}/numa_node"
             node: int | None
             try:
@@ -197,10 +197,10 @@ class CUDAPlugin(AbstractComputePlugin):
                 return {
                     "cuda_support": True,
                     "nvidia_version": libnvml.get_driver_version(),
-                    "cuda_version": "{0[0]}.{0[1]}".format(libcudart.get_version()),
+                    "cuda_version": "{0[0]}.{0[1]}".format(libcuda.get_version()),
                 }
             except ImportError:
-                log.warning("extra_info(): NVML/CUDA runtime library is not found")
+                log.warning("extra_info(): NVML/CUDA driver library is not found")
             except LibraryError as e:
                 log.warning("extra_info(): {!r}", e)
         return {

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -157,26 +157,25 @@ class CUDAPlugin(AbstractComputePlugin):
         num_devices = libcuda.get_device_count()
         for dev_id in map(lambda idx: DeviceId(str(idx)), range(num_devices)):
             raw_info = libcuda.get_device_props(int(dev_id))
-            sysfs_node_path = f"/sys/bus/pci/devices/{raw_info['pciBusID_str'].lower()}/numa_node"
+            sysfs_node_path = f"/sys/bus/pci/devices/{raw_info.pci_bus_id.lower()}/numa_node"
             node: int | None
             try:
                 node = int(Path(sysfs_node_path).read_text().strip())
             except OSError:
                 node = None
-            dev_uuid, raw_dev_uuid = None, raw_info.get("uuid", None)
-            if raw_dev_uuid is not None:
-                dev_uuid = str(uuid.UUID(bytes=raw_dev_uuid))
+            if raw_info.uuid is not None:
+                dev_uuid = str(uuid.UUID(bytes=raw_info.uuid))
             else:
                 dev_uuid = "00000000-0000-0000-0000-000000000000"
             if dev_uuid in self.device_mask:
                 continue
             dev_info = CUDADevice(
                 device_id=DeviceId(dev_id),
-                hw_location=raw_info["pciBusID_str"],
+                hw_location=raw_info.pci_bus_id,
                 numa_node=node,
-                memory_size=raw_info["totalGlobalMem"],
-                processing_units=raw_info["multiProcessorCount"],
-                model_name=raw_info["name"],
+                memory_size=raw_info.total_global_mem,
+                processing_units=raw_info.multiprocessor_count,
+                model_name=raw_info.name,
                 uuid=dev_uuid,
             )
             all_devices.append(dev_info)

--- a/tests/unit/accelerator/cuda_open/test_libcuda.py
+++ b/tests/unit/accelerator/cuda_open/test_libcuda.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import ctypes
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+
+from ai.backend.accelerator.cuda_open.nvidia import CudaDeviceProps, LibraryError, libcuda
+
+FAKE_UUID = bytes(range(16))
+FAKE_TOTAL_MEM = 80 * 1024**3  # deliberately above the legacy 32-bit ABI limit
+FAKE_MP_COUNT = 108
+FAKE_PCI_BUS_ID = b"0000:AF:00.0"
+FAKE_DEVICE_NAME = b"Fake GPU"
+FAKE_DRIVER_VERSION = 12040  # decodes to (12, 4)
+
+
+class FakeCudaLib:
+    """A stand-in for the libcuda CDLL handle.
+
+    Symbols listed in ``missing_symbols`` raise ``AttributeError`` on access
+    (mimicking a driver that lacks them), and symbols listed in ``error_rcs``
+    return the given nonzero CUresult code. All other functions write
+    deterministic fake values into the ``ctypes.byref`` output arguments and
+    return 0. Every invocation is recorded in ``calls``.
+    """
+
+    calls: list[str]
+
+    def __init__(
+        self,
+        *,
+        missing_symbols: frozenset[str] = frozenset(),
+        error_rcs: dict[str, int] | None = None,
+    ) -> None:
+        self.calls = []
+        self._missing_symbols = missing_symbols
+        self._error_rcs = error_rcs or {}
+        self._impls: dict[str, Callable[..., int]] = {
+            "cuInit": self._cu_init,
+            "cuDriverGetVersion": self._cu_driver_get_version,
+            "cuDeviceGetCount": self._cu_device_get_count,
+            "cuDeviceGet": self._cu_device_get,
+            "cuDeviceGetName": self._cu_device_get_name,
+            "cuDeviceGetUuid_v2": self._cu_device_get_uuid,
+            "cuDeviceGetUuid": self._cu_device_get_uuid,
+            "cuDeviceTotalMem_v2": self._cu_device_total_mem,
+            "cuDeviceGetAttribute": self._cu_device_get_attribute,
+            "cuDeviceGetPCIBusId": self._cu_device_get_pci_bus_id,
+        }
+
+    def __getattr__(self, name: str) -> Callable[..., int]:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        if name in self._missing_symbols:
+            raise AttributeError(name)
+        impl = self._impls.get(name)
+        if impl is None:
+            raise AttributeError(name)
+
+        def wrapper(*args: Any) -> int:
+            self.calls.append(name)
+            rc = self._error_rcs.get(name)
+            if rc is not None:
+                return rc
+            return impl(*args)
+
+        return wrapper
+
+    @staticmethod
+    def _cu_init(flags: int) -> int:
+        return 0
+
+    @staticmethod
+    def _cu_driver_get_version(ver_ref: Any) -> int:
+        ver_ref._obj.value = FAKE_DRIVER_VERSION
+        return 0
+
+    @staticmethod
+    def _cu_device_get_count(count_ref: Any) -> int:
+        count_ref._obj.value = 1
+        return 0
+
+    @staticmethod
+    def _cu_device_get(device_ref: Any, ordinal: int) -> int:
+        device_ref._obj.value = ordinal
+        return 0
+
+    @staticmethod
+    def _cu_device_get_name(buf_ref: Any, size: int, device: int) -> int:
+        buf_ref._obj.value = FAKE_DEVICE_NAME
+        return 0
+
+    @staticmethod
+    def _cu_device_get_uuid(buf_ref: Any, device: int) -> int:
+        ctypes.memmove(buf_ref._obj, FAKE_UUID, len(FAKE_UUID))
+        return 0
+
+    @staticmethod
+    def _cu_device_total_mem(mem_ref: Any, device: int) -> int:
+        mem_ref._obj.value = FAKE_TOTAL_MEM
+        return 0
+
+    @staticmethod
+    def _cu_device_get_attribute(value_ref: Any, attrib: int, device: int) -> int:
+        value_ref._obj.value = FAKE_MP_COUNT
+        return 0
+
+    @staticmethod
+    def _cu_device_get_pci_bus_id(buf_ref: Any, size: int, device: int) -> int:
+        buf_ref._obj.value = FAKE_PCI_BUS_ID
+        return 0
+
+
+@pytest.fixture(autouse=True)
+def reset_libcuda_caches(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the class-level caches so tests never observe each other's state."""
+    monkeypatch.setattr(libcuda, "_lib", None)
+    monkeypatch.setattr(libcuda, "_initialized", False)
+    monkeypatch.setattr(libcuda, "_version", (0, 0))
+    monkeypatch.setattr(libcuda, "_init_error", None)
+    yield
+
+
+def _install_fake_lib(monkeypatch: pytest.MonkeyPatch, fake_lib: FakeCudaLib) -> None:
+    monkeypatch.setattr(libcuda, "_lib", fake_lib)
+
+
+class TestGetDeviceProps:
+    """Tests for libcuda.get_device_props."""
+
+    def test_normal_path_returns_typed_props(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_lib = FakeCudaLib()
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        props = libcuda.get_device_props(0)
+
+        assert isinstance(props, CudaDeviceProps)
+        assert props.name == FAKE_DEVICE_NAME.decode()
+        assert props.uuid == FAKE_UUID
+        assert props.total_global_mem == FAKE_TOTAL_MEM
+        assert props.multiprocessor_count == FAKE_MP_COUNT
+        assert props.pci_bus_id == FAKE_PCI_BUS_ID.decode()
+        # The uuid must come from the _v2 symbol when it is available.
+        assert "cuDeviceGetUuid_v2" in fake_lib.calls
+        assert "cuDeviceGetUuid" not in fake_lib.calls
+
+    def test_uuid_falls_back_to_legacy_symbol_when_v2_is_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_lib = FakeCudaLib(missing_symbols=frozenset({"cuDeviceGetUuid_v2"}))
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        props = libcuda.get_device_props(0)
+
+        assert props.uuid == FAKE_UUID
+        assert "cuDeviceGetUuid" in fake_lib.calls
+        assert "cuDeviceGetUuid_v2" not in fake_lib.calls
+
+    def test_uuid_is_none_when_both_symbols_are_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_lib = FakeCudaLib(
+            missing_symbols=frozenset({"cuDeviceGetUuid_v2", "cuDeviceGetUuid"}),
+        )
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        props = libcuda.get_device_props(0)
+
+        assert props.uuid is None
+        # The rest of the props must still be populated.
+        assert props.name == FAKE_DEVICE_NAME.decode()
+        assert props.total_global_mem == FAKE_TOTAL_MEM
+
+    def test_nonzero_return_code_raises_library_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_lib = FakeCudaLib(error_rcs={"cuDeviceGetName": 999})
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        with pytest.raises(LibraryError) as exc_info:
+            libcuda.get_device_props(0)
+
+        assert exc_info.value.lib == "CUDA"
+        assert exc_info.value.func == "cuDeviceGetName"
+        assert exc_info.value.code == 999
+
+
+class TestGetVersion:
+    """Tests for libcuda.get_version."""
+
+    def test_decodes_driver_version_without_calling_cuinit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # cuInit failing must not matter: cuDriverGetVersion is callable
+        # before initialization (e.g., on GPU-less hosts).
+        fake_lib = FakeCudaLib(error_rcs={"cuInit": 100})
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        version = libcuda.get_version()
+
+        assert version == (12, 4)
+        assert "cuInit" not in fake_lib.calls
+
+
+class TestEnsureInit:
+    """Tests for libcuda.ensure_init."""
+
+    def test_cuinit_failure_is_sticky(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_lib = FakeCudaLib(error_rcs={"cuInit": 100})
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        with pytest.raises(LibraryError) as first:
+            libcuda.ensure_init()
+        with pytest.raises(LibraryError) as second:
+            libcuda.ensure_init()
+
+        # The cached error object is re-raised as-is, and the broken driver
+        # is not hammered with repeated cuInit calls.
+        assert second.value is first.value
+        assert first.value.func == "cuInit"
+        assert first.value.code == 100
+        assert fake_lib.calls.count("cuInit") == 1
+
+    def test_successful_init_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_lib = FakeCudaLib()
+        _install_fake_lib(monkeypatch, fake_lib)
+
+        libcuda.ensure_init()
+        libcuda.ensure_init()
+
+        assert fake_lib.calls.count("cuInit") == 1


### PR DESCRIPTION
## Summary
- Replace the `libcudart` (CUDA **runtime** API — a CUDA *toolkit* component) binding in the cuda_open plugin with a small `libcuda` (CUDA **driver** API) binding. NVML usage is unchanged. The plugin now works with only driver-installed libraries (`libcuda.so.1`, `libnvidia-ml.so.1`), which `nvidia-container-runtime` injects into containers — so a dockerized agent (BA-7264/BA-7271) needs no CUDA toolkit bundled and has no toolkit↔driver version-match fragility.
- Call mapping: `cudaGetDeviceCount`→`cuDeviceGetCount`; device props (`name`/`uuid`/`totalGlobalMem`/`multiProcessorCount`/PCI bus ID) → `cuDeviceGetName`/`cuDeviceGetUuid_v2` (with legacy fallbacks)/`cuDeviceTotalMem_v2`/`cuDeviceGetAttribute(MULTIPROCESSOR_COUNT)`/`cuDeviceGetPCIBusId`; `cudaRuntimeGetVersion`→`cuDriverGetVersion`.
- Enumeration stays on the CUDA layer (not NVML), preserving `CUDA_VISIBLE_DEVICES` handling and device ordering — existing `DeviceId` assignments are unaffected.
- Deleted ~450 lines of per-CUDA-version `cudaDeviceProp` ctypes structs (v10–v13) and the dead `cudaDeviceReset` binding.
- Semantic change: reported `cuda_version` is now the driver-supported max CUDA version (as shown by `nvidia-smi`) instead of the installed-toolkit version.
- GPU-less hosts still degrade to "CUDA acceleration is disabled" (`cuInit` failures surface as `LibraryError`, caught by the existing `RuntimeError` path).

Verified: `pants lint`/`check`/`test` on the plugin and its unit tests all pass; `grep cudart` over the plugin returns nothing; module import works without libcuda present (lazy loading).

Note for containerized deployment: the agent container needs `runtime: nvidia`, `NVIDIA_VISIBLE_DEVICES=all`, `NVIDIA_DRIVER_CAPABILITIES=compute,utility`.

Resolves BA-7275
Resolves #13598

https://claude.ai/code/session_01GT4qqMyR7xBVTQY5S45Rg9