### PR TITLE
ci: always create the backport PR even when the cherry-pick conflicts

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           ref: ${{ matrix.target_branch }}
       - name: Cherry-pick
+        id: pick
         env:
           COMMIT_AUTHOR: ${{ matrix.author }}
           COMMIT_AUTHOR_EMAIL: ${{ matrix.author_email }}
@@ -85,21 +86,24 @@ jobs:
           git config user.email "$COMMIT_AUTHOR_EMAIL"
           git fetch origin main "$TARGET_COMMIT"
           # Generated API docs: keep the release branch's copy (update-api-schema
-          # regenerates them on the backport PR); source conflicts still fail.
+          # regenerates them on the backport PR).
           git config merge.ours.driver true
           printf '%s\n' \
             "docs/manager/rest-reference/openapi.json merge=ours" \
             "docs/manager/graphql-reference/*.graphql merge=ours" \
             >> .git/info/attributes
-          git cherry-pick "$TARGET_COMMIT"
-      - name: Report the conflict
-        if: failure()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ matrix.pr_number }}
-          TARGET_BRANCH: ${{ matrix.target_branch }}
-        run: |
-          gh pr comment "$PR_NUMBER" -b "The backport to \`$TARGET_BRANCH\` did not apply cleanly and has to be done by hand."
+          if ! git cherry-pick "$TARGET_COMMIT"; then
+            # Source conflict: commit the markers as-is so the pull request is
+            # still created (without auto-merge) -- CI fails on it until a
+            # human resolves the markers on its branch.
+            {
+              echo "conflict_files<<EOF"
+              git diff --name-only --diff-filter=U
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            git add -A
+            GIT_EDITOR=true git cherry-pick --continue
+          fi
       - name: Create the backport pull request
         id: pr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7
@@ -117,7 +121,22 @@ jobs:
             ${{ matrix.labels }}
           assignees: ${{ matrix.author_login }}
       - name: Enable auto-merge
-        if: ${{ steps.pr.outputs.pull-request-number }}
+        if: ${{ steps.pr.outputs.pull-request-number && steps.pick.outputs.conflict_files == '' }}
         env:
           GH_TOKEN: ${{ secrets.OCTODOG }}
         run: gh pr merge "${{ steps.pr.outputs.pull-request-number }}" --auto --squash
+      - name: Report the conflict
+        if: ${{ failure() || steps.pick.outputs.conflict_files != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ matrix.pr_number }}
+          TARGET_BRANCH: ${{ matrix.target_branch }}
+          CONFLICT_FILES: ${{ steps.pick.outputs.conflict_files }}
+          BACKPORT_PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: |
+          if [ -n "$BACKPORT_PR_URL" ] && [ -n "$CONFLICT_FILES" ]; then
+            body=$(printf 'The backport to `%s` hit conflicts: %s was created with the conflict markers committed in:\n\n```\n%s\n```\n\nCI on it fails until the markers are resolved; check out its branch, fix, push, and merge it by hand (auto-merge is not enabled for conflicted backports).' "$TARGET_BRANCH" "$BACKPORT_PR_URL" "$CONFLICT_FILES")
+          else
+            body="The backport to \`$TARGET_BRANCH\` did not apply cleanly and has to be done by hand."
+          fi
+          gh pr comment "$PR_NUMBER" -b "$body"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -84,8 +84,13 @@ jobs:
           git config user.name "$COMMIT_AUTHOR"
           git config user.email "$COMMIT_AUTHOR_EMAIL"
           git fetch origin main "$TARGET_COMMIT"
-          # Deliberately without `-X theirs`: a conflict must surface as a
-          # failure rather than be resolved by overwriting the release branch.
+          # Generated API docs: keep the release branch's copy (update-api-schema
+          # regenerates them on the backport PR); source conflicts still fail.
+          git config merge.ours.driver true
+          printf '%s\n' \
+            "docs/manager/rest-reference/openapi.json merge=ours" \
+            "docs/manager/graphql-reference/*.graphql merge=ours" \
+            >> .git/info/attributes
           git cherry-pick "$TARGET_COMMIT"
       - name: Report the conflict
         if: failure()

--- a/changes/13614.misc.md
+++ b/changes/13614.misc.md
@@ -1,0 +1,1 @@
+Auto-resolve generated API doc conflicts in backport cherry-picks so backport PRs are still created

--- a/changes/13614.misc.md
+++ b/changes/13614.misc.md
@@ -1,1 +1,1 @@
-Auto-resolve generated API doc conflicts in backport cherry-picks so backport PRs are still created
+Always create the backport PR: auto-resolve generated API doc conflicts, and commit the conflict markers without auto-merge on source conflicts so they can be fixed in place


### PR DESCRIPTION
## Summary
- Backport cherry-picks failed (and skipped PR creation) whenever anything conflicted, e.g. https://github.com/lablup/backend.ai/actions/runs/31153667848 for #13564.
- Generated API docs (`openapi.json`, `graphql-reference/*.graphql`) resolve to the release branch's copy via a `merge=ours` driver; the `update-api-schema` workflow regenerates them on the backport PR, so these picks go straight to auto-merge.
- Source conflicts no longer abort: the markers are committed as-is and the PR is still created — without auto-merge — so CI fails on it until a human resolves the markers on its branch and merges by hand. The comment on the original PR lists the conflicted files.

## Test plan
- [x] Reproduced the #13564 cherry-pick conflict onto `26.4` locally; with the `merge=ours` attributes the pick completes and the resulting commit carries only the source changes.
- [x] Simulated a source conflict on `26.4` locally; the conflicted file list is captured and `cherry-pick --continue` commits the markers with the original message and author.
- [ ] After merge, comment `/backport` on #13564 and confirm the backport PR is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)