### PR TITLE
feat(BA-7308): add configurable preemption victim scope to resource groups

### DIFF
--- a/changes/13654.feature.md
+++ b/changes/13654.feature.md
@@ -1,0 +1,1 @@
+Add a configurable preemption victim scope (`user`, `project`, `domain`, or `resource-group`) to the resource group preemption config, so admins decide how widely victims may be drawn; the default `user` keeps the existing behavior of preempting only the pending session owner's own sessions.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -140,10 +140,14 @@ Added in 26.4.0. Active resource usage overview for a domain or project. Shows t
 type ActiveResourceOverview
   @join__type(graph: STRAWBERRY)
 {
-  """Resource slots currently occupied"""
+  """
+  Resource slots currently occupied by active sessions. Each entry represents a resource type and the total quantity in use.
+  """
   slots: ResourceSlot!
 
-  """Number of active sessions"""
+  """
+  Number of active sessions contributing to the current resource occupancy.
+  """
   sessionCount: Int!
 }
 
@@ -522,17 +526,17 @@ type AgentResource
   @join__type(graph: STRAWBERRY)
 {
   """
-  Total hardware resource capacity available on the agent. Expressed as a JSON object containing resource slots.
+  Total hardware resource capacity available on the agent. Expressed as a JSON object containing resource slots (e.g., cpu, mem, accelerators). Each slot represents the maximum amount of that resource type the agent can provide.
   """
   capacity: JSON!
 
   """
-  Total amount of resources currently consumed by running and scheduled sessions.
+  Total amount of resources currently consumed by running and scheduled compute sessions. Includes both the requested resources for sessions being prepared and already allocated resources for active sessions. The sum of occupied resources across all session states that occupy agent resources (PREPARING, PULLING, RUNNING, RESTARTING, etc.). Expressed as a JSON object with the same structure as capacity.
   """
   used: JSON!
 
   """
-  Available resources for scheduling new compute sessions (capacity - used).
+  Available resources for scheduling new compute sessions (capacity - used). This represents the maximum resources that can be allocated to new sessions without exceeding the agent's capacity. Expressed as a JSON object with the same structure as capacity.
   """
   free: JSON!
 }
@@ -615,9 +619,7 @@ enum AgentResourceSlotOrderField
 type AgentStats
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Total hardware resource capacity, usage, and availability across all agents.
-  """
+  """Total resource capacity of the agent."""
   totalResource: AgentResource!
 }
 
@@ -647,23 +649,27 @@ type AgentStatusInfo
   @join__type(graph: STRAWBERRY)
 {
   """
-  Current operational status of the agent. One of: ALIVE, LOST, TERMINATED, RESTARTING.
+  Current operational status of the agent. Indicates whether the agent is ALIVE (active and reachable), LOST (unreachable), TERMINATED (intentionally stopped), or RESTARTING (in recovery process).
   """
   status: AgentStatusEnum!
 
-  """Timestamp when the agent last changed its status."""
+  """
+  Timestamp when the agent last changed its status. Updated whenever the agent transitions between different status states (e.g., from ALIVE to LOST, or RESTARTING to ALIVE). Will be null if the agent status has never changed since initial registration.
+  """
   statusChanged: DateTime
 
-  """Timestamp when the agent first registered with the manager."""
+  """
+  Timestamp when the agent first registered with the manager. This value remains constant throughout the agent's lifecycle and can be used to track the agent's age or identify when it was initially deployed.
+  """
   firstContact: DateTime
 
   """
-  Timestamp when the agent was marked as lost or unreachable. Null if the agent has never been lost or is currently alive.
+  Timestamp when the agent was marked as lost or unreachable. Set when the manager detects the agent has stopped sending heartbeats. Will be null if the agent has never been lost or is currently alive.
   """
   lostAt: DateTime
 
   """
-  Indicates whether the agent is available for scheduling new compute sessions.
+  Indicates whether the agent is available for scheduling new compute sessions. An agent can be non-schedulable due to maintenance mode, resource constraints or other operational reasons by admin. When false, no new sessions will be assigned to this agent.
   """
   schedulable: Boolean!
 }
@@ -695,20 +701,22 @@ type AgentSystemInfo
   @join__type(graph: STRAWBERRY)
 {
   """
-  Hardware architecture of the agent's host system (e.g., "x86_64", "aarch64"). Used to match compute sessions with compatible container images.
+  Hardware architecture of the agent's host system (e.g., "x86_64", "aarch64"). Used to match compute sessions with compatible container images and ensure proper binary execution on the agent.
   """
   architecture: String!
 
   """
-  Version string of the Backend.AI agent software running on this node. Follows semantic versioning (e.g., "26.1.0").
+  Version string of the Backend.AI agent software running on this node. Follows semantic versioning (e.g., "26.1.0") and helps identify compatibility and available features.
   """
   version: String!
 
-  """Legacy configuration flag, no longer actively used in the system."""
+  """
+  Legacy configuration flag, no longer actively used in the system. Retained for backward compatibility and schema consistency. Originally intended to control automatic termination of misbehaving sessions.
+  """
   autoTerminateAbusingKernel: Boolean!
 
   """
-  List of compute plugin metadata supported by this agent. Typed as Any because this field holds a nested GQL type (ComputePluginsGQL).
+  List of compute plugin metadata supported by this agent. Each plugin represents a specific accelerator or resource type (e.g., CUDA). Entries contain plugin names and their associated metadata with plugin-specific configuration and capabilities.
   """
   computePlugins: ComputePlugins!
 }
@@ -1424,16 +1432,20 @@ enum ArtifactOrderField
 type ArtifactRegistry
   @join__type(graph: STRAWBERRY)
 {
-  """Internal identifier of the artifact registry metadata record."""
+  """
+  Added in 25.17.0. Internal identifier for the artifact registry metadata record in the 'artifact_registries' table. This ID is unique across all registry types and represents the metadata record itself. Example: When you need to reference a registry entry in the metadata table, use this ID.
+  """
   id: ID!
 
-  """Identifier of the actual registry implementation."""
+  """
+  Added in 25.17.0. Identifier of the actual registry implementation (e.g., HuggingFace registry, Reservoir registry). This ID corresponds to the primary key in the registry-type-specific table. Example: For a HuggingFace registry, this value matches the 'id' field in the 'huggingface_registries' table. Use this ID when you need to access type-specific registry details.
+  """
   registryId: ID!
 
-  """Name of the artifact registry."""
+  """Name of the default artifact registry."""
   name: String!
 
-  """Type of the artifact registry."""
+  """Type of the default artifact registry."""
   type: ArtifactRegistryType!
 }
 
@@ -1676,7 +1688,7 @@ Added in 25.17.0. Complete verification result containing results from all confi
 type ArtifactVerificationResult
   @join__type(graph: STRAWBERRY)
 {
-  """Results from each verifier that scanned the artifact."""
+  """Results from each verifier that scanned the artifact"""
   verifiers: [ArtifactVerifierResultEntry!]!
 }
 
@@ -1686,7 +1698,7 @@ Added in 26.1.0. A collection of metadata from an artifact verifier. Contains ke
 type ArtifactVerifierMetadata
   @join__type(graph: STRAWBERRY)
 {
-  """List of metadata entries."""
+  """List of metadata entries. Each entry contains a key-value pair."""
   entries: [ArtifactVerifierMetadataEntry!]!
 }
 
@@ -1709,25 +1721,25 @@ Added in 25.17.0. Result from a single malware verifier containing scan results 
 type ArtifactVerifierResult
   @join__type(graph: STRAWBERRY)
 {
-  """Whether the verification completed successfully."""
+  """Whether the verification completed successfully"""
   success: Boolean!
 
-  """Number of infected or suspicious files detected."""
+  """Number of infected or suspicious files detected"""
   infectedCount: Int!
 
-  """Timestamp when verification started."""
+  """Timestamp when verification started"""
   scannedAt: DateTime!
 
-  """Time taken to complete verification in seconds."""
+  """Time taken to complete verification in seconds"""
   scanTime: Float!
 
-  """Total number of files scanned."""
+  """Total number of files scanned"""
   scannedCount: Int!
 
-  """Additional metadata from the verifier."""
+  """Added in 26.1.0. Additional metadata from the verifier."""
   metadata: ArtifactVerifierMetadata!
 
-  """Fatal error message if the verifier failed to complete."""
+  """Fatal error message if the verifier failed to complete"""
   error: String
 }
 
@@ -1737,10 +1749,10 @@ Added in 25.17.0. Entry for a single verifier's result in the verification resul
 type ArtifactVerifierResultEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the verifier."""
+  """Name of the verifier (e.g., 'clamav', 'custom')"""
   name: String!
 
-  """Scan result from this verifier."""
+  """Scan result from this verifier"""
   result: ArtifactVerifierResult!
 }
 
@@ -2272,22 +2284,22 @@ Added in 26.4.4. Failure detail for a single permission entry in bulk add
 type BulkAddRolePermissionFailureInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Role ID of the failed entry"""
+  """Role ID of the failed entry."""
   roleId: UUID!
 
-  """Scope element type of the failed entry"""
+  """Scope element type of the failed entry."""
   scopeType: String!
 
-  """Scope element ID of the failed entry"""
+  """Scope element ID of the failed entry."""
   scopeId: String!
 
-  """Entity element type of the failed entry"""
+  """Entity element type of the failed entry."""
   entityType: String!
 
-  """Operation type of the failed entry"""
+  """Operation type of the failed entry."""
   operation: String!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -2346,10 +2358,10 @@ input BulkAddRolePermissionsInput
 type BulkAddRolePermissionsPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Successfully inserted permission rows"""
+  """Successfully inserted permission rows."""
   items: [Permission!]!
 
-  """Permission entries that failed to insert"""
+  """Permission entries that failed to insert."""
   failed: [BulkAddRolePermissionFailureInfo!]!
 }
 
@@ -2359,10 +2371,10 @@ Added in 26.3.0. Error information for a failed user in bulk role assignment.
 type BulkAssignRoleError
   @join__type(graph: STRAWBERRY)
 {
-  """UUID of the user that failed"""
+  """UUID of the user that failed."""
   userId: UUID!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -2379,10 +2391,10 @@ input BulkAssignRoleInput
 type BulkAssignRolePayload
   @join__type(graph: STRAWBERRY)
 {
-  """Successfully created role assignments"""
+  """List of successfully created role assignments."""
   assigned: [RoleAssignment!]!
 
-  """Users that failed to be assigned"""
+  """List of errors for users that failed to be assigned."""
   failed: [BulkAssignRoleError!]!
 }
 
@@ -2602,7 +2614,7 @@ type BulkPurgeVFoldersV2Payload
   """Number of virtual folders successfully purged."""
   purgedCount: Int!
 
-  """List of errors for vfolders that failed to purge."""
+  """Added in 26.4.4. List of errors for vfolders that failed to purge."""
   failed: [BulkPurgeVFolderV2Error!]!
 }
 
@@ -2623,10 +2635,10 @@ Added in 26.4.4. Failure detail for a single permission ID in bulk remove
 type BulkRemoveRolePermissionFailureInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Permission row ID that failed to delete"""
+  """Permission row ID that failed to delete."""
   permissionId: UUID!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -2666,10 +2678,10 @@ input BulkRemoveRolePermissionsInput
 type BulkRemoveRolePermissionsPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Successfully deleted permission rows"""
+  """Successfully deleted permission rows."""
   items: [Permission!]!
 
-  """Permission IDs that failed to delete"""
+  """Permission IDs that failed to delete."""
   failed: [BulkRemoveRolePermissionFailureInfo!]!
 }
 
@@ -2700,10 +2712,10 @@ Added in 26.3.0. Error information for a failed user in bulk role revocation.
 type BulkRevokeRoleError
   @join__type(graph: STRAWBERRY)
 {
-  """UUID of the user that failed"""
+  """UUID of the user that failed."""
   userId: UUID!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -2719,10 +2731,10 @@ input BulkRevokeRoleInput
 type BulkRevokeRolePayload
   @join__type(graph: STRAWBERRY)
 {
-  """Successfully revoked role assignments"""
+  """List of successfully revoked role assignments."""
   revoked: [RoleAssignment!]!
 
-  """Users that failed to be revoked"""
+  """List of errors for users that failed to be revoked."""
   failed: [BulkRevokeRoleError!]!
 }
 
@@ -2732,7 +2744,7 @@ Added in 26.4.4. Failure detail for a single permission entry in a bulk operatio
 type BulkRolePermissionPresetFailureInfo
   @join__type(graph: STRAWBERRY)
 {
-  """role_permission_presets row ID that the operation failed on."""
+  """Permission entry ID that the operation failed on."""
   permissionPresetId: UUID!
 
   """Error message describing the failure."""
@@ -3061,10 +3073,10 @@ input CloneVFolderV2Input
 type CloneVFolderV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Cloned virtual folder"""
+  """The cloned virtual folder."""
   vfolder: VFolder!
 
-  """Background task ID for the clone operation"""
+  """Background task ID for the clone operation."""
   bgtaskId: String!
 }
 
@@ -3074,7 +3086,10 @@ Added in 25.19.0. Cluster configuration for model deployment replicas. Defines t
 type ClusterConfig
   @join__type(graph: STRAWBERRY)
 {
+  """The clustering mode (e.g., SINGLE_NODE)."""
   mode: ClusterMode!
+
+  """Number of replicas in the cluster."""
   size: Int!
 }
 
@@ -3169,7 +3184,7 @@ type ComputePlugins
   @join__type(graph: STRAWBERRY)
 {
   """
-  List of compute plugins. Each entry contains a plugin name and its metadata.
+  List of compute plugins. Each entry contains a plugin name and its metadata. The list includes all accelerator and resource type plugins installed on the agent.
   """
   entries: [ComputePluginEntry!]!
 }
@@ -3726,7 +3741,7 @@ input CreateAppConfigAllowListInput
 type CreateAppConfigAllowListPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created app config allow-list entry."""
+  """The created app config allow-list entry."""
   appConfigAllowList: AppConfigAllowList!
 }
 
@@ -3742,7 +3757,7 @@ input CreateAppConfigDefinitionInput
 type CreateAppConfigDefinitionPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created app config definition."""
+  """The created app config definition."""
   appConfigDefinition: AppConfigDefinition!
 }
 
@@ -3900,7 +3915,7 @@ Added in 26.4.2. Payload for container registry create/update mutations.
 type CreateContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created container registry."""
+  """The container registry."""
   registry: ContainerRegistryV2!
 }
 
@@ -4080,10 +4095,10 @@ input CreateDownloadSessionV2Input
 type CreateDownloadSessionV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Download session token"""
+  """Download session token."""
   token: String!
 
-  """Download URL"""
+  """Download URL."""
   url: String!
 }
 
@@ -4143,6 +4158,7 @@ Added in 26.8.0. Returns the created idle checker assignment. The node contains 
 type CreateIdleCheckerAssignmentPayload
   @join__type(graph: STRAWBERRY)
 {
+  """Created idle checker assignment."""
   idleCheckerAssignment: IdleCheckerAssignment!
 }
 
@@ -4175,6 +4191,7 @@ Added in 26.8.0. Returns the created global idle checker definition. The node co
 type CreateIdleCheckerPayload
   @join__type(graph: STRAWBERRY)
 {
+  """Created idle checker."""
   idleChecker: IdleChecker!
 }
 
@@ -4280,7 +4297,7 @@ Added in 26.4.2. Payload for keypair resource policy create/update mutations.
 type CreateKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created keypair resource policy."""
+  """The keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
 
@@ -4299,7 +4316,7 @@ input CreateLoginClientTypeInput
 type CreateLoginClientTypePayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created login client type."""
+  """The created login client type."""
   loginClientType: LoginClientType!
 }
 
@@ -4516,7 +4533,7 @@ Added in 26.4.2. Payload for project resource policy create/update mutations.
 type CreateProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created project resource policy."""
+  """The project resource policy."""
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
 
@@ -4594,7 +4611,7 @@ input CreateResourceGroupInput
 type CreateResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created resource group."""
+  """The created resource group."""
   resourceGroup: ResourceGroup!
 }
 
@@ -4622,7 +4639,7 @@ input CreateResourcePresetInput
 type CreateResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created resource preset."""
+  """The created resource preset."""
   resourcePreset: ResourcePresetV2!
 }
 
@@ -4914,10 +4931,10 @@ input CreateUploadSessionV2Input
 type CreateUploadSessionV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Upload session token"""
+  """Upload session token."""
   token: String!
 
-  """Upload URL"""
+  """Upload URL."""
   url: String!
 }
 
@@ -4996,7 +5013,7 @@ Added in 26.4.2. Payload for user resource policy create/update mutations.
 type CreateUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Created user resource policy."""
+  """The user resource policy."""
   userResourcePolicy: UserResourcePolicyV2!
 }
 
@@ -5066,7 +5083,7 @@ type CreateUserV2Payload
   user: UserV2!
 
   """
-  The default keypair automatically generated for the user, including its one-time secret key.
+  Added in 26.4.4. The default keypair automatically generated for the user, including its one-time secret key.
   """
   keypair: CreateKeypairPayload!
 }
@@ -5120,7 +5137,7 @@ input CreateVFolderV2Input
 type CreateVFolderV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Created virtual folder"""
+  """The created virtual folder."""
   vfolder: VFolder!
 }
 
@@ -5410,11 +5427,11 @@ type DelegateImportArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
   """
-  List of imported artifact revisions from the reservoir registry's remote registry.
+  Connection of artifact revisions that were imported from the reservoir registry's remote registry
   """
   artifactRevisions: ArtifactRevisionConnection!
 
-  """List of background tasks created for importing the artifact revisions."""
+  """List of background tasks created for importing the artifact revisions"""
   tasks: [ArtifactRevisionImportTask!]!
 }
 
@@ -5446,7 +5463,9 @@ Added in 25.15.0. Response payload for delegated artifact scanning operation. Co
 type DelegateScanArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
-  """List of artifacts discovered during the delegated scan."""
+  """
+  List of artifacts discovered during the delegated scan from the reservoir registry's remote registry
+  """
   artifacts: [Artifact!]!
 }
 
@@ -5509,7 +5528,7 @@ Added in 26.3.0. Payload returned after deleting a query preset category.
 type DeleteCategoryPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Deleted category ID"""
+  """Deleted category ID."""
   id: UUID!
 }
 
@@ -5538,7 +5557,7 @@ type DeleteContainerRegistryNodeV2
 type DeleteContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted container registry."""
+  """ID of the deleted registry."""
   id: String!
 }
 
@@ -5614,7 +5633,7 @@ Added in 26.4.2. Payload returned after deleting files in a virtual folder.
 type DeleteFilesV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Background task ID for the deletion operation"""
+  """Background task ID for the deletion operation."""
   bgtaskId: String!
 }
 
@@ -5659,7 +5678,7 @@ type DeleteKeyPairResourcePolicy
 type DeleteKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the deleted keypair resource policy."""
+  """Name of the deleted policy."""
   name: String!
 }
 
@@ -5708,7 +5727,7 @@ input DeleteNotificationChannelInput
 type DeleteNotificationChannelPayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted notification channel"""
+  """ID of the deleted notification channel."""
   id: UUID!
 }
 
@@ -5723,7 +5742,7 @@ input DeleteNotificationRuleInput
 type DeleteNotificationRulePayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted notification rule"""
+  """ID of the deleted notification rule."""
   id: UUID!
 }
 
@@ -5738,7 +5757,7 @@ input DeleteObjectStorageInput
 type DeleteObjectStoragePayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted object storage"""
+  """ID of the deleted object storage."""
   id: UUID!
 }
 
@@ -5753,7 +5772,7 @@ input DeletePermissionInput
 type DeletePermissionPayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted permission"""
+  """ID of the deleted permission."""
   id: UUID!
 }
 
@@ -5776,7 +5795,7 @@ type DeleteProjectResourcePolicy
 type DeleteProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the deleted project resource policy."""
+  """Name of the deleted policy."""
   name: String!
 }
 
@@ -5784,7 +5803,7 @@ type DeleteProjectResourcePolicyPayload
 type DeleteQueryDefinitionPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Deleted query definition ID"""
+  """Deleted query definition ID."""
   id: UUID!
 }
 
@@ -5807,7 +5826,9 @@ type DeleteReservoirRegistryPayload
 type DeleteResourceGroupPayload
   @join__type(graph: STRAWBERRY)
 {
-  """UUID of the deleted resource group."""
+  """
+  UUID of the deleted resource group. Since 26.8.0, the value is the UUID instead of the name.
+  """
   id: UUID!
 }
 
@@ -5845,7 +5866,7 @@ input DeleteRoleInput
 type DeleteRolePayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted role"""
+  """ID of the deleted role."""
   id: UUID!
 }
 
@@ -5911,7 +5932,7 @@ type DeleteUserResourcePolicy
 type DeleteUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the deleted user resource policy."""
+  """Name of the deleted policy."""
   name: String!
 }
 
@@ -5947,7 +5968,7 @@ Added in 26.4.2. Payload returned after soft-deleting a virtual folder.
 type DeleteVFolderV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the deleted virtual folder"""
+  """ID of the deleted virtual folder."""
   id: UUID!
 }
 
@@ -6254,10 +6275,10 @@ Added in 26.4.2. A single environment variable key-value pair injected into the 
 type DeploymentRevisionPresetEnvironEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Environment variable key."""
+  """The environment variable name (e.g., CUDA_VISIBLE_DEVICES, HF_HOME)."""
   key: String!
 
-  """Environment variable value."""
+  """The value assigned to the environment variable."""
   value: String!
 }
 
@@ -7620,7 +7641,10 @@ Added in 26.1.0. A single environment variable entry with name and value.
 type EnvironmentVariableEntry
   @join__type(graph: STRAWBERRY)
 {
+  """Environment variable name (e.g., CUDA_VISIBLE_DEVICES)."""
   name: String!
+
+  """Environment variable value."""
   value: String!
 }
 
@@ -7641,6 +7665,7 @@ input EnvironmentVariableEntryInput
 type EnvironmentVariables
   @join__type(graph: STRAWBERRY)
 {
+  """List of environment variable entries."""
   entries: [EnvironmentVariableEntry!]!
 }
 
@@ -7690,15 +7715,17 @@ type ExtraVFolderMountInfo
   """The vfolder of this entity."""
   vfolder: VirtualFolderNode
   vfolderId: ID!
+
+  """Mount destination path inside the container."""
   mountDestination: String
 
   """
-  The concrete permission snapshot fixed at revision-write time. ``INHERIT`` policies are resolved against the vfolder's current permission at that point, so this value is immutable and does not change when the vfolder's permission later changes. ``None`` when the caller left it unset to inherit the vfolder's stored permission at session-creation time (task #83).
+  Added in 26.4.4. The concrete permission snapshot fixed at revision-write time; later vfolder permission changes do not retroactively affect it.
   """
   mountPerm: MountPermission!
 
   """
-  Added in 26.4.4. Subpath within the vfolder. ``None`` means the vfolder root.
+  Added in 26.4.4. Subpath within the vfolder. ``null`` means the vfolder root.
   """
   subpath: String
 }
@@ -7727,22 +7754,34 @@ type FairShareCalculationSnapshot
   """
   averageDailyDecayedUsage: ResourceSlot
 
-  """Computed fair share factor (0-1 range)"""
+  """
+  Computed fair share factor ranging from 0 to 1. Higher values indicate more entitlement to resources (less historical usage relative to others). Used by the scheduler to prioritize workloads - entities with higher factors get scheduled first.
+  """
   fairShareFactor: Decimal!
 
-  """Sum of decayed historical usage"""
+  """
+  Sum of exponentially decayed historical usage across the lookback period. Recent usage contributes more than older usage based on the half-life decay function. This is the raw usage data before normalization.
+  """
   totalDecayedUsage: ResourceSlot!
 
-  """Single scalar representing weighted consumption"""
+  """
+  Single scalar value representing weighted resource consumption. Computed by applying resource weights to the decayed usage and summing. Used to compare usage across entities with different resource consumption patterns.
+  """
   normalizedUsage: Decimal!
 
-  """Start date of the lookback window"""
+  """
+  Start date of the lookback window used in this calculation (inclusive). Usage before this date is not considered in the fair share factor computation.
+  """
   lookbackStart: Date!
 
-  """End date of the lookback window"""
+  """
+  End date of the lookback window used in this calculation (inclusive). Typically the current date or the date of the last calculation.
+  """
   lookbackEnd: Date!
 
-  """Timestamp when calculation was performed"""
+  """
+  Timestamp when this fair share calculation was performed. Fair share factors are recalculated periodically by the scheduler.
+  """
   lastCalculatedAt: DateTime!
 }
 
@@ -7752,19 +7791,29 @@ Added in 26.1.0. Fair share calculation configuration for a resource group. Defi
 type FairShareScalingGroupSpec
   @join__type(graph: STRAWBERRY)
 {
-  """Half-life for exponential decay in days"""
+  """
+  Half-life for exponential decay in days. Determines how quickly historical usage loses significance. Default is 7 days.
+  """
   halfLifeDays: Int!
 
-  """Total lookback period in days"""
+  """
+  Total lookback period in days for usage aggregation. Only usage within this window is considered. Default is 28 days.
+  """
   lookbackDays: Int!
 
-  """Granularity of decay buckets in days"""
+  """
+  Granularity of decay buckets in days. Usage is aggregated into buckets of this size. Default is 1 day.
+  """
   decayUnitDays: Int!
 
-  """Default weight for entities without explicit weight"""
+  """
+  Default weight for entities without explicit weight in this resource group. Default is 1.0.
+  """
   defaultWeight: Decimal!
 
-  """Weights for each resource type"""
+  """
+  Added in 26.2.0. Weights for each resource type with default indicators. All resource types from capacity are included. Shows which resources use explicit vs default weights.
+  """
   resourceWeights: [ResourceWeightEntry!]!
 }
 
@@ -7775,25 +7824,33 @@ type FairShareSpec
   @join__type(graph: STRAWBERRY)
 {
   """
-  Effective weight for this entity. Always the resolved value (either the explicitly set weight or the resource group's default_weight).
+  Base weight multiplier for this entity. Higher weight values result in higher scheduling priority. This is the effective weight - either the explicitly set value or the resource group's default_weight.
   """
   weight: Decimal!
 
   """
-  Whether this entity uses the resource group's default_weight. True means no explicit weight was set.
+  Added in 26.1.0. Whether this entity uses the resource group's default_weight. True means no explicit weight was set and the default is being used. False means an explicit weight value was configured for this entity.
   """
   usesDefault: Boolean!
 
-  """Half-life for exponential decay in days"""
+  """
+  Half-life for exponential decay in days. Determines how quickly historical usage loses significance. For example, with half_life_days=7, usage from 7 days ago contributes half as much as today's usage.
+  """
   halfLifeDays: Int!
 
-  """Total lookback period in days"""
+  """
+  Total lookback period in days for usage aggregation. Only usage within this window is considered. Typical values range from 7 to 30 days depending on scheduling policy.
+  """
   lookbackDays: Int!
 
-  """Granularity of decay buckets in days"""
+  """
+  Granularity of decay buckets in days. Usage is aggregated into buckets of this size. Smaller values provide more precision but require more storage. Typically 1 day.
+  """
   decayUnitDays: Int!
 
-  """Weights for each resource type with default indicators"""
+  """
+  Added in 26.2.0. Weights for each resource type with default indicators. Shows which resources use explicit vs default weights. Allows different resources to contribute differently to the fair share calculation. For example, GPU usage might be weighted higher than CPU usage.
+  """
   resourceWeights: [ResourceWeightEntry!]!
 }
 
@@ -8364,9 +8421,16 @@ Added in 26.8.0. Contains the settings used by an idle checker implementation.
 type IdleCheckerSpec
   @join__type(graph: STRAWBERRY)
 {
+  """Checker implementation type."""
   type: IdleCheckerType!
+
+  """Settings that define the maximum lifetime of a session."""
   sessionLifetime: SessionLifetimeIdleCheckerSpec
+
+  """Settings that define the maximum network inactivity period."""
   network: NetworkTimeoutIdleCheckerSpec
+
+  """Settings that define the maximum underutilized duration."""
   utilization: UtilizationIdleCheckerSpec
 }
 
@@ -8772,19 +8836,23 @@ Added in 26.2.0. Metadata information for an image. Contains tags, labels, diges
 type ImageV2MetadataInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Config digest for verification."""
+  """Config digest (image hash) for verification."""
   digest: String
 
   """Image size in bytes."""
   sizeBytes: Int!
 
-  """Image creation timestamp."""
+  """Timestamp when the image was created/registered."""
   createdAt: DateTime
 
-  """Timestamp of the most recent session created with this image."""
+  """
+  Added in 26.3.0. Timestamp of the most recent session created with this image. Returns null if the image has never been used.
+  """
   lastUsedAt: DateTime
 
-  """Parsed tag components."""
+  """
+  Parsed tag components from the image reference (e.g., python=3.11, cuda=12.1).
+  """
   tags: [ImageV2TagEntry!]!
 
   """Docker labels."""
@@ -8829,7 +8897,7 @@ Added in 26.2.0. Permission information for an image. Contains the list of permi
 type ImageV2PermissionInfo
   @join__type(graph: STRAWBERRY)
 {
-  """List of permissions the user has on this image"""
+  """List of permissions the user has on this image."""
   permissions: [ImageV2Permission!]!
 }
 
@@ -8839,10 +8907,10 @@ Added in 26.2.0. Runtime requirements information for an image. Contains resourc
 type ImageV2RequirementsInfo
   @join__type(graph: STRAWBERRY)
 {
-  """List of supported accelerator types."""
+  """List of supported accelerator types (e.g., 'cuda', 'rocm')."""
   supportedAccelerators: [String!]!
 
-  """Resource slot limits with string min/max values."""
+  """Resource slot limits (cpu, memory, accelerators, etc.)."""
   resourceLimits: [ImageV2ResourceLimit!]!
 }
 
@@ -9410,16 +9478,18 @@ input KernelV2Filter
 type KernelV2LifecycleInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Current status of the kernel."""
+  """
+  Current status of the kernel (e.g., PENDING, RUNNING, TERMINATED). Indicates the kernel's position in its lifecycle.
+  """
   status: KernelV2Status!
 
-  """The result of the kernel execution."""
+  """The result of the kernel execution (UNDEFINED, SUCCESS, FAILURE)."""
   result: SessionV2Result!
 
   """Timestamp when the kernel was created."""
   createdAt: DateTime
 
-  """Timestamp when the kernel was terminated."""
+  """Timestamp when the kernel was terminated. Null if still active."""
   terminatedAt: DateTime
 
   """Scheduled start time for the kernel, if applicable."""
@@ -9430,9 +9500,7 @@ type KernelV2LifecycleInfo
 type KernelV2NetworkInfo
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Collection of service ports exposed by this kernel. Typed as Any because this field holds a nested GQL type (ServicePortsGQL).
-  """
+  """Collection of service ports exposed by this kernel."""
   servicePorts: ServicePorts
 
   """List of ports that are pre-opened for this kernel."""
@@ -9471,22 +9539,18 @@ type KernelV2ResourceInfo
   """The resource group (scaling group) this kernel is assigned to."""
   resourceGroupName: String
 
-  """The container ID on the agent."""
+  """
+  The container ID on the agent. Null if container not yet created or hidden.
+  """
   containerId: String
 
-  """
-  Resource allocation with requested and used slots. Typed as Any because this field holds a nested GQL type (ResourceAllocationGQL).
-  """
+  """Resource allocation with requested and used slots."""
   allocation: ResourceAllocation!
 
-  """
-  The fractional resource shares occupied by this kernel. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
-  """
+  """The fractional resource shares occupied by this kernel."""
   shares: ResourceSlot!
 
-  """
-  Additional resource options and configurations. Typed as Any because this field holds a nested GQL type (ResourceOptsGQL).
-  """
+  """Additional resource options and configurations for this kernel."""
   resourceOpts: ResourceOpts
 }
 
@@ -9503,7 +9567,7 @@ type KernelV2SessionInfo
   """The name of the session."""
   name: String
 
-  """The type of session (interactive, batch, inference, system)."""
+  """The type of session (INTERACTIVE, BATCH, INFERENCE, SYSTEM)."""
   sessionType: SessionTypes!
 }
 
@@ -10008,7 +10072,7 @@ Added in 26.4.2. Payload returned after listing files in a virtual folder.
 type ListFilesV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """List of file entries"""
+  """List of file entries."""
   items: [VFolderFileEntryV2!]!
 }
 
@@ -10395,7 +10459,7 @@ Added in 26.4.2. Payload returned after creating directories in a virtual folder
 type MkdirV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """List of created directory paths"""
+  """List of created directory paths."""
   results: [String!]!
 }
 
@@ -10620,15 +10684,42 @@ Added in 26.4.2. Metadata extracted from the model-definition.yaml file in the m
 type ModelCardV2Metadata
   @join__type(graph: STRAWBERRY)
 {
+  """The author or organization that created this model."""
   author: String
+
+  """Human-readable display title for the model."""
   title: String
+
+  """Version string of the model (e.g., '1.0', '2.3.1')."""
   modelVersion: String
+
+  """Brief summary of what the model does and its intended use cases."""
   description: String
+
+  """
+  The primary ML task this model performs (e.g., 'text-generation', 'image-classification').
+  """
   task: String
+
+  """High-level category for the model (e.g., 'NLP', 'Computer Vision')."""
   category: String
+
+  """Model architecture name (e.g., 'transformer', 'diffusion', 'CNN')."""
   architecture: String
+
+  """
+  List of ML frameworks required to run the model (e.g., 'PyTorch', 'TensorFlow', 'JAX').
+  """
   framework: [String!]!
+
+  """
+  Classification labels and tags for categorization and search (e.g., 'text-generation', 'vision', 'multilingual').
+  """
   label: [String!]!
+
+  """
+  License under which the model is distributed (e.g., 'Apache-2.0', 'MIT').
+  """
   license: String
 }
 
@@ -10657,10 +10748,10 @@ Added in 26.4.2. A single resource requirement entry for a model card. The quant
 type ModelCardV2ResourceSlotEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Resource type name."""
+  """Resource type identifier (e.g., 'cpu', 'mem', 'cuda.shares')."""
   resourceType: String!
 
-  """Resource quantity."""
+  """Minimum required quantity for this resource as a decimal string."""
   quantity: String!
 }
 
@@ -10825,6 +10916,10 @@ type ModelDeploymentMetadata
   name: String!
   status: DeploymentStatus!
   tags: [String!]!
+
+  """
+  Added in 26.4.4. Name of the resource group (scaling group) this deployment runs in.
+  """
   resourceGroupName: String!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -10865,7 +10960,7 @@ type ModelHealthCheck
   @join__type(graph: STRAWBERRY)
 {
   """
-  Whether the route is health-checked. When false the route activates immediately.
+  Added in 26.4.4. Whether the route is health-checked. When false the route activates immediately and the remaining fields are ignored.
   """
   enable: Boolean!
 
@@ -11015,11 +11110,15 @@ type ModelMountConfig
   """The vfolder of this entity."""
   vfolder: VirtualFolderNode
   vfolderId: ID!
+
+  """Path inside the container where the model is mounted."""
   mountDestination: String!
+
+  """Path to the model definition file within the mounted folder."""
   definitionPath: String!
 
   """
-  Added in 26.4.4. Subpath within the model vfolder. ``None`` means the vfolder root.
+  Added in 26.4.4. Subpath within the model vfolder. ``null`` means the vfolder root.
   """
   subpath: String
 }
@@ -11259,11 +11358,19 @@ type ModelRuntimeConfig
   Added in 26.4.4. The runtime variant referenced by this runtime config.
   """
   runtimeVariant: RuntimeVariant
+
+  """
+  The runtime variant row id. Clients can resolve the full variant node via the ``runtime_variant`` field resolver.
+  """
   runtimeVariantId: UUID!
+
+  """Framework-specific configuration in JSON format."""
   inferenceRuntimeConfig: JSON
+
+  """Environment variables for the service, e.g. CUDA_VISIBLE_DEVICES=0."""
   environ: EnvironmentVariables
 
-  """Preset values materialised on this revision."""
+  """Added in 26.4.4. Preset values materialised on this revision."""
   runtimeVariantPresetValues: [RuntimeVariantPresetValue!]!
 }
 
@@ -11294,9 +11401,7 @@ type ModelServiceConfig
   """Added in 26.7.0. Single-string command to start the model service."""
   command: String
 
-  """
-  Deprecated since 26.7.0. Command to start the model service. Do not set together with `command`; when both are set, `command` takes precedence and this field is ignored.
-  """
+  """Command to start the model service."""
   startCommand: [String!] @deprecated(reason: "Use `command` instead.")
 
   """
@@ -11927,10 +12032,10 @@ Added in 26.4.2. Payload returned after moving a file in a virtual folder.
 type MoveFileV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Source path that was moved"""
+  """Source path that was moved."""
   src: String!
 
-  """Destination path"""
+  """Destination path."""
   dst: String!
 }
 
@@ -13107,7 +13212,7 @@ Added in 26.4.2. Query result returning the current client's IP address.
 type MyClientIp
   @join__type(graph: STRAWBERRY)
 {
-  """The client's IP address as seen by the server"""
+  """The client's IP address as seen by the server."""
   clientIp: String!
 }
 
@@ -13182,6 +13287,7 @@ Added in 26.8.0. Configures the maximum period without active network traffic.
 type NetworkTimeoutIdleCheckerSpec
   @join__type(graph: STRAWBERRY)
 {
+  """Maximum network inactivity period in seconds."""
   maxNetworkInactivitySeconds: Int!
 }
 
@@ -13433,7 +13539,10 @@ Added in 26.3.0. Display number format configuration for a resource slot type.
 type NumberFormat
   @join__type(graph: STRAWBERRY)
 {
+  """Whether to use binary (1024-based) or decimal (1000-based) prefixes."""
   binary: Boolean!
+
+  """Number of decimal places to round to when displaying values."""
   roundLength: Int!
 }
 
@@ -13690,7 +13799,9 @@ type PredefinedAtomicPermission
 type PreemptionConfig
   @join__type(graph: STRAWBERRY)
 {
-  """Whether preemption is enabled for this resource group (opt-in)."""
+  """
+  Added in 26.8.0. Whether preemption is enabled for this resource group (opt-in).
+  """
   enabled: Boolean!
 
   """Sessions with priority <= this value are eligible for preemption."""
@@ -13703,9 +13814,14 @@ type PreemptionConfig
   mode: PreemptionMode!
 
   """
-  Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
+  Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
   """
   preemptionMinRuntime: Float!
+
+  """
+  Added in 26.8.1. Scope preemption victims are drawn from (USER, PROJECT, DOMAIN, RESOURCE_GROUP).
+  """
+  victimScope: PreemptionVictimScope!
 }
 
 """Added in 26.3.0. Input for preemption configuration."""
@@ -13730,6 +13846,11 @@ input PreemptionConfigInput
   Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled). Default is 0.
   """
   preemptionMinRuntime: Float! = 0
+
+  """
+  Added in 26.8.1. Scope preemption victims are drawn from (USER, PROJECT, DOMAIN, RESOURCE_GROUP). Default is USER.
+  """
+  victimScope: PreemptionVictimScope! = USER
 }
 
 """
@@ -13752,6 +13873,18 @@ enum PreemptionOrder
   NEWEST @join__enumValue(graph: STRAWBERRY)
   FEWEST_SESSIONS @join__enumValue(graph: STRAWBERRY)
   SMALLEST_RESOURCES @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.8.1. Scope preemption victims are drawn from. USER limits victims to the pending session's owner; PROJECT/DOMAIN widen to sessions of the same project/domain; RESOURCE_GROUP allows any session in the resource group.
+"""
+enum PreemptionVictimScope
+  @join__type(graph: STRAWBERRY)
+{
+  USER @join__enumValue(graph: STRAWBERRY)
+  PROJECT @join__enumValue(graph: STRAWBERRY)
+  DOMAIN @join__enumValue(graph: STRAWBERRY)
+  RESOURCE_GROUP @join__enumValue(graph: STRAWBERRY)
 }
 
 type PreloadImage
@@ -13791,10 +13924,14 @@ Added in 26.4.2. Cluster topology settings for the deployment, defining whether 
 type PresetClusterSpec
   @join__type(graph: STRAWBERRY)
 {
-  """Cluster mode."""
+  """
+  Deployment topology mode: 'single-node' runs on one node, 'multi-node' distributes across multiple nodes.
+  """
   clusterMode: String!
 
-  """Cluster size."""
+  """
+  Number of worker nodes in the cluster. For single-node mode, this is typically 1.
+  """
   clusterSize: Int!
 }
 
@@ -13804,13 +13941,15 @@ Added in 26.4.2. Deployment-level defaults stored on the preset. Any null field 
 type PresetDeploymentDefaults
   @join__type(graph: STRAWBERRY)
 {
-  """Default open_to_public for deployments from this preset."""
+  """Default open_to_public for deployments created from this preset."""
   openToPublic: Boolean
 
-  """Default replica count for deployments from this preset."""
+  """Default replica count for deployments created from this preset."""
   replicaCount: Int
 
-  """Default revision history limit for deployments from this preset."""
+  """
+  Default revision history limit for deployments created from this preset.
+  """
   revisionHistoryLimit: Int
 
   """Default deployment strategy type (ROLLING or BLUE_GREEN)."""
@@ -13842,16 +13981,18 @@ Added in 26.4.2. Container execution configuration for the deployment, including
 type PresetExecutionSpec
   @join__type(graph: STRAWBERRY)
 {
-  """Container image UUID."""
+  """UUID of the container image used to run the inference server."""
   imageId: UUID
 
-  """Startup command."""
+  """Command to start the inference server process inside the container."""
   startupCommand: String
 
-  """Bootstrap script."""
+  """
+  Script executed before the main process starts, used for setup tasks like downloading model weights.
+  """
   bootstrapScript: String
 
-  """Environment variables."""
+  """Environment variables injected into the inference container."""
   environ: [DeploymentRevisionPresetEnvironEntry!]!
 }
 
@@ -13997,7 +14138,7 @@ Added in 26.4.2. Compute resource allocation for the deployment, specifying CPU,
 type PresetResourceAllocation
   @join__type(graph: STRAWBERRY)
 {
-  """Additional resource options."""
+  """Additional resource options such as shared memory (shmem) size."""
   resourceOpts: [ResourceOptsEntry!]!
 }
 
@@ -14017,16 +14158,24 @@ Added in 26.4.2. Specifies how a runtime variant preset value is applied to the 
 type PresetTargetSpec
   @join__type(graph: STRAWBERRY)
 {
-  """Target: env or args."""
+  """
+  How the value is applied to the container: 'env' sets it as an environment variable, 'args' appends it as a command-line argument.
+  """
   presetTarget: PresetTarget!
 
-  """Value type: str, int, float, bool, flag."""
+  """
+  Data type used for input validation (e.g., 'str', 'int', 'float', 'bool', 'flag').
+  """
   valueType: PresetValueType!
 
-  """Default value."""
+  """
+  The default value shown to users when they create a deployment using this preset.
+  """
   defaultValue: String
 
-  """Env key or args flag."""
+  """
+  For 'env' target, the environment variable name (e.g., VLLM_TENSOR_PARALLEL_SIZE); for 'args' target, the CLI flag name (e.g., --tensor-parallel).
+  """
   key: String!
 }
 
@@ -14089,7 +14238,7 @@ type ProjectBasicInfo
   """Optional description of the project."""
   description: String
 
-  """Project type determining its purpose. See ProjectType enum."""
+  """Project type determining its purpose. See ProjectTypeV2 enum."""
   type: ProjectTypeV2!
 
   """External system integration identifier."""
@@ -14928,6 +15077,7 @@ Added in 26.8.0. Confirms that an idle checker assignment was permanently remove
 type PurgeIdleCheckerAssignmentPayload
   @join__type(graph: STRAWBERRY)
 {
+  """Purged idle checker assignment ID."""
   id: UUID!
 }
 
@@ -14945,6 +15095,7 @@ Added in 26.8.0. Confirms that an idle checker was permanently removed. The retu
 type PurgeIdleCheckerPayload
   @join__type(graph: STRAWBERRY)
 {
+  """Purged idle checker ID."""
   id: UUID!
 }
 
@@ -15036,7 +15187,7 @@ input PurgeRoleInput
 type PurgeRolePayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the purged role"""
+  """ID of the purged role."""
   id: UUID!
 }
 
@@ -16393,10 +16544,10 @@ input QueryDefinitionFilter
 type QueryDefinitionMetricResult
   @join__type(graph: STRAWBERRY)
 {
-  """Label key-value pairs for this series"""
+  """Metric labels as key-value entries."""
   metric: [MetricLabelEntry!]!
 
-  """Data points (timestamp, value) for this series"""
+  """Time-series values."""
   values: [QueryDefinitionMetricResultValue!]!
 }
 
@@ -16459,19 +16610,19 @@ enum QueryDefinitionOrderField
 type QueryPresetCategory
   @join__type(graph: STRAWBERRY)
 {
-  """Category ID"""
+  """Category UUID."""
   id: UUID!
 
-  """Human-readable category name"""
+  """Human-readable category name."""
   name: String!
 
-  """Optional category description"""
+  """Optional category description."""
   description: String
 
-  """Creation timestamp"""
+  """Creation timestamp."""
   createdAt: DateTime!
 
-  """Last update timestamp"""
+  """Last update timestamp."""
   updatedAt: DateTime!
 }
 
@@ -16700,22 +16851,22 @@ Added in 26.4.4. Failure detail for a single permission entry in replace
 type ReplaceRolePermissionFailureInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Role ID of the failed entry"""
+  """Role ID of the failed entry."""
   roleId: UUID!
 
-  """Scope element type of the failed entry"""
+  """Scope element type of the failed entry."""
   scopeType: String!
 
-  """Scope element ID of the failed entry"""
+  """Scope element ID of the failed entry."""
   scopeId: String!
 
-  """Entity element type of the failed entry"""
+  """Entity element type of the failed entry."""
   entityType: String!
 
-  """Operation type of the failed entry"""
+  """Operation type of the failed entry."""
   operation: String!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -16735,10 +16886,10 @@ Added in 26.4.4. Payload for replacing a role's entire scoped-permission set
 type ReplaceRolePermissionsPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Permission rows that make up the new set"""
+  """Permission rows that make up the new set."""
   items: [Permission!]!
 
-  """Permission entries that failed to insert"""
+  """Permission entries that failed to insert."""
   failed: [ReplaceRolePermissionFailureInfo!]!
 }
 
@@ -17036,18 +17187,16 @@ type ReservoirRegistryEdge
 type ResourceAllocation
   @join__type(graph: STRAWBERRY)
 {
-  """
-  The resource slots originally requested. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
-  """
+  """The resource slots originally requested for this kernel."""
   requested: ResourceSlot!
 
   """
-  The resource slots currently used. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  The resource slots currently used by this kernel. May be null if not yet allocated.
   """
   used: ResourceSlot
 
   """
-  The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing). Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  Added in 26.8.0. The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing).
   """
   allocated: ResourceSlot
 }
@@ -17075,6 +17224,8 @@ type ResourceConfig
   """The resource group of this entity."""
   resourceGroup: ScalingGroupNode
   resourceGroupName: String!
+
+  """Added in 26.1.0. Additional resource options such as shared memory."""
   resourceOpts: ResourceOpts
 }
 
@@ -17259,7 +17410,7 @@ type ResourceGroupSchedulerConfig
   """
   type: SchedulerType!
 
-  """Preemption configuration for this resource group."""
+  """Added in 26.3.0. Preemption configuration for this resource group."""
   preemption: PreemptionConfig!
 }
 
@@ -17320,13 +17471,17 @@ Added in 26.1.0. Resource information for a resource group. Provides aggregated 
 type ResourceInfo
   @join__type(graph: STRAWBERRY)
 {
-  """Total available resources"""
+  """
+  Total available resources from ALIVE, schedulable agents in this resource group.
+  """
   capacity: ResourceSlot!
 
-  """Currently occupied resources"""
+  """
+  Currently occupied resources from active kernels (RUNNING/TERMINATING status).
+  """
   used: ResourceSlot!
 
-  """Available resources (capacity - used)"""
+  """Available resources (capacity - used)."""
   free: ResourceSlot!
 }
 
@@ -17366,7 +17521,7 @@ Added in 26.1.0. A collection of additional resource options for a deployment. C
 type ResourceOpts
   @join__type(graph: STRAWBERRY)
 {
-  """List of resource option entries."""
+  """List of resource option entries. Each entry contains a key-value pair."""
   entries: [ResourceOptsEntry!]!
 }
 
@@ -17376,10 +17531,10 @@ Added in 26.1.0. A single key-value entry representing a resource option. Contai
 type ResourceOptsEntry
   @join__type(graph: STRAWBERRY)
 {
-  """The name of this resource option (e.g., 'shmem')."""
+  """The name of this resource option. Example: 'shmem'."""
   name: String!
 
-  """The value for this resource option (e.g., '64m')."""
+  """The value for this resource option. Example: '64m'."""
   value: String!
 }
 
@@ -17500,7 +17655,9 @@ Added in 26.1.0. A collection of compute resource allocations. Represents the re
 type ResourceSlot
   @join__type(graph: STRAWBERRY)
 {
-  """List of resource allocations"""
+  """
+  List of resource allocations. Each entry contains a resource type and quantity pair.
+  """
   entries: [ResourceSlotEntry!]!
 }
 
@@ -17510,10 +17667,14 @@ Added in 26.1.0. A single entry representing one resource type and its allocated
 type ResourceSlotEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Resource type identifier (e.g., cpu, mem, cuda.shares)"""
+  """
+  Resource type identifier. Common types include: 'cpu' (CPU cores), 'mem' (memory in bytes), 'cuda.shares' (fractional GPU), 'cuda.device' (whole GPU devices), 'rocm.device' (AMD GPU devices). Custom accelerator plugins may define additional types.
+  """
   resourceType: String!
 
-  """Quantity of the resource"""
+  """
+  Quantity of the resource. For 'cpu': number of cores (e.g., 2.0, 0.5). For 'mem': bytes (e.g., 4294967296 for 4GB). For accelerators: device count or share fraction.
+  """
   quantity: Decimal!
 }
 
@@ -17650,13 +17811,19 @@ Added in 26.2.0. Resource weight with default indicator. Shows whether this reso
 type ResourceWeightEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Resource type identifier"""
+  """
+  Resource type identifier (e.g., 'cpu', 'mem', 'cuda.device'). Matches the resource types available in the scaling group.
+  """
   resourceType: String!
 
-  """Weight multiplier for this resource type"""
+  """
+  Weight multiplier for this resource type in fair share calculations. Higher weight means more contribution to normalized usage.
+  """
   weight: Decimal!
 
-  """Whether this resource uses the resource group's default weight"""
+  """
+  Whether this resource uses the resource group's default weight. True means no explicit weight was configured for this type.
+  """
   usesDefault: Boolean!
 }
 
@@ -17704,7 +17871,7 @@ Added in 26.4.4. Payload returned after restoring a virtual folder from trash.
 type RestoreVFolderPayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the restored virtual folder"""
+  """ID of the restored virtual folder."""
   id: UUID!
 }
 
@@ -19230,7 +19397,7 @@ type RuntimeVariantPresetValue
   """The runtime variant preset this value is bound to."""
   preset: RuntimeVariantPreset
 
-  """Runtime variant preset ID."""
+  """The preset this value is bound to."""
   presetId: UUID!
 
   """Value bound to the preset."""
@@ -19243,10 +19410,10 @@ Added in 26.4.4. A mapping of a runtime variant preset to a specific value, used
 type RuntimeVariantPresetValueEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Runtime variant preset ID."""
+  """The runtime variant preset that this value applies to."""
   presetId: UUID!
 
-  """Value for this preset."""
+  """The concrete value to set for the referenced preset parameter."""
   value: String!
 }
 
@@ -19446,7 +19613,7 @@ type ScanProjectModelCardsV2Payload
   """Number of newly created model cards."""
   createdCount: Int!
 
-  """Number of updated existing model cards."""
+  """Number of updated model cards."""
   updatedCount: Int!
 
   """Per-vfolder error messages."""
@@ -19671,11 +19838,22 @@ type ServiceCatalog implements Node
 type ServiceCatalogEndpoint
   @join__type(graph: STRAWBERRY)
 {
+  """Role of this endpoint (e.g., 'main', 'health')."""
   role: String!
+
+  """Network scope (e.g., 'public', 'private', 'internal')."""
   scope: String!
+
+  """Hostname or IP address."""
   address: String!
+
+  """Port number."""
   port: Int!
+
+  """Protocol (e.g., 'grpc', 'http', 'https')."""
   protocol: String!
+
+  """Additional metadata."""
   metadata: JSON
 }
 
@@ -19798,19 +19976,19 @@ Added in 26.2.0. A single service port entry representing an exposed service. Co
 type ServicePortEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Name of the service"""
+  """Name of the service (e.g., 'jupyter', 'tensorboard', 'ssh')."""
   name: String!
 
-  """Protocol type (http, tcp, preopen, internal)"""
+  """Protocol type for this service port (http, tcp, preopen, internal)."""
   protocol: ServicePortProtocol!
 
-  """Port numbers inside the container"""
+  """Port numbers inside the container."""
   containerPorts: [Int!]!
 
-  """Mapped port numbers on the host"""
+  """Mapped port numbers on the host. May be null if not yet assigned."""
   hostPorts: [Int]!
 
-  """Whether this port is used for inference endpoints"""
+  """Whether this port is used for inference endpoints."""
   isInference: Boolean!
 }
 
@@ -19832,7 +20010,7 @@ Added in 26.2.0. A collection of exposed service ports. Each entry defines a ser
 type ServicePorts
   @join__type(graph: STRAWBERRY)
 {
-  """List of service port entries"""
+  """List of service port entries."""
   entries: [ServicePortEntry!]!
 }
 
@@ -19885,6 +20063,7 @@ Added in 26.8.0. Configures the maximum lifetime of a running session. The check
 type SessionLifetimeIdleCheckerSpec
   @join__type(graph: STRAWBERRY)
 {
+  """Maximum session lifetime in seconds."""
   maxLifetimeSeconds: Int!
 }
 
@@ -20225,7 +20404,7 @@ type SessionV2MetadataInfo
   priority: Int!
 
   """
-  Preemption priority among the owner's own sessions. A pending session may reclaim another session's resources only when both belong to the same user and the other session's value is strictly lower, so equal values never preempt each other; among the eligible sessions the lowest value is reclaimed first. Independent of `priority`, which orders the pending queue and takes no part in this comparison.
+  Added in 26.8.0. Preemption priority among the owner's own sessions. A pending session may reclaim another session's resources only when both belong to the same user and the other session's value is strictly lower, so equal values never preempt each other; among the eligible sessions the lowest value is reclaimed first. Independent of `priority`, which orders the pending queue and takes no part in this comparison.
   """
   jobPriority: Int!
 
@@ -20275,9 +20454,7 @@ enum SessionV2OrderField
 type SessionV2ResourceInfo
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Resource allocation with requested and occupied slots. Typed as Any because this field holds a nested GQL type (ResourceAllocationGQL).
-  """
+  """Resource allocation with requested and occupied slots."""
   allocation: ResourceAllocation!
 
   """The resource group (scaling group) this session is assigned to."""
@@ -20299,9 +20476,7 @@ enum SessionV2Result
 type SessionV2RuntimeInfo
   @join__type(graph: STRAWBERRY)
 {
-  """
-  Environment variables for the session. Typed as Any because this field holds a nested GQL type (EnvironmentVariablesGQL).
-  """
+  """Environment variables for the session."""
   environ: EnvironmentVariables
 
   """Bootstrap script to run before the main process."""
@@ -20429,7 +20604,7 @@ Added in 26.4.2. A single storage host together with the permissions granted to 
 type StorageHostPermission
   @join__type(graph: STRAWBERRY)
 {
-  """Storage host name."""
+  """Storage host name (e.g., 'local:volume1')."""
   host: String!
 
   """Permissions granted to the current user on this storage host."""
@@ -20941,7 +21116,7 @@ input UpdateAppConfigAllowListInput
 type UpdateAppConfigAllowListPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated app config allow-list entry."""
+  """The updated app config allow-list entry."""
   appConfigAllowList: AppConfigAllowList!
 }
 
@@ -21034,7 +21209,7 @@ input UpdateContainerRegistryInput
 type UpdateContainerRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated container registry."""
+  """The updated container registry."""
   registry: ContainerRegistryV2!
 }
 
@@ -21244,6 +21419,7 @@ Added in 26.8.0. Returns the idle checker assignment after an update is applied.
 type UpdateIdleCheckerAssignmentPayload
   @join__type(graph: STRAWBERRY)
 {
+  """Updated idle checker assignment."""
   idleCheckerAssignment: IdleCheckerAssignment!
 }
 
@@ -21280,6 +21456,7 @@ Added in 26.8.0. Returns the idle checker after an update is applied. The node r
 type UpdateIdleCheckerPayload
   @join__type(graph: STRAWBERRY)
 {
+  """Updated idle checker."""
   idleChecker: IdleChecker!
 }
 
@@ -21329,7 +21506,7 @@ input UpdateKeypairResourcePolicyInput
 type UpdateKeypairResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated keypair resource policy."""
+  """The updated keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
 
@@ -21350,7 +21527,7 @@ input UpdateLoginClientTypeInput
 type UpdateLoginClientTypePayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated login client type."""
+  """The updated login client type."""
   loginClientType: LoginClientType!
 }
 
@@ -21571,7 +21748,7 @@ input UpdateProjectResourcePolicyInput
 type UpdateProjectResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated project resource policy."""
+  """The updated project resource policy."""
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
 
@@ -21690,7 +21867,7 @@ type UpdateResourceGroupPayload
 type UpdateResourcePresetPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated resource preset."""
+  """The updated resource preset."""
   resourcePreset: ResourcePresetV2!
 }
 
@@ -21944,7 +22121,7 @@ input UpdateUserResourcePolicyInput
 type UpdateUserResourcePolicyPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated user resource policy."""
+  """The updated user resource policy."""
   userResourcePolicy: UserResourcePolicyV2!
 }
 
@@ -22064,7 +22241,7 @@ input UpsertDomainFairShareWeightInput
 type UpsertDomainFairShareWeightPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated domain fair share data"""
+  """The updated or created domain fair share record."""
   domainFairShare: DomainFairShare!
 }
 
@@ -22095,7 +22272,7 @@ Added in 26.1.0. Payload for project fair share weight upsert mutation.
 type UpsertProjectFairShareWeightPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated project fair share data"""
+  """The updated or created project fair share record."""
   projectFairShare: ProjectFairShare!
 }
 
@@ -22127,7 +22304,7 @@ input UpsertUserFairShareWeightInput
 type UpsertUserFairShareWeightPayload
   @join__type(graph: STRAWBERRY)
 {
-  """Updated user fair share data"""
+  """The updated or created user fair share record."""
   userFairShare: UserFairShare!
 }
 
@@ -22993,7 +23170,7 @@ type UserV2BasicInfo
   """Optional description or notes about the user."""
   description: String
 
-  """External system integration identifier."""
+  """Added in 26.4.2. External system integration identifier."""
   integrationName: String
 }
 
@@ -23131,7 +23308,7 @@ type UserV2OrganizationInfo
   """Name of the domain this user belongs to."""
   domainName: String
 
-  """User's role determining access permissions. See UserRole enum."""
+  """User's role determining access permissions. See UserRoleV2 enum."""
   role: UserRoleV2
 
   """Name of the user resource policy applied to this user."""
@@ -23148,7 +23325,7 @@ type UserV2SecurityInfo
   @join__type(graph: STRAWBERRY)
 {
   """
-  List of allowed client IP addresses or CIDR ranges. If set, login is restricted to these IP addresses. Supports both IPv4 and IPv6 formats (e.g., '192.168.1.0/24', '::1').
+  List of allowed client IP addresses or CIDR ranges. If set, login is restricted to these IP addresses.
   """
   allowedClientIp: [String!]
 
@@ -23171,7 +23348,7 @@ type UserV2StatusInfo
   @join__type(graph: STRAWBERRY)
 {
   """
-  Current account status. See UserStatus enum for possible values. Replaces the deprecated is_active field.
+  Current account status. See UserStatusV2 enum for possible values. Replaces the deprecated is_active field.
   """
   status: UserStatusV2!
 
@@ -23211,7 +23388,10 @@ Added in 26.8.0. Configures how long a session may remain underutilized.
 type UtilizationIdleCheckerSpec
   @join__type(graph: STRAWBERRY)
 {
+  """Maximum underutilized duration in seconds."""
   maxUnderutilizedDurationSeconds: Int!
+
+  """Preset-backed utilization threshold."""
   threshold: UtilizationIdleCheckerThreshold!
 }
 
@@ -23230,7 +23410,10 @@ input UtilizationIdleCheckerSpecInput
 type UtilizationIdleCheckerThreshold
   @join__type(graph: STRAWBERRY)
 {
+  """Prometheus query preset ID."""
   presetId: UUID!
+
+  """Underutilization threshold."""
   threshold: Decimal!
 
   """Added in 26.9.0. Label filters injected into the preset query."""
@@ -23306,7 +23489,7 @@ input ValidateNotificationChannelInput
 type ValidateNotificationChannelPayload
   @join__type(graph: STRAWBERRY)
 {
-  """ID of the validated notification channel"""
+  """ID of the validated notification channel."""
   id: UUID!
 }
 
@@ -23380,7 +23563,14 @@ Added in 26.4.2. Access control information for a virtual folder. Includes the m
 type VFolderAccessControlInfo
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Mount permission level: READ_ONLY (ro), READ_WRITE (rw), or RW_DELETE (wd).
+  """
   permission: VFolderMountPermission!
+
+  """
+  Ownership type: USER (personal folder) or GROUP (project-shared folder).
+  """
   ownershipType: VFolderOwnershipType!
 }
 
@@ -23415,22 +23605,22 @@ type VFolderEdge
 type VFolderFileEntryV2
   @join__type(graph: STRAWBERRY)
 {
-  """File or directory name"""
+  """File or directory name."""
   name: String!
 
-  """Entry type"""
+  """Entry type (FILE, DIRECTORY, SYMLINK)."""
   type: String!
 
-  """File size in bytes"""
+  """File size in bytes."""
   size: Int!
 
-  """POSIX file permission mode (e.g., 33188 for 0o100644)"""
+  """POSIX file permission mode."""
   mode: Int!
 
-  """Creation timestamp"""
+  """Creation timestamp."""
   createdAt: String!
 
-  """Last modification timestamp"""
+  """Last modification timestamp."""
   updatedAt: String!
 }
 
@@ -23457,10 +23647,10 @@ Added in 26.2.0. Storage host permission configuration. Defines what operations 
 type VFolderHostPermissionEntry
   @join__type(graph: STRAWBERRY)
 {
-  """Virtual folder host name (e.g., 'default', 'nfs-vol1')."""
+  """Storage host identifier (e.g., 'default', 'storage-01')."""
   host: String!
 
-  """List of permission values (e.g., 'mount-in-session', 'upload-file')."""
+  """List of permissions granted for this host."""
   permissions: [VFolderHostPermissionV2!]!
 }
 
@@ -23497,11 +23687,26 @@ Added in 26.4.2. Descriptive metadata for a virtual folder. Includes the folder 
 type VFolderMetadataInfo
   @join__type(graph: STRAWBERRY)
 {
+  """Display name of the virtual folder."""
   name: String!
+
+  """
+  Usage mode: GENERAL (normal), MODEL (shared models), or DATA (shared datasets).
+  """
   usageMode: VFolderUsageMode!
+
+  """Quota scope identifier that governs storage limits for this folder."""
   quotaScopeId: String
+
+  """Timestamp when the virtual folder was created."""
   createdAt: DateTime!
+
+  """
+  Timestamp of the most recent access. Null if never accessed after creation.
+  """
   lastUsed: DateTime
+
+  """Whether this virtual folder can be cloned by other users."""
   cloneable: Boolean!
 }
 
@@ -23583,9 +23788,21 @@ type VFolderOwnershipInfo
 
   """The user who originally created this virtual folder."""
   creator: UserV2
+
+  """
+  UUID of the user who owns this virtual folder. Null for project-owned folders.
+  """
   userId: UUID
+
+  """
+  UUID of the project that owns this virtual folder. Null for user-owned folders.
+  """
   projectId: UUID
+
+  """UUID of the user who originally created this virtual folder."""
   creatorId: UUID
+
+  """Email of the user who originally created this virtual folder."""
   creatorEmail: String
 }
 
@@ -23607,7 +23824,12 @@ scalar VFolderPermissionValueField
 type VFolderQuotaInfo
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Capacity quota limit in bytes with human-readable display. Null if unlimited.
+  """
   maxSize: BinarySizeInfo
+
+  """File-count quota for the folder."""
   maxFiles: Int!
 }
 
@@ -23617,7 +23839,14 @@ Added in 26.4.4. Usage statistics for a virtual folder, measured live through th
 type VFolderUsageInfo
   @join__type(graph: STRAWBERRY)
 {
+  """
+  Number of files currently stored in the folder, measured live through the storage proxy.
+  """
   numFiles: Int!
+
+  """
+  Current used capacity in bytes with human-readable display, measured live through the storage proxy.
+  """
   usedBytes: BinarySizeInfo!
 }
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -92,10 +92,14 @@ type ActivateRevisionPayload {
 Added in 26.4.0. Active resource usage overview for a domain or project. Shows the currently occupied resource slots and the number of active sessions.
 """
 type ActiveResourceOverview {
-  """Resource slots currently occupied"""
+  """
+  Resource slots currently occupied by active sessions. Each entry represents a resource type and the total quantity in use.
+  """
   slots: ResourceSlot!
 
-  """Number of active sessions"""
+  """
+  Number of active sessions contributing to the current resource occupancy.
+  """
   sessionCount: Int!
 }
 
@@ -328,17 +332,17 @@ Added in 25.15.0. Hardware resource capacity, usage, and availability of an agen
 """
 type AgentResource {
   """
-  Total hardware resource capacity available on the agent. Expressed as a JSON object containing resource slots.
+  Total hardware resource capacity available on the agent. Expressed as a JSON object containing resource slots (e.g., cpu, mem, accelerators). Each slot represents the maximum amount of that resource type the agent can provide.
   """
   capacity: JSON!
 
   """
-  Total amount of resources currently consumed by running and scheduled sessions.
+  Total amount of resources currently consumed by running and scheduled compute sessions. Includes both the requested resources for sessions being prepared and already allocated resources for active sessions. The sum of occupied resources across all session states that occupy agent resources (PREPARING, PULLING, RUNNING, RESTARTING, etc.). Expressed as a JSON object with the same structure as capacity.
   """
   used: JSON!
 
   """
-  Available resources for scheduling new compute sessions (capacity - used).
+  Available resources for scheduling new compute sessions (capacity - used). This represents the maximum resources that can be allocated to new sessions without exceeding the agent's capacity. Expressed as a JSON object with the same structure as capacity.
   """
   free: JSON!
 }
@@ -406,9 +410,7 @@ enum AgentResourceSlotOrderField {
 
 """Added in 25.15.0. Aggregated resource statistics for an agent."""
 type AgentStats {
-  """
-  Total hardware resource capacity, usage, and availability across all agents.
-  """
+  """Total resource capacity of the agent."""
   totalResource: AgentResource!
 }
 
@@ -432,23 +434,27 @@ input AgentStatusFilter {
 """Added in 26.1.0. Status and lifecycle information for an agent."""
 type AgentStatusInfo {
   """
-  Current operational status of the agent. One of: ALIVE, LOST, TERMINATED, RESTARTING.
+  Current operational status of the agent. Indicates whether the agent is ALIVE (active and reachable), LOST (unreachable), TERMINATED (intentionally stopped), or RESTARTING (in recovery process).
   """
   status: AgentStatusEnum!
 
-  """Timestamp when the agent last changed its status."""
+  """
+  Timestamp when the agent last changed its status. Updated whenever the agent transitions between different status states (e.g., from ALIVE to LOST, or RESTARTING to ALIVE). Will be null if the agent status has never changed since initial registration.
+  """
   statusChanged: DateTime
 
-  """Timestamp when the agent first registered with the manager."""
+  """
+  Timestamp when the agent first registered with the manager. This value remains constant throughout the agent's lifecycle and can be used to track the agent's age or identify when it was initially deployed.
+  """
   firstContact: DateTime
 
   """
-  Timestamp when the agent was marked as lost or unreachable. Null if the agent has never been lost or is currently alive.
+  Timestamp when the agent was marked as lost or unreachable. Set when the manager detects the agent has stopped sending heartbeats. Will be null if the agent has never been lost or is currently alive.
   """
   lostAt: DateTime
 
   """
-  Indicates whether the agent is available for scheduling new compute sessions.
+  Indicates whether the agent is available for scheduling new compute sessions. An agent can be non-schedulable due to maintenance mode, resource constraints or other operational reasons by admin. When false, no new sessions will be assigned to this agent.
   """
   schedulable: Boolean!
 }
@@ -456,20 +462,22 @@ type AgentStatusInfo {
 """Added in 26.1.0. System and configuration information for an agent."""
 type AgentSystemInfo {
   """
-  Hardware architecture of the agent's host system (e.g., "x86_64", "aarch64"). Used to match compute sessions with compatible container images.
+  Hardware architecture of the agent's host system (e.g., "x86_64", "aarch64"). Used to match compute sessions with compatible container images and ensure proper binary execution on the agent.
   """
   architecture: String!
 
   """
-  Version string of the Backend.AI agent software running on this node. Follows semantic versioning (e.g., "26.1.0").
+  Version string of the Backend.AI agent software running on this node. Follows semantic versioning (e.g., "26.1.0") and helps identify compatibility and available features.
   """
   version: String!
 
-  """Legacy configuration flag, no longer actively used in the system."""
+  """
+  Legacy configuration flag, no longer actively used in the system. Retained for backward compatibility and schema consistency. Originally intended to control automatic termination of misbehaving sessions.
+  """
   autoTerminateAbusingKernel: Boolean!
 
   """
-  List of compute plugin metadata supported by this agent. Typed as Any because this field holds a nested GQL type (ComputePluginsGQL).
+  List of compute plugin metadata supported by this agent. Each plugin represents a specific accelerator or resource type (e.g., CUDA). Entries contain plugin names and their associated metadata with plugin-specific configuration and capabilities.
   """
   computePlugins: ComputePlugins!
 }
@@ -1069,16 +1077,20 @@ enum ArtifactOrderField {
 
 """Added in 25.14.0. Artifact registry node."""
 type ArtifactRegistry {
-  """Internal identifier of the artifact registry metadata record."""
+  """
+  Added in 25.17.0. Internal identifier for the artifact registry metadata record in the 'artifact_registries' table. This ID is unique across all registry types and represents the metadata record itself. Example: When you need to reference a registry entry in the metadata table, use this ID.
+  """
   id: ID!
 
-  """Identifier of the actual registry implementation."""
+  """
+  Added in 25.17.0. Identifier of the actual registry implementation (e.g., HuggingFace registry, Reservoir registry). This ID corresponds to the primary key in the registry-type-specific table. Example: For a HuggingFace registry, this value matches the 'id' field in the 'huggingface_registries' table. Use this ID when you need to access type-specific registry details.
+  """
   registryId: ID!
 
-  """Name of the artifact registry."""
+  """Name of the default artifact registry."""
   name: String!
 
-  """Type of the artifact registry."""
+  """Type of the default artifact registry."""
   type: ArtifactRegistryType!
 }
 
@@ -1281,7 +1293,7 @@ enum ArtifactType {
 Added in 25.17.0. Complete verification result containing results from all configured verifiers. Artifacts undergo malware scanning through multiple verifiers after being imported. This type aggregates results from all verifiers that were run on the artifact.
 """
 type ArtifactVerificationResult {
-  """Results from each verifier that scanned the artifact."""
+  """Results from each verifier that scanned the artifact"""
   verifiers: [ArtifactVerifierResultEntry!]!
 }
 
@@ -1289,7 +1301,7 @@ type ArtifactVerificationResult {
 Added in 26.1.0. A collection of metadata from an artifact verifier. Contains key-value pairs providing additional information about the verification.
 """
 type ArtifactVerifierMetadata {
-  """List of metadata entries."""
+  """List of metadata entries. Each entry contains a key-value pair."""
   entries: [ArtifactVerifierMetadataEntry!]!
 }
 
@@ -1308,25 +1320,25 @@ type ArtifactVerifierMetadataEntry {
 Added in 25.17.0. Result from a single malware verifier containing scan results and metadata. Each verifier scans the artifact for potential security issues and reports findings including infected file count, scan time, and any errors encountered.
 """
 type ArtifactVerifierResult {
-  """Whether the verification completed successfully."""
+  """Whether the verification completed successfully"""
   success: Boolean!
 
-  """Number of infected or suspicious files detected."""
+  """Number of infected or suspicious files detected"""
   infectedCount: Int!
 
-  """Timestamp when verification started."""
+  """Timestamp when verification started"""
   scannedAt: DateTime!
 
-  """Time taken to complete verification in seconds."""
+  """Time taken to complete verification in seconds"""
   scanTime: Float!
 
-  """Total number of files scanned."""
+  """Total number of files scanned"""
   scannedCount: Int!
 
-  """Additional metadata from the verifier."""
+  """Added in 26.1.0. Additional metadata from the verifier."""
   metadata: ArtifactVerifierMetadata!
 
-  """Fatal error message if the verifier failed to complete."""
+  """Fatal error message if the verifier failed to complete"""
   error: String
 }
 
@@ -1334,10 +1346,10 @@ type ArtifactVerifierResult {
 Added in 25.17.0. Entry for a single verifier's result in the verification results. Associates a verifier name with its scan results.
 """
 type ArtifactVerifierResultEntry {
-  """Name of the verifier."""
+  """Name of the verifier (e.g., 'clamav', 'custom')"""
   name: String!
 
-  """Scan result from this verifier."""
+  """Scan result from this verifier"""
   result: ArtifactVerifierResult!
 }
 
@@ -1630,22 +1642,22 @@ input BlueGreenConfigInput {
 Added in 26.4.4. Failure detail for a single permission entry in bulk add
 """
 type BulkAddRolePermissionFailureInfo {
-  """Role ID of the failed entry"""
+  """Role ID of the failed entry."""
   roleId: UUID!
 
-  """Scope element type of the failed entry"""
+  """Scope element type of the failed entry."""
   scopeType: String!
 
-  """Scope element ID of the failed entry"""
+  """Scope element ID of the failed entry."""
   scopeId: String!
 
-  """Entity element type of the failed entry"""
+  """Entity element type of the failed entry."""
   entityType: String!
 
-  """Operation type of the failed entry"""
+  """Operation type of the failed entry."""
   operation: String!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -1694,10 +1706,10 @@ input BulkAddRolePermissionsInput {
 
 """Added in 26.4.4. Payload for bulk role-permission insertion"""
 type BulkAddRolePermissionsPayload {
-  """Successfully inserted permission rows"""
+  """Successfully inserted permission rows."""
   items: [Permission!]!
 
-  """Permission entries that failed to insert"""
+  """Permission entries that failed to insert."""
   failed: [BulkAddRolePermissionFailureInfo!]!
 }
 
@@ -1705,10 +1717,10 @@ type BulkAddRolePermissionsPayload {
 Added in 26.3.0. Error information for a failed user in bulk role assignment.
 """
 type BulkAssignRoleError {
-  """UUID of the user that failed"""
+  """UUID of the user that failed."""
   userId: UUID!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -1721,10 +1733,10 @@ input BulkAssignRoleInput {
 
 """Added in 26.3.0. Payload for bulk role assignment mutation."""
 type BulkAssignRolePayload {
-  """Successfully created role assignments"""
+  """List of successfully created role assignments."""
   assigned: [RoleAssignment!]!
 
-  """Users that failed to be assigned"""
+  """List of errors for users that failed to be assigned."""
   failed: [BulkAssignRoleError!]!
 }
 
@@ -1915,7 +1927,7 @@ type BulkPurgeVFoldersV2Payload {
   """Number of virtual folders successfully purged."""
   purgedCount: Int!
 
-  """List of errors for vfolders that failed to purge."""
+  """Added in 26.4.4. List of errors for vfolders that failed to purge."""
   failed: [BulkPurgeVFolderV2Error!]!
 }
 
@@ -1923,10 +1935,10 @@ type BulkPurgeVFoldersV2Payload {
 Added in 26.4.4. Failure detail for a single permission ID in bulk remove
 """
 type BulkRemoveRolePermissionFailureInfo {
-  """Permission row ID that failed to delete"""
+  """Permission row ID that failed to delete."""
   permissionId: UUID!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -1958,10 +1970,10 @@ input BulkRemoveRolePermissionsInput {
 
 """Added in 26.4.4. Payload for bulk role-permission deletion"""
 type BulkRemoveRolePermissionsPayload {
-  """Successfully deleted permission rows"""
+  """Successfully deleted permission rows."""
   items: [Permission!]!
 
-  """Permission IDs that failed to delete"""
+  """Permission IDs that failed to delete."""
   failed: [BulkRemoveRolePermissionFailureInfo!]!
 }
 
@@ -1986,10 +1998,10 @@ type BulkRestoreRolePresetsPayload {
 Added in 26.3.0. Error information for a failed user in bulk role revocation.
 """
 type BulkRevokeRoleError {
-  """UUID of the user that failed"""
+  """UUID of the user that failed."""
   userId: UUID!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -2001,10 +2013,10 @@ input BulkRevokeRoleInput {
 
 """Added in 26.3.0. Payload for bulk role revocation mutation."""
 type BulkRevokeRolePayload {
-  """Successfully revoked role assignments"""
+  """List of successfully revoked role assignments."""
   revoked: [RoleAssignment!]!
 
-  """Users that failed to be revoked"""
+  """List of errors for users that failed to be revoked."""
   failed: [BulkRevokeRoleError!]!
 }
 
@@ -2012,7 +2024,7 @@ type BulkRevokeRolePayload {
 Added in 26.4.4. Failure detail for a single permission entry in a bulk operation.
 """
 type BulkRolePermissionPresetFailureInfo {
-  """role_permission_presets row ID that the operation failed on."""
+  """Permission entry ID that the operation failed on."""
   permissionPresetId: UUID!
 
   """Error message describing the failure."""
@@ -2244,10 +2256,10 @@ input CloneVFolderV2Input {
 
 """Added in 26.4.2. Payload returned after cloning a virtual folder."""
 type CloneVFolderV2Payload {
-  """Cloned virtual folder"""
+  """The cloned virtual folder."""
   vfolder: VFolder!
 
-  """Background task ID for the clone operation"""
+  """Background task ID for the clone operation."""
   bgtaskId: String!
 }
 
@@ -2255,7 +2267,10 @@ type CloneVFolderV2Payload {
 Added in 25.19.0. Cluster configuration for model deployment replicas. Defines the clustering mode and number of replicas.
 """
 type ClusterConfig {
+  """The clustering mode (e.g., SINGLE_NODE)."""
   mode: ClusterMode!
+
+  """Number of replicas in the cluster."""
   size: Int!
 }
 
@@ -2291,7 +2306,7 @@ Added in 26.1.0. A collection of compute plugins available on an agent. Each ent
 """
 type ComputePlugins {
   """
-  List of compute plugins. Each entry contains a plugin name and its metadata.
+  List of compute plugins. Each entry contains a plugin name and its metadata. The list includes all accelerator and resource type plugins installed on the agent.
   """
   entries: [ComputePluginEntry!]!
 }
@@ -2519,7 +2534,7 @@ input CreateAppConfigAllowListInput {
 
 """Added in 26.7.0. Payload for app config allow-list entry creation."""
 type CreateAppConfigAllowListPayload {
-  """Created app config allow-list entry."""
+  """The created app config allow-list entry."""
   appConfigAllowList: AppConfigAllowList!
 }
 
@@ -2531,7 +2546,7 @@ input CreateAppConfigDefinitionInput {
 
 """Added in 26.7.0. Payload for app config definition creation."""
 type CreateAppConfigDefinitionPayload {
-  """Created app config definition."""
+  """The created app config definition."""
   appConfigDefinition: AppConfigDefinition!
 }
 
@@ -2606,7 +2621,7 @@ input CreateContainerRegistryInputV2 {
 Added in 26.4.2. Payload for container registry create/update mutations.
 """
 type CreateContainerRegistryPayload {
-  """Created container registry."""
+  """The container registry."""
   registry: ContainerRegistryV2!
 }
 
@@ -2732,10 +2747,10 @@ input CreateDownloadSessionV2Input {
 
 """Added in 26.4.2. Payload returned after creating a download session."""
 type CreateDownloadSessionV2Payload {
-  """Download session token"""
+  """Download session token."""
   token: String!
 
-  """Download URL"""
+  """Download URL."""
   url: String!
 }
 
@@ -2770,6 +2785,7 @@ input CreateIdleCheckerAssignmentInput {
 Added in 26.8.0. Returns the created idle checker assignment. The node contains the server-assigned identifier and timestamps.
 """
 type CreateIdleCheckerAssignmentPayload {
+  """Created idle checker assignment."""
   idleCheckerAssignment: IdleCheckerAssignment!
 }
 
@@ -2798,6 +2814,7 @@ input CreateIdleCheckerInput {
 Added in 26.8.0. Returns the created global idle checker definition. The node contains the server-assigned identifier and timestamps.
 """
 type CreateIdleCheckerPayload {
+  """Created idle checker."""
   idleChecker: IdleChecker!
 }
 
@@ -2859,7 +2876,7 @@ input CreateKeypairResourcePolicyInput {
 Added in 26.4.2. Payload for keypair resource policy create/update mutations.
 """
 type CreateKeypairResourcePolicyPayload {
-  """Created keypair resource policy."""
+  """The keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
 
@@ -2874,7 +2891,7 @@ input CreateLoginClientTypeInput {
 
 """Added in 26.4.2. Payload for login client type creation."""
 type CreateLoginClientTypePayload {
-  """Created login client type."""
+  """The created login client type."""
   loginClientType: LoginClientType!
 }
 
@@ -3030,7 +3047,7 @@ input CreateProjectResourcePolicyInputV2 {
 Added in 26.4.2. Payload for project resource policy create/update mutations.
 """
 type CreateProjectResourcePolicyPayload {
-  """Created project resource policy."""
+  """The project resource policy."""
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
 
@@ -3096,13 +3113,13 @@ input CreateResourceGroupInput {
 
 """Added in 26.4.2. Payload for resource group creation."""
 type CreateResourceGroupPayload {
-  """Created resource group."""
+  """The created resource group."""
   resourceGroup: ResourceGroup!
 }
 
 """Added in 26.4.2. Payload for resource preset creation."""
 type CreateResourcePresetPayload {
-  """Created resource preset."""
+  """The created resource preset."""
   resourcePreset: ResourcePresetV2!
 }
 
@@ -3335,10 +3352,10 @@ input CreateUploadSessionV2Input {
 
 """Added in 26.4.2. Payload returned after creating an upload session."""
 type CreateUploadSessionV2Payload {
-  """Upload session token"""
+  """Upload session token."""
   token: String!
 
-  """Upload URL"""
+  """Upload URL."""
   url: String!
 }
 
@@ -3369,7 +3386,7 @@ input CreateUserResourcePolicyInputV2 {
 Added in 26.4.2. Payload for user resource policy create/update mutations.
 """
 type CreateUserResourcePolicyPayload {
-  """Created user resource policy."""
+  """The user resource policy."""
   userResourcePolicy: UserResourcePolicyV2!
 }
 
@@ -3435,7 +3452,7 @@ type CreateUserV2Payload {
   user: UserV2!
 
   """
-  The default keypair automatically generated for the user, including its one-time secret key.
+  Added in 26.4.4. The default keypair automatically generated for the user, including its one-time secret key.
   """
   keypair: CreateKeypairPayload!
 }
@@ -3496,7 +3513,7 @@ input CreateVFolderV2Input {
 
 """Added in 26.4.2. Payload returned after creating a virtual folder."""
 type CreateVFolderV2Payload {
-  """Created virtual folder"""
+  """The created virtual folder."""
   vfolder: VFolder!
 }
 
@@ -3714,11 +3731,11 @@ Added in 25.15.0. Response payload for delegated artifact import operation. Cont
 """
 type DelegateImportArtifactsPayload {
   """
-  List of imported artifact revisions from the reservoir registry's remote registry.
+  Connection of artifact revisions that were imported from the reservoir registry's remote registry
   """
   artifactRevisions: ArtifactRevisionConnection!
 
-  """List of background tasks created for importing the artifact revisions."""
+  """List of background tasks created for importing the artifact revisions"""
   tasks: [ArtifactRevisionImportTask!]!
 }
 
@@ -3746,7 +3763,9 @@ input DelegateScanArtifactsInput {
 Added in 25.15.0. Response payload for delegated artifact scanning operation. Contains the list of artifacts discovered during the scan of a reservoir registry's remote registry. These artifacts are now available for import or direct use.
 """
 type DelegateScanArtifactsPayload {
-  """List of artifacts discovered during the delegated scan."""
+  """
+  List of artifacts discovered during the delegated scan from the reservoir registry's remote registry
+  """
   artifacts: [Artifact!]!
 }
 
@@ -3801,13 +3820,13 @@ type DeleteAutoScalingRulePayload {
 Added in 26.3.0. Payload returned after deleting a query preset category.
 """
 type DeleteCategoryPayload {
-  """Deleted category ID"""
+  """Deleted category ID."""
   id: UUID!
 }
 
 """Added in 26.4.2. Payload for container registry deletion."""
 type DeleteContainerRegistryPayload {
-  """ID of the deleted container registry."""
+  """ID of the deleted registry."""
   id: String!
 }
 
@@ -3847,7 +3866,7 @@ input DeleteFilesV2Input {
 Added in 26.4.2. Payload returned after deleting files in a virtual folder.
 """
 type DeleteFilesV2Payload {
-  """Background task ID for the deletion operation"""
+  """Background task ID for the deletion operation."""
   bgtaskId: String!
 }
 
@@ -3864,7 +3883,7 @@ type DeleteHuggingFaceRegistryPayload {
 
 """Added in 26.4.2. Payload for keypair resource policy deletion."""
 type DeleteKeypairResourcePolicyPayload {
-  """Name of the deleted keypair resource policy."""
+  """Name of the deleted policy."""
   name: String!
 }
 
@@ -3895,7 +3914,7 @@ input DeleteNotificationChannelInput {
 
 """Added in 26.3.0. Payload for delete notification channel mutation."""
 type DeleteNotificationChannelPayload {
-  """ID of the deleted notification channel"""
+  """ID of the deleted notification channel."""
   id: UUID!
 }
 
@@ -3906,7 +3925,7 @@ input DeleteNotificationRuleInput {
 
 """Added in 26.3.0. Payload for delete notification rule mutation."""
 type DeleteNotificationRulePayload {
-  """ID of the deleted notification rule"""
+  """ID of the deleted notification rule."""
   id: UUID!
 }
 
@@ -3917,7 +3936,7 @@ input DeleteObjectStorageInput {
 
 """Added in 25.14.0. Payload for deleting an object storage."""
 type DeleteObjectStoragePayload {
-  """ID of the deleted object storage"""
+  """ID of the deleted object storage."""
   id: UUID!
 }
 
@@ -3928,7 +3947,7 @@ input DeletePermissionInput {
 
 """Added in 26.3.0. Payload for delete permission mutation."""
 type DeletePermissionPayload {
-  """ID of the deleted permission"""
+  """ID of the deleted permission."""
   id: UUID!
 }
 
@@ -3940,13 +3959,13 @@ type DeleteProjectPayload {
 
 """Added in 26.4.2. Payload for project resource policy deletion."""
 type DeleteProjectResourcePolicyPayload {
-  """Name of the deleted project resource policy."""
+  """Name of the deleted policy."""
   name: String!
 }
 
 """Added in 26.3.0. Payload returned after deleting a query definition."""
 type DeleteQueryDefinitionPayload {
-  """Deleted query definition ID"""
+  """Deleted query definition ID."""
   id: UUID!
 }
 
@@ -3963,7 +3982,9 @@ type DeleteReservoirRegistryPayload {
 
 """Added in 26.4.2. Payload for resource group deletion."""
 type DeleteResourceGroupPayload {
-  """UUID of the deleted resource group."""
+  """
+  UUID of the deleted resource group. Since 26.8.0, the value is the UUID instead of the name.
+  """
   id: UUID!
 }
 
@@ -3986,7 +4007,7 @@ input DeleteRoleInput {
 
 """Added in 26.3.0. Payload for delete role mutation."""
 type DeleteRolePayload {
-  """ID of the deleted role"""
+  """ID of the deleted role."""
   id: UUID!
 }
 
@@ -4016,7 +4037,7 @@ type DeleteRuntimeVariantsPayload {
 
 """Added in 26.4.2. Payload for user resource policy deletion."""
 type DeleteUserResourcePolicyPayload {
-  """Name of the deleted user resource policy."""
+  """Name of the deleted policy."""
   name: String!
 }
 
@@ -4055,7 +4076,7 @@ type DeleteVFSStoragePayload {
 Added in 26.4.2. Payload returned after soft-deleting a virtual folder.
 """
 type DeleteVFolderV2Payload {
-  """ID of the deleted virtual folder"""
+  """ID of the deleted virtual folder."""
   id: UUID!
 }
 
@@ -4390,10 +4411,10 @@ type DeploymentRevisionPresetEdge {
 Added in 26.4.2. A single environment variable key-value pair injected into the inference container when a deployment revision preset is applied.
 """
 type DeploymentRevisionPresetEnvironEntry {
-  """Environment variable key."""
+  """The environment variable name (e.g., CUDA_VISIBLE_DEVICES, HF_HOME)."""
   key: String!
 
-  """Environment variable value."""
+  """The value assigned to the environment variable."""
   value: String!
 }
 
@@ -5230,7 +5251,10 @@ input EnvironEntryInput {
 Added in 26.1.0. A single environment variable entry with name and value.
 """
 type EnvironmentVariableEntry {
+  """Environment variable name (e.g., CUDA_VISIBLE_DEVICES)."""
   name: String!
+
+  """Environment variable value."""
   value: String!
 }
 
@@ -5247,6 +5271,7 @@ input EnvironmentVariableEntryInput {
 
 """Added in 26.1.0. A collection of environment variable entries."""
 type EnvironmentVariables {
+  """List of environment variable entries."""
   entries: [EnvironmentVariableEntry!]!
 }
 
@@ -5272,15 +5297,17 @@ type ExtraVFolderMountInfo {
   """The vfolder of this entity."""
   vfolder: VirtualFolderNode
   vfolderId: ID!
+
+  """Mount destination path inside the container."""
   mountDestination: String
 
   """
-  The concrete permission snapshot fixed at revision-write time. ``INHERIT`` policies are resolved against the vfolder's current permission at that point, so this value is immutable and does not change when the vfolder's permission later changes. ``None`` when the caller left it unset to inherit the vfolder's stored permission at session-creation time (task #83).
+  Added in 26.4.4. The concrete permission snapshot fixed at revision-write time; later vfolder permission changes do not retroactively affect it.
   """
   mountPerm: MountPermission!
 
   """
-  Added in 26.4.4. Subpath within the vfolder. ``None`` means the vfolder root.
+  Added in 26.4.4. Subpath within the vfolder. ``null`` means the vfolder root.
   """
   subpath: String
 }
@@ -5305,22 +5332,34 @@ type FairShareCalculationSnapshot {
   """
   averageDailyDecayedUsage: ResourceSlot
 
-  """Computed fair share factor (0-1 range)"""
+  """
+  Computed fair share factor ranging from 0 to 1. Higher values indicate more entitlement to resources (less historical usage relative to others). Used by the scheduler to prioritize workloads - entities with higher factors get scheduled first.
+  """
   fairShareFactor: Decimal!
 
-  """Sum of decayed historical usage"""
+  """
+  Sum of exponentially decayed historical usage across the lookback period. Recent usage contributes more than older usage based on the half-life decay function. This is the raw usage data before normalization.
+  """
   totalDecayedUsage: ResourceSlot!
 
-  """Single scalar representing weighted consumption"""
+  """
+  Single scalar value representing weighted resource consumption. Computed by applying resource weights to the decayed usage and summing. Used to compare usage across entities with different resource consumption patterns.
+  """
   normalizedUsage: Decimal!
 
-  """Start date of the lookback window"""
+  """
+  Start date of the lookback window used in this calculation (inclusive). Usage before this date is not considered in the fair share factor computation.
+  """
   lookbackStart: Date!
 
-  """End date of the lookback window"""
+  """
+  End date of the lookback window used in this calculation (inclusive). Typically the current date or the date of the last calculation.
+  """
   lookbackEnd: Date!
 
-  """Timestamp when calculation was performed"""
+  """
+  Timestamp when this fair share calculation was performed. Fair share factors are recalculated periodically by the scheduler.
+  """
   lastCalculatedAt: DateTime!
 }
 
@@ -5328,19 +5367,29 @@ type FairShareCalculationSnapshot {
 Added in 26.1.0. Fair share calculation configuration for a resource group. Defines parameters for computing fair share factors across domains, projects, and users.
 """
 type FairShareScalingGroupSpec {
-  """Half-life for exponential decay in days"""
+  """
+  Half-life for exponential decay in days. Determines how quickly historical usage loses significance. Default is 7 days.
+  """
   halfLifeDays: Int!
 
-  """Total lookback period in days"""
+  """
+  Total lookback period in days for usage aggregation. Only usage within this window is considered. Default is 28 days.
+  """
   lookbackDays: Int!
 
-  """Granularity of decay buckets in days"""
+  """
+  Granularity of decay buckets in days. Usage is aggregated into buckets of this size. Default is 1 day.
+  """
   decayUnitDays: Int!
 
-  """Default weight for entities without explicit weight"""
+  """
+  Default weight for entities without explicit weight in this resource group. Default is 1.0.
+  """
   defaultWeight: Decimal!
 
-  """Weights for each resource type"""
+  """
+  Added in 26.2.0. Weights for each resource type with default indicators. All resource types from capacity are included. Shows which resources use explicit vs default weights.
+  """
   resourceWeights: [ResourceWeightEntry!]!
 }
 
@@ -5349,25 +5398,33 @@ Added in 26.1.0. Configuration parameters that control how fair share factors ar
 """
 type FairShareSpec {
   """
-  Effective weight for this entity. Always the resolved value (either the explicitly set weight or the resource group's default_weight).
+  Base weight multiplier for this entity. Higher weight values result in higher scheduling priority. This is the effective weight - either the explicitly set value or the resource group's default_weight.
   """
   weight: Decimal!
 
   """
-  Whether this entity uses the resource group's default_weight. True means no explicit weight was set.
+  Added in 26.1.0. Whether this entity uses the resource group's default_weight. True means no explicit weight was set and the default is being used. False means an explicit weight value was configured for this entity.
   """
   usesDefault: Boolean!
 
-  """Half-life for exponential decay in days"""
+  """
+  Half-life for exponential decay in days. Determines how quickly historical usage loses significance. For example, with half_life_days=7, usage from 7 days ago contributes half as much as today's usage.
+  """
   halfLifeDays: Int!
 
-  """Total lookback period in days"""
+  """
+  Total lookback period in days for usage aggregation. Only usage within this window is considered. Typical values range from 7 to 30 days depending on scheduling policy.
+  """
   lookbackDays: Int!
 
-  """Granularity of decay buckets in days"""
+  """
+  Granularity of decay buckets in days. Usage is aggregated into buckets of this size. Smaller values provide more precision but require more storage. Typically 1 day.
+  """
   decayUnitDays: Int!
 
-  """Weights for each resource type with default indicators"""
+  """
+  Added in 26.2.0. Weights for each resource type with default indicators. Shows which resources use explicit vs default weights. Allows different resources to contribute differently to the fair share calculation. For example, GPU usage might be weighted higher than CPU usage.
+  """
   resourceWeights: [ResourceWeightEntry!]!
 }
 
@@ -5743,9 +5800,16 @@ input IdleCheckerScopeTypeFilter {
 Added in 26.8.0. Contains the settings used by an idle checker implementation.
 """
 type IdleCheckerSpec {
+  """Checker implementation type."""
   type: IdleCheckerType!
+
+  """Settings that define the maximum lifetime of a session."""
   sessionLifetime: SessionLifetimeIdleCheckerSpec
+
+  """Settings that define the maximum network inactivity period."""
   network: NetworkTimeoutIdleCheckerSpec
+
+  """Settings that define the maximum underutilized duration."""
   utilization: UtilizationIdleCheckerSpec
 }
 
@@ -5967,19 +6031,23 @@ type ImageV2LabelEntry {
 Added in 26.2.0. Metadata information for an image. Contains tags, labels, digest, size, status, and creation timestamp.
 """
 type ImageV2MetadataInfo {
-  """Config digest for verification."""
+  """Config digest (image hash) for verification."""
   digest: String
 
   """Image size in bytes."""
   sizeBytes: Int!
 
-  """Image creation timestamp."""
+  """Timestamp when the image was created/registered."""
   createdAt: DateTime
 
-  """Timestamp of the most recent session created with this image."""
+  """
+  Added in 26.3.0. Timestamp of the most recent session created with this image. Returns null if the image has never been used.
+  """
   lastUsedAt: DateTime
 
-  """Parsed tag components."""
+  """
+  Parsed tag components from the image reference (e.g., python=3.11, cuda=12.1).
+  """
   tags: [ImageV2TagEntry!]!
 
   """Docker labels."""
@@ -6016,7 +6084,7 @@ enum ImageV2Permission {
 Added in 26.2.0. Permission information for an image. Contains the list of permissions the current user has on this image.
 """
 type ImageV2PermissionInfo {
-  """List of permissions the user has on this image"""
+  """List of permissions the user has on this image."""
   permissions: [ImageV2Permission!]!
 }
 
@@ -6024,10 +6092,10 @@ type ImageV2PermissionInfo {
 Added in 26.2.0. Runtime requirements information for an image. Contains resource limits and supported accelerators.
 """
 type ImageV2RequirementsInfo {
-  """List of supported accelerator types."""
+  """List of supported accelerator types (e.g., 'cuda', 'rocm')."""
   supportedAccelerators: [String!]!
 
-  """Resource slot limits with string min/max values."""
+  """Resource slot limits (cpu, memory, accelerators, etc.)."""
   resourceLimits: [ImageV2ResourceLimit!]!
 }
 
@@ -6422,16 +6490,18 @@ input KernelV2Filter {
 
 """Added in 26.2.0. Lifecycle and status information for a kernel."""
 type KernelV2LifecycleInfo {
-  """Current status of the kernel."""
+  """
+  Current status of the kernel (e.g., PENDING, RUNNING, TERMINATED). Indicates the kernel's position in its lifecycle.
+  """
   status: KernelV2Status!
 
-  """The result of the kernel execution."""
+  """The result of the kernel execution (UNDEFINED, SUCCESS, FAILURE)."""
   result: SessionV2Result!
 
   """Timestamp when the kernel was created."""
   createdAt: DateTime
 
-  """Timestamp when the kernel was terminated."""
+  """Timestamp when the kernel was terminated. Null if still active."""
   terminatedAt: DateTime
 
   """Scheduled start time for the kernel, if applicable."""
@@ -6440,9 +6510,7 @@ type KernelV2LifecycleInfo {
 
 """Added in 26.2.0. Network configuration for a kernel."""
 type KernelV2NetworkInfo {
-  """
-  Collection of service ports exposed by this kernel. Typed as Any because this field holds a nested GQL type (ServicePortsGQL).
-  """
+  """Collection of service ports exposed by this kernel."""
   servicePorts: ServicePorts
 
   """List of ports that are pre-opened for this kernel."""
@@ -6475,22 +6543,18 @@ type KernelV2ResourceInfo {
   """The resource group (scaling group) this kernel is assigned to."""
   resourceGroupName: String
 
-  """The container ID on the agent."""
+  """
+  The container ID on the agent. Null if container not yet created or hidden.
+  """
   containerId: String
 
-  """
-  Resource allocation with requested and used slots. Typed as Any because this field holds a nested GQL type (ResourceAllocationGQL).
-  """
+  """Resource allocation with requested and used slots."""
   allocation: ResourceAllocation!
 
-  """
-  The fractional resource shares occupied by this kernel. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
-  """
+  """The fractional resource shares occupied by this kernel."""
   shares: ResourceSlot!
 
-  """
-  Additional resource options and configurations. Typed as Any because this field holds a nested GQL type (ResourceOptsGQL).
-  """
+  """Additional resource options and configurations for this kernel."""
   resourceOpts: ResourceOpts
 }
 
@@ -6505,7 +6569,7 @@ type KernelV2SessionInfo {
   """The name of the session."""
   name: String
 
-  """The type of session (interactive, batch, inference, system)."""
+  """The type of session (INTERACTIVE, BATCH, INFERENCE, SYSTEM)."""
   sessionType: SessionTypes!
 }
 
@@ -6805,7 +6869,7 @@ input ListFilesV2Input {
 Added in 26.4.2. Payload returned after listing files in a virtual folder.
 """
 type ListFilesV2Payload {
-  """List of file entries"""
+  """List of file entries."""
   items: [VFolderFileEntryV2!]!
 }
 
@@ -7127,7 +7191,7 @@ input MkdirV2Input {
 Added in 26.4.2. Payload returned after creating directories in a virtual folder.
 """
 type MkdirV2Payload {
-  """List of created directory paths"""
+  """List of created directory paths."""
   results: [String!]!
 }
 
@@ -7271,15 +7335,42 @@ input ModelCardV2Filter {
 Added in 26.4.2. Metadata extracted from the model-definition.yaml file in the model VFolder. Contains authorship, classification, and framework information used for discovery and compatibility checks.
 """
 type ModelCardV2Metadata {
+  """The author or organization that created this model."""
   author: String
+
+  """Human-readable display title for the model."""
   title: String
+
+  """Version string of the model (e.g., '1.0', '2.3.1')."""
   modelVersion: String
+
+  """Brief summary of what the model does and its intended use cases."""
   description: String
+
+  """
+  The primary ML task this model performs (e.g., 'text-generation', 'image-classification').
+  """
   task: String
+
+  """High-level category for the model (e.g., 'NLP', 'Computer Vision')."""
   category: String
+
+  """Model architecture name (e.g., 'transformer', 'diffusion', 'CNN')."""
   architecture: String
+
+  """
+  List of ML frameworks required to run the model (e.g., 'PyTorch', 'TensorFlow', 'JAX').
+  """
   framework: [String!]!
+
+  """
+  Classification labels and tags for categorization and search (e.g., 'text-generation', 'vision', 'multilingual').
+  """
   label: [String!]!
+
+  """
+  License under which the model is distributed (e.g., 'Apache-2.0', 'MIT').
+  """
   license: String
 }
 
@@ -7302,10 +7393,10 @@ enum ModelCardV2OrderField {
 Added in 26.4.2. A single resource requirement entry for a model card. The quantity is represented as a string because model card requirements are descriptive (display/matching) rather than arithmetic.
 """
 type ModelCardV2ResourceSlotEntry {
-  """Resource type name."""
+  """Resource type identifier (e.g., 'cpu', 'mem', 'cuda.shares')."""
   resourceType: String!
 
-  """Resource quantity."""
+  """Minimum required quantity for this resource as a decimal string."""
   quantity: String!
 }
 
@@ -7453,6 +7544,10 @@ type ModelDeploymentMetadata {
   name: String!
   status: DeploymentStatus!
   tags: [String!]!
+
+  """
+  Added in 26.4.4. Name of the resource group (scaling group) this deployment runs in.
+  """
   resourceGroupName: String!
   createdAt: DateTime!
   updatedAt: DateTime!
@@ -7485,7 +7580,7 @@ input ModelDeploymentNetworkAccessInput {
 """Added in 26.4.2. Health check configuration for a model service."""
 type ModelHealthCheck {
   """
-  Whether the route is health-checked. When false the route activates immediately.
+  Added in 26.4.4. Whether the route is health-checked. When false the route activates immediately and the remaining fields are ignored.
   """
   enable: Boolean!
 
@@ -7627,11 +7722,15 @@ type ModelMountConfig {
   """The vfolder of this entity."""
   vfolder: VirtualFolderNode
   vfolderId: ID!
+
+  """Path inside the container where the model is mounted."""
   mountDestination: String!
+
+  """Path to the model definition file within the mounted folder."""
   definitionPath: String!
 
   """
-  Added in 26.4.4. Subpath within the model vfolder. ``None`` means the vfolder root.
+  Added in 26.4.4. Subpath within the model vfolder. ``null`` means the vfolder root.
   """
   subpath: String
 }
@@ -7847,11 +7946,19 @@ type ModelRuntimeConfig {
   Added in 26.4.4. The runtime variant referenced by this runtime config.
   """
   runtimeVariant: RuntimeVariant
+
+  """
+  The runtime variant row id. Clients can resolve the full variant node via the ``runtime_variant`` field resolver.
+  """
   runtimeVariantId: UUID!
+
+  """Framework-specific configuration in JSON format."""
   inferenceRuntimeConfig: JSON
+
+  """Environment variables for the service, e.g. CUDA_VISIBLE_DEVICES=0."""
   environ: EnvironmentVariables
 
-  """Preset values materialised on this revision."""
+  """Added in 26.4.4. Preset values materialised on this revision."""
   runtimeVariantPresetValues: [RuntimeVariantPresetValue!]!
 }
 
@@ -7878,9 +7985,7 @@ type ModelServiceConfig {
   """Added in 26.7.0. Single-string command to start the model service."""
   command: String
 
-  """
-  Deprecated since 26.7.0. Command to start the model service. Do not set together with `command`; when both are set, `command` takes precedence and this field is ignored.
-  """
+  """Command to start the model service."""
   startCommand: [String!] @deprecated(reason: "Use `command` instead.")
 
   """
@@ -7999,10 +8104,10 @@ input MoveFileV2Input {
 Added in 26.4.2. Payload returned after moving a file in a virtual folder.
 """
 type MoveFileV2Payload {
-  """Source path that was moved"""
+  """Source path that was moved."""
   src: String!
 
-  """Destination path"""
+  """Destination path."""
   dst: String!
 }
 
@@ -8851,7 +8956,7 @@ type Mutation {
 Added in 26.4.2. Query result returning the current client's IP address.
 """
 type MyClientIp {
-  """The client's IP address as seen by the server"""
+  """The client's IP address as seen by the server."""
   clientIp: String!
 }
 
@@ -8880,6 +8985,7 @@ extend type NetworkNode implements Node @key(fields: "id") {
 Added in 26.8.0. Configures the maximum period without active network traffic.
 """
 type NetworkTimeoutIdleCheckerSpec {
+  """Maximum network inactivity period in seconds."""
   maxNetworkInactivitySeconds: Int!
 }
 
@@ -9081,7 +9187,10 @@ input NullableDateTimeFilter {
 Added in 26.3.0. Display number format configuration for a resource slot type.
 """
 type NumberFormat {
+  """Whether to use binary (1024-based) or decimal (1000-based) prefixes."""
   binary: Boolean!
+
+  """Number of decimal places to round to when displaying values."""
   roundLength: Int!
 }
 
@@ -9306,7 +9415,9 @@ input PreStartActionInput {
 
 """Added in 26.3.0. Preemption configuration for a resource group."""
 type PreemptionConfig {
-  """Whether preemption is enabled for this resource group (opt-in)."""
+  """
+  Added in 26.8.0. Whether preemption is enabled for this resource group (opt-in).
+  """
   enabled: Boolean!
 
   """Sessions with priority <= this value are eligible for preemption."""
@@ -9319,9 +9430,14 @@ type PreemptionConfig {
   mode: PreemptionMode!
 
   """
-  Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
+  Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled).
   """
   preemptionMinRuntime: Float!
+
+  """
+  Added in 26.8.1. Scope preemption victims are drawn from (USER, PROJECT, DOMAIN, RESOURCE_GROUP).
+  """
+  victimScope: PreemptionVictimScope!
 }
 
 """Added in 26.3.0. Input for preemption configuration."""
@@ -9344,6 +9460,11 @@ input PreemptionConfigInput {
   Added in 26.8.0. Minimum session runtime in seconds before it becomes preemptible (0 = disabled). Default is 0.
   """
   preemptionMinRuntime: Float! = 0
+
+  """
+  Added in 26.8.1. Scope preemption victims are drawn from (USER, PROJECT, DOMAIN, RESOURCE_GROUP). Default is USER.
+  """
+  victimScope: PreemptionVictimScope! = USER
 }
 
 """
@@ -9362,6 +9483,16 @@ enum PreemptionOrder {
   NEWEST
   FEWEST_SESSIONS
   SMALLEST_RESOURCES
+}
+
+"""
+Added in 26.8.1. Scope preemption victims are drawn from. USER limits victims to the pending session's owner; PROJECT/DOMAIN widen to sessions of the same project/domain; RESOURCE_GROUP allows any session in the resource group.
+"""
+enum PreemptionVictimScope {
+  USER
+  PROJECT
+  DOMAIN
+  RESOURCE_GROUP
 }
 
 """Added in 26.4.2. A resource preset with its availability status."""
@@ -9389,10 +9520,14 @@ type PresetAvailabilityV2 {
 Added in 26.4.2. Cluster topology settings for the deployment, defining whether the inference workload runs on a single node or is distributed across multiple nodes.
 """
 type PresetClusterSpec {
-  """Cluster mode."""
+  """
+  Deployment topology mode: 'single-node' runs on one node, 'multi-node' distributes across multiple nodes.
+  """
   clusterMode: String!
 
-  """Cluster size."""
+  """
+  Number of worker nodes in the cluster. For single-node mode, this is typically 1.
+  """
   clusterSize: Int!
 }
 
@@ -9400,13 +9535,15 @@ type PresetClusterSpec {
 Added in 26.4.2. Deployment-level defaults stored on the preset. Any null field means the preset does not specify a default and callers should fall back to user input or the system default.
 """
 type PresetDeploymentDefaults {
-  """Default open_to_public for deployments from this preset."""
+  """Default open_to_public for deployments created from this preset."""
   openToPublic: Boolean
 
-  """Default replica count for deployments from this preset."""
+  """Default replica count for deployments created from this preset."""
   replicaCount: Int
 
-  """Default revision history limit for deployments from this preset."""
+  """
+  Default revision history limit for deployments created from this preset.
+  """
   revisionHistoryLimit: Int
 
   """Default deployment strategy type (ROLLING or BLUE_GREEN)."""
@@ -9434,16 +9571,18 @@ input PresetDeploymentStrategyInput {
 Added in 26.4.2. Container execution configuration for the deployment, including the inference server image, startup commands, and environment variables.
 """
 type PresetExecutionSpec {
-  """Container image UUID."""
+  """UUID of the container image used to run the inference server."""
   imageId: UUID
 
-  """Startup command."""
+  """Command to start the inference server process inside the container."""
   startupCommand: String
 
-  """Bootstrap script."""
+  """
+  Script executed before the main process starts, used for setup tasks like downloading model weights.
+  """
   bootstrapScript: String
 
-  """Environment variables."""
+  """Environment variables injected into the inference container."""
   environ: [DeploymentRevisionPresetEnvironEntry!]!
 }
 
@@ -9577,7 +9716,7 @@ input PresetModelServiceConfigInput {
 Added in 26.4.2. Compute resource allocation for the deployment, specifying CPU, memory, and accelerator requirements along with additional resource options.
 """
 type PresetResourceAllocation {
-  """Additional resource options."""
+  """Additional resource options such as shared memory (shmem) size."""
   resourceOpts: [ResourceOptsEntry!]!
 }
 
@@ -9593,16 +9732,24 @@ enum PresetTarget {
 Added in 26.4.2. Specifies how a runtime variant preset value is applied to the inference container, either as an environment variable or a command-line argument.
 """
 type PresetTargetSpec {
-  """Target: env or args."""
+  """
+  How the value is applied to the container: 'env' sets it as an environment variable, 'args' appends it as a command-line argument.
+  """
   presetTarget: PresetTarget!
 
-  """Value type: str, int, float, bool, flag."""
+  """
+  Data type used for input validation (e.g., 'str', 'int', 'float', 'bool', 'flag').
+  """
   valueType: PresetValueType!
 
-  """Default value."""
+  """
+  The default value shown to users when they create a deployment using this preset.
+  """
   defaultValue: String
 
-  """Env key or args flag."""
+  """
+  For 'env' target, the environment variable name (e.g., VLLM_TENSOR_PARALLEL_SIZE); for 'args' target, the CLI flag name (e.g., --tensor-parallel).
+  """
   key: String!
 }
 
@@ -9633,7 +9780,7 @@ type ProjectBasicInfo {
   """Optional description of the project."""
   description: String
 
-  """Project type determining its purpose. See ProjectType enum."""
+  """Project type determining its purpose. See ProjectTypeV2 enum."""
   type: ProjectTypeV2!
 
   """External system integration identifier."""
@@ -10319,6 +10466,7 @@ input PurgeIdleCheckerAssignmentInput {
 Added in 26.8.0. Confirms that an idle checker assignment was permanently removed. The returned identifier refers to the deleted assignment.
 """
 type PurgeIdleCheckerAssignmentPayload {
+  """Purged idle checker assignment ID."""
   id: UUID!
 }
 
@@ -10332,6 +10480,7 @@ input PurgeIdleCheckerInput {
 Added in 26.8.0. Confirms that an idle checker was permanently removed. The returned identifier refers to the deleted checker.
 """
 type PurgeIdleCheckerPayload {
+  """Purged idle checker ID."""
   id: UUID!
 }
 
@@ -10366,7 +10515,7 @@ input PurgeRoleInput {
 
 """Added in 26.3.0. Payload for purge role mutation."""
 type PurgeRolePayload {
-  """ID of the purged role"""
+  """ID of the purged role."""
   id: UUID!
 }
 
@@ -11291,10 +11440,10 @@ input QueryDefinitionFilter {
 
 """Added in 26.3.0. Single metric result from Prometheus query."""
 type QueryDefinitionMetricResult {
-  """Label key-value pairs for this series"""
+  """Metric labels as key-value entries."""
   metric: [MetricLabelEntry!]!
 
-  """Data points (timestamp, value) for this series"""
+  """Time-series values."""
   values: [QueryDefinitionMetricResultValue!]!
 }
 
@@ -11345,19 +11494,19 @@ enum QueryDefinitionOrderField {
 
 """Added in 26.3.0. Prometheus query preset category."""
 type QueryPresetCategory {
-  """Category ID"""
+  """Category UUID."""
   id: UUID!
 
-  """Human-readable category name"""
+  """Human-readable category name."""
   name: String!
 
-  """Optional category description"""
+  """Optional category description."""
   description: String
 
-  """Creation timestamp"""
+  """Creation timestamp."""
   createdAt: DateTime!
 
-  """Last update timestamp"""
+  """Last update timestamp."""
   updatedAt: DateTime!
 }
 
@@ -11612,22 +11761,22 @@ type ReplaceResourceGroupDefaultSessionOptionsPayload {
 Added in 26.4.4. Failure detail for a single permission entry in replace
 """
 type ReplaceRolePermissionFailureInfo {
-  """Role ID of the failed entry"""
+  """Role ID of the failed entry."""
   roleId: UUID!
 
-  """Scope element type of the failed entry"""
+  """Scope element type of the failed entry."""
   scopeType: String!
 
-  """Scope element ID of the failed entry"""
+  """Scope element ID of the failed entry."""
   scopeId: String!
 
-  """Entity element type of the failed entry"""
+  """Entity element type of the failed entry."""
   entityType: String!
 
-  """Operation type of the failed entry"""
+  """Operation type of the failed entry."""
   operation: String!
 
-  """Error message describing the failure"""
+  """Error message describing the failure."""
   message: String!
 }
 
@@ -11643,10 +11792,10 @@ input ReplaceRolePermissionsInput {
 Added in 26.4.4. Payload for replacing a role's entire scoped-permission set
 """
 type ReplaceRolePermissionsPayload {
-  """Permission rows that make up the new set"""
+  """Permission rows that make up the new set."""
   items: [Permission!]!
 
-  """Permission entries that failed to insert"""
+  """Permission entries that failed to insert."""
   failed: [ReplaceRolePermissionFailureInfo!]!
 }
 
@@ -11883,18 +12032,16 @@ type ReservoirRegistryEdge {
 
 """Added in 26.2.0. Resource allocation with requested and used slots."""
 type ResourceAllocation {
-  """
-  The resource slots originally requested. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
-  """
+  """The resource slots originally requested for this kernel."""
   requested: ResourceSlot!
 
   """
-  The resource slots currently used. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  The resource slots currently used by this kernel. May be null if not yet allocated.
   """
   used: ResourceSlot
 
   """
-  The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing). Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
+  Added in 26.8.0. The resource slots actually allocated, computed from the resource_allocations table. Unlike `used`, this persists after the session/kernel is freed or terminated (for statistics and billing).
   """
   allocated: ResourceSlot
 }
@@ -11918,6 +12065,8 @@ type ResourceConfig {
   """The resource group of this entity."""
   resourceGroup: ScalingGroupNode
   resourceGroupName: String!
+
+  """Added in 26.1.0. Additional resource options such as shared memory."""
   resourceOpts: ResourceOpts
 }
 
@@ -12075,7 +12224,7 @@ type ResourceGroupSchedulerConfig {
   """
   type: SchedulerType!
 
-  """Preemption configuration for this resource group."""
+  """Added in 26.3.0. Preemption configuration for this resource group."""
   preemption: PreemptionConfig!
 }
 
@@ -12128,13 +12277,17 @@ input ResourceGroupUserScope {
 Added in 26.1.0. Resource information for a resource group. Provides aggregated resource metrics including capacity, used, and free resources.
 """
 type ResourceInfo {
-  """Total available resources"""
+  """
+  Total available resources from ALIVE, schedulable agents in this resource group.
+  """
   capacity: ResourceSlot!
 
-  """Currently occupied resources"""
+  """
+  Currently occupied resources from active kernels (RUNNING/TERMINATING status).
+  """
   used: ResourceSlot!
 
-  """Available resources (capacity - used)"""
+  """Available resources (capacity - used)."""
   free: ResourceSlot!
 }
 
@@ -12154,7 +12307,7 @@ type ResourceLimitEntry {
 Added in 26.1.0. A collection of additional resource options for a deployment. Contains key-value pairs for resource configuration like shared memory.
 """
 type ResourceOpts {
-  """List of resource option entries."""
+  """List of resource option entries. Each entry contains a key-value pair."""
   entries: [ResourceOptsEntry!]!
 }
 
@@ -12162,10 +12315,10 @@ type ResourceOpts {
 Added in 26.1.0. A single key-value entry representing a resource option. Contains additional resource configuration such as shared memory settings.
 """
 type ResourceOptsEntry {
-  """The name of this resource option (e.g., 'shmem')."""
+  """The name of this resource option. Example: 'shmem'."""
   name: String!
 
-  """The value for this resource option (e.g., '64m')."""
+  """The value for this resource option. Example: '64m'."""
   value: String!
 }
 
@@ -12252,7 +12405,9 @@ type ResourcePresetV2Edge {
 Added in 26.1.0. A collection of compute resource allocations. Represents the resources consumed, allocated, or available for a workload. Each entry specifies a resource type and its quantity.
 """
 type ResourceSlot {
-  """List of resource allocations"""
+  """
+  List of resource allocations. Each entry contains a resource type and quantity pair.
+  """
   entries: [ResourceSlotEntry!]!
 }
 
@@ -12260,10 +12415,14 @@ type ResourceSlot {
 Added in 26.1.0. A single entry representing one resource type and its allocated quantity. Resource types include compute resources (cpu, mem), accelerators (cuda.shares, cuda.device, rocm.device), and custom resources defined by plugins.
 """
 type ResourceSlotEntry {
-  """Resource type identifier (e.g., cpu, mem, cuda.shares)"""
+  """
+  Resource type identifier. Common types include: 'cpu' (CPU cores), 'mem' (memory in bytes), 'cuda.shares' (fractional GPU), 'cuda.device' (whole GPU devices), 'rocm.device' (AMD GPU devices). Custom accelerator plugins may define additional types.
+  """
   resourceType: String!
 
-  """Quantity of the resource"""
+  """
+  Quantity of the resource. For 'cpu': number of cores (e.g., 2.0, 0.5). For 'mem': bytes (e.g., 4294967296 for 4GB). For accelerators: device count or share fraction.
+  """
   quantity: Decimal!
 }
 
@@ -12381,13 +12540,19 @@ enum ResourceSlotTypeOrderField {
 Added in 26.2.0. Resource weight with default indicator. Shows whether this resource type's weight was explicitly set or uses default.
 """
 type ResourceWeightEntry {
-  """Resource type identifier"""
+  """
+  Resource type identifier (e.g., 'cpu', 'mem', 'cuda.device'). Matches the resource types available in the scaling group.
+  """
   resourceType: String!
 
-  """Weight multiplier for this resource type"""
+  """
+  Weight multiplier for this resource type in fair share calculations. Higher weight means more contribution to normalized usage.
+  """
   weight: Decimal!
 
-  """Whether this resource uses the resource group's default weight"""
+  """
+  Whether this resource uses the resource group's default weight. True means no explicit weight was configured for this type.
+  """
   usesDefault: Boolean!
 }
 
@@ -12427,7 +12592,7 @@ type RestoreArtifactsPayload {
 Added in 26.4.4. Payload returned after restoring a virtual folder from trash.
 """
 type RestoreVFolderPayload {
-  """ID of the restored virtual folder"""
+  """ID of the restored virtual folder."""
   id: UUID!
 }
 
@@ -13633,7 +13798,7 @@ type RuntimeVariantPresetValue {
   """The runtime variant preset this value is bound to."""
   preset: RuntimeVariantPreset
 
-  """Runtime variant preset ID."""
+  """The preset this value is bound to."""
   presetId: UUID!
 
   """Value bound to the preset."""
@@ -13644,10 +13809,10 @@ type RuntimeVariantPresetValue {
 Added in 26.4.4. A mapping of a runtime variant preset to a specific value, used to auto-configure runtime parameters when this deployment preset is applied.
 """
 type RuntimeVariantPresetValueEntry {
-  """Runtime variant preset ID."""
+  """The runtime variant preset that this value applies to."""
   presetId: UUID!
 
-  """Value for this preset."""
+  """The concrete value to set for the referenced preset parameter."""
   value: String!
 }
 
@@ -13765,7 +13930,7 @@ type ScanProjectModelCardsV2Payload {
   """Number of newly created model cards."""
   createdCount: Int!
 
-  """Number of updated existing model cards."""
+  """Number of updated model cards."""
   updatedCount: Int!
 
   """Per-vfolder error messages."""
@@ -13955,11 +14120,22 @@ type ServiceCatalog implements Node {
 
 """Added in 26.3.0. An endpoint exposed by a service instance."""
 type ServiceCatalogEndpoint {
+  """Role of this endpoint (e.g., 'main', 'health')."""
   role: String!
+
+  """Network scope (e.g., 'public', 'private', 'internal')."""
   scope: String!
+
+  """Hostname or IP address."""
   address: String!
+
+  """Port number."""
   port: Int!
+
+  """Protocol (e.g., 'grpc', 'http', 'https')."""
   protocol: String!
+
+  """Additional metadata."""
   metadata: JSON
 }
 
@@ -14023,19 +14199,19 @@ input ServiceCatalogStatusFilter {
 Added in 26.2.0. A single service port entry representing an exposed service. Contains port mapping and protocol information for accessing services.
 """
 type ServicePortEntry {
-  """Name of the service"""
+  """Name of the service (e.g., 'jupyter', 'tensorboard', 'ssh')."""
   name: String!
 
-  """Protocol type (http, tcp, preopen, internal)"""
+  """Protocol type for this service port (http, tcp, preopen, internal)."""
   protocol: ServicePortProtocol!
 
-  """Port numbers inside the container"""
+  """Port numbers inside the container."""
   containerPorts: [Int!]!
 
-  """Mapped port numbers on the host"""
+  """Mapped port numbers on the host. May be null if not yet assigned."""
   hostPorts: [Int]!
 
-  """Whether this port is used for inference endpoints"""
+  """Whether this port is used for inference endpoints."""
   isInference: Boolean!
 }
 
@@ -14053,7 +14229,7 @@ enum ServicePortProtocol {
 Added in 26.2.0. A collection of exposed service ports. Each entry defines a service accessible through the compute session.
 """
 type ServicePorts {
-  """List of service port entries"""
+  """List of service port entries."""
   entries: [ServicePortEntry!]!
 }
 
@@ -14096,6 +14272,7 @@ enum SessionFailurePolicy {
 Added in 26.8.0. Configures the maximum lifetime of a running session. The checker expires a session after the configured duration is reached.
 """
 type SessionLifetimeIdleCheckerSpec {
+  """Maximum session lifetime in seconds."""
   maxLifetimeSeconds: Int!
 }
 
@@ -14365,7 +14542,7 @@ type SessionV2MetadataInfo {
   priority: Int!
 
   """
-  Preemption priority among the owner's own sessions. A pending session may reclaim another session's resources only when both belong to the same user and the other session's value is strictly lower, so equal values never preempt each other; among the eligible sessions the lowest value is reclaimed first. Independent of `priority`, which orders the pending queue and takes no part in this comparison.
+  Added in 26.8.0. Preemption priority among the owner's own sessions. A pending session may reclaim another session's resources only when both belong to the same user and the other session's value is strictly lower, so equal values never preempt each other; among the eligible sessions the lowest value is reclaimed first. Independent of `priority`, which orders the pending queue and takes no part in this comparison.
   """
   jobPriority: Int!
 
@@ -14407,9 +14584,7 @@ enum SessionV2OrderField {
 
 """Added in 26.3.0. Resource allocation information for a session."""
 type SessionV2ResourceInfo {
-  """
-  Resource allocation with requested and occupied slots. Typed as Any because this field holds a nested GQL type (ResourceAllocationGQL).
-  """
+  """Resource allocation with requested and occupied slots."""
   allocation: ResourceAllocation!
 
   """The resource group (scaling group) this session is assigned to."""
@@ -14427,9 +14602,7 @@ enum SessionV2Result {
 
 """Added in 26.3.0. Runtime execution configuration for a session."""
 type SessionV2RuntimeInfo {
-  """
-  Environment variables for the session. Typed as Any because this field holds a nested GQL type (EnvironmentVariablesGQL).
-  """
+  """Environment variables for the session."""
   environ: EnvironmentVariables
 
   """Bootstrap script to run before the main process."""
@@ -14508,7 +14681,7 @@ type SourceInfo {
 Added in 26.4.2. A single storage host together with the permissions granted to a user.
 """
 type StorageHostPermission {
-  """Storage host name."""
+  """Storage host name (e.g., 'local:volume1')."""
   host: String!
 
   """Permissions granted to the current user on this storage host."""
@@ -14912,7 +15085,7 @@ input UpdateAppConfigAllowListInput {
 
 """Added in 26.8.0. Payload for app config allow-list entry update."""
 type UpdateAppConfigAllowListPayload {
-  """Updated app config allow-list entry."""
+  """The updated app config allow-list entry."""
   appConfigAllowList: AppConfigAllowList!
 }
 
@@ -14993,7 +15166,7 @@ input UpdateContainerRegistryInput {
 
 """Added in 26.4.2. Payload for container registry update mutation."""
 type UpdateContainerRegistryPayload {
-  """Updated container registry."""
+  """The updated container registry."""
   registry: ContainerRegistryV2!
 }
 
@@ -15173,6 +15346,7 @@ input UpdateIdleCheckerAssignmentInput {
 Added in 26.8.0. Returns the idle checker assignment after an update is applied. The node reflects the complete persisted state, including unchanged fields.
 """
 type UpdateIdleCheckerAssignmentPayload {
+  """Updated idle checker assignment."""
   idleCheckerAssignment: IdleCheckerAssignment!
 }
 
@@ -15205,6 +15379,7 @@ input UpdateIdleCheckerInput {
 Added in 26.8.0. Returns the idle checker after an update is applied. The node reflects the complete persisted state, including unchanged fields.
 """
 type UpdateIdleCheckerPayload {
+  """Updated idle checker."""
   idleChecker: IdleChecker!
 }
 
@@ -15250,7 +15425,7 @@ input UpdateKeypairResourcePolicyInput {
 
 """Added in 26.4.2. Payload for keypair resource policy update mutation."""
 type UpdateKeypairResourcePolicyPayload {
-  """Updated keypair resource policy."""
+  """The updated keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
 
@@ -15267,7 +15442,7 @@ input UpdateLoginClientTypeInput {
 
 """Added in 26.4.2. Payload for login client type update."""
 type UpdateLoginClientTypePayload {
-  """Updated login client type."""
+  """The updated login client type."""
   loginClientType: LoginClientType!
 }
 
@@ -15456,7 +15631,7 @@ input UpdateProjectResourcePolicyInput {
 
 """Added in 26.4.2. Payload for project resource policy update mutation."""
 type UpdateProjectResourcePolicyPayload {
-  """Updated project resource policy."""
+  """The updated project resource policy."""
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
 
@@ -15561,7 +15736,7 @@ type UpdateResourceGroupPayload {
 
 """Added in 26.4.2. Payload for resource preset update."""
 type UpdateResourcePresetPayload {
-  """Updated resource preset."""
+  """The updated resource preset."""
   resourcePreset: ResourcePresetV2!
 }
 
@@ -15783,7 +15958,7 @@ input UpdateUserResourcePolicyInput {
 
 """Added in 26.4.2. Payload for user resource policy update mutation."""
 type UpdateUserResourcePolicyPayload {
-  """Updated user resource policy."""
+  """The updated user resource policy."""
   userResourcePolicy: UserResourcePolicyV2!
 }
 
@@ -15889,7 +16064,7 @@ input UpsertDomainFairShareWeightInput {
 
 """Added in 26.1.0. Payload for domain fair share weight upsert mutation."""
 type UpsertDomainFairShareWeightPayload {
-  """Updated domain fair share data"""
+  """The updated or created domain fair share record."""
   domainFairShare: DomainFairShare!
 }
 
@@ -15916,7 +16091,7 @@ input UpsertProjectFairShareWeightInput {
 Added in 26.1.0. Payload for project fair share weight upsert mutation.
 """
 type UpsertProjectFairShareWeightPayload {
-  """Updated project fair share data"""
+  """The updated or created project fair share record."""
   projectFairShare: ProjectFairShare!
 }
 
@@ -15944,7 +16119,7 @@ input UpsertUserFairShareWeightInput {
 
 """Added in 26.1.0. Payload for user fair share weight upsert mutation."""
 type UpsertUserFairShareWeightPayload {
-  """Updated user fair share data"""
+  """The updated or created user fair share record."""
   userFairShare: UserFairShare!
 }
 
@@ -16508,7 +16683,7 @@ type UserV2BasicInfo {
   """Optional description or notes about the user."""
   description: String
 
-  """External system integration identifier."""
+  """Added in 26.4.2. External system integration identifier."""
   integrationName: String
 }
 
@@ -16632,7 +16807,7 @@ type UserV2OrganizationInfo {
   """Name of the domain this user belongs to."""
   domainName: String
 
-  """User's role determining access permissions. See UserRole enum."""
+  """User's role determining access permissions. See UserRoleV2 enum."""
   role: UserRoleV2
 
   """Name of the user resource policy applied to this user."""
@@ -16647,7 +16822,7 @@ Added in 26.2.0. User security settings and authentication configuration. Contai
 """
 type UserV2SecurityInfo {
   """
-  List of allowed client IP addresses or CIDR ranges. If set, login is restricted to these IP addresses. Supports both IPv4 and IPv6 formats (e.g., '192.168.1.0/24', '::1').
+  List of allowed client IP addresses or CIDR ranges. If set, login is restricted to these IP addresses.
   """
   allowedClientIp: [String!]
 
@@ -16668,7 +16843,7 @@ Added in 26.2.0. User account status information. Contains current status and pa
 """
 type UserV2StatusInfo {
   """
-  Current account status. See UserStatus enum for possible values. Replaces the deprecated is_active field.
+  Current account status. See UserStatusV2 enum for possible values. Replaces the deprecated is_active field.
   """
   status: UserStatusV2!
 
@@ -16704,7 +16879,10 @@ input UserWeightInputItem {
 Added in 26.8.0. Configures how long a session may remain underutilized.
 """
 type UtilizationIdleCheckerSpec {
+  """Maximum underutilized duration in seconds."""
   maxUnderutilizedDurationSeconds: Int!
+
+  """Preset-backed utilization threshold."""
   threshold: UtilizationIdleCheckerThreshold!
 }
 
@@ -16719,7 +16897,10 @@ input UtilizationIdleCheckerSpecInput {
 
 """Added in 26.8.0. Defines a preset-backed utilization threshold."""
 type UtilizationIdleCheckerThreshold {
+  """Prometheus query preset ID."""
   presetId: UUID!
+
+  """Underutilization threshold."""
   threshold: Decimal!
 
   """Added in 26.9.0. Label filters injected into the preset query."""
@@ -16825,7 +17006,14 @@ type VFolder implements Node {
 Added in 26.4.2. Access control information for a virtual folder. Includes the mount permission level (read-only, read-write, read-write-delete) and ownership type (user or project).
 """
 type VFolderAccessControlInfo {
+  """
+  Mount permission level: READ_ONLY (ro), READ_WRITE (rw), or RW_DELETE (wd).
+  """
   permission: VFolderMountPermission!
+
+  """
+  Ownership type: USER (personal folder) or GROUP (project-shared folder).
+  """
   ownershipType: VFolderOwnershipType!
 }
 
@@ -16854,22 +17042,22 @@ type VFolderEdge {
 
 """Added in 26.4.2. A file or directory entry inside a virtual folder."""
 type VFolderFileEntryV2 {
-  """File or directory name"""
+  """File or directory name."""
   name: String!
 
-  """Entry type"""
+  """Entry type (FILE, DIRECTORY, SYMLINK)."""
   type: String!
 
-  """File size in bytes"""
+  """File size in bytes."""
   size: Int!
 
-  """POSIX file permission mode (e.g., 33188 for 0o100644)"""
+  """POSIX file permission mode."""
   mode: Int!
 
-  """Creation timestamp"""
+  """Creation timestamp."""
   createdAt: String!
 
-  """Last modification timestamp"""
+  """Last modification timestamp."""
   updatedAt: String!
 }
 
@@ -16892,10 +17080,10 @@ input VFolderFilter {
 Added in 26.2.0. Storage host permission configuration. Defines what operations are allowed for a specific storage host.
 """
 type VFolderHostPermissionEntry {
-  """Virtual folder host name (e.g., 'default', 'nfs-vol1')."""
+  """Storage host identifier (e.g., 'default', 'storage-01')."""
   host: String!
 
-  """List of permission values (e.g., 'mount-in-session', 'upload-file')."""
+  """List of permissions granted for this host."""
   permissions: [VFolderHostPermissionV2!]!
 }
 
@@ -16926,11 +17114,26 @@ enum VFolderHostPermissionV2 {
 Added in 26.4.2. Descriptive metadata for a virtual folder. Includes the folder name, usage mode, quota scope, timestamps, and clone eligibility.
 """
 type VFolderMetadataInfo {
+  """Display name of the virtual folder."""
   name: String!
+
+  """
+  Usage mode: GENERAL (normal), MODEL (shared models), or DATA (shared datasets).
+  """
   usageMode: VFolderUsageMode!
+
+  """Quota scope identifier that governs storage limits for this folder."""
   quotaScopeId: String
+
+  """Timestamp when the virtual folder was created."""
   createdAt: DateTime!
+
+  """
+  Timestamp of the most recent access. Null if never accessed after creation.
+  """
   lastUsed: DateTime
+
+  """Whether this virtual folder can be cloned by other users."""
   cloneable: Boolean!
 }
 
@@ -17000,9 +17203,21 @@ type VFolderOwnershipInfo {
 
   """The user who originally created this virtual folder."""
   creator: UserV2
+
+  """
+  UUID of the user who owns this virtual folder. Null for project-owned folders.
+  """
   userId: UUID
+
+  """
+  UUID of the project that owns this virtual folder. Null for user-owned folders.
+  """
   projectId: UUID
+
+  """UUID of the user who originally created this virtual folder."""
   creatorId: UUID
+
+  """Email of the user who originally created this virtual folder."""
   creatorEmail: String
 }
 
@@ -17014,7 +17229,12 @@ enum VFolderOwnershipType {
 
 """Added in 26.4.4. Quota limits configured for a virtual folder."""
 type VFolderQuotaInfo {
+  """
+  Capacity quota limit in bytes with human-readable display. Null if unlimited.
+  """
   maxSize: BinarySizeInfo
+
+  """File-count quota for the folder."""
   maxFiles: Int!
 }
 
@@ -17022,7 +17242,14 @@ type VFolderQuotaInfo {
 Added in 26.4.4. Usage statistics for a virtual folder, measured live through the storage proxy.
 """
 type VFolderUsageInfo {
+  """
+  Number of files currently stored in the folder, measured live through the storage proxy.
+  """
   numFiles: Int!
+
+  """
+  Current used capacity in bytes with human-readable display, measured live through the storage proxy.
+  """
   usedBytes: BinarySizeInfo!
 }
 
@@ -17059,7 +17286,7 @@ input ValidateNotificationChannelInput {
 
 """Added in 26.3.0. Payload for validate notification channel mutation."""
 type ValidateNotificationChannelPayload {
-  """ID of the validated notification channel"""
+  """ID of the validated notification channel."""
   id: UUID!
 }
 

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -20797,10 +20797,26 @@
             "minimum": 0.0,
             "title": "Preemption Min Runtime",
             "type": "number"
+          },
+          "victim_scope": {
+            "$ref": "#/components/schemas/PreemptionVictimScope",
+            "default": "user",
+            "description": "Scope preemption victims are drawn from (user/project/domain/resource-group). Default is user."
           }
         },
         "title": "PreemptionConfigInputDTO",
         "type": "object"
+      },
+      "PreemptionVictimScope": {
+        "description": "Which sessions may become preemption victims for a pending session.\n\nUSER limits victims to the pending session's own sessions;\nPROJECT/DOMAIN widen to sessions of the same project/domain;\nRESOURCE_GROUP allows any session in the resource group.",
+        "enum": [
+          "user",
+          "project",
+          "domain",
+          "resource-group"
+        ],
+        "title": "PreemptionVictimScope",
+        "type": "string"
       },
       "UpdateResourceGroupConfigInput": {
         "description": "Input for updating resource group configuration via GQL (all fields optional).",

--- a/src/ai/backend/common/dto/manager/v2/resource_group/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/request.py
@@ -19,6 +19,7 @@ from ai.backend.common.dto.manager.v2.resource_group.types import (
 )
 from ai.backend.common.dto.manager.v2.session_options import DefaultSessionOptionsInput
 from ai.backend.common.identifier.resource_group import ResourceGroupName
+from ai.backend.common.types import PreemptionVictimScope
 
 __all__ = (
     "AdminSearchResourceGroupsInput",
@@ -210,6 +211,13 @@ class PreemptionConfigInputDTO(BaseRequestModel):
         ge=0.0,
         description=(
             "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+        ),
+    )
+    victim_scope: PreemptionVictimScope = Field(
+        default=PreemptionVictimScope.USER,
+        description=(
+            "Scope preemption victims are drawn from (user/project/domain/resource-group). "
+            "Default is user."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/resource_group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_group/response.py
@@ -23,7 +23,7 @@ from ai.backend.common.dto.manager.v2.resource_group.types import (
 )
 from ai.backend.common.dto.manager.v2.session_options import DefaultSessionOptionsInfo
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.types import PreemptionOrder
+from ai.backend.common.types import PreemptionOrder, PreemptionVictimScope
 
 __all__ = (
     "AdminSearchResourceGroupsPayload",
@@ -131,6 +131,12 @@ class PreemptionConfigInfo(BaseResponseModel):
         description=(
             "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
         )
+    )
+    victim_scope: PreemptionVictimScope = Field(
+        default=PreemptionVictimScope.USER,
+        description=(
+            "Scope preemption victims are drawn from (user/project/domain/resource-group)."
+        ),
     )
 
 

--- a/src/ai/backend/common/dto/manager/v2/scaling_group/request.py
+++ b/src/ai/backend/common/dto/manager/v2/scaling_group/request.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.types import PreemptionOrder
+from ai.backend.common.types import PreemptionOrder, PreemptionVictimScope
 
 from .types import PreemptionMode, SchedulerType
 
@@ -44,6 +44,13 @@ class PreemptionConfigInput(BaseRequestModel):
         description=(
             "Minimum session runtime in seconds before it becomes preemptible "
             "(0 = disabled). Default is 0."
+        ),
+    )
+    victim_scope: PreemptionVictimScope = Field(
+        default=PreemptionVictimScope.USER,
+        description=(
+            "Scope preemption victims are drawn from (user/project/domain/resource-group). "
+            "Default is user."
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/scaling_group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/scaling_group/response.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.types import PreemptionOrder
+from ai.backend.common.types import PreemptionOrder, PreemptionVictimScope
 
 from .types import PreemptionMode, SchedulerType
 
@@ -77,6 +77,12 @@ class PreemptionConfigInfo(BaseResponseModel):
     preemption_min_runtime: float = Field(
         description=(
             "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+        ),
+    )
+    victim_scope: PreemptionVictimScope = Field(
+        default=PreemptionVictimScope.USER,
+        description=(
+            "Scope preemption victims are drawn from (user/project/domain/resource-group)."
         ),
     )
 

--- a/src/ai/backend/common/schema/resource_group.py
+++ b/src/ai/backend/common/schema/resource_group.py
@@ -11,7 +11,12 @@ from datetime import timedelta
 
 from pydantic import ConfigDict, field_serializer
 
-from ai.backend.common.types import BackendAISchema, PreemptionMode, PreemptionOrder
+from ai.backend.common.types import (
+    BackendAISchema,
+    PreemptionMode,
+    PreemptionOrder,
+    PreemptionVictimScope,
+)
 
 __all__ = ("PreemptionConfig",)
 
@@ -33,6 +38,9 @@ class PreemptionConfig(BackendAISchema):
 
     preemption_min_runtime: timedelta = timedelta(seconds=0)
     """Minimum session runtime before it becomes preemptible (0 = disabled)"""
+
+    victim_scope: PreemptionVictimScope = PreemptionVictimScope.USER
+    """Which owner scope preemption victims are drawn from"""
 
     @field_serializer("order", mode="plain")
     def serialize_order(self, value: PreemptionOrder) -> str:

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -131,6 +131,7 @@ __all__ = (
     "MovingStatValue",
     "PreemptionMode",
     "PreemptionOrder",
+    "PreemptionVictimScope",
     "PromMetric",
     "PromMetricGroup",
     "PromMetricPrimitive",
@@ -2272,6 +2273,20 @@ class PreemptionOrder(enum.StrEnum):
     NEWEST = "newest"
     FEWEST_SESSIONS = "fewest-sessions"
     SMALLEST_RESOURCES = "smallest-resources"
+
+
+class PreemptionVictimScope(enum.StrEnum):
+    """Which sessions may become preemption victims for a pending session.
+
+    USER limits victims to the pending session's own sessions;
+    PROJECT/DOMAIN widen to sessions of the same project/domain;
+    RESOURCE_GROUP allows any session in the resource group.
+    """
+
+    USER = "user"
+    PROJECT = "project"
+    DOMAIN = "domain"
+    RESOURCE_GROUP = "resource-group"
 
 
 class SchedulerStatus(TypedDict):

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -647,6 +647,7 @@ class ResourceGroupAdapter(BaseAdapter):
                     preemption_min_runtime=timedelta(
                         seconds=input.preemption.preemption_min_runtime
                     ),
+                    victim_scope=input.preemption.victim_scope,
                 )
             )
 
@@ -868,6 +869,7 @@ class ResourceGroupAdapter(BaseAdapter):
                     order=data.scheduler.options.preemption.order,
                     mode=PreemptionModeDTO(data.scheduler.options.preemption.mode.value),
                     preemption_min_runtime=data.scheduler.options.preemption.preemption_min_runtime.total_seconds(),
+                    victim_scope=data.scheduler.options.preemption.victim_scope,
                 ),
             ),
             default_deployment_options=deployment_options_to_info(data.default_deployment_options),

--- a/src/ai/backend/manager/api/gql/decorators.py
+++ b/src/ai/backend/manager/api/gql/decorators.py
@@ -33,6 +33,7 @@ from pydantic import BaseModel
 from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
 from strawberry.relay import Connection
 from strawberry.schema_directives import OneOf
+from strawberry.types.base import get_object_definition
 from strawberry.types.field import StrawberryField
 from strawberry.types.field import field as strawberry_field
 
@@ -206,8 +207,14 @@ def gql_pydantic_type[PydanticModel: BaseModel](
     Strawberry auto-generates from_pydantic() and to_pydantic() methods.
     Use all_fields=True for scalar-only types, or declare fields explicitly
     for types with nested GQL node fields.
+
+    Field descriptions declared via ``gql_field``/``gql_added_field`` take
+    precedence over the DTO's ``Field(description=...)``: Strawberry's
+    pydantic integration rebuilds every resolver-less field with the
+    pydantic description, so the declared ones are restored after wrapping
+    (the DTO description remains the fallback).
     """
-    return strawberry.experimental.pydantic.type(
+    strawberry_wrap = strawberry.experimental.pydantic.type(
         model=model,
         name=name,
         description=_build_description(meta),
@@ -215,6 +222,21 @@ def gql_pydantic_type[PydanticModel: BaseModel](
         all_fields=all_fields,
         use_pydantic_alias=use_pydantic_alias,
     )
+
+    def wrap(cls: type) -> type[StrawberryTypeFromPydantic[PydanticModel]]:
+        declared_descriptions = {
+            field_name: value.description
+            for field_name, value in vars(cls).items()
+            if isinstance(value, StrawberryField) and value.description is not None
+        }
+        wrapped = strawberry_wrap(cls)
+        for field in get_object_definition(wrapped, strict=True).fields:
+            declared = declared_descriptions.get(field.python_name)
+            if declared is not None:
+                field.description = declared
+        return wrapped
+
+    return wrap
 
 
 def gql_field(

--- a/src/ai/backend/manager/api/gql/resource_group/types.py
+++ b/src/ai/backend/manager/api/gql/resource_group/types.py
@@ -81,7 +81,7 @@ from ai.backend.common.dto.manager.v2.resource_group.response import (
     ReplaceResourceGroupDefaultSessionOptionsPayload as ReplaceResourceGroupDefaultSessionOptionsPayloadDTO,
 )
 from ai.backend.common.identifier.resource_group import ResourceGroupID
-from ai.backend.common.types import PreemptionOrder
+from ai.backend.common.types import PreemptionOrder, PreemptionVictimScope
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -115,6 +115,7 @@ __all__ = (
     "PreemptionConfigInput",
     "PreemptionModeGQL",
     "PreemptionOrderGQL",
+    "PreemptionVictimScopeGQL",
     "ResourceGroupFilterGQL",
     "ResourceGroupGQL",
     "ResourceGroupMetadataGQL",
@@ -176,6 +177,20 @@ PreemptionOrderGQL: type[PreemptionOrder] = gql_enum(
 )
 
 
+PreemptionVictimScopeGQL: type[PreemptionVictimScope] = gql_enum(
+    BackendAIGQLMeta(
+        added_version="26.8.1",
+        description=(
+            "Scope preemption victims are drawn from. USER limits victims to the "
+            "pending session's owner; PROJECT/DOMAIN widen to sessions of the same "
+            "project/domain; RESOURCE_GROUP allows any session in the resource group."
+        ),
+    ),
+    PreemptionVictimScope,
+    name="PreemptionVictimScope",
+)
+
+
 @gql_pydantic_type(
     BackendAIGQLMeta(
         added_version="26.3.0",
@@ -205,6 +220,14 @@ class PreemptionConfigGQL(PydanticOutputMixin[PreemptionConfigInfo]):
             added_version="26.8.0",
             description=(
                 "Minimum session runtime in seconds before it becomes preemptible (0 = disabled)."
+            ),
+        )
+    )
+    victim_scope: PreemptionVictimScopeGQL = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.8.1",
+            description=(
+                "Scope preemption victims are drawn from (USER, PROJECT, DOMAIN, RESOURCE_GROUP)."
             ),
         )
     )
@@ -501,6 +524,16 @@ class PreemptionConfigInput(PydanticInputMixin[PreemptionConfigInputDTO]):
             ),
         ),
         default=0.0,
+    )
+    victim_scope: PreemptionVictimScopeGQL = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.8.1",
+            description=(
+                "Scope preemption victims are drawn from (USER, PROJECT, DOMAIN, "
+                "RESOURCE_GROUP). Default is USER."
+            ),
+        ),
+        default=PreemptionVictimScopeGQL.USER,
     )
 
 

--- a/src/ai/backend/manager/data/scaling_group/types.py
+++ b/src/ai/backend/manager/data/scaling_group/types.py
@@ -16,6 +16,7 @@ from ai.backend.common.types import (
     BackendAISchema,
     PreemptionMode,
     PreemptionOrder,
+    PreemptionVictimScope,
     ResourceSlot,
     SessionTypes,
     SlotQuantity,
@@ -78,6 +79,7 @@ class PreemptionConfig:
     order: PreemptionOrder = PreemptionOrder.OLDEST
     mode: PreemptionMode = PreemptionMode.TERMINATE
     preemption_min_runtime: timedelta = timedelta(seconds=0)
+    victim_scope: PreemptionVictimScope = PreemptionVictimScope.USER
 
 
 @dataclass
@@ -109,6 +111,7 @@ class ScalingGroupSchedulerOptions:
                 "order": self.preemption.order.value,
                 "mode": self.preemption.mode.value,
                 "preemption_min_runtime": self.preemption.preemption_min_runtime.total_seconds(),
+                "victim_scope": self.preemption.victim_scope.value,
             },
         }
 

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -369,6 +369,7 @@ class ScalingGroupRow(CreatedAtMixin, Base):
                         order=self.scheduler_opts.preemption.order,
                         mode=self.scheduler_opts.preemption.mode,
                         preemption_min_runtime=self.scheduler_opts.preemption.preemption_min_runtime,
+                        victim_scope=self.scheduler_opts.preemption.victim_scope,
                     ),
                 ),
             ),

--- a/src/ai/backend/manager/repositories/scaling_group/updaters.py
+++ b/src/ai/backend/manager/repositories/scaling_group/updaters.py
@@ -147,6 +147,7 @@ class ScalingGroupSchedulerConfigUpdaterSpec(UpdaterSpec[ScalingGroupRow]):
                 "order": preemption.order.value,
                 "mode": preemption.mode.value,
                 "preemption_min_runtime": preemption.preemption_min_runtime.total_seconds(),
+                "victim_scope": preemption.victim_scope.value,
             }
             to_update["scheduler_opts"] = func.jsonb_set(
                 sa.literal_column("scheduler_opts"),

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -43,6 +43,7 @@ from ai.backend.common.types import (
     ClusterMode,
     KernelId,
     PreemptionMode,
+    PreemptionVictimScope,
     ResourceSlot,
     SessionId,
     SessionTypes,
@@ -173,14 +174,15 @@ from ai.backend.manager.views.sokovan.snapshot import (
     ResourceLimit,
     ResourceOccupancySnapshot,
     ResourcePolicySnapshot,
+    ScopeVictimCandidates,
     SessionDependencySnapshot,
     SlotAllocation,
     UserResourceAllocation,
     UserResourceLimit,
-    UserVictimCandidates,
 )
 from ai.backend.manager.views.sokovan.workload import (
     KernelWorkload,
+    PreemptionScopeKey,
     ResourceRequest,
     SessionDependencyInfo,
     SessionGroupPolicy,
@@ -234,6 +236,19 @@ class _PreemptionCandidateAccumulator:
 
     row: sa.Row[Any]
     slots_by_agent: dict[AgentId, dict[ResourceSlotName, Decimal]]
+
+
+@dataclass(frozen=True)
+class _PreemptionScopeMatch:
+    """The victim scope projected onto the candidate query: the labeled
+    select/group-by columns of the session column victims are matched on,
+    and the per-scope-key priority prefilter. A group-wide scope
+    (RESOURCE_GROUP) has no matching column — ``group_wide_key`` then
+    carries the single key every candidate row groups under."""
+
+    scope_value_columns: list[sa.Label[Any]]
+    candidate_filter: sa.ColumnElement[bool]
+    group_wide_key: PreemptionScopeKey | None
 
 
 class ScheduleDBSource:
@@ -973,15 +988,19 @@ class ScheduleDBSource:
         pending_sessions: PendingSessions,
         observed_at: datetime,
     ) -> PreemptionCandidateSnapshot:
-        """Load this resource group's preemption victim candidates per owner.
+        """Load this resource group's preemption victim candidates per scope key.
 
         A candidate is one whole session (the preemption unit): a
         preemptible, non-private session that holds unfreed agent
         allocations (SCHEDULED onward, terminatable — same hold definition
-        as the occupancy scan), owned by a pending owner, with
-        ``job_priority`` strictly below that owner's max pending
+        as the occupancy scan), within a pending owner's victim scope, with
+        ``job_priority`` strictly below that scope's max pending
         ``job_priority`` — a superset of every per-pending comparison, so
-        no valid victim is dropped. With a minimum runtime configured,
+        no valid victim is dropped. The group's ``victim_scope`` decides
+        the grouping: the pending owners' scope keys, the session column
+        victims are matched on, and the key candidate rows are grouped
+        under all derive from it (RESOURCE_GROUP degenerates to one key
+        with no matching column). With a minimum runtime configured,
         sessions below it are dropped too (NULL ``starts_at`` counts as
         zero runtime). Candidates are unordered — reclaim ordering is
         per-pending, so it stays in the selection layer. No query runs
@@ -989,29 +1008,25 @@ class ScheduleDBSource:
         """
         if not resource_group.preemption.enabled:
             return PreemptionCandidateSnapshot.empty()
-        max_pending_priority: dict[UserID, int] = {}
+        scope = resource_group.preemption.victim_scope
+        max_pending_priority: dict[PreemptionScopeKey, int] = {}
         for workload in pending_sessions.sessions:
             # Private (SFTP/system) sessions never initiate preemption,
             # just as they are never victims
             if workload.is_private:
                 continue
-            owner = workload.meta.owner.user_uuid
-            current = max_pending_priority.get(owner)
+            key = workload.meta.preemption_scope_key(scope)
+            current = max_pending_priority.get(key)
             if current is None or workload.job_priority > current:
-                max_pending_priority[owner] = workload.job_priority
+                max_pending_priority[key] = workload.job_priority
         if not max_pending_priority:
             return PreemptionCandidateSnapshot.empty()
 
         ra = ResourceAllocationRow.__table__
         k = KernelRow.__table__
         s = SessionRow.__table__
-        # Victim prefilter: owned by a pending owner AND strictly below
-        # that owner's own max pending job_priority
-        candidate_filter = sa.or_(
-            *(
-                sa.and_(s.c.user_uuid == user_uuid, s.c.job_priority < threshold)
-                for user_uuid, threshold in max_pending_priority.items()
-            )
+        scope_match = self._preemption_scope_match(
+            scope, resource_group.meta.id, max_pending_priority
         )
         # Per allocation row the agent holds ``used`` once reported, else
         # the ``requested`` reservation — the amount freed on preemption.
@@ -1019,12 +1034,12 @@ class ScheduleDBSource:
         stmt = (
             sa.select(
                 s.c.id,
-                s.c.user_uuid,
                 s.c.job_priority,
                 s.c.starts_at,
                 k.c.agent,
                 ra.c.slot_name,
                 allocated_sum,
+                *scope_match.scope_value_columns,
             )
             .select_from(ra.join(k, ra.c.kernel_id == k.c.id).join(s, k.c.session_id == s.c.id))
             .where(
@@ -1033,18 +1048,18 @@ class ScheduleDBSource:
                 s.c.is_preemptible == sa.true(),
                 # Private (SFTP/system) sessions are never preemption victims
                 s.c.session_type.not_in(SessionTypes.private_types()),
-                candidate_filter,
+                scope_match.candidate_filter,
                 k.c.status.in_(KernelStatus.resource_holding_statuses()),
                 k.c.agent.is_not(None),
                 ra.c.free_at.is_(None),
             )
             .group_by(
                 s.c.id,
-                s.c.user_uuid,
                 s.c.job_priority,
                 s.c.starts_at,
                 k.c.agent,
                 ra.c.slot_name,
+                *scope_match.scope_value_columns,
             )
         )
         min_runtime = resource_group.preemption.preemption_min_runtime
@@ -1065,9 +1080,14 @@ class ScheduleDBSource:
                 ResourceSlotName(row.slot_name)
             ] = row.allocated
 
-        by_user: dict[UserID, list[PreemptionCandidate]] = defaultdict(list)
+        # Group candidate rows by their scope value — the key itself; a
+        # group-wide scope groups every row under the single group key.
+        by_key: dict[PreemptionScopeKey, list[PreemptionCandidate]] = defaultdict(list)
         for session_id, accumulator in candidates.items():
-            by_user[UserID(accumulator.row.user_uuid)].append(
+            row_key = scope_match.group_wide_key
+            if row_key is None:
+                row_key = PreemptionScopeKey(accumulator.row.scope_value)
+            by_key[row_key].append(
                 PreemptionCandidate(
                     session_id=session_id,
                     job_priority=accumulator.row.job_priority,
@@ -1076,10 +1096,58 @@ class ScheduleDBSource:
                 )
             )
         return PreemptionCandidateSnapshot(
-            by_user={
-                user_uuid: UserVictimCandidates(candidates=user_candidates)
-                for user_uuid, user_candidates in by_user.items()
-            }
+            scope=scope,
+            by_key={
+                key: ScopeVictimCandidates(candidates=scope_candidates)
+                for key, scope_candidates in by_key.items()
+            },
+        )
+
+    def _preemption_scope_column(self, scope: PreemptionVictimScope) -> sa.Column[Any] | None:
+        """Session column victims are matched (and grouped) on under the
+        scope; its value is the scope key (``WorkloadMeta.preemption_scope_key``).
+        None for RESOURCE_GROUP — the query is already filtered to the
+        group, so no further matching applies."""
+        s = SessionRow.__table__
+        match scope:
+            case PreemptionVictimScope.USER:
+                return s.c.user_uuid
+            case PreemptionVictimScope.PROJECT:
+                return s.c.group_id
+            case PreemptionVictimScope.DOMAIN:
+                return s.c.domain_id
+            case PreemptionVictimScope.RESOURCE_GROUP:
+                return None
+
+    def _preemption_scope_match(
+        self,
+        scope: PreemptionVictimScope,
+        resource_group_id: ResourceGroupID,
+        max_pending_priority: Mapping[PreemptionScopeKey, int],
+    ) -> _PreemptionScopeMatch:
+        """Project the victim scope into the candidate query's scope
+        points: the matching column's select/group-by labels and the
+        per-scope-key priority prefilter (victims strictly below that
+        scope's own max pending ``job_priority``). A group-wide scope
+        yields no labels and the group's single key instead."""
+        s = SessionRow.__table__
+        scope_column = self._preemption_scope_column(scope)
+        if scope_column is None:
+            group_wide_key = PreemptionScopeKey(resource_group_id)
+            return _PreemptionScopeMatch(
+                scope_value_columns=[],
+                candidate_filter=s.c.job_priority < max_pending_priority[group_wide_key],
+                group_wide_key=group_wide_key,
+            )
+        return _PreemptionScopeMatch(
+            scope_value_columns=[scope_column.label("scope_value")],
+            candidate_filter=sa.or_(
+                *(
+                    sa.and_(scope_column == key, s.c.job_priority < threshold)
+                    for key, threshold in max_pending_priority.items()
+                )
+            ),
+            group_wide_key=None,
         )
 
     async def mark_sessions_terminating(

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/provisioner.py
@@ -27,7 +27,7 @@ from ai.backend.manager.views.sokovan.allocation import (
 )
 from ai.backend.manager.views.sokovan.resource_group import ResourceGroupMeta
 from ai.backend.manager.views.sokovan.scheduling import SchedulingData
-from ai.backend.manager.views.sokovan.snapshot import SystemSnapshot, UserVictimCandidates
+from ai.backend.manager.views.sokovan.snapshot import ScopeVictimCandidates, SystemSnapshot
 from ai.backend.manager.views.sokovan.workload import SessionWorkload
 
 from .selectors.selector import (
@@ -336,11 +336,11 @@ class SessionProvisioner:
         state: SchedulingState,
         session_workload: SessionWorkload,
         claimed_victim_ids: set[SessionId],
-    ) -> UserVictimCandidates | None:
+    ) -> ScopeVictimCandidates | None:
         """The owner's victim candidates still unclaimed by this pass's
         earlier preemption plans (None when nothing is reclaimable)."""
-        owner_candidates = state.snapshot.resource_group.preemption_candidates.by_user.get(
-            session_workload.meta.owner.user_uuid
+        owner_candidates = state.snapshot.resource_group.preemption_candidates.candidates_for(
+            session_workload.meta
         )
         if owner_candidates is None:
             return None
@@ -351,7 +351,7 @@ class SessionProvisioner:
         ]
         if not remaining:
             return None
-        return UserVictimCandidates(candidates=remaining)
+        return ScopeVictimCandidates(candidates=remaining)
 
     @staticmethod
     def _build_session_allocation(

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/selectors/selector.py
@@ -29,7 +29,7 @@ from ai.backend.manager.data.session.options import AgentSelectionPolicy
 from ai.backend.manager.sokovan.recorder.context import RecorderContext
 from ai.backend.manager.sokovan.recorder.recorder import TransitionRecorder
 from ai.backend.manager.views.sokovan.agent import AgentInfo, AgentLimit
-from ai.backend.manager.views.sokovan.snapshot import PreemptionCandidate, UserVictimCandidates
+from ai.backend.manager.views.sokovan.snapshot import PreemptionCandidate, ScopeVictimCandidates
 from ai.backend.manager.views.sokovan.workload import (
     ResourceRequest,
     SessionGroupPolicy,
@@ -99,7 +99,7 @@ class AgentSelectionCriteria:
     job_priority: int
     # The owner's preemption victim candidates (None disables the
     # preemption path, e.g. the fitting check)
-    victim_candidates: UserVictimCandidates | None
+    victim_candidates: ScopeVictimCandidates | None
     # Placement policy of the session's group (None means unconstrained)
     session_group: SessionGroupPolicy | None
 
@@ -108,7 +108,7 @@ class AgentSelectionCriteria:
         cls,
         workload: SessionWorkload,
         plan: PlacementPlan,
-        victim_candidates: UserVictimCandidates | None,
+        victim_candidates: ScopeVictimCandidates | None,
     ) -> AgentSelectionCriteria:
         """Project a session workload (and its grouped plan) into criteria."""
         return cls(
@@ -457,7 +457,7 @@ class AgentSelector:
         strategy: AgentSelectionStrategy,
         trackers: Sequence[AgentStateTracker],
         candidates: Sequence[AgentStateTracker],
-        victims: UserVictimCandidates,
+        victims: ScopeVictimCandidates,
         criteria: AgentSelectionCriteria,
         resource_req: ResourceRequirements,
         limit: AgentLimit,
@@ -532,7 +532,7 @@ class AgentSelector:
         self,
         criteria: AgentSelectionCriteria,
         claimed_victims: Sequence[PreemptionCandidate],
-    ) -> UserVictimCandidates | None:
+    ) -> ScopeVictimCandidates | None:
         """The owner's victims this session may still reclaim (strictly
         lower job_priority, not already claimed), or None when the
         preemption path does not apply."""
@@ -547,7 +547,7 @@ class AgentSelector:
         ]
         if not reclaimable:
             return None
-        return UserVictimCandidates(candidates=reclaimable)
+        return ScopeVictimCandidates(candidates=reclaimable)
 
     def _reset_reclaims(
         self,

--- a/src/ai/backend/manager/views/sokovan/snapshot.py
+++ b/src/ai/backend/manager/views/sokovan/snapshot.py
@@ -17,14 +17,17 @@ from ai.backend.common.types import (
     AgentId,
     AgentSelectionStrategy,
     PreemptionOrder,
+    PreemptionVictimScope,
     SessionId,
 )
 
 from .agent import AgentLimit, ResourceGroupResource
 from .workload import (
+    PreemptionScopeKey,
     ResourceRequest,
     SessionDependencyInfo,
     SessionResourceRequest,
+    WorkloadMeta,
 )
 
 
@@ -239,8 +242,8 @@ class AgentVictimCandidates:
 
 
 @dataclass(frozen=True)
-class UserVictimCandidates:
-    """One owner's victim candidates with the per-agent decomposition derived.
+class ScopeVictimCandidates:
+    """One scope key's victim candidates with the per-agent decomposition derived.
 
     ``candidates`` is the stored form (one entry per session — the
     preemption unit); the per-agent grouping and reclaimable totals are
@@ -265,13 +268,18 @@ class UserVictimCandidates:
 
 @dataclass(frozen=True)
 class PreemptionCandidateSnapshot:
-    """Preemption victim candidates of the resource group, grouped per owner."""
+    """Preemption victim candidates of the resource group, grouped by the
+    scope key the group's victim scope derives."""
 
-    by_user: Mapping[UserID, UserVictimCandidates]
+    scope: PreemptionVictimScope
+    by_key: Mapping[PreemptionScopeKey, ScopeVictimCandidates]
 
     @classmethod
     def empty(cls) -> PreemptionCandidateSnapshot:
-        return PreemptionCandidateSnapshot(by_user={})
+        return PreemptionCandidateSnapshot(scope=PreemptionVictimScope.USER, by_key={})
+
+    def candidates_for(self, meta: WorkloadMeta) -> ScopeVictimCandidates | None:
+        return self.by_key.get(meta.preemption_scope_key(self.scope))
 
 
 @dataclass

--- a/src/ai/backend/manager/views/sokovan/workload.py
+++ b/src/ai/backend/manager/views/sokovan/workload.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from functools import cached_property
+from typing import NewType
+from uuid import UUID
 
 from ai.backend.common.identifier.architecture import ArchName
 from ai.backend.common.identifier.domain import DomainID
@@ -20,6 +22,7 @@ from ai.backend.common.types import (
     AgentId,
     ClusterMode,
     KernelId,
+    PreemptionVictimScope,
     SessionId,
     SessionResult,
     SessionTypes,
@@ -84,6 +87,12 @@ class WorkloadOwner:
     domain_id: DomainID
 
 
+PreemptionScopeKey = NewType("PreemptionScopeKey", UUID)
+"""Id of the scope entity one victim-candidate group belongs to: the user /
+project / domain id, or the resource group's own id for the RESOURCE_GROUP
+scope (one key for the whole snapshot, since scheduling runs per group)."""
+
+
 @dataclass(frozen=True)
 class WorkloadMeta:
     """Identity of one schedulable workload."""
@@ -91,6 +100,21 @@ class WorkloadMeta:
     session_id: SessionId
     resource_group_id: ResourceGroupID
     owner: WorkloadOwner
+
+    def preemption_scope_key(self, scope: PreemptionVictimScope) -> PreemptionScopeKey:
+        """Key of the scope entity this workload belongs to under the scope.
+
+        The single derivation shared by the candidate loader's grouping and
+        the snapshot's lookup."""
+        match scope:
+            case PreemptionVictimScope.USER:
+                return PreemptionScopeKey(self.owner.user_uuid)
+            case PreemptionVictimScope.PROJECT:
+                return PreemptionScopeKey(self.owner.project_id)
+            case PreemptionVictimScope.DOMAIN:
+                return PreemptionScopeKey(self.owner.domain_id)
+            case PreemptionVictimScope.RESOURCE_GROUP:
+                return PreemptionScopeKey(self.resource_group_id)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
+++ b/tests/unit/manager/repositories/scaling_group/test_scaling_group_repository.py
@@ -10,9 +10,16 @@ from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import ScalingGroupConflict
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.types import AccessKey, DefaultForUnspecified, ResourceSlot, SessionTypes
+from ai.backend.common.types import (
+    AccessKey,
+    DefaultForUnspecified,
+    PreemptionVictimScope,
+    ResourceSlot,
+    SessionTypes,
+)
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.types import RBACElementRef
+from ai.backend.manager.data.scaling_group.types import PreemptionConfig as DataPreemptionConfig
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.resource import ScalingGroupNotFound
@@ -737,6 +744,29 @@ class TestScalingGroupRepositoryDB:
         assert result.scheduler.name.value == "drf"
         assert SessionTypes.BATCH in result.scheduler.options.allowed_session_types
         assert result.network.use_host_network is True
+
+    async def test_update_preemption_victim_scope_round_trips(
+        self,
+        scaling_group_repository: ScalingGroupRepository,
+        sample_scaling_group_for_update: str,
+    ) -> None:
+        """A preemption-config update persists ``victim_scope`` and the
+        re-read data reflects it."""
+        spec = ScalingGroupUpdaterSpec(
+            scheduler=ScalingGroupSchedulerConfigUpdaterSpec(
+                preemption_config=OptionalState.update(
+                    DataPreemptionConfig(
+                        enabled=True,
+                        victim_scope=PreemptionVictimScope.DOMAIN,
+                    )
+                ),
+            ),
+        )
+        updater = Updater(spec=spec, pk_value=sample_scaling_group_for_update)
+        result = await scaling_group_repository.update_scaling_group(updater)
+
+        assert result.scheduler.options.preemption.enabled is True
+        assert result.scheduler.options.preemption.victim_scope == PreemptionVictimScope.DOMAIN
 
     async def test_update_scaling_group_not_found(
         self,

--- a/tests/unit/manager/repositories/scaling_group/test_updaters.py
+++ b/tests/unit/manager/repositories/scaling_group/test_updaters.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import pytest
 
-from ai.backend.common.types import PreemptionMode, PreemptionOrder
+from ai.backend.common.types import PreemptionMode, PreemptionOrder, PreemptionVictimScope
 from ai.backend.manager.data.scaling_group.types import PreemptionConfig
 from ai.backend.manager.repositories.scaling_group.updaters import (
     ScalingGroupSchedulerConfigUpdaterSpec,
@@ -18,6 +18,7 @@ def preemption_config() -> PreemptionConfig:
         order=PreemptionOrder.NEWEST,
         mode=PreemptionMode.RESCHEDULE,
         preemption_min_runtime=timedelta(seconds=30),
+        victim_scope=PreemptionVictimScope.PROJECT,
     )
 
 
@@ -37,4 +38,5 @@ class TestSchedulerConfigUpdater:
             "order": "newest",
             "mode": "reschedule",
             "preemption_min_runtime": 30.0,
+            "victim_scope": "project",
         }

--- a/tests/unit/manager/repositories/scheduler/test_preemption_candidates.py
+++ b/tests/unit/manager/repositories/scheduler/test_preemption_candidates.py
@@ -17,11 +17,11 @@ import sqlalchemy as sa
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
-from ai.backend.common.identifier.user import UserID
 from ai.backend.common.schema.resource_group import PreemptionConfig
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
+    PreemptionVictimScope,
     ResourceSlot,
     SecretKey,
     SessionId,
@@ -32,14 +32,22 @@ from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.agent import AgentRow
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.scheduler.db_source.db_source import ScheduleDBSource
+from ai.backend.manager.views.sokovan.workload import PreemptionScopeKey
 
 from .conftest import create_pending_session_with_kernels
+
+
+def _user_key(user_uuid: uuid.UUID) -> PreemptionScopeKey:
+    """Snapshot key of an owner under the default (user) victim scope."""
+    return PreemptionScopeKey(user_uuid)
 
 
 async def _create_allocated_session(
@@ -120,6 +128,52 @@ async def _create_extra_user(
         )
         await db_sess.flush()
     return user_uuid, access_key
+
+
+async def _create_extra_project(
+    db: ExtendedAsyncSAEngine,
+    *,
+    domain_name: str,
+    project_resource_policy: str,
+) -> uuid.UUID:
+    """Create a second project in the given domain."""
+    group_id = uuid.uuid4()
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            GroupRow(
+                id=group_id,
+                name=f"extra-group-{uuid.uuid4().hex[:8]}",
+                description="Extra test group",
+                is_active=True,
+                domain_name=domain_name,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts={},
+                resource_policy=project_resource_policy,
+            )
+        )
+        await db_sess.flush()
+    return group_id
+
+
+async def _create_extra_domain(
+    db: ExtendedAsyncSAEngine,
+) -> tuple[DomainID, str]:
+    """Create a second domain."""
+    domain_id = DomainID(uuid.uuid4())
+    domain_name = f"extra-domain-{uuid.uuid4().hex[:8]}"
+    async with db.begin_session() as db_sess:
+        db_sess.add(
+            DomainRow(
+                id=domain_id,
+                name=domain_name,
+                total_resource_slots=ResourceSlot({
+                    "cpu": Decimal("1000"),
+                    "mem": Decimal("1048576"),
+                }),
+            )
+        )
+        await db_sess.flush()
+    return domain_id, domain_name
 
 
 async def _create_extra_agent(
@@ -248,7 +302,7 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        assert fetch.preemption_candidates.by_user == {}
+        assert fetch.preemption_candidates.by_key == {}
 
     async def test_excludes_non_victim_sessions(
         self,
@@ -352,9 +406,10 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        by_user = fetch.preemption_candidates.by_user
-        assert set(by_user.keys()) == {UserID(test_user_uuid)}
-        candidates = by_user[UserID(test_user_uuid)].candidates
+        assert fetch.preemption_candidates.scope == PreemptionVictimScope.USER
+        by_key = fetch.preemption_candidates.by_key
+        assert set(by_key.keys()) == {_user_key(test_user_uuid)}
+        candidates = by_key[_user_key(test_user_uuid)].candidates
         assert [c.session_id for c in candidates] == [victim_id]
         candidate = candidates[0]
         assert candidate.job_priority == 5
@@ -413,7 +468,7 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        candidates = fetch.preemption_candidates.by_user[UserID(test_user_uuid)].candidates
+        candidates = fetch.preemption_candidates.by_key[_user_key(test_user_uuid)].candidates
         assert [c.session_id for c in candidates] == [scheduled_victim_id]
         # Pre-running candidate: reservation amounts, no execution start
         candidate = candidates[0]
@@ -519,10 +574,10 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        by_user = fetch.preemption_candidates.by_user
-        assert set(by_user.keys()) == {UserID(test_user_uuid), UserID(other_user)}
-        assert [c.session_id for c in by_user[UserID(test_user_uuid)].candidates] == [victim_id]
-        other_candidates = by_user[UserID(other_user)].candidates
+        by_key = fetch.preemption_candidates.by_key
+        assert set(by_key.keys()) == {_user_key(test_user_uuid), _user_key(other_user)}
+        assert [c.session_id for c in by_key[_user_key(test_user_uuid)].candidates] == [victim_id]
+        other_candidates = by_key[_user_key(other_user)].candidates
         assert [c.session_id for c in other_candidates] == [other_victim_id]
         assert other_candidates[0].job_priority == 2
 
@@ -607,9 +662,9 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        by_user = fetch.preemption_candidates.by_user
-        assert set(by_user.keys()) == {UserID(other_user)}
-        assert [c.session_id for c in by_user[UserID(other_user)].candidates] == [other_victim_id]
+        by_key = fetch.preemption_candidates.by_key
+        assert set(by_key.keys()) == {_user_key(other_user)}
+        assert [c.session_id for c in by_key[_user_key(other_user)].candidates] == [other_victim_id]
 
     async def test_reclaimable_totals_sum_owner_victims_per_agent(
         self,
@@ -666,7 +721,7 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        user_entry = fetch.preemption_candidates.by_user[UserID(test_user_uuid)]
+        user_entry = fetch.preemption_candidates.by_key[_user_key(test_user_uuid)]
         agent_entry = user_entry.by_agent[AgentId(test_agent_id)]
         assert {c.session_id for c in agent_entry.candidates} == victim_ids
         assert agent_entry.total_reclaimable == {
@@ -726,9 +781,9 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        by_user = fetch.preemption_candidates.by_user
-        assert set(by_user.keys()) == {UserID(test_user_uuid)}
-        user_entry = by_user[UserID(test_user_uuid)]
+        by_key = fetch.preemption_candidates.by_key
+        assert set(by_key.keys()) == {_user_key(test_user_uuid)}
+        user_entry = by_key[_user_key(test_user_uuid)]
         assert len(user_entry.candidates) == 1
         candidate = user_entry.candidates[0]
         assert candidate.session_id == victim_id
@@ -834,5 +889,287 @@ class TestFetchPreemptionCandidates:
         )
 
         assert fetch is not None
-        candidates = fetch.preemption_candidates.by_user[UserID(test_user_uuid)].candidates
+        candidates = fetch.preemption_candidates.by_key[_user_key(test_user_uuid)].candidates
         assert [c.session_id for c in candidates] == [old_victim_id]
+
+
+class TestPreemptionVictimScope:
+    """BA-7308: widening the victim pool by the group's ``victim_scope``."""
+
+    async def test_project_scope_pools_candidates_within_project(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        test_resource_policy_name: str,
+        test_user_resource_policy_name: str,
+        test_keypair_resource_policy_name: str,
+        resource_slot_types: None,
+    ) -> None:
+        """Other users' sessions in the same project qualify; other projects
+        and equal-or-higher priorities never do."""
+        await _set_preemption_config(
+            db_with_cleanup,
+            test_scaling_group_id,
+            PreemptionConfig(enabled=True, victim_scope=PreemptionVictimScope.PROJECT),
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        other_user, other_access_key = await _create_extra_user(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            user_resource_policy=test_user_resource_policy_name,
+            keypair_resource_policy=test_keypair_resource_policy_name,
+        )
+        # Included: another user's session in the pending owner's project
+        victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+        # Excluded: same project but job_priority not strictly below the max pending
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+        # Excluded: lower priority but in a different project
+        other_project = await _create_extra_project(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            project_resource_policy=test_resource_policy_name,
+        )
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=other_project,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        snapshot = fetch.preemption_candidates
+        assert snapshot.scope == PreemptionVictimScope.PROJECT
+        assert set(snapshot.by_key.keys()) == {PreemptionScopeKey(test_group_id)}
+        candidates = snapshot.by_key[PreemptionScopeKey(test_group_id)].candidates
+        assert [c.session_id for c in candidates] == [victim_id]
+
+    async def test_domain_scope_pools_candidates_across_projects(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        test_resource_policy_name: str,
+        test_user_resource_policy_name: str,
+        test_keypair_resource_policy_name: str,
+        resource_slot_types: None,
+    ) -> None:
+        """Any project inside the pending owner's domain qualifies; other
+        domains in the same resource group never do."""
+        await _set_preemption_config(
+            db_with_cleanup,
+            test_scaling_group_id,
+            PreemptionConfig(enabled=True, victim_scope=PreemptionVictimScope.DOMAIN),
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Included: another user's session in a different project of the same domain
+        other_user, other_access_key = await _create_extra_user(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            user_resource_policy=test_user_resource_policy_name,
+            keypair_resource_policy=test_keypair_resource_policy_name,
+        )
+        other_project = await _create_extra_project(
+            db_with_cleanup,
+            domain_name=test_domain_name,
+            project_resource_policy=test_resource_policy_name,
+        )
+        victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=5,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=other_project,
+            user_uuid=other_user,
+            access_key=other_access_key,
+        )
+        # Excluded: lower priority but in a different domain of the same group
+        extra_domain_id, extra_domain_name = await _create_extra_domain(db_with_cleanup)
+        extra_domain_project = await _create_extra_project(
+            db_with_cleanup,
+            domain_name=extra_domain_name,
+            project_resource_policy=test_resource_policy_name,
+        )
+        extra_domain_user, extra_domain_access_key = await _create_extra_user(
+            db_with_cleanup,
+            domain_name=extra_domain_name,
+            user_resource_policy=test_user_resource_policy_name,
+            keypair_resource_policy=test_keypair_resource_policy_name,
+        )
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=5,
+            domain_id=extra_domain_id,
+            domain_name=extra_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=extra_domain_project,
+            user_uuid=extra_domain_user,
+            access_key=extra_domain_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        snapshot = fetch.preemption_candidates
+        assert snapshot.scope == PreemptionVictimScope.DOMAIN
+        assert set(snapshot.by_key.keys()) == {PreemptionScopeKey(test_domain_id)}
+        candidates = snapshot.by_key[PreemptionScopeKey(test_domain_id)].candidates
+        assert [c.session_id for c in candidates] == [victim_id]
+
+    async def test_resource_group_scope_pools_all_sessions(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain_id: DomainID,
+        test_domain_name: str,
+        test_scaling_group_id: ResourceGroupID,
+        test_scaling_group_name: str,
+        test_group_id: uuid.UUID,
+        test_user_uuid: uuid.UUID,
+        test_access_key: AccessKey,
+        test_agent_id: str,
+        test_resource_policy_name: str,
+        test_user_resource_policy_name: str,
+        test_keypair_resource_policy_name: str,
+        resource_slot_types: None,
+    ) -> None:
+        """Every session in the resource group qualifies regardless of owner;
+        the priority rule still filters equal-or-higher victims."""
+        await _set_preemption_config(
+            db_with_cleanup,
+            test_scaling_group_id,
+            PreemptionConfig(enabled=True, victim_scope=PreemptionVictimScope.RESOURCE_GROUP),
+        )
+        await create_pending_session_with_kernels(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=test_domain_id,
+            domain_name=test_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=test_group_id,
+            user_uuid=test_user_uuid,
+            access_key=test_access_key,
+        )
+        # Included: a session of an entirely different domain/project/user
+        extra_domain_id, extra_domain_name = await _create_extra_domain(db_with_cleanup)
+        extra_domain_project = await _create_extra_project(
+            db_with_cleanup,
+            domain_name=extra_domain_name,
+            project_resource_policy=test_resource_policy_name,
+        )
+        extra_domain_user, extra_domain_access_key = await _create_extra_user(
+            db_with_cleanup,
+            domain_name=extra_domain_name,
+            user_resource_policy=test_user_resource_policy_name,
+            keypair_resource_policy=test_keypair_resource_policy_name,
+        )
+        victim_id = await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("2"), Decimal("4096"))],
+            job_priority=5,
+            domain_id=extra_domain_id,
+            domain_name=extra_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=extra_domain_project,
+            user_uuid=extra_domain_user,
+            access_key=extra_domain_access_key,
+        )
+        # Excluded: job_priority not strictly below the group's max pending
+        await _create_allocated_session(
+            db_with_cleanup,
+            agent_assignments=[(test_agent_id, Decimal("1"), Decimal("1024"))],
+            job_priority=10,
+            domain_id=extra_domain_id,
+            domain_name=extra_domain_name,
+            resource_group_id=test_scaling_group_id,
+            scaling_group_name=test_scaling_group_name,
+            group_id=extra_domain_project,
+            user_uuid=extra_domain_user,
+            access_key=extra_domain_access_key,
+        )
+
+        fetch = await ScheduleDBSource(db_with_cleanup).fetch_scheduling_fetch(
+            test_scaling_group_id
+        )
+
+        assert fetch is not None
+        snapshot = fetch.preemption_candidates
+        assert snapshot.scope == PreemptionVictimScope.RESOURCE_GROUP
+        assert set(snapshot.by_key.keys()) == {PreemptionScopeKey(test_scaling_group_id)}
+        candidates_entry = snapshot.by_key[PreemptionScopeKey(test_scaling_group_id)]
+        assert [c.session_id for c in candidates_entry.candidates] == [victim_id]

--- a/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_preemption_selection.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/selectors/test_preemption_selection.py
@@ -36,7 +36,7 @@ from ai.backend.manager.views.sokovan.agent import (
 )
 from ai.backend.manager.views.sokovan.snapshot import (
     PreemptionCandidate,
-    UserVictimCandidates,
+    ScopeVictimCandidates,
 )
 from ai.backend.manager.views.sokovan.workload import ResourceRequest
 
@@ -94,7 +94,7 @@ def _criteria(
     requirements: list[ResourceRequirements],
     *,
     job_priority: int,
-    victim_candidates: UserVictimCandidates | None,
+    victim_candidates: ScopeVictimCandidates | None,
 ) -> AgentSelectionCriteria:
     return AgentSelectionCriteria(
         session_id=SessionId(uuid.uuid4()),
@@ -133,7 +133,7 @@ class TestPreemptionPath:
         self,
         full_agent: list[AgentInfo],
     ) -> None:
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "2"}}),
                 _victim(NEW_SESSION, 1, 2024, {"agent-a": {"cpu": "2"}}),
@@ -160,7 +160,7 @@ class TestPreemptionPath:
         self,
         full_agent: list[AgentInfo],
     ) -> None:
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "2"}}),
                 _victim(NEW_SESSION, 1, 2024, {"agent-a": {"cpu": "2"}}),
@@ -183,7 +183,7 @@ class TestPreemptionPath:
         full_agent: list[AgentInfo],
     ) -> None:
         """job_priority ascending precedes the order key."""
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(OLD_SESSION, 3, 2020, {"agent-a": {"cpu": "2"}}),
                 _victim(NEW_SESSION, 1, 2024, {"agent-a": {"cpu": "2"}}),
@@ -206,7 +206,7 @@ class TestPreemptionPath:
         full_agent: list[AgentInfo],
     ) -> None:
         """Only strictly lower job_priority sessions may be reclaimed."""
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(HIGH_PRIORITY_SESSION, 5, 2020, {"agent-a": {"cpu": "8"}}),
             ]
@@ -228,7 +228,7 @@ class TestPreemptionPath:
         self,
         full_agent: list[AgentInfo],
     ) -> None:
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "1"}}),
             ]
@@ -250,7 +250,7 @@ class TestPreemptionPath:
         self,
         full_agent: list[AgentInfo],
     ) -> None:
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "2"}}),
                 _victim(NEW_SESSION, 1, 2024, {"agent-a": {"cpu": "2"}}),
@@ -276,7 +276,7 @@ class TestPreemptionPath:
         small_a = SessionId(uuid.UUID(int=11))
         small_b = SessionId(uuid.UUID(int=12))
         big = SessionId(uuid.UUID(int=13))
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(small_a, 1, 2020, {"agent-many": {"cpu": "1"}}),
                 _victim(small_b, 1, 2021, {"agent-many": {"cpu": "1"}}),
@@ -301,7 +301,7 @@ class TestPreemptionPath:
         self,
         full_agent: list[AgentInfo],
     ) -> None:
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[_victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "4"}})]
         )
         criteria = _criteria([_req({"cpu": "2"})], job_priority=5, victim_candidates=victims)
@@ -326,7 +326,7 @@ class TestPreemptionPath:
         """A session with preemption reserves its resources for real: the
         diffs commit so later sessions see the paper occupancy, while the
         victims' credit is dropped (their resources are not free yet)."""
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[_victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "4"}})]
         )
         criteria = _criteria([_req({"cpu": "2"})], job_priority=5, victim_candidates=victims)
@@ -350,7 +350,7 @@ class TestMultiNodePreemption:
 
     async def test_one_victim_admits_both_kernels(self) -> None:
         agents = [_agent("agent-a", {"cpu": "8"}, used={"cpu": "8"})]
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[_victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "8"}})]
         )
         criteria = _criteria(
@@ -381,7 +381,7 @@ class TestMultiNodePreemption:
         """A victim already claimed by an earlier kernel cannot admit a
         later one again."""
         agents = [_agent("agent-a", {"cpu": "8"}, used={"cpu": "8"})]
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[_victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "2"}})]
         )
         criteria = _criteria(
@@ -408,7 +408,7 @@ class TestMultiNodePreemption:
             _agent("agent-a", {"cpu": "8"}, used={"cpu": "8"}),
             _agent("agent-b", {"cpu": "8"}, used={"cpu": "6"}),
         ]
-        victims = UserVictimCandidates(
+        victims = ScopeVictimCandidates(
             candidates=[
                 _victim(OLD_SESSION, 1, 2020, {"agent-a": {"cpu": "2"}, "agent-b": {"cpu": "2"}})
             ]


### PR DESCRIPTION
## Summary
- Add `PreemptionVictimScope` (`user` / `project` / `domain` / `resource-group`, default `user`) to the resource group preemption config, letting admins choose which sessions may become preemption victims for a pending session. The JSON `scheduler_opts` column needs no migration and existing groups keep the current per-user behavior.
- Generalize the victim-candidate snapshot from per-user to per-scope-key: `WorkloadMeta.preemption_scope_key` is the single key derivation shared by the loader's grouping and the provisioner's lookup, and the candidate query matches/groups on the scope's session column (`RESOURCE_GROUP` degenerates to one group-wide key with no matching column). The strict `job_priority` comparison is unchanged and applies within every scope.
- Expose `victim_scope` through the v2 DTOs, GraphQL types (marked `Added in 26.8.1.`), the adapter, and the scheduler-config updater. `gql_pydantic_type` now restores field descriptions declared with `gql_field`/`gql_added_field` over the DTO descriptions, so field-level version markers render in the SDL.

## Test plan
- [x] Scope scenarios against a real DB: unset/user default, project (same project other users in, other projects out), domain (cross-project in, other domains out), resource-group (whole group in), plus the equal-or-higher-priority exclusion in every scope (`test_preemption_candidates.py`)
- [x] Preemption config update round-trip including `victim_scope` (`test_scaling_group_repository.py`, `test_updaters.py`)
- [x] Selection-layer behavior unchanged under the renamed snapshot types (`test_preemption_selection.py`)

Backport: 26.8

Resolves BA-7308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13654.org.readthedocs.build/en/13654/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13654.org.readthedocs.build/ko/13654/

<!-- readthedocs-preview sorna-ko end -->