### PR TITLE
ci(BA-7292): force-cancel superseded runs that survive the graceful cancel

### DIFF
--- a/.github/scripts/cancel-superseded-runs.sh
+++ b/.github/scripts/cancel-superseded-runs.sh
@@ -22,6 +22,10 @@
 #   - only runs older than <head-sha>'s own run are touched, so a canceller
 #     that executes late can never cancel a run newer than its event.
 #
+# A run with a hung job ignores the graceful cancel and stays in_progress
+# indefinitely, so after cancelling, the script waits for the runs to actually
+# complete and force-cancels whatever survived the wait.
+#
 # The arguments decide everything -- no CI environment is read and nothing has
 # to be checked out. `gh` takes its credentials from GH_TOKEN under CI and from
 # `gh auth login` elsewhere. Run it against the live repository:
@@ -87,6 +91,7 @@ if [ -z "$targets" ]; then
   exit 0
 fi
 
+cancelled=()
 while read -r id status sha; do
   if [ "$dry_run" = 1 ]; then
     echo "Would cancel run $id ($status, $sha): superseded by $head_sha."
@@ -95,7 +100,31 @@ while read -r id status sha; do
   # A run may finish between the listing and the cancel; that is not a failure.
   if gh api --silent -X POST "repos/$repo/actions/runs/$id/cancel"; then
     echo "Cancelled run $id ($status, $sha): superseded by $head_sha."
+    cancelled+=("$id")
   else
     echo "Run $id ($status, $sha) refused the cancel; likely finished already."
   fi
 done <<< "$targets"
+[ "${#cancelled[@]}" -eq 0 ] && exit 0
+
+# The cancel above is a request, not a result: a run whose job hangs ignores
+# it and keeps blocking the superseding run. Wait for the cancelled runs to
+# actually complete, then force-cancel the survivors.
+for _ in 1 2 3 4 5 6; do
+  sleep 10
+  remaining=()
+  for id in "${cancelled[@]}"; do
+    if [ "$(gh api "repos/$repo/actions/runs/$id" --jq .status)" != "completed" ]; then
+      remaining+=("$id")
+    fi
+  done
+  [ "${#remaining[@]}" -eq 0 ] && exit 0
+  cancelled=("${remaining[@]}")
+done
+for id in "${cancelled[@]}"; do
+  if gh api --silent -X POST "repos/$repo/actions/runs/$id/force-cancel"; then
+    echo "Force-cancelled run $id: it survived the graceful cancel."
+  else
+    echo "Run $id refused the force-cancel; check it by hand."
+  fi
+done

--- a/changes/13629.misc.md
+++ b/changes/13629.misc.md
@@ -1,0 +1,1 @@
+Force-cancel superseded CI runs that ignore the graceful cancel because of a hung job, so they no longer block the newest run


### PR DESCRIPTION
## Summary
- The superseded-run canceller added in #13627 issues a graceful cancel, but that API call is a request, not a result: a run with a hung job accepts the cancel and keeps running anyway, still blocking the superseding run. Observed live on PR #13628 — the canceller cancelled run 31245825485 at 07:18 and again at 07:22, a hung `test-component` job ignored both, and the run only died to a manual force-cancel.
- After cancelling, the script now polls the cancelled runs for up to 60 seconds and force-cancels whatever has not completed, logging which runs needed it. Graceful cancel stays first so normally-behaving runs keep their post-step cleanup.

## Test plan
- [x] `shellcheck` and `actionlint` pass; live `--dry-run` against the repository behaves as before
- [x] Faked `gh` shim, normal path: the cancelled run reports `completed` on the first poll — the script exits without calling force-cancel
- [x] Faked `gh` shim, hung path: the run stays `in_progress` through all 6 polls — the script issues exactly one force-cancel and logs it
- [ ] After merge, verify on the next hung superseded run that the fallback fires without manual intervention

Follow-up to BA-7292 (#13627).

🤖 Generated with [Claude Code](https://claude.com/claude-code)