### PR TITLE
feat(BA-7286): make the processor registry spec-aware

### DIFF
--- a/changes/13624.enhance.md
+++ b/changes/13624.enhance.md
@@ -1,0 +1,1 @@
+Make the processor registry spec-aware: wiring factories now take the action class and accumulate the catalog of wired actions, replacing the unused hand-written `supported_actions` lists.

--- a/src/ai/backend/manager/actions/registry.py
+++ b/src/ai/backend/manager/actions/registry.py
@@ -7,6 +7,10 @@ where the audit trail and the RBAC validators read it from. An ``<shape>_<operat
 factory does vary by operation, which decides the generic service it builds, the spec it
 demands of the action, and the result type.
 
+Every factory takes the action class it wires as its first argument: the processor is
+typed by that class, and the registry accumulates every wired spec — the catalog of
+entity-operation combinations actually in use.
+
 The ``validators`` / ``monitors`` arguments only append — what the shape carries is
 always applied.
 """
@@ -17,6 +21,7 @@ from typing import Any
 
 from ai.backend.common.data.entity.types import EntityData
 from ai.backend.manager.actions.monitors import ActionMonitors
+from ai.backend.manager.actions.types import ActionSpec
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
 from ai.backend.manager.actions.v2.bulk.monitor import BulkActionMonitor
 from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
@@ -101,17 +106,24 @@ class ProcessorDependencies[TData: EntityData]:
 
 class ProcessorGroup[TData: EntityData]:
     _deps: ProcessorDependencies[TData]
+    _specs: list[ActionSpec]
 
-    def __init__(self, deps: ProcessorDependencies[TData]) -> None:
+    def __init__(self, deps: ProcessorDependencies[TData], specs: list[ActionSpec]) -> None:
         self._deps = deps
+        self._specs = specs
+
+    def _record(self, spec: ActionSpec) -> None:
+        self._specs.append(spec)
 
     def single_entity[TAction: BaseSingleEntityAction, TResult](
         self,
+        action_cls: type[TAction],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
         validators: Sequence[SingleEntityActionValidator] = (),
         monitors: Sequence[SingleEntityActionMonitor] = (),
     ) -> SingleEntityActionProcessor[TAction, TResult]:
+        self._record(action_cls.spec())
         return SingleEntityActionProcessor(
             func,
             monitors=(*self._deps.monitors.single_entity, *monitors),
@@ -120,11 +132,13 @@ class ProcessorGroup[TData: EntityData]:
 
     def scope[TAction: BaseScopeAction, TResult: BaseScopeActionResult](
         self,
+        action_cls: type[TAction],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
         validators: Sequence[ScopeActionValidator] = (),
         monitors: Sequence[ScopeActionMonitor] = (),
     ) -> ScopeActionProcessor[TAction, TResult]:
+        self._record(action_cls.spec())
         return ScopeActionProcessor(
             func,
             monitors=(*self._deps.monitors.scope, *monitors),
@@ -133,11 +147,13 @@ class ProcessorGroup[TData: EntityData]:
 
     def bulk[TAction: BaseBulkAction, TResult: BaseBulkActionResult](
         self,
+        action_cls: type[TAction],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
         validators: Sequence[BulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
     ) -> BulkActionProcessor[TAction, TResult]:
+        self._record(action_cls.spec())
         return BulkActionProcessor(
             func,
             monitors=(*self._deps.monitors.bulk, *monitors),
@@ -146,11 +162,13 @@ class ProcessorGroup[TData: EntityData]:
 
     def global_scope[TAction: BaseGlobalAction, TResult](
         self,
+        action_cls: type[TAction],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
         validators: Sequence[GlobalActionValidator] = (),
         monitors: Sequence[GlobalActionMonitor] = (),
     ) -> GlobalActionProcessor[TAction, TResult]:
+        self._record(action_cls.spec())
         return GlobalActionProcessor(
             func,
             monitors=(*self._deps.monitors.global_scope, *monitors),
@@ -159,223 +177,251 @@ class ProcessorGroup[TData: EntityData]:
 
     def lookup[TAction: BaseLookupAction, TResult: BaseLookupActionResult](
         self,
+        action_cls: type[TAction],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
         validators: Sequence[LookupActionValidator] = (),
         monitors: Sequence[LookupActionMonitor] = (),
     ) -> LookupActionProcessor[TAction, TResult]:
+        self._record(action_cls.spec())
         return LookupActionProcessor(
             func,
             monitors=(*self._deps.monitors.lookup, *monitors),
             validators=(*self._deps.validators.lookup, *validators),
         )
 
-    def single_get_ops(
+    def single_get_ops[TAction: GetSingleEntityOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[SingleEntityActionValidator] = (),
         monitors: Sequence[SingleEntityActionMonitor] = (),
-    ) -> SingleEntityActionProcessor[GetSingleEntityOpsAction[Any, TData], EntityOpsResult[TData]]:
+    ) -> SingleEntityActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return SingleEntityActionProcessor(
             GetService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.single_entity, *monitors),
             validators=(*self._deps.validators.single_entity, *validators),
         )
 
-    def single_update_ops(
+    def single_update_ops[TAction: UpdateSingleEntityOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[SingleEntityActionValidator] = (),
         monitors: Sequence[SingleEntityActionMonitor] = (),
-    ) -> SingleEntityActionProcessor[
-        UpdateSingleEntityOpsAction[Any, TData], EntityOpsResult[TData]
-    ]:
+    ) -> SingleEntityActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return SingleEntityActionProcessor(
             UpdateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.single_entity, *monitors),
             validators=(*self._deps.validators.single_entity, *validators),
         )
 
-    def single_delete_ops(
+    def single_delete_ops[TAction: DeleteSingleEntityOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[SingleEntityActionValidator] = (),
         monitors: Sequence[SingleEntityActionMonitor] = (),
-    ) -> SingleEntityActionProcessor[
-        DeleteSingleEntityOpsAction[Any, TData], EntityOpsResult[TData]
-    ]:
+    ) -> SingleEntityActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return SingleEntityActionProcessor(
             DeleteService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.single_entity, *monitors),
             validators=(*self._deps.validators.single_entity, *validators),
         )
 
-    def single_upsert_ops(
+    def single_upsert_ops[TAction: UpsertSingleEntityOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[SingleEntityActionValidator] = (),
         monitors: Sequence[SingleEntityActionMonitor] = (),
-    ) -> SingleEntityActionProcessor[
-        UpsertSingleEntityOpsAction[Any, TData], EntityOpsResult[TData]
-    ]:
+    ) -> SingleEntityActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return SingleEntityActionProcessor(
             UpsertService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.single_entity, *monitors),
             validators=(*self._deps.validators.single_entity, *validators),
         )
 
-    def single_purge_ops(
+    def single_purge_ops[TAction: PurgeSingleEntityOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[SingleEntityActionValidator] = (),
         monitors: Sequence[SingleEntityActionMonitor] = (),
-    ) -> SingleEntityActionProcessor[
-        PurgeSingleEntityOpsAction[Any, TData], EntityOpsResult[TData]
-    ]:
+    ) -> SingleEntityActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return SingleEntityActionProcessor(
             PurgeService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.single_entity, *monitors),
             validators=(*self._deps.validators.single_entity, *validators),
         )
 
-    def bulk_update_ops(
+    def bulk_update_ops[TAction: UpdateBulkOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[BulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[UpdateBulkOpsAction[Any, TData], BulkOpsResult[TData]]:
+    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+        self._record(action_cls.spec())
         return BulkActionProcessor(
             BulkUpdateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.bulk, *monitors),
             validators=(*self._deps.validators.bulk, *validators),
         )
 
-    def bulk_delete_ops(
+    def bulk_delete_ops[TAction: DeleteBulkOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[BulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[DeleteBulkOpsAction[Any, TData], BulkOpsResult[TData]]:
+    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+        self._record(action_cls.spec())
         return BulkActionProcessor(
             BulkDeleteService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.bulk, *monitors),
             validators=(*self._deps.validators.bulk, *validators),
         )
 
-    def bulk_purge_ops(
+    def bulk_purge_ops[TAction: PurgeBulkOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[BulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[PurgeBulkOpsAction[Any, TData], BulkOpsResult[TData]]:
+    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+        self._record(action_cls.spec())
         return BulkActionProcessor(
             BulkPurgeService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.bulk, *monitors),
             validators=(*self._deps.validators.bulk, *validators),
         )
 
-    def scope_create_ops(
+    def scope_create_ops[TAction: CreateScopeOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[ScopeActionValidator] = (),
         monitors: Sequence[ScopeActionMonitor] = (),
-    ) -> ScopeActionProcessor[CreateScopeOpsAction[Any, TData], CreatedEntityOpsResult[TData]]:
+    ) -> ScopeActionProcessor[TAction, CreatedEntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return ScopeActionProcessor(
             CreateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.scope, *monitors),
             validators=(*self._deps.validators.scope, *validators),
         )
 
-    def scope_bulk_create_ops(
+    def scope_bulk_create_ops[TAction: BulkCreateScopeOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[ScopeActionValidator] = (),
         monitors: Sequence[ScopeActionMonitor] = (),
-    ) -> ScopeActionProcessor[BulkCreateScopeOpsAction[Any, TData], EntitiesOpsResult[TData]]:
+    ) -> ScopeActionProcessor[TAction, EntitiesOpsResult[TData]]:
+        self._record(action_cls.spec())
         return ScopeActionProcessor(
             BulkCreateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.scope, *monitors),
             validators=(*self._deps.validators.scope, *validators),
         )
 
-    def scope_batch_update_ops(
+    def scope_batch_update_ops[TAction: BatchUpdateScopeOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[ScopeActionValidator] = (),
         monitors: Sequence[ScopeActionMonitor] = (),
-    ) -> ScopeActionProcessor[BatchUpdateScopeOpsAction[Any, TData], EntitiesOpsResult[TData]]:
+    ) -> ScopeActionProcessor[TAction, EntitiesOpsResult[TData]]:
+        self._record(action_cls.spec())
         return ScopeActionProcessor(
             BatchUpdateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.scope, *monitors),
             validators=(*self._deps.validators.scope, *validators),
         )
 
-    def scope_batch_purge_ops(
+    def scope_batch_purge_ops[TAction: BatchPurgeScopeOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[ScopeActionValidator] = (),
         monitors: Sequence[ScopeActionMonitor] = (),
-    ) -> ScopeActionProcessor[BatchPurgeScopeOpsAction[Any, TData], EntitiesOpsResult[TData]]:
+    ) -> ScopeActionProcessor[TAction, EntitiesOpsResult[TData]]:
+        self._record(action_cls.spec())
         return ScopeActionProcessor(
             BatchPurgeService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.scope, *monitors),
             validators=(*self._deps.validators.scope, *validators),
         )
 
-    def scope_search_ops(
+    def scope_search_ops[TAction: SearchScopeOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[ScopeActionValidator] = (),
         monitors: Sequence[ScopeActionMonitor] = (),
-    ) -> ScopeActionProcessor[SearchScopeOpsAction[Any, TData], ScopedBatchOpsResult[TData]]:
+    ) -> ScopeActionProcessor[TAction, ScopedBatchOpsResult[TData]]:
+        self._record(action_cls.spec())
         return ScopeActionProcessor(
             SearchService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.scope, *monitors),
             validators=(*self._deps.validators.scope, *validators),
         )
 
-    def global_create_ops(
+    def global_create_ops[TAction: CreateGlobalOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[GlobalActionValidator] = (),
         monitors: Sequence[GlobalActionMonitor] = (),
-    ) -> GlobalActionProcessor[CreateGlobalOpsAction[Any, TData], CreatedEntityOpsResult[TData]]:
+    ) -> GlobalActionProcessor[TAction, CreatedEntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return GlobalActionProcessor(
             CreateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.global_scope, *monitors),
             validators=(*self._deps.validators.global_scope, *validators),
         )
 
-    def global_update_ops(
+    def global_update_ops[TAction: UpdateGlobalOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[GlobalActionValidator] = (),
         monitors: Sequence[GlobalActionMonitor] = (),
-    ) -> GlobalActionProcessor[UpdateGlobalOpsAction[Any, TData], EntityOpsResult[TData]]:
+    ) -> GlobalActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return GlobalActionProcessor(
             UpdateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.global_scope, *monitors),
             validators=(*self._deps.validators.global_scope, *validators),
         )
 
-    def global_purge_ops(
+    def global_purge_ops[TAction: PurgeGlobalOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[GlobalActionValidator] = (),
         monitors: Sequence[GlobalActionMonitor] = (),
-    ) -> GlobalActionProcessor[PurgeGlobalOpsAction[Any, TData], EntityOpsResult[TData]]:
+    ) -> GlobalActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
         return GlobalActionProcessor(
             PurgeService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.global_scope, *monitors),
             validators=(*self._deps.validators.global_scope, *validators),
         )
 
-    def global_search_ops(
+    def global_search_ops[TAction: SearchGlobalOpsAction[Any, Any]](
         self,
+        action_cls: type[TAction],
         *,
         validators: Sequence[GlobalActionValidator] = (),
         monitors: Sequence[GlobalActionMonitor] = (),
-    ) -> GlobalActionProcessor[SearchGlobalOpsAction[Any, TData], BatchOpsResult[TData]]:
+    ) -> GlobalActionProcessor[TAction, BatchOpsResult[TData]]:
+        self._record(action_cls.spec())
         return GlobalActionProcessor(
             GlobalSearchService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.global_scope, *monitors),
@@ -385,9 +431,15 @@ class ProcessorGroup[TData: EntityData]:
 
 class ProcessorRegistry[TData: EntityData]:
     _deps: ProcessorDependencies[TData]
+    _specs: list[ActionSpec]
 
     def __init__(self, deps: ProcessorDependencies[TData]) -> None:
         self._deps = deps
+        self._specs = []
 
     def group(self) -> ProcessorGroup[TData]:
-        return ProcessorGroup(self._deps)
+        return ProcessorGroup(self._deps, self._specs)
+
+    def wired_specs(self) -> Sequence[ActionSpec]:
+        """Every spec wired through this registry's groups, in wiring order."""
+        return tuple(self._specs)

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -1,5 +1,4 @@
 import enum
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Final
 
@@ -111,13 +110,6 @@ class ActionSpec:
 
     def type(self) -> str:
         return f"{self.entity_type}:{self.operation_type}"
-
-
-class AbstractProcessorPackage(ABC):
-    @abstractmethod
-    def supported_actions(self) -> list[ActionSpec]:
-        """Get the list of action specs that this processors can handle."""
-        raise NotImplementedError
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/AGENTS.md
+++ b/src/ai/backend/manager/services/AGENTS.md
@@ -29,7 +29,9 @@ grows a branch; the generic services take no hook or callback to hide one in.
 ## Processor rules
 
 - Wrap every service method in an `ActionProcessor`. Do NOT expose raw service methods to handlers.
-- It MUST inherit from `AbstractProcessorPackage` and override `supported_actions()`.
+- v2 processors MUST be built through the `ProcessorGroup` factories, passing the action
+  class as the first argument — the registry accumulates the wired specs
+  (`ProcessorRegistry.wired_specs()`), so no hand-written action list exists.
 
 ## What belongs here
 

--- a/src/ai/backend/manager/services/README.md
+++ b/src/ai/backend/manager/services/README.md
@@ -746,46 +746,35 @@ class CreateStorageNamespaceActionResult(StorageNamespaceActionResult):
 Processors orchestrate action execution with hooks, metrics, and middleware:
 
 ```python
-from ai.backend.manager.services.processors import (
-    AbstractProcessorPackage,
-    ActionProcessor,
-)
+from ai.backend.manager.actions.monitors.monitor import ActionMonitor
+from ai.backend.manager.actions.processor import ActionProcessor
 
 
-class StorageNamespaceProcessorPackage(AbstractProcessorPackage):
+class StorageNamespaceProcessors:
     """Processor package for storage namespace operations."""
+
+    create_storage_namespace: ActionProcessor[
+        CreateStorageNamespaceAction,
+        CreateStorageNamespaceActionResult,
+    ]
 
     def __init__(
         self,
-        service: StorageNamespaceServiceProtocol,
+        service: StorageNamespaceService,
+        action_monitors: list[ActionMonitor],
     ) -> None:
-        self._service = service
-        self._create_processor = ActionProcessor[
-            CreateStorageNamespaceAction,
-            CreateStorageNamespaceActionResult,
-        ](
-            action_name="create_storage_namespace",
-            handler=service.create_storage_namespace,
+        self.create_storage_namespace = ActionProcessor(
+            service.create_storage_namespace, action_monitors
         )
-
-    @property
-    def create_storage_namespace(
-        self,
-    ) -> ActionProcessor[
-        CreateStorageNamespaceAction,
-        CreateStorageNamespaceActionResult,
-    ]:
-        return self._create_processor
 ```
 
 **Key Components:**
-- **ProcessorPackage**: Container for all domain processors
+- **Processors package**: Container holding one processor field per action
 - **ActionProcessor**: Wraps service method with:
   - Pre/post hook execution
   - Metrics collection
   - Error handling
   - Logging
-- **Property Pattern**: Expose processors as properties for clean API
 
 ### Service Implementation Workflow
 

--- a/src/ai/backend/manager/services/agent/processors.py
+++ b/src/ai/backend/manager/services/agent/processors.py
@@ -1,9 +1,6 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.audit_log import AuditLogMonitor
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
@@ -68,7 +65,7 @@ from ai.backend.manager.services.agent.actions.watcher_agent_stop import (
 from ai.backend.manager.services.agent.service import AgentService
 
 
-class AgentProcessors(AbstractProcessorPackage):
+class AgentProcessors:
     sync_agent_registry: ActionProcessor[SyncAgentRegistryAction, SyncAgentRegistryActionResult]
     get_watcher_status: ActionProcessor[GetWatcherStatusAction, GetWatcherStatusActionResult]
     watcher_agent_start: ActionProcessor[WatcherAgentStartAction, WatcherAgentStartActionResult]
@@ -126,21 +123,3 @@ class AgentProcessors(AbstractProcessorPackage):
         self.search_agents = ActionProcessor(service.search_agents, action_monitors)
         self.load_container_counts = ActionProcessor(service.load_container_counts, action_monitors)
         self.update_resource_group = ActionProcessor(service.update_resource_group, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            SyncAgentRegistryAction.spec(),
-            GetWatcherStatusAction.spec(),
-            WatcherAgentStartAction.spec(),
-            WatcherAgentRestartAction.spec(),
-            WatcherAgentStopAction.spec(),
-            RecalculateUsageAction.spec(),
-            GetTotalResourcesAction.spec(),
-            HandleHeartbeatAction.spec(),
-            RemoveAgentFromImagesAction.spec(),
-            RemoveAgentFromImagesByCanonicalsAction.spec(),
-            SearchAgentsAction.spec(),
-            LoadContainerCountsAction.spec(),
-            UpdateAgentResourceGroupAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/app_config/processors.py
+++ b/src/ai/backend/manager/services/app_config/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.app_config.actions.get import (
     GetAppConfigsAction,
     GetAppConfigsActionResult,
@@ -12,7 +9,7 @@ from ai.backend.manager.services.app_config.actions.get import (
 from ai.backend.manager.services.app_config.service import AppConfigService
 
 
-class AppConfigProcessors(AbstractProcessorPackage):
+class AppConfigProcessors:
     get_app_configs: ScopeActionProcessor[GetAppConfigsAction, GetAppConfigsActionResult]
 
     def __init__(
@@ -23,9 +20,3 @@ class AppConfigProcessors(AbstractProcessorPackage):
         # No RBAC validator on purpose: the adapter fills the action's user_id from the
         # session, so a get is only ever for the acting user.
         self.get_app_configs = ScopeActionProcessor(service.get_app_configs, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetAppConfigsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/app_config_allow_list/processors.py
+++ b/src/ai/backend/manager/services/app_config_allow_list/processors.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.registry import ProcessorRegistry
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
@@ -29,7 +26,7 @@ from ai.backend.manager.services.app_config_allow_list.actions.update import (
 )
 
 
-class AppConfigAllowListProcessors(AbstractProcessorPackage):
+class AppConfigAllowListProcessors:
     """Every operation runs straight against ops, so this domain has no service."""
 
     create: GlobalActionProcessor[
@@ -60,13 +57,3 @@ class AppConfigAllowListProcessors(AbstractProcessorPackage):
         self.update = p.single_update_ops(UpdateAppConfigAllowListAction)
         self.purge = p.single_purge_ops(PurgeAppConfigAllowListAction)
         self.admin_search = p.global_search_ops(AdminSearchAppConfigAllowListAction)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateAppConfigAllowListAction.spec(),
-            GetAppConfigAllowListAction.spec(),
-            AdminSearchAppConfigAllowListAction.spec(),
-            UpdateAppConfigAllowListAction.spec(),
-            PurgeAppConfigAllowListAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/app_config_allow_list/processors.py
+++ b/src/ai/backend/manager/services/app_config_allow_list/processors.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, override
+from typing import override
 
 from ai.backend.manager.actions.registry import ProcessorRegistry
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
-from ai.backend.manager.actions.v2.ops.base import (
-    CreateGlobalOpsAction,
-    GetSingleEntityOpsAction,
-    PurgeSingleEntityOpsAction,
-    SearchGlobalOpsAction,
-    UpdateSingleEntityOpsAction,
-)
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
     CreatedEntityOpsResult,
@@ -40,33 +33,33 @@ class AppConfigAllowListProcessors(AbstractProcessorPackage):
     """Every operation runs straight against ops, so this domain has no service."""
 
     create: GlobalActionProcessor[
-        CreateGlobalOpsAction[Any, AppConfigAllowListData],
+        CreateAppConfigAllowListAction,
         CreatedEntityOpsResult[AppConfigAllowListData],
     ]
     get: SingleEntityActionProcessor[
-        GetSingleEntityOpsAction[Any, AppConfigAllowListData],
+        GetAppConfigAllowListAction,
         EntityOpsResult[AppConfigAllowListData],
     ]
     update: SingleEntityActionProcessor[
-        UpdateSingleEntityOpsAction[Any, AppConfigAllowListData],
+        UpdateAppConfigAllowListAction,
         EntityOpsResult[AppConfigAllowListData],
     ]
     purge: SingleEntityActionProcessor[
-        PurgeSingleEntityOpsAction[Any, AppConfigAllowListData],
+        PurgeAppConfigAllowListAction,
         EntityOpsResult[AppConfigAllowListData],
     ]
     admin_search: GlobalActionProcessor[
-        SearchGlobalOpsAction[Any, AppConfigAllowListData],
+        AdminSearchAppConfigAllowListAction,
         BatchOpsResult[AppConfigAllowListData],
     ]
 
     def __init__(self, registry: ProcessorRegistry[AppConfigAllowListData]) -> None:
         p = registry.group()
-        self.create = p.global_create_ops()
-        self.get = p.single_get_ops()
-        self.update = p.single_update_ops()
-        self.purge = p.single_purge_ops()
-        self.admin_search = p.global_search_ops()
+        self.create = p.global_create_ops(CreateAppConfigAllowListAction)
+        self.get = p.single_get_ops(GetAppConfigAllowListAction)
+        self.update = p.single_update_ops(UpdateAppConfigAllowListAction)
+        self.purge = p.single_purge_ops(PurgeAppConfigAllowListAction)
+        self.admin_search = p.global_search_ops(AdminSearchAppConfigAllowListAction)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:

--- a/src/ai/backend/manager/services/app_config_definition/processors.py
+++ b/src/ai/backend/manager/services/app_config_definition/processors.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor.global_action import GlobalActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.app_config_definition.actions.admin_search import (
     AdminSearchAppConfigDefinitionsAction,
     SearchAppConfigDefinitionsActionResult,
@@ -28,7 +25,7 @@ from ai.backend.manager.services.app_config_definition.service import (
 )
 
 
-class AppConfigDefinitionProcessors(AbstractProcessorPackage):
+class AppConfigDefinitionProcessors:
     create: ScopeActionProcessor[
         CreateAppConfigDefinitionAction, CreateAppConfigDefinitionActionResult
     ]
@@ -51,12 +48,3 @@ class AppConfigDefinitionProcessors(AbstractProcessorPackage):
         self.get = SingleEntityActionProcessor(service.get, action_monitors)
         self.admin_search = GlobalActionProcessor(service.admin_search, action_monitors)
         self.purge = SingleEntityActionProcessor(service.purge, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateAppConfigDefinitionAction.spec(),
-            GetAppConfigDefinitionAction.spec(),
-            AdminSearchAppConfigDefinitionsAction.spec(),
-            PurgeAppConfigDefinitionAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/app_config_fragment/processors.py
+++ b/src/ai/backend/manager/services/app_config_fragment/processors.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
 from ai.backend.manager.actions.processor.global_action import GlobalActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.app_config_fragment.actions.admin_search import (
     AdminSearchAppConfigFragmentAction,
@@ -38,7 +35,7 @@ from ai.backend.manager.services.app_config_fragment.service import (
 )
 
 
-class AppConfigFragmentProcessors(AbstractProcessorPackage):
+class AppConfigFragmentProcessors:
     bulk_upsert: ScopeActionProcessor[
         BulkUpsertAppConfigFragmentsAction, BulkUpsertAppConfigFragmentsActionResult
     ]
@@ -82,14 +79,3 @@ class AppConfigFragmentProcessors(AbstractProcessorPackage):
         self.bulk_purge = BulkActionProcessor(
             service.bulk_purge, monitors=action_monitors, validators=[validators.rbac.bulk]
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            BulkUpsertAppConfigFragmentsAction.spec(),
-            GetAppConfigFragmentAction.spec(),
-            AdminSearchAppConfigFragmentAction.spec(),
-            ScopedSearchAppConfigFragmentAction.spec(),
-            PurgeAppConfigFragmentAction.spec(),
-            BulkPurgeAppConfigFragmentAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/artifact/processors.py
+++ b/src/ai/backend/manager/services/artifact/processors.py
@@ -1,9 +1,6 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.artifact.actions.delegate_scan import (
     DelegateScanArtifactsAction,
@@ -57,7 +54,7 @@ from ai.backend.manager.services.artifact.actions.upsert_multi import (
 from .service import ArtifactService
 
 
-class ArtifactProcessors(AbstractProcessorPackage):
+class ArtifactProcessors:
     scan: ActionProcessor[ScanArtifactsAction, ScanArtifactsActionResult]
     get: SingleEntityActionProcessor[GetArtifactAction, GetArtifactActionResult]
     search_artifacts: ActionProcessor[SearchArtifactsAction, SearchArtifactsActionResult]
@@ -103,20 +100,3 @@ class ArtifactProcessors(AbstractProcessorPackage):
         self.delete_artifacts = ActionProcessor(service.delete_artifacts, action_monitors)
         self.restore_artifacts = ActionProcessor(service.restore_artifacts, action_monitors)
         self.delegate_scan = ActionProcessor(service.delegate_scan_artifacts, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ScanArtifactsAction.spec(),
-            DelegateScanArtifactsAction.spec(),
-            GetArtifactAction.spec(),
-            SearchArtifactsAction.spec(),
-            SearchArtifactsWithRevisionsAction.spec(),
-            GetArtifactRevisionsAction.spec(),
-            UpdateArtifactAction.spec(),
-            UpsertArtifactsAction.spec(),
-            RetrieveModelAction.spec(),
-            RetrieveModelsAction.spec(),
-            DeleteArtifactsAction.spec(),
-            RestoreArtifactsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/artifact_registry/processors.py
+++ b/src/ai/backend/manager/services/artifact_registry/processors.py
@@ -1,10 +1,7 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.artifact_registry.actions.common.get_meta import (
     GetArtifactRegistryMetaAction,
@@ -78,7 +75,7 @@ from ai.backend.manager.services.artifact_registry.actions.reservoir.update impo
 from .service import ArtifactRegistryService
 
 
-class ArtifactRegistryProcessors(AbstractProcessorPackage):
+class ArtifactRegistryProcessors:
     create_huggingface_registry: ActionProcessor[
         CreateHuggingFaceRegistryAction, CreateHuggingFaceRegistryActionResult
     ]
@@ -206,25 +203,3 @@ class ArtifactRegistryProcessors(AbstractProcessorPackage):
             service.get_reservoir_registries, action_monitors
         )
         self.get_registry_metas = ActionProcessor(service.get_registry_metas, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateHuggingFaceRegistryAction.spec(),
-            UpdateHuggingFaceRegistryAction.spec(),
-            DeleteHuggingFaceRegistryAction.spec(),
-            GetHuggingFaceRegistryAction.spec(),
-            GetHuggingFaceRegistriesAction.spec(),
-            ListHuggingFaceRegistryAction.spec(),
-            SearchHuggingFaceRegistriesAction.spec(),
-            CreateReservoirRegistryAction.spec(),
-            UpdateReservoirRegistryAction.spec(),
-            DeleteReservoirRegistryAction.spec(),
-            GetReservoirRegistryAction.spec(),
-            GetReservoirRegistriesAction.spec(),
-            ListReservoirRegistriesAction.spec(),
-            SearchReservoirRegistriesAction.spec(),
-            GetArtifactRegistryMetaAction.spec(),
-            GetArtifactRegistryMetasAction.spec(),
-            SearchArtifactRegistriesAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/artifact_revision/processors.py
+++ b/src/ai/backend/manager/services/artifact_revision/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.artifact_revision.actions.approve import (
     ApproveArtifactRevisionAction,
@@ -59,7 +56,7 @@ from ai.backend.manager.services.artifact_revision.actions.search import (
 from ai.backend.manager.services.artifact_revision.service import ArtifactRevisionService
 
 
-class ArtifactRevisionProcessors(AbstractProcessorPackage):
+class ArtifactRevisionProcessors:
     get: ActionProcessor[GetArtifactRevisionAction, GetArtifactRevisionActionResult]
     get_readme: ActionProcessor[
         GetArtifactRevisionReadmeAction, GetArtifactRevisionReadmeActionResult
@@ -118,21 +115,3 @@ class ArtifactRevisionProcessors(AbstractProcessorPackage):
         self.disassociate_with_storage = ActionProcessor(
             service.disassociate_with_storage, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetArtifactRevisionAction.spec(),
-            GetArtifactRevisionReadmeAction.spec(),
-            GetArtifactRevisionVerificationResultAction.spec(),
-            GetDownloadProgressAction.spec(),
-            SearchArtifactRevisionsAction.spec(),
-            ApproveArtifactRevisionAction.spec(),
-            RejectArtifactRevisionAction.spec(),
-            ImportArtifactRevisionAction.spec(),
-            CancelImportAction.spec(),
-            CleanupArtifactRevisionAction.spec(),
-            AssociateWithStorageAction.spec(),
-            DisassociateWithStorageAction.spec(),
-            DelegateImportArtifactRevisionBatchAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/audit_log/processors.py
+++ b/src/ai/backend/manager/services/audit_log/processors.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.audit_log.actions.create import (
     CreateAuditLogAction,
@@ -22,7 +19,7 @@ from ai.backend.manager.services.audit_log.actions.search import (
 from ai.backend.manager.services.audit_log.service import AuditLogService
 
 
-class AuditLogProcessors(AbstractProcessorPackage):
+class AuditLogProcessors:
     create: ActionProcessor[CreateAuditLogAction, CreateAuditLogActionResult]
     search: ActionProcessor[SearchAuditLogsAction, SearchAuditLogsActionResult]
     scoped_search: BulkActionProcessor[
@@ -42,11 +39,3 @@ class AuditLogProcessors(AbstractProcessorPackage):
             monitors=action_monitors,
             validators=[validators.rbac.bulk],
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateAuditLogAction.spec(),
-            SearchAuditLogsAction.spec(),
-            ScopedSearchAuditLogsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/auth/processors.py
+++ b/src/ai/backend/manager/services/auth/processors.py
@@ -1,10 +1,7 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.auth.actions.authorize import (
     AuthorizeAction,
@@ -72,7 +69,7 @@ from ai.backend.manager.services.auth.actions.upload_ssh_keypair import (
 from ai.backend.manager.services.auth.service import AuthService
 
 
-class AuthProcessors(AbstractProcessorPackage):
+class AuthProcessors:
     logout: ActionProcessor[LogoutAction, LogoutActionResult]
     signout: ActionProcessor[SignoutAction, SignoutActionResult]
     update_full_name: ActionProcessor[UpdateFullNameAction, UpdateFullNameActionResult]
@@ -160,29 +157,3 @@ class AuthProcessors(AbstractProcessorPackage):
             service.my_revoke_login_session, action_monitors
         )
         self.admin_unblock_user = ActionProcessor(service.admin_unblock_user, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            LogoutAction.spec(),
-            SignoutAction.spec(),
-            UpdateFullNameAction.spec(),
-            GetSSHKeypairAction.spec(),
-            GenerateSSHKeypairAction.spec(),
-            UploadSSHKeypairAction.spec(),
-            GetRoleAction.spec(),
-            AuthorizeAction.spec(),
-            SignupAction.spec(),
-            UpdatePasswordAction.spec(),
-            UpdatePasswordNoAuthAction.spec(),
-            ResolveAccessKeyScopeAction.spec(),
-            ResolveUserScopeAction.spec(),
-            ResolveUserIDByAccessKeyAction.spec(),
-            AdminSearchLoginSessionsAction.spec(),
-            SearchLoginSessionsAction.spec(),
-            AdminSearchLoginHistoryAction.spec(),
-            SearchLoginHistoryAction.spec(),
-            AdminRevokeLoginSessionAction.spec(),
-            MyRevokeLoginSessionAction.spec(),
-            AdminUnblockUserAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/container_registry/processors.py
+++ b/src/ai/backend/manager/services/container_registry/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.container_registry.actions.clear_images import (
     ClearImagesAction,
@@ -63,7 +60,7 @@ from ai.backend.manager.services.container_registry.actions.update_registry_quot
 from ai.backend.manager.services.container_registry.service import ContainerRegistryService
 
 
-class ContainerRegistryProcessors(AbstractProcessorPackage):
+class ContainerRegistryProcessors:
     rescan_images: ActionProcessor[RescanImagesAction, RescanImagesActionResult]
     clear_images: ActionProcessor[ClearImagesAction, ClearImagesActionResult]
     load_container_registries: ActionProcessor[
@@ -135,22 +132,3 @@ class ContainerRegistryProcessors(AbstractProcessorPackage):
         self.read_registry_quota = ActionProcessor(service.read_registry_quota, action_monitors)
         self.update_registry_quota = ActionProcessor(service.update_registry_quota, action_monitors)
         self.delete_registry_quota = ActionProcessor(service.delete_registry_quota, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            RescanImagesAction.spec(),
-            ClearImagesAction.spec(),
-            LoadContainerRegistriesAction.spec(),
-            LoadAllContainerRegistriesAction.spec(),
-            GetContainerRegistriesAction.spec(),
-            CreateContainerRegistryAction.spec(),
-            ModifyContainerRegistryAction.spec(),
-            DeleteContainerRegistryAction.spec(),
-            SearchContainerRegistriesAction.spec(),
-            HandleHarborWebhookAction.spec(),
-            CreateRegistryQuotaAction.spec(),
-            ReadRegistryQuotaAction.spec(),
-            UpdateRegistryQuotaAction.spec(),
-            DeleteRegistryQuotaAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast, override
+from typing import TYPE_CHECKING, cast
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.deployment.actions.access_token.bulk_delete_access_tokens import (
@@ -149,7 +148,7 @@ if TYPE_CHECKING:
     from ai.backend.manager.services.deployment.service import DeploymentService
 
 
-class DeploymentProcessors(AbstractProcessorPackage):
+class DeploymentProcessors:
     """Processors for deployment operations."""
 
     # Deployment CRUD
@@ -337,49 +336,3 @@ class DeploymentProcessors(AbstractProcessorPackage):
             service.bulk_delete_access_tokens, action_monitors
         )
         self.search_access_tokens = ActionProcessor(service.search_access_tokens, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            # Deployment CRUD
-            CreateDeploymentAction.spec(),
-            CreateLegacyDeploymentAction.spec(),
-            UpdateDeploymentAction.spec(),
-            ReplaceDeploymentOptionsAction.spec(),
-            DestroyDeploymentAction.spec(),
-            SearchDeploymentsAction.spec(),
-            SearchLegacyDeploymentsAction.spec(),
-            SearchDeploymentsInProjectAction.spec(),
-            GetDeploymentByIdAction.spec(),
-            GetLegacyDeploymentByIdAction.spec(),
-            GetDeploymentPolicyAction.spec(),
-            SearchDeploymentPoliciesAction.spec(),
-            UpsertDeploymentPolicyAction.spec(),
-            # Revision operations
-            AddModelRevisionAction.spec(),
-            GetRevisionByIdAction.spec(),
-            SearchRevisionsAction.spec(),
-            SearchRevisionResourceSlotsAction.spec(),
-            ActivateRevisionAction.spec(),
-            RefreshDeploymentRevisionsAction.spec(),
-            # Route operations
-            SyncReplicaAction.spec(),
-            SearchRoutesAction.spec(),
-            UpdateRouteTrafficStatusAction.spec(),
-            # Replica operations
-            GetReplicaByIdAction.spec(),
-            SearchReplicasAction.spec(),
-            # Auto-scaling rules
-            CreateAutoScalingRuleAction.spec(),
-            GetAutoScalingRuleAction.spec(),
-            UpdateAutoScalingRuleAction.spec(),
-            DeleteAutoScalingRuleAction.spec(),
-            BulkDeleteAutoScalingRulesAction.spec(),
-            SearchAutoScalingRulesAction.spec(),
-            # Access token
-            CreateAccessTokenAction.spec(),
-            GetAccessTokenAction.spec(),
-            DeleteAccessTokenAction.spec(),
-            BulkDeleteAccessTokensAction.spec(),
-            SearchAccessTokensAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/deployment_revision_preset/processors.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.deployment_revision_preset.actions.create import (
     CreateDeploymentRevisionPresetAction,
@@ -29,7 +26,7 @@ from ai.backend.manager.services.deployment_revision_preset.service import (
 )
 
 
-class DeploymentRevisionPresetProcessors(AbstractProcessorPackage):
+class DeploymentRevisionPresetProcessors:
     create: ActionProcessor[
         CreateDeploymentRevisionPresetAction, CreateDeploymentRevisionPresetActionResult
     ]
@@ -57,13 +54,3 @@ class DeploymentRevisionPresetProcessors(AbstractProcessorPackage):
         self.delete = ActionProcessor(service.delete, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
         self.search_resource_slots = ActionProcessor(service.search_resource_slots, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateDeploymentRevisionPresetAction.spec(),
-            UpdateDeploymentRevisionPresetAction.spec(),
-            DeleteDeploymentRevisionPresetAction.spec(),
-            SearchDeploymentRevisionPresetsAction.spec(),
-            SearchPresetResourceSlotsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/domain/processors.py
+++ b/src/ai/backend/manager/services/domain/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.domain.actions.create_domain import (
     CreateDomainAction,
@@ -48,7 +45,7 @@ from ai.backend.manager.services.domain.actions.search_rg_domains import (
 from .service import DomainService
 
 
-class DomainProcessors(AbstractProcessorPackage):
+class DomainProcessors:
     create_domain_node: ActionProcessor[CreateDomainNodeAction, CreateDomainNodeActionResult]
     modify_domain_node: ActionProcessor[ModifyDomainNodeAction, ModifyDomainNodeActionResult]
     create_domain: ActionProcessor[CreateDomainAction, CreateDomainActionResult]
@@ -80,18 +77,3 @@ class DomainProcessors(AbstractProcessorPackage):
         self.resolve_domain_id_by_name = ActionProcessor(
             service.resolve_domain_id_by_name, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateDomainNodeAction.spec(),
-            ModifyDomainNodeAction.spec(),
-            CreateDomainAction.spec(),
-            ModifyDomainAction.spec(),
-            DeleteDomainAction.spec(),
-            PurgeDomainAction.spec(),
-            GetDomainAction.spec(),
-            SearchDomainsAction.spec(),
-            SearchRGDomainsAction.spec(),
-            ResolveDomainIDByNameAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/dotfile/processors.py
+++ b/src/ai/backend/manager/services/dotfile/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions.check_group_membership import (
@@ -23,7 +20,7 @@ from .service import DotfileService
 __all__ = ("DotfileProcessors",)
 
 
-class DotfileProcessors(AbstractProcessorPackage):
+class DotfileProcessors:
     """Processor package for dotfile operations."""
 
     create: ActionProcessor[CreateDotfileAction, CreateDotfileActionResult]
@@ -55,16 +52,3 @@ class DotfileProcessors(AbstractProcessorPackage):
         )
         self.get_bootstrap = ActionProcessor(service.get_bootstrap_script, action_monitors)
         self.update_bootstrap = ActionProcessor(service.update_bootstrap_script, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateDotfileAction.spec(),
-            ListOrGetDotfilesAction.spec(),
-            UpdateDotfileAction.spec(),
-            DeleteDotfileAction.spec(),
-            ResolveGroupAction.spec(),
-            CheckGroupMembershipAction.spec(),
-            GetBootstrapScriptAction.spec(),
-            UpdateBootstrapScriptAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/error_log/processors.py
+++ b/src/ai/backend/manager/services/error_log/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import CreateErrorLogAction, CreateErrorLogActionResult
@@ -16,7 +13,7 @@ from .service import ErrorLogService
 __all__ = ("ErrorLogProcessors",)
 
 
-class ErrorLogProcessors(AbstractProcessorPackage):
+class ErrorLogProcessors:
     """Processor package for error log operations."""
 
     create: ActionProcessor[CreateErrorLogAction, CreateErrorLogActionResult]
@@ -34,12 +31,3 @@ class ErrorLogProcessors(AbstractProcessorPackage):
         self.search = ActionProcessor(service.search, action_monitors)
         self.list_logs = ActionProcessor(service.list_logs, action_monitors)
         self.mark_cleared = ActionProcessor(service.mark_cleared, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateErrorLogAction.spec(),
-            SearchErrorLogsAction.spec(),
-            ListErrorLogsAction.spec(),
-            MarkClearedErrorLogAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/etcd_config/processors.py
+++ b/src/ai/backend/manager/services/etcd_config/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions.delete_config import DeleteConfigAction, DeleteConfigActionResult
@@ -21,7 +18,7 @@ from .service import EtcdConfigService
 __all__ = ("EtcdConfigProcessors",)
 
 
-class EtcdConfigProcessors(AbstractProcessorPackage):
+class EtcdConfigProcessors:
     """Processor package for etcd config operations."""
 
     get_resource_slots: ActionProcessor[GetResourceSlotsAction, GetResourceSlotsActionResult]
@@ -45,14 +42,3 @@ class EtcdConfigProcessors(AbstractProcessorPackage):
         self.get_config = ActionProcessor(service.get_config, action_monitors)
         self.set_config = ActionProcessor(service.set_config, action_monitors)
         self.delete_config = ActionProcessor(service.delete_config, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetResourceSlotsAction.spec(),
-            GetResourceMetadataAction.spec(),
-            GetVfolderTypesAction.spec(),
-            GetConfigAction.spec(),
-            SetConfigAction.spec(),
-            DeleteConfigAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/events/processors.py
+++ b/src/ai/backend/manager/services/events/processors.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, override
+from typing import Any
 
 from aiohttp_sse import EventSourceResponse
 
@@ -7,7 +7,6 @@ from ai.backend.common.events.fetcher import EventFetcher
 from ai.backend.common.events.hub.hub import EventHub
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.events.hub.propagators.session import SessionEventPropagator
 from ai.backend.manager.services.events.actions.resolve_group_for_events import (
     ResolveGroupForEventsAction,
@@ -20,7 +19,7 @@ from ai.backend.manager.services.events.actions.resolve_session_for_events impor
 from ai.backend.manager.services.events.service import EventsService
 
 
-class EventsProcessors(AbstractProcessorPackage):
+class EventsProcessors:
     _service: EventsService
     event_hub: EventHub
     event_fetcher: EventFetcher
@@ -50,10 +49,3 @@ class EventsProcessors(AbstractProcessorPackage):
         filters: Mapping[str, Any],
     ) -> SessionEventPropagator:
         return self._service.create_session_propagator(response, filters)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ResolveSessionForEventsAction.spec(),
-            ResolveGroupForEventsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/export/processors.py
+++ b/src/ai/backend/manager/services/export/processors.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
@@ -38,7 +35,7 @@ from .service import ExportService
 __all__ = ("ExportProcessors",)
 
 
-class ExportProcessors(AbstractProcessorPackage):
+class ExportProcessors:
     """Processor package for export operations.
 
     Provides processors for:
@@ -92,19 +89,3 @@ class ExportProcessors(AbstractProcessorPackage):
         self.export_my_keypairs_csv = ActionProcessor(
             service.export_my_keypairs_csv, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ListReportsAction.spec(),
-            GetReportAction.spec(),
-            ExportUsersCSVAction.spec(),
-            ExportSessionsCSVAction.spec(),
-            ExportProjectsCSVAction.spec(),
-            ExportKeypairsCSVAction.spec(),
-            ExportAuditLogsCSVAction.spec(),
-            ExportSessionsByProjectCSVAction.spec(),
-            ExportUsersByDomainCSVAction.spec(),
-            ExportMySessionsCSVAction.spec(),
-            ExportMyKeypairsCSVAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/fair_share/processors.py
+++ b/src/ai/backend/manager/services/fair_share/processors.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
@@ -46,7 +43,7 @@ from .service import FairShareService
 __all__ = ("FairShareProcessors",)
 
 
-class FairShareProcessors(AbstractProcessorPackage):
+class FairShareProcessors:
     """Processor package for fair share operations."""
 
     # Domain Fair Share
@@ -156,28 +153,3 @@ class FairShareProcessors(AbstractProcessorPackage):
         self.bulk_upsert_user_fair_share_weight = ActionProcessor(
             service.bulk_upsert_user_fair_share_weight, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            # Domain
-            GetDomainFairShareAction.spec(),
-            SearchDomainFairSharesAction.spec(),
-            SearchRGDomainFairSharesAction.spec(),
-            # Project
-            GetProjectFairShareAction.spec(),
-            SearchProjectFairSharesAction.spec(),
-            SearchRGProjectFairSharesAction.spec(),
-            # User
-            GetUserFairShareAction.spec(),
-            SearchUserFairSharesAction.spec(),
-            SearchRGUserFairSharesAction.spec(),
-            # Upsert Weight
-            UpsertDomainFairShareWeightAction.spec(),
-            UpsertProjectFairShareWeightAction.spec(),
-            UpsertUserFairShareWeightAction.spec(),
-            # Bulk Upsert Weight
-            BulkUpsertDomainFairShareWeightAction.spec(),
-            BulkUpsertProjectFairShareWeightAction.spec(),
-            BulkUpsertUserFairShareWeightAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/group/processors.py
+++ b/src/ai/backend/manager/services/group/processors.py
@@ -1,10 +1,7 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.group.actions.assign_users_to_project import (
     AssignUsersToProjectAction,
@@ -54,7 +51,7 @@ from ai.backend.manager.services.group.actions.usage_per_period import (
 from ai.backend.manager.services.group.service import GroupService
 
 
-class GroupProcessors(AbstractProcessorPackage):
+class GroupProcessors:
     create_group: ScopeActionProcessor[CreateGroupAction, CreateGroupActionResult]
     modify_group: SingleEntityActionProcessor[ModifyGroupAction, ModifyGroupActionResult]
     delete_group: SingleEntityActionProcessor[DeleteGroupAction, DeleteGroupActionResult]
@@ -124,21 +121,3 @@ class GroupProcessors(AbstractProcessorPackage):
         self.resolve_project_id_by_name = ActionProcessor(
             group_service.resolve_project_id_by_name, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateGroupAction.spec(),
-            ModifyGroupAction.spec(),
-            DeleteGroupAction.spec(),
-            PurgeGroupAction.spec(),
-            UsagePerMonthAction.spec(),
-            UsagePerPeriodAction.spec(),
-            SearchProjectsAction.spec(),
-            SearchProjectsByDomainAction.spec(),
-            SearchProjectsByUserAction.spec(),
-            GetProjectAction.spec(),
-            AssignUsersToProjectAction.spec(),
-            UnassignUsersFromProjectAction.spec(),
-            ResolveProjectIdByNameAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/idle_checker/processors.py
+++ b/src/ai/backend/manager/services/idle_checker/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor.global_action import GlobalActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.idle_checker.actions.admin_search import (
     AdminSearchIdleCheckersAction,
     SearchIdleCheckersActionResult,
@@ -22,7 +19,7 @@ from ai.backend.manager.services.idle_checker.actions.update import (
 from ai.backend.manager.services.idle_checker.service import IdleCheckerService
 
 
-class IdleCheckerProcessors(AbstractProcessorPackage):
+class IdleCheckerProcessors:
     admin_search: GlobalActionProcessor[
         AdminSearchIdleCheckersAction,
         SearchIdleCheckersActionResult,
@@ -40,12 +37,3 @@ class IdleCheckerProcessors(AbstractProcessorPackage):
         self.create = GlobalActionProcessor(service.create, action_monitors)
         self.update = GlobalActionProcessor(service.update, action_monitors)
         self.purge = GlobalActionProcessor(service.purge, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            AdminSearchIdleCheckersAction.spec(),
-            CreateIdleCheckerAction.spec(),
-            UpdateIdleCheckerAction.spec(),
-            PurgeIdleCheckerAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/idle_checker_assignment/processors.py
+++ b/src/ai/backend/manager/services/idle_checker_assignment/processors.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.idle_checker_assignment.actions.admin_search import (
     AdminSearchIdleCheckerAssignmentsAction,
@@ -31,7 +28,7 @@ from ai.backend.manager.services.idle_checker_assignment.actions.update import (
 from ai.backend.manager.services.idle_checker_assignment.service import IdleCheckerAssignmentService
 
 
-class IdleCheckerAssignmentProcessors(AbstractProcessorPackage):
+class IdleCheckerAssignmentProcessors:
     create: ActionProcessor[
         CreateIdleCheckerAssignmentAction, CreateIdleCheckerAssignmentActionResult
     ]
@@ -69,13 +66,3 @@ class IdleCheckerAssignmentProcessors(AbstractProcessorPackage):
             monitors=action_monitors,
             validators=[validators.rbac.bulk],
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateIdleCheckerAssignmentAction.spec(),
-            UpdateIdleCheckerAssignmentAction.spec(),
-            PurgeIdleCheckerAssignmentAction.spec(),
-            AdminSearchIdleCheckerAssignmentsAction.spec(),
-            ScopedSearchIdleCheckerAssignmentsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -1,9 +1,6 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators
@@ -93,7 +90,7 @@ from ai.backend.manager.services.image.actions.update_image_by_id import (
 from .service import ImageService
 
 
-class ImageProcessors(AbstractProcessorPackage):
+class ImageProcessors:
     forget_image: ActionProcessor[ForgetImageAction, ForgetImageActionResult]
     forget_image_by_id: SingleEntityActionProcessor[
         ForgetImageByIdAction, ForgetImageByIdActionResult
@@ -204,24 +201,3 @@ class ImageProcessors(AbstractProcessorPackage):
             service.set_image_resource_limit_by_id, action_monitors
         )
         self.search_aliases = ActionProcessor(service.search_aliases, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ForgetImageAction.spec(),
-            ForgetImageByIdAction.spec(),
-            PurgeImageByIdAction.spec(),
-            AliasImageAction.spec(),
-            AliasImageByIdAction.spec(),
-            DealiasImageAction.spec(),
-            ModifyImageAction.spec(),
-            UpdateImageByIdAction.spec(),
-            PreloadImageAction.spec(),
-            UnloadImageAction.spec(),
-            UntagImageFromRegistryAction.spec(),
-            ScanImageAction.spec(),
-            PurgeImagesAction.spec(),
-            ClearImageCustomResourceLimitAction.spec(),
-            ClearImageCustomResourceLimitByIdAction.spec(),
-            SetImageResourceLimitByIdAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/keypair_resource_policy/processors.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.keypair_resource_policy.actions.create_keypair_resource_policy import (
     CreateKeyPairResourcePolicyAction,
@@ -33,7 +30,7 @@ from ai.backend.manager.services.keypair_resource_policy.service import (
 )
 
 
-class KeypairResourcePolicyProcessors(AbstractProcessorPackage):
+class KeypairResourcePolicyProcessors:
     get_keypair_resource_policy: ActionProcessor[
         GetKeypairResourcePolicyAction, GetKeypairResourcePolicyActionResult
     ]
@@ -77,14 +74,3 @@ class KeypairResourcePolicyProcessors(AbstractProcessorPackage):
         self.delete_keypair_resource_policy = ActionProcessor(
             service.delete_keypair_resource_policy, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetKeypairResourcePolicyAction.spec(),
-            GetMyKeypairResourcePolicyAction.spec(),
-            SearchKeypairResourcePoliciesAction.spec(),
-            CreateKeyPairResourcePolicyAction.spec(),
-            ModifyKeyPairResourcePolicyAction.spec(),
-            DeleteKeyPairResourcePolicyAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/login_client_type/processors.py
+++ b/src/ai/backend/manager/services/login_client_type/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.login_client_type.actions.create import (
     CreateLoginClientTypeAction,
     CreateLoginClientTypeActionResult,
@@ -29,7 +26,7 @@ from ai.backend.manager.services.login_client_type.admin_service import (
 from ai.backend.manager.services.login_client_type.service import LoginClientTypeService
 
 
-class LoginClientTypeProcessors(AbstractProcessorPackage):
+class LoginClientTypeProcessors:
     get: ActionProcessor[GetLoginClientTypeAction, GetLoginClientTypeActionResult]
     search: ActionProcessor[SearchLoginClientTypesAction, SearchLoginClientTypesActionResult]
 
@@ -41,15 +38,8 @@ class LoginClientTypeProcessors(AbstractProcessorPackage):
         self.get = ActionProcessor(service.get, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
 
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetLoginClientTypeAction.spec(),
-            SearchLoginClientTypesAction.spec(),
-        ]
 
-
-class LoginClientTypeAdminProcessors(AbstractProcessorPackage):
+class LoginClientTypeAdminProcessors:
     create: ActionProcessor[CreateLoginClientTypeAction, CreateLoginClientTypeActionResult]
     update: ActionProcessor[UpdateLoginClientTypeAction, UpdateLoginClientTypeActionResult]
     delete: ActionProcessor[DeleteLoginClientTypeAction, DeleteLoginClientTypeActionResult]
@@ -62,11 +52,3 @@ class LoginClientTypeAdminProcessors(AbstractProcessorPackage):
         self.create = ActionProcessor(service.create, action_monitors)
         self.update = ActionProcessor(service.update, action_monitors)
         self.delete = ActionProcessor(service.delete, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateLoginClientTypeAction.spec(),
-            UpdateLoginClientTypeAction.spec(),
-            DeleteLoginClientTypeAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/manager_admin/processors.py
+++ b/src/ai/backend/manager/services/manager_admin/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions.fetch_status import FetchManagerStatusAction, FetchManagerStatusActionResult
@@ -21,7 +18,7 @@ from .service import ManagerAdminService
 __all__ = ("ManagerAdminProcessors",)
 
 
-class ManagerAdminProcessors(AbstractProcessorPackage):
+class ManagerAdminProcessors:
     """Processor package for manager admin operations."""
 
     fetch_status: ActionProcessor[FetchManagerStatusAction, FetchManagerStatusActionResult]
@@ -45,14 +42,3 @@ class ManagerAdminProcessors(AbstractProcessorPackage):
         self.update_announcement = ActionProcessor(service.update_announcement, action_monitors)
         self.perform_scheduler_ops = ActionProcessor(service.perform_scheduler_ops, action_monitors)
         self.get_db_cxn_status = ActionProcessor(service.get_db_cxn_status, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            FetchManagerStatusAction.spec(),
-            UpdateManagerStatusAction.spec(),
-            GetAnnouncementAction.spec(),
-            UpdateAnnouncementAction.spec(),
-            PerformSchedulerOpsAction.spec(),
-            GetDbCxnStatusAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/metric/processors.py
+++ b/src/ai/backend/manager/services/metric/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.metric.actions.container import (
     ContainerMetricAction,
@@ -17,7 +14,7 @@ from ai.backend.manager.services.metric.actions.live_stat import (
 from ai.backend.manager.services.metric.service import MetricService
 
 
-class MetricProcessors(AbstractProcessorPackage):
+class MetricProcessors:
     query_container: ActionProcessor[ContainerMetricAction, ContainerMetricActionResult]
     query_container_metadata: ActionProcessor[
         ContainerMetricMetadataAction, ContainerMetricMetadataActionResult
@@ -39,11 +36,3 @@ class MetricProcessors(AbstractProcessorPackage):
         self.query_container_live_stat = ActionProcessor(
             service.query_container_live_stats, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ContainerMetricAction.spec(),
-            ContainerMetricMetadataAction.spec(),
-            ContainerLiveStatAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/model_card/processors.py
+++ b/src/ai/backend/manager/services/model_card/processors.py
@@ -1,8 +1,7 @@
-from typing import cast, override
+from typing import cast
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.model_card.actions.available_presets import (
@@ -40,7 +39,7 @@ from ai.backend.manager.services.model_card.actions.update import (
 from ai.backend.manager.services.model_card.service import ModelCardService
 
 
-class ModelCardProcessors(AbstractProcessorPackage):
+class ModelCardProcessors:
     create: ActionProcessor[CreateModelCardAction, CreateModelCardActionResult]
     update: ActionProcessor[UpdateModelCardAction, UpdateModelCardActionResult]
     delete: ActionProcessor[DeleteModelCardAction, DeleteModelCardActionResult]
@@ -72,16 +71,3 @@ class ModelCardProcessors(AbstractProcessorPackage):
         )
         self.scan = ActionProcessor(service.scan, action_monitors)
         self.available_presets = ActionProcessor(service.available_presets, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateModelCardAction.spec(),
-            UpdateModelCardAction.spec(),
-            DeleteModelCardAction.spec(),
-            BulkDeleteModelCardAction.spec(),
-            SearchModelCardsAction.spec(),
-            SearchModelCardsInProjectAction.spec(),
-            ScanProjectModelCardsAction.spec(),
-            AvailablePresetsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/model_serving/processors/auto_scaling.py
+++ b/src/ai/backend/manager/services/model_serving/processors/auto_scaling.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.model_serving.actions.create_auto_scaling_rule import (
     CreateEndpointAutoScalingRuleAction,
@@ -23,7 +20,7 @@ from ai.backend.manager.services.model_serving.actions.scale_service_replicas im
 from ai.backend.manager.services.model_serving.services.auto_scaling import AutoScalingService
 
 
-class ModelServingAutoScalingProcessors(AbstractProcessorPackage):
+class ModelServingAutoScalingProcessors:
     scale_service_replicas: ActionProcessor[
         ScaleServiceReplicasAction, ScaleServiceReplicasActionResult
     ]
@@ -55,12 +52,3 @@ class ModelServingAutoScalingProcessors(AbstractProcessorPackage):
         self.modify_endpoint_auto_scaling_rule = ActionProcessor(
             service.modify_endpoint_auto_scaling_rule, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ScaleServiceReplicasAction.spec(),
-            CreateEndpointAutoScalingRuleAction.spec(),
-            DeleteEndpointAutoScalingRuleAction.spec(),
-            ModifyEndpointAutoScalingRuleAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/model_serving/processors/model_serving.py
+++ b/src/ai/backend/manager/services/model_serving/processors/model_serving.py
@@ -1,9 +1,6 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import LegacyRBACValidators
@@ -64,7 +61,7 @@ from ai.backend.manager.services.model_serving.services.model_serving import (
 )
 
 
-class ModelServingProcessors(AbstractProcessorPackage):
+class ModelServingProcessors:
     list_model_service: ActionProcessor[ListModelServiceAction, ListModelServiceActionResult]
     search_services: ActionProcessor[SearchServicesAction, SearchServicesActionResult]
 
@@ -137,21 +134,3 @@ class ModelServingProcessors(AbstractProcessorPackage):
         self.validate_model_service = ActionProcessor(
             service.validate_model_service, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ListModelServiceAction.spec(),
-            DeleteModelServiceAction.spec(),
-            DryRunModelServiceAction.spec(),
-            GetModelServiceInfoAction.spec(),
-            ListErrorsAction.spec(),
-            ClearErrorAction.spec(),
-            ForceSyncAction.spec(),
-            UpdateRouteAction.spec(),
-            DeleteRouteAction.spec(),
-            GenerateTokenAction.spec(),
-            ModifyEndpointAction.spec(),
-            SearchServicesAction.spec(),
-            ValidateModelServiceAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/notification/processors.py
+++ b/src/ai/backend/manager/services/notification/processors.py
@@ -1,10 +1,7 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
@@ -38,7 +35,7 @@ from .actions import (
 from .service import NotificationService
 
 
-class NotificationProcessors(AbstractProcessorPackage):
+class NotificationProcessors:
     """Processor package for notification operations."""
 
     # Scope actions (operate on GLOBAL scope)
@@ -102,21 +99,3 @@ class NotificationProcessors(AbstractProcessorPackage):
         self.validate_rule = ActionProcessor(service.validate_rule, action_monitors)
 
         self.process_notification = ActionProcessor(service.process_notification, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateChannelAction.spec(),
-            SearchChannelsAction.spec(),
-            GetChannelAction.spec(),
-            UpdateChannelAction.spec(),
-            DeleteChannelAction.spec(),
-            ValidateChannelAction.spec(),
-            CreateRuleAction.spec(),
-            SearchRulesAction.spec(),
-            GetRuleAction.spec(),
-            UpdateRuleAction.spec(),
-            DeleteRuleAction.spec(),
-            ValidateRuleAction.spec(),
-            ProcessNotificationAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/object_storage/processors.py
+++ b/src/ai/backend/manager/services/object_storage/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.object_storage.actions.create import (
     CreateObjectStorageAction,
@@ -39,7 +36,7 @@ from ai.backend.manager.services.object_storage.actions.update import (
 from ai.backend.manager.services.object_storage.service import ObjectStorageService
 
 
-class ObjectStorageProcessors(AbstractProcessorPackage):
+class ObjectStorageProcessors:
     create: ActionProcessor[CreateObjectStorageAction, CreateObjectStorageActionResult]
     update: ActionProcessor[UpdateObjectStorageAction, UpdateObjectStorageActionResult]
     delete: ActionProcessor[DeleteObjectStorageAction, DeleteObjectStorageActionResult]
@@ -73,16 +70,3 @@ class ObjectStorageProcessors(AbstractProcessorPackage):
             service.get_presigned_upload_url, action_monitors
         )
         self.search_object_storages = ActionProcessor(service.search, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateObjectStorageAction.spec(),
-            UpdateObjectStorageAction.spec(),
-            DeleteObjectStorageAction.spec(),
-            GetObjectStorageAction.spec(),
-            ListObjectStorageAction.spec(),
-            GetDownloadPresignedURLAction.spec(),
-            GetUploadPresignedURLAction.spec(),
-            SearchObjectStoragesAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -1,10 +1,7 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
@@ -24,7 +21,6 @@ from .actions import (
     DeleteRoleActionResult,
     GetRoleDetailAction,
     GetRoleDetailActionResult,
-    PurgeRoleAction,
     ReplaceRolePermissionsAction,
     ReplaceRolePermissionsActionResult,
     RevokeRoleAction,
@@ -103,7 +99,7 @@ from .actions.update_permission import (
 from .service import PermissionControllerService
 
 
-class PermissionControllerProcessors(AbstractProcessorPackage):
+class PermissionControllerProcessors:
     """Processor package for RBAC permission controller operations."""
 
     create_role: ActionProcessor[CreateRoleAction, CreateRoleActionResult]
@@ -251,42 +247,3 @@ class PermissionControllerProcessors(AbstractProcessorPackage):
         self.admin_search_role_invitations = ActionProcessor(
             service.admin_search_role_invitations, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateRoleAction.spec(),
-            UpdateRoleAction.spec(),
-            DeleteRoleAction.spec(),
-            PurgeRoleAction.spec(),
-            AssignRoleAction.spec(),
-            RevokeRoleAction.spec(),
-            BulkAssignRoleAction.spec(),
-            BulkRevokeRoleAction.spec(),
-            GetRoleDetailAction.spec(),
-            SearchRolesAction.spec(),
-            SearchRolesInScopeAction.spec(),
-            SearchUsersAssignedToRoleAction.spec(),
-            UpdateRolePermissionsAction.spec(),
-            BulkAddRolePermissionsAction.spec(),
-            BulkRemoveRolePermissionsAction.spec(),
-            ReplaceRolePermissionsAction.spec(),
-            SearchScopesAction.spec(),
-            GetScopeTypesAction.spec(),
-            GetEntityTypesAction.spec(),
-            GetPermissionMatrixAction.spec(),
-            SearchEntitiesAction.spec(),
-            SearchElementAssociationsAction.spec(),
-            SearchPermissionsAction.spec(),
-            CreatePermissionAction.spec(),
-            UpdatePermissionAction.spec(),
-            DeletePermissionAction.spec(),
-            CreateRoleInvitationAction.spec(),
-            AcceptInvitationAction.spec(),
-            RejectInvitationAction.spec(),
-            CancelInvitationAction.spec(),
-            SearchMyRoleInvitationsAction.spec(),
-            SearchMySentRoleInvitationsAction.spec(),
-            SearchRoleInvitationsByRoleAction.spec(),
-            AdminSearchRoleInvitationsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING
 
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.v2.validators import ActionValidators
 
 # fmt: off
@@ -469,7 +468,7 @@ class ProcessorArgs:
 
 
 @dataclass
-class Processors(AbstractProcessorPackage):
+class Processors:
     agent: AgentProcessors
     app_config: AppConfigProcessors
     app_config_allow_list: AppConfigAllowListProcessors
@@ -531,69 +530,3 @@ class Processors(AbstractProcessorPackage):
     events: EventsProcessors
     login_client_type: LoginClientTypeProcessors
     login_client_type_admin: LoginClientTypeAdminProcessors
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            *self.agent.supported_actions(),
-            *self.app_config.supported_actions(),
-            *self.app_config_allow_list.supported_actions(),
-            *self.app_config_definition.supported_actions(),
-            *self.app_config_fragment.supported_actions(),
-            *self.domain.supported_actions(),
-            *self.dotfile.supported_actions(),
-            *self.error_log.supported_actions(),
-            *self.etcd_config.supported_actions(),
-            *self.export.supported_actions(),
-            *self.fair_share.supported_actions(),
-            *self.group.supported_actions(),
-            *self.user.supported_actions(),
-            *self.idle_checker.supported_actions(),
-            *self.image.supported_actions(),
-            *self.container_registry.supported_actions(),
-            *self.vfolder.supported_actions(),
-            *self.vfolder_admin.supported_actions(),
-            *self.vfolder_file.supported_actions(),
-            *self.vfolder_invite.supported_actions(),
-            *self.vfolder_sharing.supported_actions(),
-            *self.session.supported_actions(),
-            *self.keypair_resource_policy.supported_actions(),
-            *self.manager_admin.supported_actions(),
-            *self.user_resource_policy.supported_actions(),
-            *self.project_resource_policy.supported_actions(),
-            *self.prometheus_query_preset.supported_actions(),
-            *self.prometheus_query_preset_category.supported_actions(),
-            *self.resource_preset.supported_actions(),
-            *self.resource_slot.supported_actions(),
-            *self.retention_policy.supported_actions(),
-            *self.role_preset.supported_actions(),
-            *self.runtime_variant.supported_actions(),
-            *self.runtime_variant_preset.supported_actions(),
-            *self.deployment_revision_preset.supported_actions(),
-            *self.model_card.supported_actions(),
-            *self.resource_usage.supported_actions(),
-            *self.scaling_group.supported_actions(),
-            *self.metric.supported_actions(),
-            *self.model_serving.supported_actions(),
-            *self.model_serving_auto_scaling.supported_actions(),
-            *self.auth.supported_actions(),
-            *self.notification.supported_actions(),
-            *self.object_storage.supported_actions(),
-            *self.permission_controller.supported_actions(),
-            *self.vfs_storage.supported_actions(),
-            *self.artifact_registry.supported_actions(),
-            *self.artifact_revision.supported_actions(),
-            *self.artifact.supported_actions(),
-            *self.deployment.supported_actions(),
-            *self.storage_namespace.supported_actions(),
-            *self.audit_log.supported_actions(),
-            *self.idle_checker_assignment.supported_actions(),
-            *self.scheduling_history.supported_actions(),
-            *self.service_catalog.supported_actions(),
-            *self.template.supported_actions(),
-            *self.resource_allocation.supported_actions(),
-            *self.stream.supported_actions(),
-            *self.events.supported_actions(),
-            *self.login_client_type.supported_actions(),
-            *self.login_client_type_admin.supported_actions(),
-        ]

--- a/src/ai/backend/manager/services/project_resource_policy/processors.py
+++ b/src/ai/backend/manager/services/project_resource_policy/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.project_resource_policy.actions.create_project_resource_policy import (
     CreateProjectResourcePolicyAction,
@@ -27,7 +24,7 @@ from ai.backend.manager.services.project_resource_policy.actions.search_project_
 from ai.backend.manager.services.project_resource_policy.service import ProjectResourcePolicyService
 
 
-class ProjectResourcePolicyProcessors(AbstractProcessorPackage):
+class ProjectResourcePolicyProcessors:
     get_project_resource_policy: ActionProcessor[
         GetProjectResourcePolicyAction, GetProjectResourcePolicyActionResult
     ]
@@ -65,13 +62,3 @@ class ProjectResourcePolicyProcessors(AbstractProcessorPackage):
         self.delete_project_resource_policy = ActionProcessor(
             service.delete_project_resource_policy, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetProjectResourcePolicyAction.spec(),
-            SearchProjectResourcePoliciesAction.spec(),
-            CreateProjectResourcePolicyAction.spec(),
-            ModifyProjectResourcePolicyAction.spec(),
-            DeleteProjectResourcePolicyAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/prometheus_query_preset/processors.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.prometheus_query_preset.actions import (
     CreatePresetAction,
@@ -25,7 +22,7 @@ from ai.backend.manager.services.prometheus_query_preset.service import (
 )
 
 
-class PrometheusQueryPresetProcessors(AbstractProcessorPackage):
+class PrometheusQueryPresetProcessors:
     create_preset: ActionProcessor[CreatePresetAction, CreatePresetActionResult]
     get_preset: ActionProcessor[GetPresetAction, GetPresetActionResult]
     search_presets: ActionProcessor[SearchPresetsAction, SearchPresetsActionResult]
@@ -47,15 +44,3 @@ class PrometheusQueryPresetProcessors(AbstractProcessorPackage):
         self.delete_preset = ActionProcessor(service.delete_preset, action_monitors)
         self.execute_preset = ActionProcessor(service.execute_preset, action_monitors)
         self.preview_preset = ActionProcessor(service.preview_preset, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreatePresetAction.spec(),
-            GetPresetAction.spec(),
-            SearchPresetsAction.spec(),
-            ModifyPresetAction.spec(),
-            DeletePresetAction.spec(),
-            ExecutePresetAction.spec(),
-            PreviewPresetAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/prometheus_query_preset_category/processors.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset_category/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.prometheus_query_preset_category.actions import (
     CreateCategoryAction,
@@ -19,7 +16,7 @@ from ai.backend.manager.services.prometheus_query_preset_category.service import
 )
 
 
-class PrometheusQueryPresetCategoryProcessors(AbstractProcessorPackage):
+class PrometheusQueryPresetCategoryProcessors:
     create_category: ActionProcessor[CreateCategoryAction, CreateCategoryActionResult]
     get_category: ActionProcessor[GetCategoryAction, GetCategoryActionResult]
     search_categories: ActionProcessor[SearchCategoriesAction, SearchCategoriesActionResult]
@@ -35,12 +32,3 @@ class PrometheusQueryPresetCategoryProcessors(AbstractProcessorPackage):
         self.get_category = ActionProcessor(service.get_category, action_monitors)
         self.search_categories = ActionProcessor(service.search_categories, action_monitors)
         self.delete_category = ActionProcessor(service.delete_category, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateCategoryAction.spec(),
-            GetCategoryAction.spec(),
-            SearchCategoriesAction.spec(),
-            DeleteCategoryAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/resource_allocation/processors.py
+++ b/src/ai/backend/manager/services/resource_allocation/processors.py
@@ -1,10 +1,7 @@
 """Processors for resource allocation operations."""
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.resource_allocation.actions.check_preset_availability import (
     CheckPresetAvailabilityAction,
@@ -37,7 +34,7 @@ from ai.backend.manager.services.resource_allocation.actions.resolve_keypair_con
 from ai.backend.manager.services.resource_allocation.service import ResourceAllocationService
 
 
-class ResourceAllocationProcessors(AbstractProcessorPackage):
+class ResourceAllocationProcessors:
     resolve_keypair_context: ActionProcessor[
         ResolveKeypairContextAction, ResolveKeypairContextActionResult
     ]
@@ -75,15 +72,3 @@ class ResourceAllocationProcessors(AbstractProcessorPackage):
         self.check_preset_availability = ActionProcessor(
             service.check_preset_availability, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ResolveKeypairContextAction.spec(),
-            GetKeypairUsageAction.spec(),
-            GetProjectUsageAction.spec(),
-            GetDomainUsageAction.spec(),
-            GetResourceGroupUsageAction.spec(),
-            GetEffectiveAllocationAction.spec(),
-            CheckPresetAvailabilityAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/resource_preset/processors.py
+++ b/src/ai/backend/manager/services/resource_preset/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.resource_preset.actions.check_presets import (
     CheckResourcePresetsAction,
@@ -31,7 +28,7 @@ from ai.backend.manager.services.resource_preset.actions.search_presets import (
 from ai.backend.manager.services.resource_preset.service import ResourcePresetService
 
 
-class ResourcePresetProcessors(AbstractProcessorPackage):
+class ResourcePresetProcessors:
     create_preset: ActionProcessor[CreateResourcePresetAction, CreateResourcePresetActionResult]
     modify_preset: ActionProcessor[ModifyResourcePresetAction, ModifyResourcePresetActionResult]
     delete_preset: ActionProcessor[DeleteResourcePresetAction, DeleteResourcePresetActionResult]
@@ -53,14 +50,3 @@ class ResourcePresetProcessors(AbstractProcessorPackage):
         self.list_presets = ActionProcessor(service.list_presets, action_monitors)
         self.check_presets = ActionProcessor(service.check_presets, action_monitors)
         self.search_presets_v2 = ActionProcessor(service.search_presets_v2, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateResourcePresetAction.spec(),
-            ModifyResourcePresetAction.spec(),
-            DeleteResourcePresetAction.spec(),
-            ListResourcePresetsAction.spec(),
-            CheckResourcePresetsAction.spec(),
-            SearchResourcePresetsV2Action.spec(),
-        ]

--- a/src/ai/backend/manager/services/resource_slot/processors.py
+++ b/src/ai/backend/manager/services/resource_slot/processors.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.registry import ProcessorGroup
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import CreatedEntityOpsResult, EntityOpsResult
 from ai.backend.manager.actions.validators import ActionValidators
@@ -39,7 +36,7 @@ from .actions import (
 from .service import ResourceSlotService
 
 
-class ResourceSlotProcessors(AbstractProcessorPackage):
+class ResourceSlotProcessors:
     get_agent_resource_by_slot: ActionProcessor[
         GetAgentResourceBySlotAction, GetAgentResourceBySlotResult
     ]
@@ -113,21 +110,3 @@ class ResourceSlotProcessors(AbstractProcessorPackage):
         self.create_resource_slot_type = group.global_create_ops(CreateResourceSlotTypeAction)
         self.update_resource_slot_type = group.global_update_ops(UpdateResourceSlotTypeAction)
         self.purge_resource_slot_type = group.global_purge_ops(PurgeResourceSlotTypeAction)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetAgentResourceBySlotAction.spec(),
-            GetAgentResourcesAction.spec(),
-            GetKernelAllocationBySlotAction.spec(),
-            SearchAgentResourcesAction.spec(),
-            GetKernelAllocationsAction.spec(),
-            SearchResourceAllocationsAction.spec(),
-            GetResourceSlotTypeAction.spec(),
-            SearchResourceSlotTypesAction.spec(),
-            GetDomainResourceOverviewAction.spec(),
-            GetProjectResourceOverviewAction.spec(),
-            CreateResourceSlotTypeAction.spec(),
-            UpdateResourceSlotTypeAction.spec(),
-            PurgeResourceSlotTypeAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/resource_slot/processors.py
+++ b/src/ai/backend/manager/services/resource_slot/processors.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, override
+from typing import override
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.registry import ProcessorGroup
 from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
-from ai.backend.manager.actions.v2.ops.base import (
-    CreateGlobalOpsAction,
-    PurgeGlobalOpsAction,
-    UpdateGlobalOpsAction,
-)
 from ai.backend.manager.actions.v2.ops.result import CreatedEntityOpsResult, EntityOpsResult
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
@@ -68,15 +63,15 @@ class ResourceSlotProcessors(AbstractProcessorPackage):
         GetProjectResourceOverviewAction, GetProjectResourceOverviewResult
     ]
     create_resource_slot_type: GlobalActionProcessor[
-        CreateGlobalOpsAction[Any, ResourceSlotTypeData],
+        CreateResourceSlotTypeAction,
         CreatedEntityOpsResult[ResourceSlotTypeData],
     ]
     update_resource_slot_type: GlobalActionProcessor[
-        UpdateGlobalOpsAction[Any, ResourceSlotTypeData],
+        UpdateResourceSlotTypeAction,
         EntityOpsResult[ResourceSlotTypeData],
     ]
     purge_resource_slot_type: GlobalActionProcessor[
-        PurgeGlobalOpsAction[Any, ResourceSlotTypeData],
+        PurgeResourceSlotTypeAction,
         EntityOpsResult[ResourceSlotTypeData],
     ]
 
@@ -115,9 +110,9 @@ class ResourceSlotProcessors(AbstractProcessorPackage):
         self.get_project_resource_overview = ActionProcessor(
             service.get_project_resource_overview, action_monitors
         )
-        self.create_resource_slot_type = group.global_create_ops()
-        self.update_resource_slot_type = group.global_update_ops()
-        self.purge_resource_slot_type = group.global_purge_ops()
+        self.create_resource_slot_type = group.global_create_ops(CreateResourceSlotTypeAction)
+        self.update_resource_slot_type = group.global_update_ops(UpdateResourceSlotTypeAction)
+        self.purge_resource_slot_type = group.global_purge_ops(PurgeResourceSlotTypeAction)
 
     @override
     def supported_actions(self) -> list[ActionSpec]:

--- a/src/ai/backend/manager/services/resource_usage/processors.py
+++ b/src/ai/backend/manager/services/resource_usage/processors.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
@@ -28,7 +25,7 @@ from .service import ResourceUsageService
 __all__ = ("ResourceUsageProcessors",)
 
 
-class ResourceUsageProcessors(AbstractProcessorPackage):
+class ResourceUsageProcessors:
     """Processor package for resource usage operations."""
 
     # Domain Usage Buckets
@@ -84,17 +81,3 @@ class ResourceUsageProcessors(AbstractProcessorPackage):
         self.search_scoped_user_usage_buckets = ActionProcessor(
             service.search_scoped_user_usage_buckets, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            # Domain
-            SearchDomainUsageBucketsAction.spec(),
-            SearchScopedDomainUsageBucketsAction.spec(),
-            # Project
-            SearchProjectUsageBucketsAction.spec(),
-            SearchScopedProjectUsageBucketsAction.spec(),
-            # User
-            SearchUserUsageBucketsAction.spec(),
-            SearchScopedUserUsageBucketsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/retention_policy/processors.py
+++ b/src/ai/backend/manager/services/retention_policy/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor.global_action import GlobalActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.retention_policy.actions.create import (
     CreateRetentionPolicyAction,
     CreateRetentionPolicyActionResult,
@@ -26,7 +23,7 @@ from ai.backend.manager.services.retention_policy.actions.update import (
 from ai.backend.manager.services.retention_policy.service import RetentionPolicyService
 
 
-class RetentionPolicyProcessors(AbstractProcessorPackage):
+class RetentionPolicyProcessors:
     create: GlobalActionProcessor[CreateRetentionPolicyAction, CreateRetentionPolicyActionResult]
     update: GlobalActionProcessor[UpdateRetentionPolicyAction, UpdateRetentionPolicyActionResult]
     delete: GlobalActionProcessor[DeleteRetentionPolicyAction, DeleteRetentionPolicyActionResult]
@@ -45,13 +42,3 @@ class RetentionPolicyProcessors(AbstractProcessorPackage):
         self.delete = GlobalActionProcessor(service.delete, action_monitors)
         self.purge = GlobalActionProcessor(service.purge, action_monitors)
         self.search = GlobalActionProcessor(service.search, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateRetentionPolicyAction.spec(),
-            UpdateRetentionPolicyAction.spec(),
-            DeleteRetentionPolicyAction.spec(),
-            PurgeRetentionPolicyAction.spec(),
-            SearchRetentionPoliciesAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/role_preset/processors.py
+++ b/src/ai/backend/manager/services/role_preset/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.role_preset.actions.bulk_add_permissions import (
     BulkAddRolePermissionPresetsAction,
@@ -51,7 +48,7 @@ from ai.backend.manager.services.role_preset.actions.update import (
 from ai.backend.manager.services.role_preset.service import RolePresetService
 
 
-class RolePresetProcessors(AbstractProcessorPackage):
+class RolePresetProcessors:
     create: ActionProcessor[CreateRolePresetAction, CreateRolePresetActionResult]
     get: ActionProcessor[GetRolePresetAction, GetRolePresetActionResult]
     search: ActionProcessor[SearchRolePresetsAction, SearchRolePresetsActionResult]
@@ -91,19 +88,3 @@ class RolePresetProcessors(AbstractProcessorPackage):
         self.bulk_remove_permissions = ActionProcessor(
             service.bulk_remove_permissions, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateRolePresetAction.spec(),
-            GetRolePresetAction.spec(),
-            SearchRolePresetsAction.spec(),
-            SearchRolePermissionPresetsAction.spec(),
-            UpdateRolePresetAction.spec(),
-            BulkDeleteRolePresetsAction.spec(),
-            BulkRestoreRolePresetsAction.spec(),
-            PurgeRolePresetAction.spec(),
-            BulkPurgeRolePresetsAction.spec(),
-            BulkAddRolePermissionPresetsAction.spec(),
-            BulkRemoveRolePermissionPresetsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/runtime_variant/processors.py
+++ b/src/ai/backend/manager/services/runtime_variant/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.runtime_variant.actions.create import (
     CreateRuntimeVariantAction,
@@ -27,7 +24,7 @@ from ai.backend.manager.services.runtime_variant.actions.update import (
 from ai.backend.manager.services.runtime_variant.service import RuntimeVariantService
 
 
-class RuntimeVariantProcessors(AbstractProcessorPackage):
+class RuntimeVariantProcessors:
     create: ActionProcessor[CreateRuntimeVariantAction, CreateRuntimeVariantActionResult]
     update: ActionProcessor[UpdateRuntimeVariantAction, UpdateRuntimeVariantActionResult]
     delete: ActionProcessor[DeleteRuntimeVariantAction, DeleteRuntimeVariantActionResult]
@@ -47,13 +44,3 @@ class RuntimeVariantProcessors(AbstractProcessorPackage):
         self.delete = ActionProcessor(service.delete, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
         self.resolve_by_name = ActionProcessor(service.resolve_by_name, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateRuntimeVariantAction.spec(),
-            UpdateRuntimeVariantAction.spec(),
-            DeleteRuntimeVariantAction.spec(),
-            SearchRuntimeVariantsAction.spec(),
-            ResolveRuntimeVariantByNameAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/runtime_variant_preset/processors.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.runtime_variant_preset.actions.create import (
     CreateRuntimeVariantPresetAction,
@@ -23,7 +20,7 @@ from ai.backend.manager.services.runtime_variant_preset.actions.update import (
 from ai.backend.manager.services.runtime_variant_preset.service import RuntimeVariantPresetService
 
 
-class RuntimeVariantPresetProcessors(AbstractProcessorPackage):
+class RuntimeVariantPresetProcessors:
     create: ActionProcessor[
         CreateRuntimeVariantPresetAction, CreateRuntimeVariantPresetActionResult
     ]
@@ -47,12 +44,3 @@ class RuntimeVariantPresetProcessors(AbstractProcessorPackage):
         self.update = ActionProcessor(service.update, action_monitors)
         self.delete = ActionProcessor(service.delete, action_monitors)
         self.search = ActionProcessor(service.search, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateRuntimeVariantPresetAction.spec(),
-            UpdateRuntimeVariantPresetAction.spec(),
-            DeleteRuntimeVariantPresetAction.spec(),
-            SearchRuntimeVariantPresetsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/scaling_group/processors.py
+++ b/src/ai/backend/manager/services/scaling_group/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.scaling_group.actions.associate_with_domain import (
     AssociateScalingGroupWithDomainsAction,
@@ -111,7 +108,7 @@ from ai.backend.manager.services.scaling_group.actions.update_fair_share_spec im
 from ai.backend.manager.services.scaling_group.service import ScalingGroupService
 
 
-class ScalingGroupProcessors(AbstractProcessorPackage):
+class ScalingGroupProcessors:
     create_scaling_group: ActionProcessor[CreateScalingGroupAction, CreateScalingGroupActionResult]
     purge_scaling_group: ActionProcessor[PurgeScalingGroupAction, PurgeScalingGroupActionResult]
     modify_scaling_group: ActionProcessor[ModifyScalingGroupAction, ModifyScalingGroupActionResult]
@@ -264,34 +261,3 @@ class ScalingGroupProcessors(AbstractProcessorPackage):
         self.resolve_resource_group_ids_by_names = ActionProcessor(
             service.resolve_resource_group_ids_by_names, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateScalingGroupAction.spec(),
-            PurgeScalingGroupAction.spec(),
-            ModifyScalingGroupAction.spec(),
-            SearchScalingGroupsAction.spec(),
-            ListAllowedScalingGroupsAction.spec(),
-            GetWsproxyVersionAction.spec(),
-            GetResourceInfoAction.spec(),
-            UpdateFairShareSpecAction.spec(),
-            ReplaceDefaultDeploymentOptionsAction.spec(),
-            ReplaceDefaultSessionOptionsAction.spec(),
-            AssociateScalingGroupWithDomainsAction.spec(),
-            DisassociateScalingGroupWithDomainsAction.spec(),
-            AssociateScalingGroupWithKeypairsAction.spec(),
-            DisassociateScalingGroupWithKeypairsAction.spec(),
-            AssociateScalingGroupWithUserGroupsAction.spec(),
-            DisassociateScalingGroupWithUserGroupsAction.spec(),
-            UpdateAllowedResourceGroupsForDomainAction.spec(),
-            UpdateAllowedResourceGroupsForProjectAction.spec(),
-            UpdateAllowedDomainsForResourceGroupAction.spec(),
-            UpdateAllowedProjectsForResourceGroupAction.spec(),
-            GetAllowedResourceGroupsForDomainAction.spec(),
-            GetAllowedResourceGroupsForProjectAction.spec(),
-            GetAllowedDomainsForResourceGroupAction.spec(),
-            GetAllowedProjectsForResourceGroupAction.spec(),
-            ResolveResourceGroupIDByNameAction.spec(),
-            ResolveResourceGroupIDsByNamesAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/scheduling_history/processors.py
+++ b/src/ai/backend/manager/services/scheduling_history/processors.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.global_action import GlobalActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions import (
@@ -36,7 +33,7 @@ from .actions import (
 from .service import SchedulingHistoryService
 
 
-class SchedulingHistoryProcessors(AbstractProcessorPackage):
+class SchedulingHistoryProcessors:
     """Processor package for scheduling history operations."""
 
     # Admin processors
@@ -118,21 +115,3 @@ class SchedulingHistoryProcessors(AbstractProcessorPackage):
         self.search_route_scoped_history = ActionProcessor(
             service.search_route_scoped_history, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            # Admin actions
-            SearchSessionHistoryAction.spec(),
-            SearchKernelHistoryAction.spec(),
-            SearchDeploymentHistoryAction.spec(),
-            GlobalSearchReplicaGroupHistoryAction.spec(),
-            SearchRouteHistoryAction.spec(),
-            # Scoped actions (added in 26.2.0)
-            SearchSessionScopedHistoryAction.spec(),
-            ResolveKernelSessionAction.spec(),
-            SearchKernelScopedHistoryAction.spec(),
-            SearchDeploymentScopedHistoryAction.spec(),
-            ScopedSearchReplicaGroupHistoryAction.spec(),
-            SearchRouteScopedHistoryAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/service_catalog/processors.py
+++ b/src/ai/backend/manager/services/service_catalog/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.service_catalog.actions.search import (
     SearchServiceCatalogsAction,
@@ -13,7 +10,7 @@ from ai.backend.manager.services.service_catalog.actions.search import (
 from ai.backend.manager.services.service_catalog.service import ServiceCatalogService
 
 
-class ServiceCatalogProcessors(AbstractProcessorPackage):
+class ServiceCatalogProcessors:
     """Processor package for service catalog operations."""
 
     search_service_catalogs: ActionProcessor[
@@ -29,9 +26,3 @@ class ServiceCatalogProcessors(AbstractProcessorPackage):
         self.search_service_catalogs = ActionProcessor(
             service.search_service_catalogs, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            SearchServiceCatalogsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -1,10 +1,9 @@
-from typing import cast, override
+from typing import cast
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.bulk import BulkActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
@@ -154,7 +153,7 @@ from ai.backend.manager.services.session.actions.upload_files import (
 from ai.backend.manager.services.session.service import SessionService
 
 
-class SessionProcessors(AbstractProcessorPackage):
+class SessionProcessors:
     commit_session: ActionProcessor[CommitSessionAction, CommitSessionActionResult]
     compute_schedule: ActionProcessor[ComputeScheduleAction, ComputeScheduleActionResult]
     complete: ActionProcessor[CompleteAction, CompleteActionResult]
@@ -319,44 +318,3 @@ class SessionProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=rbac_single_entity_validators,
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CommitSessionAction.spec(),
-            ComputeScheduleAction.spec(),
-            CompleteAction.spec(),
-            ConvertSessionToImageAction.spec(),
-            CreateClusterAction.spec(),
-            EnqueueSessionAction.spec(),
-            CreateFromParamsAction.spec(),
-            CreateFromTemplateAction.spec(),
-            DestroySessionAction.spec(),
-            DownloadFileAction.spec(),
-            DownloadFilesAction.spec(),
-            ExecuteSessionAction.spec(),
-            GetAbusingReportAction.spec(),
-            GetCommitStatusAction.spec(),
-            GetContainerLogsAction.spec(),
-            GetDependencyGraphAction.spec(),
-            GetDirectAccessInfoAction.spec(),
-            GetSessionInfoAction.spec(),
-            GetStatusHistoryAction.spec(),
-            InterruptSessionAction.spec(),
-            ListFilesAction.spec(),
-            MatchSessionsAction.spec(),
-            RenameSessionAction.spec(),
-            ResolveSessionAction.spec(),
-            ResolveSessionNameAction.spec(),
-            SearchKernelsAction.spec(),
-            BatchGetSessionResourceAllocationAction.spec(),
-            BatchGetKernelResourceAllocationAction.spec(),
-            SearchSessionsAction.spec(),
-            SearchSessionsInProjectAction.spec(),
-            ShutdownServiceAction.spec(),
-            StartServiceAction.spec(),
-            TerminateSessionsAction.spec(),
-            UploadFilesAction.spec(),
-            GetSessionAction.spec(),
-            ModifySessionAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/storage_namespace/processors.py
+++ b/src/ai/backend/manager/services/storage_namespace/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.storage_namespace.actions.get_all import (
     GetAllNamespacesAction,
@@ -27,7 +24,7 @@ from ai.backend.manager.services.storage_namespace.actions.unregister import (
 from ai.backend.manager.services.storage_namespace.service import StorageNamespaceService
 
 
-class StorageNamespaceProcessors(AbstractProcessorPackage):
+class StorageNamespaceProcessors:
     register: ActionProcessor[RegisterNamespaceAction, RegisterNamespaceActionResult]
     unregister: ActionProcessor[UnregisterNamespaceAction, UnregisterNamespaceActionResult]
     get_namespaces: ActionProcessor[GetNamespacesAction, GetNamespacesActionResult]
@@ -47,13 +44,3 @@ class StorageNamespaceProcessors(AbstractProcessorPackage):
         self.get_namespaces = ActionProcessor(service.get_namespaces, action_monitors)
         self.get_all_namespaces = ActionProcessor(service.get_all_namespaces, action_monitors)
         self.search_storage_namespaces = ActionProcessor(service.search, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            RegisterNamespaceAction.spec(),
-            UnregisterNamespaceAction.spec(),
-            GetNamespacesAction.spec(),
-            GetAllNamespacesAction.spec(),
-            SearchStorageNamespacesAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/stream/processors.py
+++ b/src/ai/backend/manager/services/stream/processors.py
@@ -1,10 +1,8 @@
 from collections.abc import Awaitable, Callable
-from typing import override
 
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.stream.actions.execute_in_stream import (
     ExecuteInStreamAction,
     ExecuteInStreamActionResult,
@@ -40,7 +38,7 @@ from ai.backend.manager.services.stream.actions.untrack_connection import (
 from ai.backend.manager.services.stream.service import StreamService
 
 
-class StreamProcessors(AbstractProcessorPackage):
+class StreamProcessors:
     _service: StreamService
 
     get_streaming_session: ActionProcessor[
@@ -79,16 +77,3 @@ class StreamProcessors(AbstractProcessorPackage):
         return self._service.create_connection_refresh_callback(
             session_id, kernel_id, service, stream_id
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetStreamingSessionAction.spec(),
-            TrackConnectionAction.spec(),
-            UntrackConnectionAction.spec(),
-            GCStaleConnectionsAction.spec(),
-            ExecuteInStreamAction.spec(),
-            RestartInStreamAction.spec(),
-            InterruptInStreamAction.spec(),
-            StartServiceInStreamAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/template/processors.py
+++ b/src/ai/backend/manager/services/template/processors.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 
 from .actions.create_cluster_template import (
@@ -52,7 +49,7 @@ from .service import TemplateService
 __all__ = ("TemplateProcessors",)
 
 
-class TemplateProcessors(AbstractProcessorPackage):
+class TemplateProcessors:
     """Processor package for session and cluster template operations."""
 
     create_task: ActionProcessor[CreateTaskTemplateAction, CreateTaskTemplateActionResult]
@@ -84,18 +81,3 @@ class TemplateProcessors(AbstractProcessorPackage):
         self.get_cluster = ActionProcessor(service.get_cluster_template, action_monitors)
         self.update_cluster = ActionProcessor(service.update_cluster_template, action_monitors)
         self.delete_cluster = ActionProcessor(service.delete_cluster_template, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateTaskTemplateAction.spec(),
-            ListTaskTemplatesAction.spec(),
-            GetTaskTemplateAction.spec(),
-            UpdateTaskTemplateAction.spec(),
-            DeleteTaskTemplateAction.spec(),
-            CreateClusterTemplateAction.spec(),
-            ListClusterTemplatesAction.spec(),
-            GetClusterTemplateAction.spec(),
-            UpdateClusterTemplateAction.spec(),
-            DeleteClusterTemplateAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/user/processors.py
+++ b/src/ai/backend/manager/services/user/processors.py
@@ -1,10 +1,9 @@
-from typing import cast, override
+from typing import cast
 
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validator.base import ActionValidator
 from ai.backend.manager.actions.validator.scope import ScopeActionValidator
 from ai.backend.manager.actions.validator.single_entity import SingleEntityActionValidator
@@ -99,7 +98,7 @@ from ai.backend.manager.services.user.actions.user_month_stats import (
 from ai.backend.manager.services.user.service import UserService
 
 
-class UserProcessors(AbstractProcessorPackage):
+class UserProcessors:
     # Scope actions with RBAC
     create_user: ScopeActionProcessor[CreateUserAction, CreateUserActionResult]
     search_users_by_domain: ActionProcessor[
@@ -261,39 +260,3 @@ class UserProcessors(AbstractProcessorPackage):
         self.admin_get_ssh_keypair = ActionProcessor(
             user_service.admin_get_ssh_keypair, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateUserAction.spec(),
-            BulkCreateUserAction.spec(),
-            ModifyUserAction.spec(),
-            ModifyUserByIdAction.spec(),
-            BulkModifyUserAction.spec(),
-            DeleteUserAction.spec(),
-            DeleteUserByIdAction.spec(),
-            GetUserAction.spec(),
-            PurgeUserAction.spec(),
-            PurgeUserByIdAction.spec(),
-            BulkPurgeUserAction.spec(),
-            UserMonthStatsAction.spec(),
-            AdminMonthStatsAction.spec(),
-            SearchUsersAction.spec(),
-            SearchUsersByDomainAction.spec(),
-            SearchUsersByProjectAction.spec(),
-            SearchUsersByRoleAction.spec(),
-            IssueMyKeypairAction.spec(),
-            RevokeMyKeypairAction.spec(),
-            SwitchMyMainAccessKeyAction.spec(),
-            UpdateMyKeypairAction.spec(),
-            SearchMyKeypairsAction.spec(),
-            SearchKeypairsByResourcePolicyAction.spec(),
-            AdminCreateKeypairAction.spec(),
-            AdminUpdateKeypairAction.spec(),
-            AdminDeleteKeypairAction.spec(),
-            AdminSearchKeypairsAction.spec(),
-            AdminGetKeypairAction.spec(),
-            AdminRegisterSSHKeypairAction.spec(),
-            AdminDeleteSSHKeypairAction.spec(),
-            AdminGetSSHKeypairAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/user_resource_policy/processors.py
+++ b/src/ai/backend/manager/services/user_resource_policy/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.user_resource_policy.actions.create_user_resource_policy import (
     CreateUserResourcePolicyAction,
@@ -31,7 +28,7 @@ from ai.backend.manager.services.user_resource_policy.actions.search_user_resour
 from ai.backend.manager.services.user_resource_policy.service import UserResourcePolicyService
 
 
-class UserResourcePolicyProcessors(AbstractProcessorPackage):
+class UserResourcePolicyProcessors:
     get_user_resource_policy: ActionProcessor[
         GetUserResourcePolicyAction, GetUserResourcePolicyActionResult
     ]
@@ -75,14 +72,3 @@ class UserResourcePolicyProcessors(AbstractProcessorPackage):
         self.delete_user_resource_policy = ActionProcessor(
             service.delete_user_resource_policy, action_monitors
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            GetUserResourcePolicyAction.spec(),
-            GetMyUserResourcePolicyAction.spec(),
-            SearchUserResourcePoliciesAction.spec(),
-            CreateUserResourcePolicyAction.spec(),
-            ModifyUserResourcePolicyAction.spec(),
-            DeleteUserResourcePolicyAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/vfolder/processors/file.py
+++ b/src/ai/backend/manager/services/vfolder/processors/file.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.vfolder.actions.file import (
     CreateArchiveDownloadSessionAction,
@@ -39,7 +36,7 @@ from ai.backend.manager.services.vfolder.actions.file_v2 import (
 from ai.backend.manager.services.vfolder.services.file import VFolderFileService
 
 
-class VFolderFileProcessors(AbstractProcessorPackage):
+class VFolderFileProcessors:
     upload_file: ActionProcessor[CreateUploadSessionAction, CreateUploadSessionActionResult]
     download_file: ActionProcessor[CreateDownloadSessionAction, CreateDownloadSessionActionResult]
     create_archive_download_session: ActionProcessor[
@@ -83,22 +80,3 @@ class VFolderFileProcessors(AbstractProcessorPackage):
         self.move_file_v2 = ActionProcessor(service.move_file_v2, action_monitors)
         self.delete_files_v2 = ActionProcessor(service.delete_files_v2, action_monitors)
         self.download_file_v2 = ActionProcessor(service.download_file_v2, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateUploadSessionAction.spec(),
-            CreateDownloadSessionAction.spec(),
-            CreateArchiveDownloadSessionAction.spec(),
-            ListFilesAction.spec(),
-            RenameFileAction.spec(),
-            DeleteFilesAction.spec(),
-            DeleteFilesAsyncAction.spec(),
-            MkdirAction.spec(),
-            MoveFileAction.spec(),
-            ListFilesV2Action.spec(),
-            MkdirV2Action.spec(),
-            MoveFileV2Action.spec(),
-            DeleteFilesV2Action.spec(),
-            CreateDownloadSessionV2Action.spec(),
-        ]

--- a/src/ai/backend/manager/services/vfolder/processors/invite.py
+++ b/src/ai/backend/manager/services/vfolder/processors/invite.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.vfolder.actions.invite import (
     AcceptInvitationAction,
@@ -27,7 +24,7 @@ from ai.backend.manager.services.vfolder.actions.invite import (
 from ai.backend.manager.services.vfolder.services.invite import VFolderInviteService
 
 
-class VFolderInviteProcessors(AbstractProcessorPackage):
+class VFolderInviteProcessors:
     invite_vfolder: ActionProcessor[InviteVFolderAction, InviteVFolderActionResult]
     accept_invitation: ActionProcessor[AcceptInvitationAction, AcceptInvitationActionResult]
     reject_invitation: ActionProcessor[RejectInvitationAction, RejectInvitationActionResult]
@@ -65,17 +62,3 @@ class VFolderInviteProcessors(AbstractProcessorPackage):
             service.update_invited_vfolder_mount_permission, action_monitors
         )
         self.list_sent_invitations = ActionProcessor(service.list_sent_invitations, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            InviteVFolderAction.spec(),
-            AcceptInvitationAction.spec(),
-            RejectInvitationAction.spec(),
-            UpdateInvitationAction.spec(),
-            ListInvitationAction.spec(),
-            LeaveInvitedVFolderAction.spec(),
-            RevokeInvitedVFolderAction.spec(),
-            UpdateInvitedVFolderMountPermissionAction.spec(),
-            ListSentInvitationsAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/vfolder/processors/sharing.py
+++ b/src/ai/backend/manager/services/vfolder/processors/sharing.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.vfolder.actions.sharing import (
     ListSharedVFoldersAction,
@@ -17,7 +14,7 @@ from ai.backend.manager.services.vfolder.actions.sharing import (
 from ai.backend.manager.services.vfolder.services.sharing import VFolderSharingService
 
 
-class VFolderSharingProcessors(AbstractProcessorPackage):
+class VFolderSharingProcessors:
     share: ActionProcessor[ShareVFolderAction, ShareVFolderActionResult]
     unshare: ActionProcessor[UnshareVFolderAction, UnshareVFolderActionResult]
     list_shared: ActionProcessor[ListSharedVFoldersAction, ListSharedVFoldersActionResult]
@@ -35,12 +32,3 @@ class VFolderSharingProcessors(AbstractProcessorPackage):
         self.unshare = ActionProcessor(service.unshare, action_monitors)
         self.list_shared = ActionProcessor(service.list_shared_vfolders, action_monitors)
         self.update_sharing_status = ActionProcessor(service.update_sharing_status, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            ShareVFolderAction.spec(),
-            UnshareVFolderAction.spec(),
-            ListSharedVFoldersAction.spec(),
-            UpdateVFolderSharingStatusAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder.py
@@ -1,10 +1,7 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
 from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.services.vfolder.actions.base import (
     CloneVFolderAction,
@@ -117,7 +114,7 @@ from ai.backend.manager.services.vfolder.actions.vfolder_v2 import (
 from ai.backend.manager.services.vfolder.services.vfolder import VFolderService
 
 
-class VFolderProcessors(AbstractProcessorPackage):
+class VFolderProcessors:
     create_vfolder: ScopeActionProcessor[CreateVFolderAction, CreateVFolderActionResult]
     get_vfolder: SingleEntityActionProcessor[GetVFolderAction, GetVFolderActionResult]
     list_vfolder: ScopeActionProcessor[ListVFolderAction, ListVFolderActionResult]
@@ -302,47 +299,3 @@ class VFolderProcessors(AbstractProcessorPackage):
             action_monitors,
             validators=scope_rbac_validators,
         )
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateVFolderAction.spec(),
-            GetVFolderAction.spec(),
-            ListVFolderAction.spec(),
-            SearchVFoldersInProjectAction.spec(),
-            SearchUserVFoldersAction.spec(),
-            UpdateVFolderAttributeAction.spec(),
-            MoveToTrashVFolderAction.spec(),
-            RestoreVFolderFromTrashAction.spec(),
-            DeleteForeverVFolderAction.spec(),
-            PurgeVFolderAction.spec(),
-            ForceDeleteVFolderAction.spec(),
-            CloneVFolderAction.spec(),
-            GetTaskLogsAction.spec(),
-            ListAllowedTypesAction.spec(),
-            ListAllHostsAction.spec(),
-            GetVolumePerfMetricAction.spec(),
-            GetVFolderUsageLegacyAction.spec(),
-            GetVFolderUsedBytesAction.spec(),
-            ListHostsAction.spec(),
-            GetMyStorageHostPermissionsAction.spec(),
-            GetQuotaAction.spec(),
-            UpdateQuotaAction.spec(),
-            ChangeVFolderOwnershipAction.spec(),
-            ListMountsAction.spec(),
-            MountHostAction.spec(),
-            UmountHostAction.spec(),
-            GetFstabContentsAction.spec(),
-            GetAccessibleVFolderAction.spec(),
-            GetVFolderLegacyRowAction.spec(),
-            BatchLoadVFoldersByIdsAction.spec(),
-            ResolveIdsByNamesAction.spec(),
-            CreateVFolderV2Action.spec(),
-            CreateUploadSessionV2Action.spec(),
-            GetVFolderV2Action.spec(),
-            GetVFolderUsageAction.spec(),
-            DeleteVFolderV2Action.spec(),
-            PurgeVFolderV2Action.spec(),
-            CloneVFolderV2Action.spec(),
-            CreateVFolderInProjectAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/vfolder/processors/vfolder_admin.py
+++ b/src/ai/backend/manager/services/vfolder/processors/vfolder_admin.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.services.vfolder.actions.admin_search_vfolders import (
     AdminSearchVFoldersAction,
     AdminSearchVFoldersActionResult,
@@ -10,7 +7,7 @@ from ai.backend.manager.services.vfolder.actions.admin_search_vfolders import (
 from ai.backend.manager.services.vfolder.services.vfolder_admin import VFolderAdminService
 
 
-class VFolderAdminProcessors(AbstractProcessorPackage):
+class VFolderAdminProcessors:
     admin_search_vfolders: ActionProcessor[
         AdminSearchVFoldersAction, AdminSearchVFoldersActionResult
     ]
@@ -21,9 +18,3 @@ class VFolderAdminProcessors(AbstractProcessorPackage):
         action_monitors: list[ActionMonitor],
     ) -> None:
         self.admin_search_vfolders = ActionProcessor(service.admin_search_vfolders, action_monitors)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            AdminSearchVFoldersAction.spec(),
-        ]

--- a/src/ai/backend/manager/services/vfs_storage/processors.py
+++ b/src/ai/backend/manager/services/vfs_storage/processors.py
@@ -1,8 +1,5 @@
-from typing import override
-
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.types import AbstractProcessorPackage, ActionSpec
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.clients.storage_proxy.manager_facing_client import (
     StorageProxyManagerFacingClient,
@@ -50,7 +47,7 @@ from ai.backend.manager.services.vfs_storage.actions.update import (
 from ai.backend.manager.services.vfs_storage.service import VFSStorageService
 
 
-class VFSStorageProcessors(AbstractProcessorPackage):
+class VFSStorageProcessors:
     create: ActionProcessor[CreateVFSStorageAction, CreateVFSStorageActionResult]
     update: ActionProcessor[UpdateVFSStorageAction, UpdateVFSStorageActionResult]
     delete: ActionProcessor[DeleteVFSStorageAction, DeleteVFSStorageActionResult]
@@ -87,18 +84,3 @@ class VFSStorageProcessors(AbstractProcessorPackage):
         """
         storage_manager = self._service._ensure_storage_manager()
         return storage_manager.get_manager_facing_client(proxy_name)
-
-    @override
-    def supported_actions(self) -> list[ActionSpec]:
-        return [
-            CreateVFSStorageAction.spec(),
-            UpdateVFSStorageAction.spec(),
-            DeleteVFSStorageAction.spec(),
-            GetVFSStorageAction.spec(),
-            ListVFSStorageAction.spec(),
-            SearchVFSStoragesAction.spec(),
-            GetQuotaScopeAction.spec(),
-            SearchQuotaScopesAction.spec(),
-            SetQuotaScopeAction.spec(),
-            UnsetQuotaScopeAction.spec(),
-        ]

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -1,0 +1,81 @@
+"""The wiring-time spec catalog vs the v2 actions defined in the import closure.
+
+Constructing a v2-wired package accumulates every wired spec on its registry, and
+recursing ``__subclasses__()`` from the five v2 action bases finds every concrete
+v2 action class defined. The two sets matching is what catches an action that was
+defined but never wired. A new v2 wiring extends this guard by being imported and
+constructed here.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+from ai.backend.manager.actions.monitors import ActionMonitors
+from ai.backend.manager.actions.registry import ProcessorDependencies, ProcessorRegistry
+from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
+from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction
+from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
+from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.actions.v2.validators import ActionValidators
+from ai.backend.manager.repositories.ops.repository import OpsRepository
+from ai.backend.manager.services.app_config_allow_list.processors import (
+    AppConfigAllowListProcessors,
+)
+from ai.backend.manager.services.resource_slot.processors import ResourceSlotProcessors
+
+_V2_ACTION_BASES: tuple[type[Any], ...] = (
+    BaseSingleEntityAction,
+    BaseBulkAction,
+    BaseScopeAction,
+    BaseGlobalAction,
+    BaseLookupAction,
+)
+
+
+def _concrete_v2_action_classes() -> set[type[Any]]:
+    """Every non-abstract v2 action class defined in the imported manager modules.
+
+    Filtered to the manager package so action classes defined locally by other test
+    modules in the same process cannot leak into the sweep.
+    """
+    found: set[type[Any]] = set()
+    stack: list[type[Any]] = list(_V2_ACTION_BASES)
+    while stack:
+        cls = stack.pop()
+        for subclass in cls.__subclasses__():
+            stack.append(subclass)
+            if not inspect.isabstract(subclass) and subclass.__module__.startswith(
+                "ai.backend.manager."
+            ):
+                found.add(subclass)
+    return found
+
+
+def _ops_registry() -> ProcessorRegistry[Any]:
+    return ProcessorRegistry(
+        ProcessorDependencies(
+            monitors=ActionMonitors(),
+            validators=ActionValidators(),
+            repository=OpsRepository(MagicMock()),
+        )
+    )
+
+
+def test_every_defined_v2_action_is_wired() -> None:
+    allow_list_registry = _ops_registry()
+    AppConfigAllowListProcessors(allow_list_registry)
+    resource_slot_registry = _ops_registry()
+    ResourceSlotProcessors(MagicMock(), [], MagicMock(), resource_slot_registry.group())
+
+    wired = sorted(
+        spec.type()
+        for registry in (allow_list_registry, resource_slot_registry)
+        for spec in registry.wired_specs()
+    )
+    defined = sorted(cls.spec().type() for cls in _concrete_v2_action_classes())
+
+    assert wired == defined


### PR DESCRIPTION
## Summary
- Every `ProcessorGroup` factory now takes the action class it wires as its first argument: the returned processor is typed by the concrete action class, and the registry records each wired action's spec. `ProcessorRegistry.wired_specs()` exposes the accumulated catalog of entity-operation combinations in use.
- Add a test that cross-checks the wired catalog against every concrete v2 action collected via `__subclasses__()`, catching actions that are defined but never wired.
- Drop the `AbstractProcessorPackage.supported_actions()` contract: it had no consumer (its only caller was the `Processors` aggregate, which nothing invoked), and the hand-written per-package lists are superseded by the registry catalog.

## Test plan
- [x] `pants fmt/fix/lint/check/test` over the full change set pass locally
- [x] New unit test `tests/unit/manager/actions/test_registry_catalog.py` asserts the wired spec catalog matches the defined v2 actions

Resolves BA-7286

🤖 Generated with [Claude Code](https://claude.com/claude-code)