### PR TITLE
feat(BA-7287): add public read processor for authenticated global reads

### DIFF
--- a/changes/13634.feature.md
+++ b/changes/13634.feature.md
@@ -1,0 +1,1 @@
+Open resource slot type reads to all authenticated users via a new public read processor path.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -50215,7 +50215,7 @@
           }
         },
         "parameters": [],
-        "description": "Search resource slot types with filters, orders, and pagination.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+        "description": "Search resource slot types with filters, orders, and pagination.\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/resource-slots/slot-types": {
@@ -64743,7 +64743,7 @@
           }
         },
         "parameters": [],
-        "description": "Search resource slot types with filters, orders, and pagination.\n\n**Preconditions:**\n* Superadmin privilege required.\n* Manager status required: RUNNING\n"
+        "description": "Search resource slot types with filters, orders, and pagination.\n\n**Preconditions:**\n* User privilege required.\n* Manager status required: RUNNING\n"
       }
     },
     "/resource-slot-types/{slot_name}": {
@@ -64772,7 +64772,7 @@
             }
           }
         ],
-        "description": "Get a single resource slot type by slot_name.\n\n**Preconditions:**\n* Superadmin privilege required.\n* Manager status required: RUNNING\n"
+        "description": "Get a single resource slot type by slot_name.\n\n**Preconditions:**\n* User privilege required.\n* Manager status required: RUNNING\n"
       }
     },
     "/resource/prometheus-query-definitions": {

--- a/src/ai/backend/manager/actions/registry.py
+++ b/src/ai/backend/manager/actions/registry.py
@@ -29,7 +29,10 @@ from ai.backend.manager.actions.v2.bulk.result import BaseBulkActionResult
 from ai.backend.manager.actions.v2.bulk.validator import BulkActionValidator
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.global_scope.monitor import GlobalActionMonitor
-from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
+from ai.backend.manager.actions.v2.global_scope.processor import (
+    GlobalActionProcessor,
+    PublicActionProcessor,
+)
 from ai.backend.manager.actions.v2.global_scope.validator import GlobalActionValidator
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction, BaseLookupActionResult
 from ai.backend.manager.actions.v2.lookup.monitor import LookupActionMonitor
@@ -53,6 +56,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     CreateRoleManagedEntityOpsAction,
     DeleteBulkOpsAction,
     DeleteSingleEntityOpsAction,
+    GetGlobalOpsAction,
     GetSingleEntityOpsAction,
     LookupEntityOpsAction,
     OperationScopeOpsAction,
@@ -272,6 +276,36 @@ class ProcessorGroup[TData: EntityData]:
     ) -> GlobalActionProcessor[TAction, BatchOpsResult[TData]]:
         self._record(action_cls.spec())
         return GlobalActionProcessor(
+            GlobalSearchService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.global_scope, *monitors),
+            validators=(*self._deps.validators.global_scope, *validators),
+        )
+
+    def public_get_ops[TAction: GetGlobalOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        validators: Sequence[GlobalActionValidator] = (),
+        monitors: Sequence[GlobalActionMonitor] = (),
+    ) -> PublicActionProcessor[TAction, EntityOpsResult[TData]]:
+        self._record(action_cls.spec())
+        return PublicActionProcessor(
+            action_cls,
+            GetService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.global_scope, *monitors),
+            validators=(*self._deps.validators.global_scope, *validators),
+        )
+
+    def public_search_ops[TAction: SearchGlobalOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        validators: Sequence[GlobalActionValidator] = (),
+        monitors: Sequence[GlobalActionMonitor] = (),
+    ) -> PublicActionProcessor[TAction, BatchOpsResult[TData]]:
+        self._record(action_cls.spec())
+        return PublicActionProcessor(
+            action_cls,
             GlobalSearchService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.global_scope, *monitors),
             validators=(*self._deps.validators.global_scope, *validators),

--- a/src/ai/backend/manager/actions/v2/global_scope/__init__.py
+++ b/src/ai/backend/manager/actions/v2/global_scope/__init__.py
@@ -1,15 +1,21 @@
 from .base import BaseGlobalAction
 from .monitor import GlobalActionMonitor
-from .processor import GlobalActionProcessor
+from .processor import GlobalActionProcessor, PublicActionProcessor
 from .result import GlobalActionProcessResult, GlobalActionResultMeta
-from .validator import GlobalActionValidator, SuperAdminActionValidator
+from .validator import (
+    AuthenticatedActionValidator,
+    GlobalActionValidator,
+    SuperAdminActionValidator,
+)
 
 __all__ = (
+    "AuthenticatedActionValidator",
     "BaseGlobalAction",
     "GlobalActionMonitor",
     "GlobalActionProcessResult",
     "GlobalActionProcessor",
     "GlobalActionResultMeta",
     "GlobalActionValidator",
+    "PublicActionProcessor",
     "SuperAdminActionValidator",
 )

--- a/src/ai/backend/manager/actions/v2/global_scope/processor.py
+++ b/src/ai/backend/manager/actions/v2/global_scope/processor.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.run_status import ActionRunStatus
+from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.global_scope.monitor import GlobalActionMonitor
 from ai.backend.manager.actions.v2.global_scope.result import (
@@ -13,11 +14,16 @@ from ai.backend.manager.actions.v2.global_scope.result import (
     GlobalActionResultMeta,
 )
 from ai.backend.manager.actions.v2.global_scope.validator import (
+    AuthenticatedActionValidator,
     GlobalActionValidator,
     SuperAdminActionValidator,
 )
+from ai.backend.manager.errors.common import ServerMisconfiguredError
 
-__all__ = ("GlobalActionProcessor",)
+__all__ = (
+    "GlobalActionProcessor",
+    "PublicActionProcessor",
+)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -67,6 +73,98 @@ class GlobalActionProcessor[TAction: BaseGlobalAction, TResult]:
 
         # Validation runs inside the monitor lifecycle so a rejected action is
         # recorded too; monitors that only wrapped execution missed every denial.
+        await self._prepare_monitors(action, trigger_meta)
+        try:
+            try:
+                for validator in self._validators:
+                    await validator.validate(action, trigger_meta)
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=True)
+                raise
+            try:
+                result = await self._func(action)
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=False)
+                raise
+            else:
+                run_status = ActionRunStatus.success()
+                return result
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = GlobalActionResultMeta(
+                action_id=action_id,
+                status=run_status.status,
+                description=run_status.description,
+                started_at=started_at,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+                error_code=run_status.error_code,
+            )
+            await self._finalize_monitors(action, meta)
+
+
+class PublicActionProcessor[TAction: BaseGlobalAction, TResult]:
+    """Validate authentication only, run monitors around, then execute a global read.
+
+    The counterpart of :class:`GlobalActionProcessor` for global state everyone may
+    read — the SUPERADMIN gate is replaced by an authentication check, and nothing
+    else. The action shape stays ``BaseGlobalAction``, so the global monitor set
+    (audit, reporter, prometheus) applies unchanged.
+
+    "Public" means every authenticated user, not anonymous access: unlike the REST
+    v2 ``/public/`` URL segment, which marks routes with no auth middleware, this
+    path always demands a caller identity.
+
+    Only reads may run without the gate, and the constructor enforces it: wiring an
+    action whose ``operation_type()`` is not a read operation fails immediately, so
+    a write can never reach the public path by miswiring.
+    """
+
+    _func: Callable[[TAction], Awaitable[TResult]]
+    _monitors: Sequence[GlobalActionMonitor]
+    _validators: Sequence[GlobalActionValidator]
+
+    def __init__(
+        self,
+        action_cls: type[TAction],
+        func: Callable[[TAction], Awaitable[TResult]],
+        monitors: Sequence[GlobalActionMonitor] | None = None,
+        validators: Sequence[GlobalActionValidator] | None = None,
+    ) -> None:
+        operation_type = action_cls.operation_type()
+        if operation_type not in ActionOperationType.read_operations():
+            raise ServerMisconfiguredError(
+                f"{action_cls.__name__} declares operation_type()={operation_type}, "
+                "but the public path only accepts read actions."
+            )
+        self._func = func
+        self._monitors = monitors or []
+        self._validators = [AuthenticatedActionValidator(), *(validators or [])]
+
+    async def _prepare_monitors(self, action: TAction, trigger_meta: BaseActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(action, trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(self, action: TAction, meta: GlobalActionResultMeta) -> None:
+        process_result = GlobalActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(action, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> TResult:
+        started_at = datetime.now(UTC)
+        action_id = uuid.uuid4()
+        trigger_meta = BaseActionTriggerMeta(action_id=action_id, started_at=started_at)
+
+        run_status = ActionRunStatus.unknown()
+
+        # Same lifecycle as the global processor: validation runs inside the monitor
+        # lifecycle so a rejected action is recorded too.
         await self._prepare_monitors(action, trigger_meta)
         try:
             try:

--- a/src/ai/backend/manager/actions/v2/global_scope/validator/__init__.py
+++ b/src/ai/backend/manager/actions/v2/global_scope/validator/__init__.py
@@ -1,4 +1,9 @@
+from .authenticated import AuthenticatedActionValidator
 from .base import GlobalActionValidator
 from .superadmin import SuperAdminActionValidator
 
-__all__ = ("GlobalActionValidator", "SuperAdminActionValidator")
+__all__ = (
+    "AuthenticatedActionValidator",
+    "GlobalActionValidator",
+    "SuperAdminActionValidator",
+)

--- a/src/ai/backend/manager/actions/v2/global_scope/validator/authenticated.py
+++ b/src/ai/backend/manager/actions/v2/global_scope/validator/authenticated.py
@@ -1,0 +1,26 @@
+from typing import override
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
+from ai.backend.manager.actions.v2.global_scope.validator.base import GlobalActionValidator
+from ai.backend.manager.errors.common import GenericForbidden
+from ai.backend.manager.errors.user import UserNotFound
+
+__all__ = ("AuthenticatedActionValidator",)
+
+
+class AuthenticatedActionValidator(GlobalActionValidator):
+    """The sole gate of the public read path: the caller must be authenticated.
+
+    Mirrors the lookup layer's validator of the same name — the action targets
+    state everyone may read, so authorization reduces to knowing who is asking.
+    """
+
+    @override
+    async def validate(self, action: BaseGlobalAction, meta: BaseActionTriggerMeta) -> None:
+        user = current_user()
+        if user is None:
+            raise UserNotFound("User not found in context")
+        if not user.is_authorized:
+            raise GenericForbidden("Only authorized requests are allowed to perform this action")

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -96,6 +96,7 @@ __all__ = (
     "BatchUpdateGlobalOpsAction",
     "BatchPurgeScopeOpsAction",
     "BatchPurgeGlobalOpsAction",
+    "GetGlobalOpsAction",
 )
 
 
@@ -714,6 +715,20 @@ class UpsertFieldEntityOpsAction[TOwnerID: OwnerEntityID, TRow: Base, TData](
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.UPSERT
+
+
+class GetGlobalOpsAction[TRow: Base, TData](BaseGlobalAction, GetOpsAction[TRow, TData], ABC):
+    """A read of one row of system-wide state, named by the key its querier carries.
+
+    Global rather than single-entity for the same reason the update is: the row
+    belongs to no RBAC scope, and the catalogs this shape serves are keyed by a
+    name the caller passes as-is.
+    """
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
 
 
 class UpdateGlobalOpsAction[TRow: Base, TData](BaseGlobalAction, UpdateOpsAction[TRow, TData], ABC):

--- a/src/ai/backend/manager/api/adapters/resource_slot/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_slot/adapter.py
@@ -67,6 +67,7 @@ from ai.backend.manager.models.resource_slot.purgers import ResourceSlotTypePurg
 from ai.backend.manager.models.resource_slot.types import NumberFormat
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.resource_slot.searchers import ResourceSlotTypeSearcher
 from ai.backend.manager.repositories.resource_slot.updaters import ResourceSlotTypeUpdater
 from ai.backend.manager.services.resource_slot.actions.create import CreateResourceSlotTypeAction
 from ai.backend.manager.services.resource_slot.actions.get_agent_resource_by_slot import (
@@ -119,12 +120,10 @@ class ResourceSlotAdapter(BaseAdapter):
         Returns:
             Pydantic payload with items and pagination info.
         """
-        querier = self._build_slot_type_querier(input)
+        searcher = self._build_slot_type_searcher(input)
 
-        action_result = (
-            await self._processors.resource_slot.search_resource_slot_types.wait_for_complete(
-                SearchResourceSlotTypesAction(querier=querier)
-            )
+        action_result = await self._processors.resource_slot.search_resource_slot_types.run(
+            SearchResourceSlotTypesAction(searcher=searcher)
         )
 
         return AdminSearchResourceSlotTypesPayload(
@@ -134,8 +133,10 @@ class ResourceSlotAdapter(BaseAdapter):
             has_previous_page=action_result.has_previous_page,
         )
 
-    def _build_slot_type_querier(self, input: AdminSearchResourceSlotTypesInput) -> BatchQuerier:
-        """Build a BatchQuerier for resource slot type search."""
+    def _build_slot_type_searcher(
+        self, input: AdminSearchResourceSlotTypesInput
+    ) -> ResourceSlotTypeSearcher:
+        """Build a Searcher for resource slot type search."""
         conditions = self._convert_slot_type_filter(input.filter) if input.filter else []
         orders = (
             self._convert_slot_type_orders(input.order)
@@ -144,7 +145,7 @@ class ResourceSlotAdapter(BaseAdapter):
         )
         orders.append(SLOT_TYPE_TIEBREAKER_ORDER)
         pagination = self._build_slot_type_pagination(input)
-        return BatchQuerier(conditions=conditions, orders=orders, pagination=pagination)
+        return ResourceSlotTypeSearcher(conditions=conditions, orders=orders, pagination=pagination)
 
     def _convert_slot_type_filter(self, filter: ResourceSlotTypeFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
@@ -475,12 +476,10 @@ class ResourceSlotAdapter(BaseAdapter):
 
     async def get_slot_type(self, slot_name: str) -> ResourceSlotTypeNode:
         """Retrieve a single resource slot type by slot name."""
-        action_result = (
-            await self._processors.resource_slot.get_resource_slot_type.wait_for_complete(
-                GetResourceSlotTypeAction(slot_name=slot_name)
-            )
+        action_result = await self._processors.resource_slot.get_resource_slot_type.run(
+            GetResourceSlotTypeAction(slot_name=slot_name)
         )
-        return self._slot_type_data_to_node(action_result.item)
+        return self._slot_type_data_to_node(action_result.data)
 
     async def get_agent_resource(self, agent_id: str, slot_name: str) -> AgentResourceNode:
         """Retrieve a single agent resource by agent ID and slot name."""

--- a/src/ai/backend/manager/api/gql/resource_slot/types.py
+++ b/src/ai/backend/manager/api/gql/resource_slot/types.py
@@ -201,13 +201,13 @@ class ResourceSlotTypeGQL(PydanticNodeMixin[Any]):
         node_ids: Iterable[str],
         required: bool = False,
     ) -> Iterable[Self | None]:
-        from ai.backend.manager.errors.resource_slot import ResourceSlotTypeNotFound
+        from ai.backend.manager.errors.repository import EntityNotFoundError
 
         results: list[Self | None] = []
         for slot_name in node_ids:
             try:
                 node = await load_resource_slot_type_node(info, slot_name)
-            except ResourceSlotTypeNotFound:
+            except EntityNotFoundError:
                 if required:
                     raise
                 results.append(None)

--- a/src/ai/backend/manager/api/rest/resource_slot/adapter.py
+++ b/src/ai/backend/manager/api/rest/resource_slot/adapter.py
@@ -20,8 +20,8 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.resource_slot.conditions import ResourceSlotTypeConditions
 from ai.backend.manager.models.resource_slot.orders import ResourceSlotTypeOrders
 from ai.backend.manager.models.specs.pagination import OffsetPagination
-from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.filter_adapter import BaseFilterAdapter
+from ai.backend.manager.repositories.resource_slot.searchers import ResourceSlotTypeSearcher
 
 __all__ = ("ResourceSlotAdapter",)
 
@@ -45,12 +45,12 @@ class ResourceSlotAdapter(BaseFilterAdapter):
             rank=data.rank,
         )
 
-    def build_querier(self, request: SearchResourceSlotTypesRequest) -> BatchQuerier:
-        """Build a BatchQuerier from search request."""
+    def build_searcher(self, request: SearchResourceSlotTypesRequest) -> ResourceSlotTypeSearcher:
+        """Build a Searcher from search request."""
         conditions = self._convert_filter(request.filter) if request.filter else []
         orders = [self._convert_order(o) for o in request.order] if request.order else []
 
-        return BatchQuerier(
+        return ResourceSlotTypeSearcher(
             conditions=conditions,
             orders=orders,
             pagination=OffsetPagination(limit=request.limit, offset=request.offset),

--- a/src/ai/backend/manager/api/rest/resource_slot/handler.py
+++ b/src/ai/backend/manager/api/rest/resource_slot/handler.py
@@ -46,10 +46,10 @@ class ResourceSlotHandler:
         """Search resource slot types with filters, orders, and pagination."""
         log.info("SEARCH_RESOURCE_SLOT_TYPES")
 
-        querier = self._adapter.build_querier(body.parsed)
+        searcher = self._adapter.build_searcher(body.parsed)
 
-        action_result = await self._resource_slot.search_resource_slot_types.wait_for_complete(
-            SearchResourceSlotTypesAction(querier=querier)
+        action_result = await self._resource_slot.search_resource_slot_types.run(
+            SearchResourceSlotTypesAction(searcher=searcher)
         )
 
         resp = SearchResourceSlotTypesResponse(
@@ -70,11 +70,11 @@ class ResourceSlotHandler:
         slot_name = path.parsed.slot_name
         log.info("GET_RESOURCE_SLOT_TYPE (slot_name:{})", slot_name)
 
-        action_result = await self._resource_slot.get_resource_slot_type.wait_for_complete(
+        action_result = await self._resource_slot.get_resource_slot_type.run(
             GetResourceSlotTypeAction(slot_name=slot_name)
         )
 
         resp = GetResourceSlotTypeResponse(
-            item=self._adapter.convert_to_dto(action_result.item),
+            item=self._adapter.convert_to_dto(action_result.data),
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=resp)

--- a/src/ai/backend/manager/api/rest/resource_slot/registry.py
+++ b/src/ai/backend/manager/api/rest/resource_slot/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ai.backend.manager.api.rest.middleware.auth import superadmin_required
+from ai.backend.manager.api.rest.middleware.auth import auth_required
 from ai.backend.manager.api.rest.routing import RouteRegistry
 
 from .handler import ResourceSlotHandler
@@ -24,7 +24,7 @@ def register_resource_slot_routes(
         "/search",
         handler.search_resource_slot_types,
         middlewares=[
-            superadmin_required,
+            auth_required,
             route_deps.all_status_mw,
         ],
     )
@@ -33,7 +33,7 @@ def register_resource_slot_routes(
         "/{slot_name}",
         handler.get_resource_slot_type,
         middlewares=[
-            superadmin_required,
+            auth_required,
             route_deps.all_status_mw,
         ],
     )

--- a/src/ai/backend/manager/api/rest/v2/resource_slot/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/resource_slot/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ai.backend.manager.api.rest.middleware.auth import superadmin_required
+from ai.backend.manager.api.rest.middleware.auth import auth_required, superadmin_required
 from ai.backend.manager.api.rest.routing import RouteRegistry
 
 from .handler import V2ResourceSlotHandler
@@ -24,7 +24,7 @@ def register_v2_resource_slot_routes(
         "POST",
         "/slot-types/search",
         handler.search_slot_types,
-        middlewares=[superadmin_required],
+        middlewares=[auth_required],
     )
     registry.add(
         "POST",

--- a/src/ai/backend/manager/data/resource_slot/__init__.py
+++ b/src/ai/backend/manager/data/resource_slot/__init__.py
@@ -6,7 +6,6 @@ from .types import (
     ResourceAllocationSearchResult,
     ResourceOccupancy,
     ResourceSlotTypeData,
-    ResourceSlotTypeSearchResult,
 )
 
 __all__ = [
@@ -17,5 +16,4 @@ __all__ = [
     "ResourceAllocationSearchResult",
     "ResourceOccupancy",
     "ResourceSlotTypeData",
-    "ResourceSlotTypeSearchResult",
 ]

--- a/src/ai/backend/manager/data/resource_slot/types.py
+++ b/src/ai/backend/manager/data/resource_slot/types.py
@@ -59,14 +59,6 @@ class ResourceSlotTypeData(EntityData):
 
 
 @dataclass(frozen=True)
-class ResourceSlotTypeSearchResult:
-    items: list[ResourceSlotTypeData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
-
-
-@dataclass(frozen=True)
 class AgentResourceData:
     agent_id: str
     slot_name: str

--- a/src/ai/backend/manager/repositories/resource_slot/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_slot/db_source/db_source.py
@@ -21,14 +21,12 @@ from ai.backend.manager.data.resource_slot.types import (
     ResourceAllocationData,
     ResourceAllocationSearchResult,
     ResourceOccupancy,
-    ResourceSlotTypeSearchResult,
     TerminalSessionKernelReconciliation,
 )
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.errors.resource_slot import (
     AgentResourceNotFound,
     ResourceAllocationNotFound,
-    ResourceSlotTypeNotFound,
 )
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.resource_slot import (
@@ -78,44 +76,6 @@ class ResourceSlotDBSource:
             )
             result = await db_sess.execute(stmt)
             return list(result.scalars().all())
-
-    async def get_slot_type(
-        self,
-        slot_name: str,
-    ) -> ResourceSlotTypeRow:
-        """Get a specific resource slot type by name.
-
-        Args:
-            slot_name: The slot type name to look up.
-
-        Returns:
-            ResourceSlotTypeRow for the given slot name.
-
-        Raises:
-            ResourceSlotTypeNotFound: If the slot type does not exist.
-        """
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
-            stmt = sa.select(ResourceSlotTypeRow).where(
-                ResourceSlotTypeRow.slot_name == slot_name,
-            )
-            result = await db_sess.execute(stmt)
-            row = result.scalar_one_or_none()
-            if row is None:
-                raise ResourceSlotTypeNotFound(f"Resource slot type '{slot_name}' not found.")
-            return row
-
-    async def search_slot_types(self, querier: BatchQuerier) -> ResourceSlotTypeSearchResult:
-        """Paginated search across all resource_slot_types rows."""
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
-            query = sa.select(ResourceSlotTypeRow)
-            result = await execute_batch_querier(db_sess, query, querier)
-            items = [row.ResourceSlotTypeRow.to_data() for row in result.rows]
-            return ResourceSlotTypeSearchResult(
-                items=items,
-                total_count=result.total_count,
-                has_next_page=result.has_next_page,
-                has_previous_page=result.has_previous_page,
-            )
 
     # ==================== agent_resources Read ====================
 

--- a/src/ai/backend/manager/repositories/resource_slot/queriers.py
+++ b/src/ai/backend/manager/repositories/resource_slot/queriers.py
@@ -1,0 +1,27 @@
+"""DataQuerier implementations for the resource slot repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
+from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
+from ai.backend.manager.models.specs.querier import DataQuerier
+
+
+@dataclass
+class ResourceSlotTypeQuerier(DataQuerier[ResourceSlotTypeRow, ResourceSlotTypeData]):
+    slot_name: str
+
+    @override
+    def row_class(self) -> type[ResourceSlotTypeRow]:
+        return ResourceSlotTypeRow
+
+    @override
+    def pk_value(self) -> str:
+        return self.slot_name
+
+    @override
+    def to_data(self, row: ResourceSlotTypeRow) -> ResourceSlotTypeData:
+        return row.to_data()

--- a/src/ai/backend/manager/repositories/resource_slot/repository.py
+++ b/src/ai/backend/manager/repositories/resource_slot/repository.py
@@ -20,7 +20,6 @@ from ai.backend.manager.data.resource_slot.types import (
     ReconciliationResult,
     ResourceAllocationSearchResult,
     ResourceOccupancy,
-    ResourceSlotTypeSearchResult,
 )
 from ai.backend.manager.models.resource_slot import (
     AgentResourceRow,
@@ -73,16 +72,6 @@ class ResourceSlotRepository:
     async def all_slot_types(self) -> list[ResourceSlotTypeRow]:
         """List all registered resource slot types."""
         return await self._db_source.all_slot_types()
-
-    @resource_slot_repository_resilience.apply()
-    async def get_slot_type(self, slot_name: str) -> ResourceSlotTypeRow:
-        """Get a specific resource slot type by name."""
-        return await self._db_source.get_slot_type(slot_name)
-
-    @resource_slot_repository_resilience.apply()
-    async def search_slot_types(self, querier: BatchQuerier) -> ResourceSlotTypeSearchResult:
-        """Paginated search across resource slot types."""
-        return await self._db_source.search_slot_types(querier)
 
     # ==================== agent_resources ====================
 

--- a/src/ai/backend/manager/repositories/resource_slot/searchers.py
+++ b/src/ai/backend/manager/repositories/resource_slot/searchers.py
@@ -1,0 +1,23 @@
+"""Searcher implementations for the resource slot repository."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
+from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
+from ai.backend.manager.models.specs.searcher import Searcher
+
+
+@dataclass
+class ResourceSlotTypeSearcher(Searcher[ResourceSlotTypeRow, ResourceSlotTypeData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(ResourceSlotTypeRow)
+
+    @override
+    def to_data(self, row: ResourceSlotTypeRow) -> ResourceSlotTypeData:
+        return row.to_data()

--- a/src/ai/backend/manager/services/resource_slot/actions/__init__.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/__init__.py
@@ -16,13 +16,13 @@ from .get_project_resource_overview import (
     GetProjectResourceOverviewAction,
     GetProjectResourceOverviewResult,
 )
-from .get_resource_slot_type import GetResourceSlotTypeAction, GetResourceSlotTypeResult
+from .get_resource_slot_type import GetResourceSlotTypeAction
 from .search_agent_resources import SearchAgentResourcesAction, SearchAgentResourcesResult
 from .search_resource_allocations import (
     SearchResourceAllocationsAction,
     SearchResourceAllocationsResult,
 )
-from .search_resource_slot_types import SearchResourceSlotTypesAction, SearchResourceSlotTypesResult
+from .search_resource_slot_types import SearchResourceSlotTypesAction
 
 __all__ = (
     "GetAgentResourceBySlotAction",
@@ -38,11 +38,9 @@ __all__ = (
     "GetProjectResourceOverviewAction",
     "GetProjectResourceOverviewResult",
     "GetResourceSlotTypeAction",
-    "GetResourceSlotTypeResult",
     "SearchAgentResourcesAction",
     "SearchAgentResourcesResult",
     "SearchResourceAllocationsAction",
     "SearchResourceAllocationsResult",
     "SearchResourceSlotTypesAction",
-    "SearchResourceSlotTypesResult",
 )

--- a/src/ai/backend/manager/services/resource_slot/actions/get_resource_slot_type.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/get_resource_slot_type.py
@@ -3,37 +3,30 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import EntityType
-from ai.backend.manager.actions.action import BaseActionResult
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import GetGlobalOpsAction
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
-
-from .base import ResourceSlotAction
+from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
+from ai.backend.manager.repositories.resource_slot.queriers import ResourceSlotTypeQuerier
 
 
 @dataclass
-class GetResourceSlotTypeAction(ResourceSlotAction):
+class GetResourceSlotTypeAction(GetGlobalOpsAction[ResourceSlotTypeRow, ResourceSlotTypeData]):
+    """Read one resource slot type from the catalog; every authenticated user may."""
+
     slot_name: str
 
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.RESOURCE_SLOT_TYPE
+        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
 
     @override
     @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.GET
+    def action_name(cls) -> str:
+        return "get_resource_slot_type"
 
     @override
-    def entity_id(self) -> str | None:
-        return self.slot_name
-
-
-@dataclass
-class GetResourceSlotTypeResult(BaseActionResult):
-    item: ResourceSlotTypeData
-
-    @override
-    def entity_id(self) -> str | None:
-        return self.item.slot_name
+    def to_querier(self) -> ResourceSlotTypeQuerier:
+        return ResourceSlotTypeQuerier(slot_name=self.slot_name)

--- a/src/ai/backend/manager/services/resource_slot/actions/search_resource_slot_types.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/search_resource_slot_types.py
@@ -3,41 +3,32 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import EntityType
-from ai.backend.manager.actions.action import BaseActionResult
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
-from ai.backend.manager.repositories.base import BatchQuerier
-
-from .base import ResourceSlotAction
+from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
+from ai.backend.manager.repositories.resource_slot.searchers import ResourceSlotTypeSearcher
 
 
 @dataclass
-class SearchResourceSlotTypesAction(ResourceSlotAction):
-    querier: BatchQuerier
+class SearchResourceSlotTypesAction(
+    SearchGlobalOpsAction[ResourceSlotTypeRow, ResourceSlotTypeData]
+):
+    """Page through the resource slot type catalog; every authenticated user may."""
+
+    searcher: ResourceSlotTypeSearcher
 
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.RESOURCE_SLOT_TYPE
+        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
 
     @override
     @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def action_name(cls) -> str:
+        return "search_resource_slot_types"
 
     @override
-    def entity_id(self) -> str | None:
-        return None
-
-
-@dataclass
-class SearchResourceSlotTypesResult(BaseActionResult):
-    items: list[ResourceSlotTypeData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
-
-    @override
-    def entity_id(self) -> str | None:
-        return None
+    def to_searcher(self) -> ResourceSlotTypeSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/resource_slot/processors.py
+++ b/src/ai/backend/manager/services/resource_slot/processors.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.registry import ProcessorGroup
-from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
-from ai.backend.manager.actions.v2.ops.result import CreatedEntityOpsResult, EntityOpsResult
+from ai.backend.manager.actions.v2.global_scope.processor import (
+    GlobalActionProcessor,
+    PublicActionProcessor,
+)
+from ai.backend.manager.actions.v2.ops.result import (
+    BatchOpsResult,
+    CreatedEntityOpsResult,
+    EntityOpsResult,
+)
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
 from ai.backend.manager.services.resource_slot.actions.create import CreateResourceSlotTypeAction
@@ -25,13 +32,11 @@ from .actions import (
     GetProjectResourceOverviewAction,
     GetProjectResourceOverviewResult,
     GetResourceSlotTypeAction,
-    GetResourceSlotTypeResult,
     SearchAgentResourcesAction,
     SearchAgentResourcesResult,
     SearchResourceAllocationsAction,
     SearchResourceAllocationsResult,
     SearchResourceSlotTypesAction,
-    SearchResourceSlotTypesResult,
 )
 from .service import ResourceSlotService
 
@@ -49,9 +54,13 @@ class ResourceSlotProcessors:
     search_resource_allocations: ActionProcessor[
         SearchResourceAllocationsAction, SearchResourceAllocationsResult
     ]
-    get_resource_slot_type: ActionProcessor[GetResourceSlotTypeAction, GetResourceSlotTypeResult]
-    search_resource_slot_types: ActionProcessor[
-        SearchResourceSlotTypesAction, SearchResourceSlotTypesResult
+    get_resource_slot_type: PublicActionProcessor[
+        GetResourceSlotTypeAction,
+        EntityOpsResult[ResourceSlotTypeData],
+    ]
+    search_resource_slot_types: PublicActionProcessor[
+        SearchResourceSlotTypesAction,
+        BatchOpsResult[ResourceSlotTypeData],
     ]
     get_domain_resource_overview: ActionProcessor[
         GetDomainResourceOverviewAction, GetDomainResourceOverviewResult
@@ -95,12 +104,8 @@ class ResourceSlotProcessors:
         self.search_resource_allocations = ActionProcessor(
             service.search_resource_allocations, action_monitors
         )
-        self.get_resource_slot_type = ActionProcessor(
-            service.get_resource_slot_type, action_monitors
-        )
-        self.search_resource_slot_types = ActionProcessor(
-            service.search_resource_slot_types, action_monitors
-        )
+        self.get_resource_slot_type = group.public_get_ops(GetResourceSlotTypeAction)
+        self.search_resource_slot_types = group.public_search_ops(SearchResourceSlotTypesAction)
         self.get_domain_resource_overview = ActionProcessor(
             service.get_domain_resource_overview, action_monitors
         )

--- a/src/ai/backend/manager/services/resource_slot/service.py
+++ b/src/ai/backend/manager/services/resource_slot/service.py
@@ -25,15 +25,10 @@ from .actions.get_project_resource_overview import (
     GetProjectResourceOverviewAction,
     GetProjectResourceOverviewResult,
 )
-from .actions.get_resource_slot_type import GetResourceSlotTypeAction, GetResourceSlotTypeResult
 from .actions.search_agent_resources import SearchAgentResourcesAction, SearchAgentResourcesResult
 from .actions.search_resource_allocations import (
     SearchResourceAllocationsAction,
     SearchResourceAllocationsResult,
-)
-from .actions.search_resource_slot_types import (
-    SearchResourceSlotTypesAction,
-    SearchResourceSlotTypesResult,
 )
 
 
@@ -117,23 +112,6 @@ class ResourceSlotService:
     ) -> SearchResourceAllocationsResult:
         result = await self._repository.search_resource_allocations(action.querier)
         return SearchResourceAllocationsResult(
-            items=result.items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
-    async def get_resource_slot_type(
-        self, action: GetResourceSlotTypeAction
-    ) -> GetResourceSlotTypeResult:
-        row = await self._repository.get_slot_type(action.slot_name)
-        return GetResourceSlotTypeResult(item=row.to_data())
-
-    async def search_resource_slot_types(
-        self, action: SearchResourceSlotTypesAction
-    ) -> SearchResourceSlotTypesResult:
-        result = await self._repository.search_slot_types(action.querier)
-        return SearchResourceSlotTypesResult(
             items=result.items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,

--- a/tests/unit/manager/actions/test_public_processor.py
+++ b/tests/unit/manager/actions/test_public_processor.py
@@ -1,0 +1,167 @@
+"""The public path of the global layer: authentication only, and reads only.
+
+``PublicActionProcessor`` runs ``BaseGlobalAction`` reads without the SUPERADMIN
+gate, so two invariants are worth pinning: a write action cannot be wired onto it
+at all, and the gated ``GlobalActionProcessor`` keeps its SUPERADMIN gate untouched.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+import pytest
+
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.common.identifier.domain import DomainID
+from ai.backend.manager.actions.action import BaseActionTriggerMeta
+from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
+from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
+from ai.backend.manager.actions.v2.global_scope.monitor.base import GlobalActionMonitor
+from ai.backend.manager.actions.v2.global_scope.processor import (
+    GlobalActionProcessor,
+    PublicActionProcessor,
+)
+from ai.backend.manager.actions.v2.global_scope.result import GlobalActionProcessResult
+from ai.backend.manager.errors.auth import InsufficientPrivilege
+from ai.backend.manager.errors.common import GenericForbidden, ServerMisconfiguredError
+from ai.backend.manager.errors.user import UserNotFound
+
+
+@dataclass
+class _SearchAction(BaseGlobalAction):
+    @classmethod
+    @override
+    def entity_type(cls) -> EntityType:
+        return EntityType("resource_slot_type")
+
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "search_things"
+
+
+@dataclass
+class _GetAction(_SearchAction):
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "get_thing"
+
+
+@dataclass
+class _CreateAction(_SearchAction):
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "create_thing"
+
+
+@dataclass
+class _Result:
+    pass
+
+
+async def _run(_: _SearchAction) -> _Result:
+    return _Result()
+
+
+class _RecordingMonitor(GlobalActionMonitor):
+    def __init__(self) -> None:
+        self.done_results: list[GlobalActionProcessResult] = []
+
+    @override
+    async def prepare(self, action: BaseGlobalAction, meta: BaseActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(self, action: BaseGlobalAction, result: GlobalActionProcessResult) -> None:
+        self.done_results.append(result)
+
+
+def _user(*, is_authorized: bool = True, is_superadmin: bool = False) -> UserData:
+    return UserData(
+        user_id=uuid.uuid4(),
+        is_authorized=is_authorized,
+        is_admin=is_superadmin,
+        is_superadmin=is_superadmin,
+        role=UserRole.SUPERADMIN if is_superadmin else UserRole.USER,
+        domain_name="default",
+        domain_id=DomainID(uuid.uuid4()),
+    )
+
+
+def test_only_get_and_search_actions_can_be_wired_public() -> None:
+    PublicActionProcessor[_GetAction, _Result](_GetAction, _run)
+    PublicActionProcessor[_SearchAction, _Result](_SearchAction, _run)
+
+    with pytest.raises(ServerMisconfiguredError):
+        PublicActionProcessor[_CreateAction, _Result](_CreateAction, _run)
+
+
+async def test_the_public_path_rejects_a_missing_user_context() -> None:
+    processor = PublicActionProcessor[_SearchAction, _Result](_SearchAction, _run)
+
+    with pytest.raises(UserNotFound):
+        await processor.run(_SearchAction())
+
+
+async def test_the_public_path_rejects_an_unauthorized_user() -> None:
+    processor = PublicActionProcessor[_SearchAction, _Result](_SearchAction, _run)
+
+    with with_user(_user(is_authorized=False)):
+        with pytest.raises(GenericForbidden):
+            await processor.run(_SearchAction())
+
+
+async def test_the_public_path_passes_a_regular_authenticated_user() -> None:
+    processor = PublicActionProcessor[_SearchAction, _Result](_SearchAction, _run)
+
+    with with_user(_user()):
+        result = await processor.run(_SearchAction())
+
+    assert isinstance(result, _Result)
+
+
+async def test_a_public_denial_still_reaches_the_monitors() -> None:
+    monitor = _RecordingMonitor()
+    processor = PublicActionProcessor[_SearchAction, _Result](
+        _SearchAction, _run, monitors=[monitor]
+    )
+
+    with with_user(_user(is_authorized=False)):
+        with pytest.raises(GenericForbidden):
+            await processor.run(_SearchAction())
+
+    assert monitor.done_results[0].meta.status is OperationStatus.DENIED
+
+
+async def test_the_global_path_still_gates_on_superadmin() -> None:
+    processor = GlobalActionProcessor[_SearchAction, _Result](_run)
+
+    with with_user(_user()):
+        with pytest.raises(InsufficientPrivilege):
+            await processor.run(_SearchAction())
+
+    with with_user(_user(is_superadmin=True)):
+        result = await processor.run(_SearchAction())
+
+    assert isinstance(result, _Result)

--- a/tests/unit/manager/repositories/resource_slot/test_db_source.py
+++ b/tests/unit/manager/repositories/resource_slot/test_db_source.py
@@ -16,9 +16,6 @@ from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SlotName
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
-from ai.backend.manager.errors.resource_slot import (
-    ResourceSlotTypeNotFound,
-)
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
@@ -53,23 +50,6 @@ class TestSlotTypes:
         names = [t.slot_name for t in types]
         assert "cpu" in names
         assert "mem" in names
-
-    async def test_get_slot_type_found(
-        self,
-        db_source: ResourceSlotDBSource,
-        slot_types: list[str],
-    ) -> None:
-        slot_type = await db_source.get_slot_type("cpu")
-        assert slot_type.slot_name == "cpu"
-        assert slot_type.slot_type == "count"
-
-    async def test_get_slot_type_not_found(
-        self,
-        db_source: ResourceSlotDBSource,
-        slot_types: list[str],
-    ) -> None:
-        with pytest.raises(ResourceSlotTypeNotFound):
-            await db_source.get_slot_type("nonexistent")
 
 
 class TestAgentResources:


### PR DESCRIPTION
## Summary
- Add `PublicActionProcessor`: runs `BaseGlobalAction` reads behind an authentication-only gate, leaving `GlobalActionProcessor`'s hard-wired SUPERADMIN gate untouched. Wiring an action whose `operation_type()` is not a read operation fails at construction time, so a write can never reach the public path.
- Add `public_get_ops` / `public_search_ops` ProcessorGroup factories that reuse the global monitor set (audit, reporter, prometheus) unchanged.
- First application: resource slot type get/search now run through the public path (converted to v2 ops actions with querier/searcher specs), and their REST read routes are relaxed from `superadmin_required` to `auth_required`.

## Test plan
- [x] `tests/unit/manager/actions/test_public_processor.py`: write actions fail to wire at construction; the public path rejects a missing or unauthorized user and passes a regular user; a denial reaches the monitors as DENIED; the global path still gates on SUPERADMIN
- [x] Registry catalog sweep (`test_registry_catalog.py`) passes with the two new v2 actions

Resolves BA-7287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13634.org.readthedocs.build/en/13634/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13634.org.readthedocs.build/ko/13634/

<!-- readthedocs-preview sorna-ko end -->