### PR TITLE
fix(BA-7257): return structured 400 errors for GQL input validation failures (#13576)

### DIFF
--- a/changes/13576.fix.md
+++ b/changes/13576.fix.md
@@ -1,0 +1,1 @@
+Add structured per-field error details (`extensions.errors`) and a 400-class error code to GraphQL v2 input validation failures, replacing the generic internal error

--- a/src/ai/backend/manager/api/gql/extensions/exception_handler.py
+++ b/src/ai/backend/manager/api/gql/extensions/exception_handler.py
@@ -6,13 +6,30 @@ from collections.abc import Awaitable, Callable
 from typing import Any, Final
 
 from graphql import GraphQLError, GraphQLResolveInfo
+from pydantic import ValidationError
 from strawberry.extensions.base_extension import SchemaExtension
 from strawberry.utils.await_maybe import AwaitableOrValue
 
-from ai.backend.common.exception import BackendAIError, ErrorCode
+from ai.backend.common.exception import (
+    BackendAIError,
+    BackendAISchemaValidationFailed,
+    ErrorCode,
+)
 from ai.backend.logging.utils import BraceStyleAdapter
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+def _to_graphql_validation_error(e: ValidationError) -> GraphQLError:
+    """Map a raw pydantic ``ValidationError`` to a 400-class GraphQL error."""
+    # ``input``/``ctx`` may carry non-JSON-serializable objects.
+    errors = e.errors(include_input=False, include_context=False)
+    summary = "; ".join(str(err.get("msg", "")) for err in errors)
+    converted = BackendAISchemaValidationFailed(extra_msg=summary)
+    return GraphQLError(
+        message=str(converted),
+        extensions={"code": str(converted.error_code()), "errors": errors},
+    )
 
 
 class GQLExceptionHandlerExtension(SchemaExtension):
@@ -37,6 +54,9 @@ class GQLExceptionHandlerExtension(SchemaExtension):
                 message=str(e),
                 extensions={"code": str(e.error_code())},
             ) from e
+        except ValidationError as e:
+            log.debug("GraphQL input validation error: {}", e)
+            raise _to_graphql_validation_error(e) from e
         except Exception as e:
             log.exception("GraphQL unexpected error: {}", e)
             raise GraphQLError(
@@ -59,6 +79,9 @@ class GQLExceptionHandlerExtension(SchemaExtension):
                 message=str(e),
                 extensions={"code": str(e.error_code())},
             ) from e
+        except ValidationError as e:
+            log.debug("GraphQL input validation error: {}", e)
+            raise _to_graphql_validation_error(e) from e
         except Exception as e:
             log.exception("GraphQL unexpected error: {}", e)
             raise GraphQLError(


### PR DESCRIPTION
This is an auto-generated backport of #13576 to the 26.4 release.