### PR TITLE
ci(BA-7292): cancel superseded CI runs that cancel-in-progress missed

### DIFF
--- a/.github/scripts/cancel-superseded-runs.sh
+++ b/.github/scripts/cancel-superseded-runs.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Cancel workflow runs that a newer push to the same branch has superseded.
+#
+#   cancel-superseded-runs.sh <repo> <workflow> <branch> <head-sha> [--dry-run]
+#
+#     <repo>      the repository whose runs to inspect, e.g. lablup/backend.ai
+#     <workflow>  the workflow file whose runs to inspect, e.g. ci.yml
+#     <branch>    the head branch the push landed on
+#     <head-sha>  the commit that supersedes the others; its runs are never
+#                 touched
+#     --dry-run   report which runs would be cancelled; cancel nothing
+#
+# `cancel-in-progress` on the workflow's own concurrency group intermittently
+# misses the older run when two pushes land close together; the newer run then
+# sits pending, jobless, until the older one finishes. This cancels the
+# superseded run explicitly.
+#
+# Two guards keep it from cancelling the wrong run:
+#   - only runs from <repo> itself are touched, so a fork branch that happens
+#     to share the name cannot be hit;
+#   - only runs older than <head-sha>'s own run are touched, so a canceller
+#     that executes late can never cancel a run newer than its event.
+#
+# The arguments decide everything -- no CI environment is read and nothing has
+# to be checked out. `gh` takes its credentials from GH_TOKEN under CI and from
+# `gh auth login` elsewhere. Run it against the live repository:
+#
+#   .github/scripts/cancel-superseded-runs.sh lablup/backend.ai ci.yml \
+#     my-branch "$(git rev-parse HEAD)" --dry-run
+set -e
+
+usage() {
+  echo "Usage: $0 <repo> <workflow> <branch> <head-sha> [--dry-run]"
+  echo "  <repo>      the repository whose runs to inspect, e.g. lablup/backend.ai"
+  echo "  <workflow>  the workflow file whose runs to inspect, e.g. ci.yml"
+  echo "  <branch>    the head branch the push landed on"
+  echo "  <head-sha>  the commit that supersedes the others"
+  echo "  --dry-run   report which runs would be cancelled; cancel nothing"
+}
+
+dry_run=0
+positional=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *) positional+=("$1") ;;
+  esac
+  shift
+done
+if [ "${#positional[@]}" -ne 4 ]; then
+  echo "Error: expected <repo> <workflow> <branch> <head-sha>" >&2
+  usage >&2
+  exit 2
+fi
+repo="${positional[0]}"
+workflow="${positional[1]}"
+branch="${positional[2]}"
+head_sha="${positional[3]}"
+
+runs=$(gh api "repos/$repo/actions/workflows/$workflow/runs?branch=$branch&per_page=100" \
+  --jq '.workflow_runs')
+
+# The newest run of <head-sha> anchors the comparison: anything older than it
+# is superseded, anything newer belongs to an event this invocation has not
+# seen and must be left alone.
+anchor=$(jq -r --arg sha "$head_sha" \
+  '[.[] | select(.head_sha == $sha) | .id] | max // ""' <<< "$runs")
+if [ -z "$anchor" ]; then
+  echo "No $workflow run for $head_sha on $branch yet; nothing to compare against."
+  exit 0
+fi
+
+targets=$(jq -r --arg sha "$head_sha" --arg repo "$repo" --argjson anchor "$anchor" '
+  .[]
+  | select(.id < $anchor)
+  | select(.head_sha != $sha)
+  | select(.status == "queued" or .status == "in_progress"
+           or .status == "pending" or .status == "waiting")
+  | select(.head_repository.full_name == $repo)
+  | "\(.id) \(.status) \(.head_sha)"' <<< "$runs")
+
+if [ -z "$targets" ]; then
+  echo "No superseded $workflow run on $branch."
+  exit 0
+fi
+
+while read -r id status sha; do
+  if [ "$dry_run" = 1 ]; then
+    echo "Would cancel run $id ($status, $sha): superseded by $head_sha."
+    continue
+  fi
+  # A run may finish between the listing and the cancel; that is not a failure.
+  if gh api --silent -X POST "repos/$repo/actions/runs/$id/cancel"; then
+    echo "Cancelled run $id ($status, $sha): superseded by $head_sha."
+  else
+    echo "Run $id ($status, $sha) refused the cancel; likely finished already."
+  fi
+done <<< "$targets"

--- a/.github/workflows/cancel-superseded.yml
+++ b/.github/workflows/cancel-superseded.yml
@@ -1,0 +1,42 @@
+name: cancel-superseded
+
+# `ci.yml` relies on `cancel-in-progress` to stop the previous run when a new
+# push lands, but when two pushes arrive close together that cancel is
+# intermittently missed: the newer run then sits pending, jobless, until the
+# older one finishes. This workflow cancels the superseded run explicitly.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# No concurrency group on purpose: sharing a group (or any cancel-in-progress
+# of its own) would expose this workflow to the very pending glitch it exists
+# to correct. Runs are cheap and idempotent, so letting every event run is fine.
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cancel:
+    # A fork's pull_request carries a read-only token that cannot cancel runs,
+    # and its branch name may collide with an unrelated same-repo branch, so
+    # fork PRs are out of scope for now (pull_request_target is a later
+    # decision).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the canceller script
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          sparse-checkout: .github/scripts
+      - name: Cancel superseded ci runs
+        # A branch name is written by someone else; it is never interpolated
+        # into the shell, only handed over as an argument.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: .github/scripts/cancel-superseded-runs.sh "$REPO" ci.yml "$BRANCH" "$HEAD_SHA"

--- a/changes/13627.misc.md
+++ b/changes/13627.misc.md
@@ -1,0 +1,1 @@
+Explicitly cancel superseded CI runs when a rapid successive push leaves the newer run pending behind an older run that `cancel-in-progress` failed to cancel


### PR DESCRIPTION
## Summary
- When two pushes land on the same branch close together, `ci.yml`'s `cancel-in-progress` intermittently misses the older run; the newer run then sits pending with zero jobs until the older one finishes (observed on PR #13624: run 31244019134 kept running while 31244060337 stayed pending for minutes until the old run was cancelled by hand).
- Add a lightweight `pull_request` workflow, `cancel-superseded.yml`, with no concurrency group of its own, that explicitly cancels queued/in-progress `ci.yml` runs of older commits on the same branch. The decision logic lives in `.github/scripts/cancel-superseded-runs.sh`, runnable by hand with `--dry-run`.
- Safety guards: the current head's run is never touched; runs newer than the current head's run are never touched (a late canceller cannot cancel a newer run); only runs from the base repository are touched, so a same-named fork branch cannot be hit. Fork PRs are out of scope for now — their `pull_request` token is read-only (`pull_request_target` is a later decision).

## Test plan
- [x] `actionlint` and `shellcheck` pass on the new workflow and script
- [x] Dry-run against the live repository: an open PR branch reports "no superseded run", an unknown branch reports "no run to compare against", both exit 0
- [x] Selection logic verified on synthetic run data: only older queued/in-progress same-repo runs are selected; the current head's run, newer runs, completed runs, and fork runs are excluded
- [ ] After merge, observe the workflow cancelling the older run on the next rapid double-push (cancelled run ids are logged for frequency measurement)

Resolves BA-7292

🤖 Generated with [Claude Code](https://claude.com/claude-code)