### PR TITLE
feat(BA-7283): expose resource group is_default through the create/update API

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -89,7 +89,7 @@ Check options with `--help`.
 
 ### Resource Management
 
-- **resource-group**: user(empty group) · admin(search, get, create, delete, resource-info, default-options, default-session-options, allow-domains, allowed-domains, allow-projects, allowed-projects, allow-for-domain, allowed-for-domain, allow-for-project, allowed-for-project)
+- **resource-group**: user(empty group) · admin(search, get, create, update, delete, resource-info, default-options, default-session-options, allow-domains, allowed-domains, allow-projects, allowed-projects, allow-for-domain, allowed-for-domain, allow-for-project, allowed-for-project)
 - **resource-allocation**: user(project-usage, resource-group-usage) · admin(domain-usage, effective) · my(effective, keypair-usage)
 - **resource-preset**: admin(search, get, create, update, delete, check-availability)
 - **resource-policy**: admin(sub keypair / project / user — each create, get, search, update, delete) · my(keypair, user)

--- a/changes/13615.feature.md
+++ b/changes/13615.feature.md
@@ -1,0 +1,1 @@
+Allow setting the default resource group through the create and update APIs.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -4605,6 +4605,11 @@ input CreateResourceGroupInput
 
   """Optional description."""
   description: String = null
+
+  """
+  Added in 26.9.0. Make this the default resource group. At most one resource group may hold the flag, so this is rejected while another one holds it; clear that one first.
+  """
+  isDefault: Boolean! = false
 }
 
 """Added in 26.4.2. Payload for resource group creation."""
@@ -21831,6 +21836,11 @@ input UpdateResourceGroupInput
   Whether the resource group is public. Leave null to keep existing value.
   """
   isPublic: Boolean = null
+
+  """
+  Added in 26.9.0. Whether this is the default resource group. At most one resource group may hold the flag, so setting it to true is rejected while another one holds it; clear that one first. Leave null to keep existing value.
+  """
+  isDefault: Boolean = null
 
   """Human-readable description. Leave null to keep existing value."""
   description: String = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3109,6 +3109,11 @@ input CreateResourceGroupInput {
 
   """Optional description."""
   description: String = null
+
+  """
+  Added in 26.9.0. Make this the default resource group. At most one resource group may hold the flag, so this is rejected while another one holds it; clear that one first.
+  """
+  isDefault: Boolean! = false
 }
 
 """Added in 26.4.2. Payload for resource group creation."""
@@ -15704,6 +15709,11 @@ input UpdateResourceGroupInput {
   Whether the resource group is public. Leave null to keep existing value.
   """
   isPublic: Boolean = null
+
+  """
+  Added in 26.9.0. Whether this is the default resource group. At most one resource group may hold the flag, so setting it to true is rejected while another one holds it; clear that one first. Leave null to keep existing value.
+  """
+  isDefault: Boolean = null
 
   """Human-readable description. Leave null to keep existing value."""
   description: String = null

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -20523,6 +20523,12 @@
             "default": null,
             "description": "Resource policy name to apply to this resource group.",
             "title": "Resource Policy"
+          },
+          "is_default": {
+            "default": false,
+            "description": "Make this the default resource group. At most one resource group may hold the flag, so this is rejected while another one holds it; clear that one first.",
+            "title": "Is Default",
+            "type": "boolean"
           }
         },
         "required": [
@@ -20576,6 +20582,19 @@
             "default": null,
             "description": "Whether the resource group is active. Leave null to keep existing value.",
             "title": "Is Active"
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether this is the default resource group. At most one resource group may hold the flag, so setting it to true is rejected while another one holds it; clear that one first. Leave null to keep existing value.",
+            "title": "Is Default"
           },
           "total_resource_slots": {
             "anyOf": [
@@ -20851,6 +20870,19 @@
             "default": null,
             "description": "Whether the resource group is public. Leave null to keep existing value.",
             "title": "Is Public"
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Whether this is the default resource group. At most one resource group may hold the flag, so setting it to true is rejected while another one holds it; clear that one first. Leave null to keep existing value.",
+            "title": "Is Default"
           },
           "description": {
             "anyOf": [

--- a/src/ai/backend/client/cli/v2/admin/resource_group.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_group.py
@@ -114,7 +114,8 @@ def get(name: str) -> None:
 @click.option("--domain-name", required=True, help="Domain name.")
 @click.option("--description", default=None, help="Description.")
 @click.option(
-    "--is-default/--no-is-default",
+    "--set-default/--unset-default",
+    "is_default",
     default=False,
     help="Make this the default resource group. Clear the current default first.",
 )
@@ -154,7 +155,8 @@ def create(name: str, domain_name: str, description: str | None, is_default: boo
     help="Whether the resource group is visible to all users.",
 )
 @click.option(
-    "--is-default/--no-is-default",
+    "--set-default/--unset-default",
+    "is_default",
     default=None,
     help="Make this the default resource group. Clear the current default first.",
 )

--- a/src/ai/backend/client/cli/v2/admin/resource_group.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_group.py
@@ -113,7 +113,12 @@ def get(name: str) -> None:
 @click.option("--name", required=True, help="Resource group name.")
 @click.option("--domain-name", required=True, help="Domain name.")
 @click.option("--description", default=None, help="Description.")
-def create(name: str, domain_name: str, description: str | None) -> None:
+@click.option(
+    "--is-default/--no-is-default",
+    default=False,
+    help="Make this the default resource group. Clear the current default first.",
+)
+def create(name: str, domain_name: str, description: str | None, is_default: bool) -> None:
     """Create a new resource group (superadmin only)."""
     from ai.backend.common.dto.manager.v2.resource_group.request import CreateResourceGroupInput
 
@@ -125,6 +130,57 @@ def create(name: str, domain_name: str, description: str | None) -> None:
                     name=name,
                     domain_name=domain_name,
                     description=description,
+                    is_default=is_default,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@resource_group.command()
+@click.argument("name", type=str)
+@click.option("--description", default=None, help="Human-readable description.")
+@click.option(
+    "--is-active/--no-is-active",
+    default=None,
+    help="Whether the resource group accepts new sessions.",
+)
+@click.option(
+    "--is-public/--no-is-public",
+    default=None,
+    help="Whether the resource group is visible to all users.",
+)
+@click.option(
+    "--is-default/--no-is-default",
+    default=None,
+    help="Make this the default resource group. Clear the current default first.",
+)
+def update(
+    name: str,
+    description: str | None,
+    is_active: bool | None,
+    is_public: bool | None,
+    is_default: bool | None,
+) -> None:
+    """Update a resource group (superadmin only). Omitted options keep their current value."""
+    from ai.backend.common.dto.manager.v2.resource_group.request import (
+        UpdateResourceGroupConfigInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.resource_group.update_config(
+                name,
+                UpdateResourceGroupConfigInput(
+                    resource_group_name=name,
+                    description=description,
+                    is_active=is_active,
+                    is_public=is_public,
+                    is_default=is_default,
                 ),
             )
             print_result(result)

--- a/src/ai/backend/client/cli/v2/admin/resource_group.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_group.py
@@ -145,12 +145,14 @@ def create(name: str, domain_name: str, description: str | None, is_default: boo
 @click.argument("name", type=str)
 @click.option("--description", default=None, help="Human-readable description.")
 @click.option(
-    "--is-active/--no-is-active",
+    "--set-active/--unset-active",
+    "is_active",
     default=None,
     help="Whether the resource group accepts new sessions.",
 )
 @click.option(
-    "--is-public/--no-is-public",
+    "--set-public/--unset-public",
+    "is_public",
     default=None,
     help="Whether the resource group is visible to all users.",
 )

--- a/src/ai/backend/common/dto/manager/v2/resource_group/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/request.py
@@ -74,6 +74,13 @@ class CreateResourceGroupInput(BaseRequestModel):
         default=None,
         description="Resource policy name to apply to this resource group.",
     )
+    is_default: bool = Field(
+        default=False,
+        description=(
+            "Make this the default resource group. At most one resource group may hold the"
+            " flag, so this is rejected while another one holds it; clear that one first."
+        ),
+    )
 
     @field_validator("name", mode="before")
     @classmethod
@@ -99,6 +106,14 @@ class UpdateResourceGroupInput(BaseRequestModel):
     is_active: bool | None = Field(
         default=None,
         description="Whether the resource group is active. Leave null to keep existing value.",
+    )
+    is_default: bool | None = Field(
+        default=None,
+        description=(
+            "Whether this is the default resource group. At most one resource group may hold"
+            " the flag, so setting it to true is rejected while another one holds it; clear"
+            " that one first. Leave null to keep existing value."
+        ),
     )
     total_resource_slots: dict[str, Any] | Sentinel | None = Field(
         default=SENTINEL,
@@ -259,6 +274,14 @@ class UpdateResourceGroupConfigInput(BaseRequestModel):
     is_public: bool | None = Field(
         default=None,
         description="Whether the resource group is public. Leave null to keep existing value.",
+    )
+    is_default: bool | None = Field(
+        default=None,
+        description=(
+            "Whether this is the default resource group. At most one resource group may hold"
+            " the flag, so setting it to true is rejected while another one holds it; clear"
+            " that one first. Leave null to keep existing value."
+        ),
     )
     description: str | None = Field(
         default=None,

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -406,6 +406,7 @@ class ResourceGroupAdapter(BaseAdapter):
             scheduler="fifo",
             description=input.description,
             is_active=True,
+            is_default=input.is_default,
         )
         creator = Creator(spec=creator_spec)
         action_result = await self._processors.scaling_group.create_scaling_group.wait_for_complete(
@@ -436,6 +437,7 @@ class ResourceGroupAdapter(BaseAdapter):
                 if input.is_active is not None
                 else OptionalState.nop()
             ),
+            is_default=OptionalState.from_nullable(input.is_default),
         )
         metadata_spec = ScalingGroupMetadataUpdaterSpec(
             description=(
@@ -604,6 +606,7 @@ class ResourceGroupAdapter(BaseAdapter):
                 if input.is_public is not None
                 else OptionalState.nop()
             ),
+            is_default=OptionalState.from_nullable(input.is_default),
         )
 
         metadata_spec = ScalingGroupMetadataUpdaterSpec(

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -81,6 +81,7 @@ from ai.backend.common.dto.manager.v2.resource_group.response import (
     ReplaceResourceGroupDefaultSessionOptionsPayload as ReplaceResourceGroupDefaultSessionOptionsPayloadDTO,
 )
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import PreemptionOrder, PreemptionVictimScope
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
@@ -613,6 +614,17 @@ class UpdateResourceGroupInput(PydanticInputMixin[UpdateResourceGroupConfigInput
         description="Whether the resource group is public. Leave null to keep existing value.",
         default=None,
     )
+    is_default: bool | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Whether this is the default resource group. At most one resource group may"
+                " hold the flag, so setting it to true is rejected while another one holds it;"
+                " clear that one first. Leave null to keep existing value."
+            ),
+        ),
+        default=None,
+    )
 
     # Metadata fields (ScalingGroupMetadataUpdaterSpec)
     description: str | None = gql_field(
@@ -674,6 +686,16 @@ class CreateResourceGroupInputGQL(PydanticInputMixin[CreateResourceGroupInputDTO
     name: str = gql_field(description="Resource group name.")
     domain_name: str = gql_field(description="Domain to create the resource group in.")
     description: str | None = gql_field(default=None, description="Optional description.")
+    is_default: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Make this the default resource group. At most one resource group may hold"
+                " the flag, so this is rejected while another one holds it; clear that one first."
+            ),
+        ),
+        default=False,
+    )
 
 
 @gql_pydantic_type(

--- a/src/ai/backend/manager/errors/resource.py
+++ b/src/ai/backend/manager/errors/resource.py
@@ -98,6 +98,19 @@ class UnresolvableResourceGroup(BackendAIError, web.HTTPBadRequest):
         )
 
 
+class DefaultScalingGroupAlreadyExists(BackendAIError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/default-scaling-group-already-exists"
+    error_title = "Another resource group is already the default."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SCALING_GROUP,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )
+
+
 class ScalingGroupSessionTypeNotAllowed(BackendAIError, web.HTTPUnprocessableEntity):
     error_type = "https://api.backend.ai/probs/scaling-group-session-type-not-allowed"
     error_title = "Scaling group does not allow this session type."

--- a/src/ai/backend/manager/repositories/scaling_group/creators.py
+++ b/src/ai/backend/manager/repositories/scaling_group/creators.py
@@ -40,6 +40,7 @@ class ScalingGroupCreatorSpec(CreatorSpec[ScalingGroupRow]):
     description: str | None = None
     is_active: bool = True
     is_public: bool = True
+    is_default: bool = False
     wsproxy_addr: str | None = None
     wsproxy_api_token: str | None = None
     driver_opts: Mapping[str, Any] = field(default_factory=dict)
@@ -64,6 +65,7 @@ class ScalingGroupCreatorSpec(CreatorSpec[ScalingGroupRow]):
             description=self.description,
             is_active=self.is_active,
             is_public=self.is_public,
+            is_default=self.is_default,
             wsproxy_addr=self.wsproxy_addr,
             wsproxy_api_token=self.wsproxy_api_token,
             driver=self.driver,

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
 
@@ -13,9 +13,14 @@ from sqlalchemy.dialects.postgresql import array as pg_array
 
 from ai.backend.manager.data.scaling_group.types import FairShareScalingGroupSpec
 from ai.backend.manager.data.scaling_group.types import PreemptionConfig as DataPreemptionConfig
+from ai.backend.manager.errors.repository import UniqueConstraintViolationError
+from ai.backend.manager.errors.resource import DefaultScalingGroupAlreadyExists
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
+from ai.backend.manager.repositories.base.types import IntegrityErrorCheck
 from ai.backend.manager.repositories.base.updater import UpdaterSpec
 from ai.backend.manager.types import OptionalState, TriState
+
+DEFAULT_SCALING_GROUP_INDEX = "uq_scaling_groups_is_default"
 
 
 @dataclass
@@ -27,6 +32,7 @@ class ScalingGroupStatusUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
 
     is_active: OptionalState[bool] = field(default_factory=OptionalState[bool].nop)
     is_public: OptionalState[bool] = field(default_factory=OptionalState[bool].nop)
+    is_default: OptionalState[bool] = field(default_factory=OptionalState[bool].nop)
 
     @property
     @override
@@ -38,6 +44,7 @@ class ScalingGroupStatusUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
         to_update: dict[str, Any] = {}
         self.is_active.update_dict(to_update, "is_active")
         self.is_public.update_dict(to_update, "is_public")
+        self.is_default.update_dict(to_update, "is_default")
         return to_update
 
 
@@ -199,6 +206,19 @@ class ScalingGroupUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
     @override
     def row_class(self) -> type[ScalingGroupRow]:
         return ScalingGroupRow
+
+    @property
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return (
+            IntegrityErrorCheck(
+                violation_type=UniqueConstraintViolationError,
+                constraint_name=DEFAULT_SCALING_GROUP_INDEX,
+                error=DefaultScalingGroupAlreadyExists(
+                    "Another resource group is already the default, clear it first"
+                ),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/tests/unit/common/dto/manager/v2/resource_group/test_request.py
+++ b/tests/unit/common/dto/manager/v2/resource_group/test_request.py
@@ -28,6 +28,7 @@ class TestCreateResourceGroupInput:
         assert req.allowed_vfolder_hosts is None
         assert req.integration_name is None
         assert req.resource_policy is None
+        assert req.is_default is False
 
     def test_valid_creation_with_all_fields(self) -> None:
         req = CreateResourceGroupInput(
@@ -38,10 +39,12 @@ class TestCreateResourceGroupInput:
             allowed_vfolder_hosts={"default": "rw"},
             integration_name="ext-001",
             resource_policy="default",
+            is_default=True,
         )
         assert req.name == "my-group"
         assert req.description == "A test group"
         assert req.total_resource_slots == {"cpu": "4"}
+        assert req.is_default is True
 
     def test_name_whitespace_is_stripped(self) -> None:
         req = CreateResourceGroupInput(name="  my-group  ", domain_name="default")

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -22,7 +22,10 @@ from ai.backend.manager.data.permission.types import RBACElementRef
 from ai.backend.manager.data.scaling_group.types import PreemptionConfig as DataPreemptionConfig
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
-from ai.backend.manager.errors.resource import ScalingGroupNotFound
+from ai.backend.manager.errors.resource import (
+    DefaultScalingGroupAlreadyExists,
+    ScalingGroupNotFound,
+)
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
@@ -162,6 +165,7 @@ class TestScalingGroupRepositoryDB:
         description: str | None = None,
         is_active: bool = True,
         is_public: bool = True,
+        is_default: bool = False,
         wsproxy_addr: str | None = None,
         wsproxy_api_token: str | None = None,
         driver_opts: dict[str, Any] | None = None,
@@ -176,6 +180,7 @@ class TestScalingGroupRepositoryDB:
             description=description,
             is_active=is_active,
             is_public=is_public,
+            is_default=is_default,
             wsproxy_addr=wsproxy_addr,
             wsproxy_api_token=wsproxy_api_token,
             driver_opts=driver_opts if driver_opts is not None else {},
@@ -782,6 +787,108 @@ class TestScalingGroupRepositoryDB:
 
         with pytest.raises(ScalingGroupNotFound):
             await scaling_group_repository.update_scaling_group(updater)
+
+    # Default Resource Group Tests
+
+    @pytest.fixture
+    async def existing_default_scaling_group(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[str, None]:
+        """Create a scaling group that is already the default one"""
+        sgroup_name = f"test-sgroup-default-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as db_sess:
+            sgroup = ScalingGroupRow(
+                name=sgroup_name,
+                description="Existing default scaling group",
+                is_active=True,
+                is_public=True,
+                is_default=True,
+                created_at=datetime.now(tz=UTC),
+                wsproxy_addr=None,
+                wsproxy_api_token=None,
+                driver="static",
+                driver_opts={},
+                scheduler="fifo",
+                scheduler_opts=ScalingGroupOpts(),
+                use_host_network=False,
+            )
+            db_sess.add(sgroup)
+            await db_sess.flush()
+        yield sgroup_name
+
+    async def _default_scaling_group_names(
+        self,
+        db_engine: ExtendedAsyncSAEngine,
+    ) -> list[str]:
+        """Names of every scaling group currently flagged as the default"""
+        async with db_engine.begin_readonly_session() as db_sess:
+            result = await db_sess.execute(
+                sa.select(ScalingGroupRow.name).where(ScalingGroupRow.is_default.is_(True))
+            )
+            return list(result.scalars())
+
+    async def test_set_true_while_another_group_is_default_is_rejected(
+        self,
+        scaling_group_repository: ScalingGroupRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        existing_default_scaling_group: str,
+        scaling_group_for_update: str,
+    ) -> None:
+        """A second default is rejected as a bad request; the current one is untouched"""
+        updater = Updater(
+            spec=ScalingGroupUpdaterSpec(
+                status=ScalingGroupStatusUpdaterSpec(is_default=OptionalState.update(True)),
+            ),
+            pk_value=scaling_group_for_update,
+        )
+
+        with pytest.raises(DefaultScalingGroupAlreadyExists):
+            await scaling_group_repository.update_scaling_group(updater)
+
+        assert await self._default_scaling_group_names(db_with_cleanup) == [
+            existing_default_scaling_group
+        ]
+
+    async def test_set_true_while_no_group_is_default_succeeds(
+        self,
+        scaling_group_repository: ScalingGroupRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        scaling_group_for_update: str,
+    ) -> None:
+        """Setting the flag works while it is free"""
+        updater = Updater(
+            spec=ScalingGroupUpdaterSpec(
+                status=ScalingGroupStatusUpdaterSpec(is_default=OptionalState.update(True)),
+            ),
+            pk_value=scaling_group_for_update,
+        )
+
+        result = await scaling_group_repository.update_scaling_group(updater)
+
+        assert result.status.is_default is True
+        assert await self._default_scaling_group_names(db_with_cleanup) == [
+            scaling_group_for_update
+        ]
+
+    async def test_set_false_on_the_only_default_leaves_none(
+        self,
+        scaling_group_repository: ScalingGroupRepository,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        existing_default_scaling_group: str,
+    ) -> None:
+        """Clearing the flag on the sole default is allowed and leaves no default behind"""
+        updater = Updater(
+            spec=ScalingGroupUpdaterSpec(
+                status=ScalingGroupStatusUpdaterSpec(is_default=OptionalState.update(False)),
+            ),
+            pk_value=existing_default_scaling_group,
+        )
+
+        result = await scaling_group_repository.update_scaling_group(updater)
+
+        assert result.status.is_default is False
+        assert await self._default_scaling_group_names(db_with_cleanup) == []
 
     # Purge Tests
 


### PR DESCRIPTION
## Summary
- `scaling_groups.is_default` landed schema-only in BA-6824, so the default resource group could only be changed by writing to the database directly. This wires the flag through the write paths: the v2 create/update DTOs, the adapter, `ScalingGroupCreatorSpec` / `ScalingGroupStatusUpdaterSpec`, the GraphQL create/update inputs, and the admin CLI (`create --is-default` plus a new `update` command).
- The partial unique index still permits a single default, so promoting a group while another one holds the flag is rejected — the default is switched by clearing the old one first. `ScalingGroupUpdaterSpec` now carries an `integrity_error_checks` entry that maps the `uq_scaling_groups_is_default` violation to a 400 (`DefaultScalingGroupAlreadyExists`) instead of leaking the raw unique-violation error.
- The CLI `update` command targets `PATCH /v2/resource-groups/{name}/config` rather than the plain update endpoint, because the latter treats an omitted `description` as "clear it" (see the note below).

## Test plan
- [x] `pants test tests/unit/manager/repositories/scaling_group::` — four real-DB cases covering `is_default` true/false against another default existing/not existing
- [x] `pants test tests/unit/common/dto/manager/v2/resource_group::`
- [x] Verify against a live server: `./bai admin resource-group update <name> --is-default`, then confirm the second promotion returns 400 until the first is cleared

## Note for reviewers
Two pre-existing issues were left untouched here:
- `ResourceGroupAdapter.update()` inverts the SENTINEL convention for `description` (SENTINEL clears, `None` keeps), the opposite of every other adapter. Combined with the SDK's `exclude_unset` serialization, a PATCH that omits `description` wipes it.
- `ScalingGroupCreatorSpec.integrity_error_checks` matches any unique violation without filtering on the constraint name, so creating a group with `is_default=true` while another default exists reports "Duplicate scaling group name".

Resolves BA-7283

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13615.org.readthedocs.build/en/13615/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13615.org.readthedocs.build/ko/13615/

<!-- readthedocs-preview sorna-ko end -->