### PR TITLE
feat(BA-7193): expose the keypair owner's email and deprecate the legacy user_id field

### DIFF
--- a/changes/13611.feature.md
+++ b/changes/13611.feature.md
@@ -1,0 +1,1 @@
+Report the keypair owner's email as `user_email` on the legacy GraphQL type and deprecate `user_id`, which currently holds the email under a name that means the owner's uuid everywhere else

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1202,7 +1202,10 @@ type UserList implements PaginatedList {
 
 type KeyPair implements Item {
   id: ID
-  user_id: String
+  user_id: String @deprecated(reason: "Deprecated since 26.9.0. Holds the owner's email address; use user_email for the email or user for the owner's uuid.")
+
+  """Added in 26.9.0. The owner's email address, read from the users table."""
+  user_email: String
   full_name: String
   access_key: String
   secret_key: String

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -9501,7 +9501,10 @@ type KeyPair implements Item
   @join__type(graph: GRAPHENE)
 {
   id: ID
-  user_id: String
+  user_id: String @deprecated(reason: "Deprecated since 26.9.0. Holds the owner's email address; use user_email for the email or user for the owner's uuid.")
+
+  """Added in 26.9.0. The owner's email address, read from the users table."""
+  user_email: String
   full_name: String
   access_key: String
   secret_key: String

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -97,7 +97,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
     class Meta:
         interfaces = (Item,)
 
-    user_id = graphene.String()
+    user_id = graphene.String(
+        deprecation_reason="Deprecated since 26.9.0. Holds the owner's email address; use user_email for the email or user for the owner's uuid."
+    )
+    user_email = graphene.String(
+        description="Added in 26.9.0. The owner's email address, read from the users table."
+    )
     full_name = graphene.String()
     access_key = graphene.String()
     secret_key = graphene.String()
@@ -161,6 +166,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
         return cls(
             id=row.access_key,
             user_id=row.user_id,
+            user_email=row._mapping.get("email"),
             full_name=row._mapping.get("full_name"),
             access_key=row.access_key,
             secret_key=row.secret_key,
@@ -243,7 +249,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             users,
             keypairs.c.user == users.c.uuid,
         )
-        query = sa.select(keypairs).select_from(j)
+        query = sa.select(keypairs, users.c.email).select_from(j)
         if domain_name is not None:
             query = query.where(users.c.domain_name == domain_name)
         if is_active is not None:


### PR DESCRIPTION
Resolves #13610

Part of the schema-truth epic #13475 (BA-7193). Like #13607, this is an API pairing the epic's breakdown missed; it has no JIRA key yet, so the title carries the epic's.

## Summary

- BA-7206 (#13491) consolidates the two owner columns on `keypairs` into one named `user_id` holding `users.uuid`. Its acceptance criteria say *"No API field changes"* — true of the v2 stack, false of the legacy graphene type.
- `gql_legacy/keypair.py` declares `user_id = graphene.String()` and fills it from `row.user_id`, the `String(256)` column holding the owner's **email**; the uuid is exposed separately as `user`. Repointing the column would silently turn `user_id` from an email into a uuid — no deprecation, no replacement, no release where a client sees both.
- So the replacement ships first: `user_email` carries the email, and `user_id` is deprecated naming both successors.

| Change | Detail |
|---|---|
| `KeyPair.user_email` | new, `Added in 26.9.0.`, read from the joined `users.email` |
| `KeyPair.user_id` | deprecated → `user_email` for the email, `user` for the uuid |
| `KeyPair.load_all` | now selects `users.email`; the other three loaders already did |

The email comes from the joined `users` row, not the `keypairs` copy — nothing keeps that copy in step with `users.email`, and the loaders already join `users` on `keypairs.user == users.uuid`.

```graphql
-  user_id: String
+  user_id: String @deprecated(reason: "Deprecated since 26.9.0. Holds the owner's email address; use user_email for the email or user for the owner's uuid.")
+
+  """Added in 26.9.0. The owner's email address, read from the users table."""
+  user_email: String
```

No behaviour change for existing clients: `user_id` keeps returning what it returns today. BA-7206 is then free to repoint the column.

## Test plan

- [x] `pants fmt fix lint check` across `src/ai/backend` — clean
- [x] `gql_legacy.keypair` imports; GraphQL schema dumps regenerated with `scripts/generate-graphql-schema.sh`
- [x] Checked every `KeyPair.from_row` caller for whether its query provides `users.email` — `load_all` did not, and now does
- [ ] Unit and component suites in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
