### PR TITLE
test(BA-7291): seed virtual-scope chain rows in component test fixtures

### DIFF
--- a/changes/13628.test.md
+++ b/changes/13628.test.md
@@ -1,0 +1,1 @@
+Seed the virtual-scope chain rows for user-project memberships in component test fixtures.

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -811,35 +811,86 @@ async def group_fixture(
         await conn.execute(GroupRow.__table__.delete().where(GroupRow.__table__.c.id == group_id))
 
 
-async def _insert_user_virtual_scope(conn: AsyncConnection, user_uuid: UserID) -> None:
-    """Give a directly-inserted user the RBAC rows ``create_full_user`` would have made.
+class VirtualScopeSeeder:
+    """Seeds the RBAC virtual-scope chain rows for directly-inserted users,
+    mirroring the row shape the enrollment path and the backfill migration produce.
 
-    Without them the member-binding paths cannot resolve the user's virtual scope.
+    Exposed as the ``virtual_scope_seeder`` fixture so subdirectory conftests can
+    use it without importing this module.
     """
-    virtual_scope_id = uuid.uuid4()
-    await conn.execute(
-        sa.insert(VirtualScopeRow.__table__).values(
-            id=virtual_scope_id,
-            scope_type=ScopeType.USER,
-            scope_id=str(user_uuid),
+
+    async def insert_user_scope(self, conn: AsyncConnection, user_uuid: UserID) -> None:
+        """Give a directly-inserted user the RBAC rows ``create_full_user`` would
+        have made. Without them the member-binding paths cannot resolve the user's
+        virtual scope."""
+        virtual_scope_id = uuid.uuid4()
+        await conn.execute(
+            sa.insert(VirtualScopeRow.__table__).values(
+                id=virtual_scope_id,
+                scope_type=ScopeType.USER,
+                scope_id=str(user_uuid),
+            )
         )
-    )
-    await conn.execute(
-        sa.insert(EntityMembershipRow.__table__).values(
-            virtual_scope_id=virtual_scope_id,
-            entity_type=EntityType.USER,
-            entity_id=str(user_uuid),
-            permission_cap=None,
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                entity_type=EntityType.USER,
+                entity_id=str(user_uuid),
+                permission_cap=None,
+            )
         )
-    )
-    await conn.execute(
-        sa.insert(ScopeBindingRow.__table__).values(
-            virtual_scope_id=virtual_scope_id,
-            scope_type=ScopeType.USER,
-            scope_id=str(user_uuid),
-            permission_cap=None,
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=virtual_scope_id,
+                scope_type=ScopeType.USER,
+                scope_id=str(user_uuid),
+                permission_cap=None,
+            )
         )
-    )
+
+    async def enroll_user_in_project(
+        self, conn: AsyncConnection, group_id: uuid.UUID, user_uuid: UserID
+    ) -> None:
+        """Write the virtual-scope chain rows the enrollment path creates for a
+        user-project membership: the user joins the project's virtual scope and the
+        project is bound into the user's own virtual scope."""
+        project_scope_id = (
+            await conn.execute(
+                sa.select(VirtualScopeRow.__table__.c.id).where(
+                    VirtualScopeRow.__table__.c.scope_type == ScopeType.PROJECT,
+                    VirtualScopeRow.__table__.c.scope_id == group_id,
+                )
+            )
+        ).scalar_one()
+        user_scope_id = (
+            await conn.execute(
+                sa.select(VirtualScopeRow.__table__.c.id).where(
+                    VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,
+                    VirtualScopeRow.__table__.c.scope_id == str(user_uuid),
+                )
+            )
+        ).scalar_one()
+        await conn.execute(
+            sa.insert(EntityMembershipRow.__table__).values(
+                virtual_scope_id=project_scope_id,
+                entity_type=EntityType.USER,
+                entity_id=str(user_uuid),
+                permission_cap=None,
+            )
+        )
+        await conn.execute(
+            sa.insert(ScopeBindingRow.__table__).values(
+                virtual_scope_id=user_scope_id,
+                scope_type=ScopeType.PROJECT,
+                scope_id=group_id,
+                permission_cap=None,
+            )
+        )
+
+
+@pytest.fixture()
+def virtual_scope_seeder() -> VirtualScopeSeeder:
+    return VirtualScopeSeeder()
 
 
 @pytest.fixture()
@@ -848,6 +899,7 @@ async def admin_user_fixture(
     group_fixture: uuid.UUID,
     domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
+    virtual_scope_seeder: VirtualScopeSeeder,
 ) -> AsyncIterator[UserFixtureData]:
     """Insert admin user, keypair, and group membership; yield identifiers."""
     unique_id = secrets.token_hex(4)
@@ -897,7 +949,7 @@ async def admin_user_fixture(
                 user=str(data.user_uuid),
             )
         )
-        await _insert_user_virtual_scope(conn, data.user_uuid)
+        await virtual_scope_seeder.insert_user_scope(conn, data.user_uuid)
         await conn.execute(
             users.update()
             .where(users.c.uuid == str(data.user_uuid))
@@ -917,6 +969,7 @@ async def admin_user_fixture(
                 entity_id=str(data.user_uuid),
             )
         )
+        await virtual_scope_seeder.enroll_user_in_project(conn, group_fixture, data.user_uuid)
     yield data
     async with db_engine.begin() as conn:
         # Clean side-effect tables that tests may populate via the running server
@@ -935,6 +988,12 @@ async def admin_user_fixture(
         await conn.execute(
             AssociationScopesEntitiesRow.__table__.delete().where(
                 AssociationScopesEntitiesRow.__table__.c.entity_id == str(data.user_uuid)
+            )
+        )
+        await conn.execute(
+            EntityMembershipRow.__table__.delete().where(
+                EntityMembershipRow.__table__.c.entity_type == EntityType.USER,
+                EntityMembershipRow.__table__.c.entity_id == str(data.user_uuid),
             )
         )
         await conn.execute(
@@ -959,6 +1018,7 @@ async def regular_user_fixture(
     group_fixture: uuid.UUID,
     domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
+    virtual_scope_seeder: VirtualScopeSeeder,
 ) -> AsyncIterator[UserFixtureData]:
     """Insert regular user, keypair, and group membership; yield identifiers."""
     unique_id = secrets.token_hex(4)
@@ -1008,7 +1068,7 @@ async def regular_user_fixture(
                 user=str(data.user_uuid),
             )
         )
-        await _insert_user_virtual_scope(conn, data.user_uuid)
+        await virtual_scope_seeder.insert_user_scope(conn, data.user_uuid)
         await conn.execute(
             users.update()
             .where(users.c.uuid == str(data.user_uuid))
@@ -1028,6 +1088,7 @@ async def regular_user_fixture(
                 entity_id=str(data.user_uuid),
             )
         )
+        await virtual_scope_seeder.enroll_user_in_project(conn, group_fixture, data.user_uuid)
     yield data
     async with db_engine.begin() as conn:
         # Clean side-effect tables that tests may populate via the running server
@@ -1043,6 +1104,12 @@ async def regular_user_fixture(
         await conn.execute(
             AssociationScopesEntitiesRow.__table__.delete().where(
                 AssociationScopesEntitiesRow.__table__.c.entity_id == str(data.user_uuid)
+            )
+        )
+        await conn.execute(
+            EntityMembershipRow.__table__.delete().where(
+                EntityMembershipRow.__table__.c.entity_type == EntityType.USER,
+                EntityMembershipRow.__table__.c.entity_id == str(data.user_uuid),
             )
         )
         await conn.execute(

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -25,6 +25,7 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
@@ -86,7 +87,7 @@ from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_valid
 from ai.backend.testutils.fixtures import DomainFixtureData
 
 if TYPE_CHECKING:
-    from tests.component.conftest import ServerInfo, UserFixtureData
+    from tests.component.conftest import ServerInfo, UserFixtureData, VirtualScopeSeeder
 
 
 def _build_validators(
@@ -536,6 +537,7 @@ async def assigned_users(
     group_fixture: uuid.UUID,
     domain_fixture: DomainFixtureData,
     resource_policy_fixture: str,
+    virtual_scope_seeder: VirtualScopeSeeder,
 ) -> AsyncIterator[list[uuid.UUID]]:
     """Insert test users and assign them to the target project via ASE.
 
@@ -597,6 +599,8 @@ async def assigned_users(
                     relation_type=RelationType.AUTO,
                 )
             )
+            await virtual_scope_seeder.insert_user_scope(conn, UserID(uid))
+            await virtual_scope_seeder.enroll_user_in_project(conn, group_fixture, UserID(uid))
             user_ids.append(uid)
             emails.append(email)
             access_keys.append(ak)
@@ -611,6 +615,18 @@ async def assigned_users(
                     AssociationScopesEntitiesRow.scope_id == str(group_fixture),
                     AssociationScopesEntitiesRow.entity_type == EntityType.USER,
                     AssociationScopesEntitiesRow.entity_id == str(uid),
+                )
+            )
+            await conn.execute(
+                EntityMembershipRow.__table__.delete().where(
+                    EntityMembershipRow.__table__.c.entity_type == EntityType.USER,
+                    EntityMembershipRow.__table__.c.entity_id == str(uid),
+                )
+            )
+            await conn.execute(
+                VirtualScopeRow.__table__.delete().where(
+                    VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,
+                    VirtualScopeRow.__table__.c.scope_id == str(uid),
                 )
             )
         for ak in reversed(access_keys):


### PR DESCRIPTION
## Summary
- Component test fixtures recorded user-project memberships only in `association_scopes_entities`, while membership reads now go through the virtual-scope chain (`entity_memberships` / `scope_bindings`) since #13556 — so `tests/component/resource_preset` failed with `ProjectNotFound` and the project unassign tests read empty membership.
- Add a `VirtualScopeSeeder` helper in the shared component conftest (exposed as the `virtual_scope_seeder` fixture) that seeds the user's own virtual scope and the project-membership chain rows, matching the row shape of the backfill migration (`3ebcf2c3c959`).
- Wire it into `admin_user_fixture` / `regular_user_fixture` and the project `assigned_users` fixture, with matching teardown.

## Test plan
- [x] `pants test tests/component/resource_preset::` (previously failing on main)
- [x] `pants test tests/component/project::` (unassign tests previously failing)
- [x] `pants fmt/fix/lint/check --changed-since=HEAD~1`
- [x] Full component suite locally with `--changed-dependents=direct`; CI will re-confirm

Resolves BA-7291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

