### PR TITLE
fix(BA-7252): honor X-Forwarded-URL only from trusted proxies

### DIFF
--- a/changes/13663.fix.md
+++ b/changes/13663.fix.md
@@ -1,1 +1,1 @@
-Honor the `X-Forwarded-URL` header when deriving the HMAC signature host and path only for requests coming from `manager.trusted-proxies`.
+Honor the `X-Forwarded-URL` header when deriving the HMAC signature host and path only for requests coming from `manager.trusted-proxies`, and resolve the client IP across any number of proxy hops instead of rejecting requests whose `X-Forwarded-For` hop count does not match.

--- a/changes/13663.fix.md
+++ b/changes/13663.fix.md
@@ -1,0 +1,1 @@
+Honor the `X-Forwarded-URL` header when deriving the HMAC signature host and path only for requests coming from `manager.trusted-proxies`.

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -191,8 +191,11 @@
   # List of trusted reverse proxy IP addresses or CIDR ranges. When configured,
   # the manager uses aiohttp_remotes.XForwardedStrict middleware to securely
   # resolve client IPs from X-Forwarded-For headers. Only proxies in this list
-  # are trusted to set forwarding headers. If empty (default), the manager falls
-  # back to manual X-Forwarded-For parsing.
+  # are trusted to set forwarding headers. The X-Forwarded-URL header, which
+  # overrides the host and path used for HMAC signature verification, is also
+  # honored only when the request comes from one of these proxies. If empty
+  # (default), the manager falls back to manual X-Forwarded-For parsing and
+  # accepts X-Forwarded-URL from any client, which is deprecated.
   # Added in 26.4.2
   trusted-proxies = ["10.0.0.0/8", "172.16.0.0/12"]
   # Event loop implementation to use for async operations. 'asyncio' is the

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -189,13 +189,14 @@
   # Added in 25.8.0
   ## ssl-privkey = "/etc/backend.ai/ssl/manager.key"
   # List of trusted reverse proxy IP addresses or CIDR ranges. When configured,
-  # the manager uses aiohttp_remotes.XForwardedStrict middleware to securely
-  # resolve client IPs from X-Forwarded-For headers. Only proxies in this list
-  # are trusted to set forwarding headers. The X-Forwarded-URL header, which
-  # overrides the host and path used for HMAC signature verification, is also
-  # honored only when the request comes from one of these proxies. If empty
-  # (default), the manager falls back to manual X-Forwarded-For parsing and
-  # accepts X-Forwarded-URL from any client, which is deprecated.
+  # the client IP is resolved by walking the X-Forwarded-For chain inwards from
+  # the peer of the connection and taking the first address that is not one of
+  # these proxies, so any number of proxy hops is supported. The X-Forwarded-URL
+  # header, which overrides the host and path used for HMAC signature
+  # verification, is honored only when the request comes directly from one of
+  # these proxies. If empty (default), the manager falls back to manual
+  # X-Forwarded-For parsing and accepts X-Forwarded-URL from any client, which
+  # is deprecated.
   # Added in 26.4.2
   trusted-proxies = ["10.0.0.0/8", "172.16.0.0/12"]
   # Event loop implementation to use for async operations. 'asyncio' is the

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -22,7 +22,7 @@ import ipaddress
 import logging
 import secrets
 import uuid
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from contextlib import ExitStack
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, Final
@@ -69,6 +69,9 @@ if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+TRUSTED_PROXY_NETWORKS_KEY: Final = "_trusted_proxy_networks"
+FORWARDED_URL_HEADER: Final = "X-Forwarded-URL"
 
 _whois_timezone_info: Final = {
     "A": 1 * 3600,
@@ -350,6 +353,79 @@ def _extract_auth_params(request: web.Request) -> tuple[str, str, str] | None:
         raise InvalidAuthParameters("Missing or malformed authorization parameters") from e
 
 
+def parse_trusted_proxy_networks(
+    raw_networks: Iterable[str],
+) -> list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]]:
+    """Parse the configured trusted proxy addresses or CIDR ranges.
+
+    A bare address is treated as a single-host network, and the wildcard form
+    (e.g. ``10.1.*.*``) accepted for ``allowed_client_ip`` is also allowed.
+    Raises ``InvalidIpAddressValue`` for a malformed entry.
+    """
+    return [ReadableCIDR(raw) for raw in raw_networks]
+
+
+def _peer_address(request: web.Request) -> str | None:
+    transport = request.transport
+    if transport is None:
+        return None
+    peername = transport.get_extra_info("peername")
+    if isinstance(peername, tuple) and peername:
+        return str(peername[0])
+    return None
+
+
+def is_from_trusted_proxy(request: web.Request) -> bool:
+    """Tell whether the request arrived directly from a configured trusted proxy.
+
+    The decision is made on the peer address of the connection, which a client
+    cannot forge.  Returns ``False`` when no trusted proxy is configured.
+    """
+    networks: list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]] = (
+        request.config_dict.get(TRUSTED_PROXY_NETWORKS_KEY, [])
+    )
+    if not networks:
+        return False
+    raw_peer = _peer_address(request)
+    if raw_peer is None:
+        return False
+    try:
+        peer = ipaddress.ip_address(raw_peer)
+    except ValueError:
+        return False
+    return any(peer in network.address for network in networks if network.address is not None)
+
+
+@functools.cache
+def _warn_forwarded_url_without_trusted_proxies() -> None:
+    log.warning(
+        "Accepting the X-Forwarded-URL header without verifying its origin because "
+        "manager.trusted-proxies is not configured. Configure manager.trusted-proxies; "
+        "this fallback will be removed in a future release."
+    )
+
+
+def _resolve_forwarded_url(request: web.Request) -> str | None:
+    """Return the ``X-Forwarded-URL`` value only when its origin may be trusted.
+
+    An untrusted origin is ignored rather than rejected so that a misconfigured
+    proxy cannot turn otherwise valid requests into hard failures.
+    """
+    upstream_url = request.headers.get(FORWARDED_URL_HEADER)
+    if upstream_url is None:
+        return None
+    if not request.config_dict.get(TRUSTED_PROXY_NETWORKS_KEY):
+        _warn_forwarded_url_without_trusted_proxies()
+        return upstream_url
+    if not is_from_trusted_proxy(request):
+        log.debug(
+            "ignored the X-Forwarded-URL header sent from an untrusted peer (peer:{})",
+            _peer_address(request),
+        )
+        return None
+    return upstream_url
+
+
 def check_date(request: web.Request) -> bool:
     raw_date = request.headers.get("Date")
     if not raw_date:
@@ -392,7 +468,7 @@ async def sign_request(sign_method: str, request: web.Request, secret_key: str) 
         body_hash = hashlib.new(hash_type, body).hexdigest()
         path = request.raw_path
         host = request.host
-        if upstream_url := request.headers.get("X-Forwarded-URL", None):
+        if upstream_url := _resolve_forwarded_url(request):
             parsed_url = urlparse(upstream_url)
             path = parsed_url.path
             host = parsed_url.netloc

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -375,25 +375,39 @@ def _peer_address(request: web.Request) -> str | None:
     return None
 
 
+def _trusted_proxy_networks(
+    request: web.Request,
+) -> list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]]:
+    networks: list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]] = (
+        request.config_dict.get(TRUSTED_PROXY_NETWORKS_KEY, [])
+    )
+    return networks
+
+
+def _is_trusted_address(
+    raw_address: str,
+    networks: list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]],
+) -> bool:
+    try:
+        address = ipaddress.ip_address(raw_address)
+    except ValueError:
+        return False
+    return any(address in network.address for network in networks if network.address is not None)
+
+
 def is_from_trusted_proxy(request: web.Request) -> bool:
     """Tell whether the request arrived directly from a configured trusted proxy.
 
     The decision is made on the peer address of the connection, which a client
     cannot forge.  Returns ``False`` when no trusted proxy is configured.
     """
-    networks: list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]] = (
-        request.config_dict.get(TRUSTED_PROXY_NETWORKS_KEY, [])
-    )
+    networks = _trusted_proxy_networks(request)
     if not networks:
         return False
     raw_peer = _peer_address(request)
     if raw_peer is None:
         return False
-    try:
-        peer = ipaddress.ip_address(raw_peer)
-    except ValueError:
-        return False
-    return any(peer in network.address for network in networks if network.address is not None)
+    return _is_trusted_address(raw_peer, networks)
 
 
 @functools.cache
@@ -492,15 +506,45 @@ async def sign_request(sign_method: str, request: web.Request, secret_key: str) 
         raise AuthorizationFailed("Invalid signature") from e
 
 
+def _forwarded_for_chain(request: web.Request) -> list[str]:
+    raw = request.headers.get("X-Forwarded-For")
+    if not raw:
+        return []
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+
+def _resolve_client_ip_via_trusted_proxies(
+    request: web.Request,
+    networks: list[ReadableCIDR[ipaddress.IPv4Network | ipaddress.IPv6Network]],
+) -> str | None:
+    """Walk the forwarding chain inwards and return the first untrusted address.
+
+    The chain runs from the outermost claim in ``X-Forwarded-For`` to the peer of
+    this connection.  Every trailing hop that belongs to a trusted proxy is
+    skipped, so the first address that is not one of them is the real client:
+    a client that forges ``X-Forwarded-For`` while connecting directly is caught
+    by its own peer address ending the walk.
+    """
+    chain = _forwarded_for_chain(request)
+    peer = _peer_address(request)
+    if peer is not None:
+        chain.append(peer)
+    for raw_address in reversed(chain):
+        if not _is_trusted_address(raw_address, networks):
+            return raw_address
+    return chain[0] if chain else None
+
+
 def extract_client_ip(request: web.Request) -> str | None:
     """Extract the client IP from the request.
 
-    When XForwardedStrict middleware is active, request.remote is already
-    resolved to the real client IP, so use it directly.  Otherwise, fall back
-    to manual X-Forwarded-For parsing (first IP in the comma-separated list).
+    With trusted proxies configured, the address is resolved from the forwarding
+    chain.  Otherwise, fall back to manual X-Forwarded-For parsing (first IP in
+    the comma-separated list).
     """
-    if request.app.get("_trusted_proxies_enabled"):
-        return request.remote
+    networks = _trusted_proxy_networks(request)
+    if networks:
+        return _resolve_client_ip_via_trusted_proxies(request, networks)
     raw: str | None = request.headers.get("X-Forwarded-For") or request.remote
     if raw:
         return raw.split(",")[0].strip()

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -823,7 +823,11 @@ class ManagerConfig(BaseConfigSchema):
                 "When configured, the manager uses aiohttp_remotes.XForwardedStrict middleware "
                 "to securely resolve client IPs from X-Forwarded-For headers. "
                 "Only proxies in this list are trusted to set forwarding headers. "
-                "If empty (default), the manager falls back to manual X-Forwarded-For parsing."
+                "The X-Forwarded-URL header, which overrides the host and path used for HMAC "
+                "signature verification, is also honored only when the request comes from one of "
+                "these proxies. "
+                "If empty (default), the manager falls back to manual X-Forwarded-For parsing and "
+                "accepts X-Forwarded-URL from any client, which is deprecated."
             ),
             added_version="26.4.2",
             example=ConfigExample(local="", prod='["10.0.0.0/8", "172.16.0.0/12"]'),

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -820,12 +820,12 @@ class ManagerConfig(BaseConfigSchema):
         BackendAIConfigMeta(
             description=(
                 "List of trusted reverse proxy IP addresses or CIDR ranges. "
-                "When configured, the manager uses aiohttp_remotes.XForwardedStrict middleware "
-                "to securely resolve client IPs from X-Forwarded-For headers. "
-                "Only proxies in this list are trusted to set forwarding headers. "
+                "When configured, the client IP is resolved by walking the X-Forwarded-For chain "
+                "inwards from the peer of the connection and taking the first address that is not "
+                "one of these proxies, so any number of proxy hops is supported. "
                 "The X-Forwarded-URL header, which overrides the host and path used for HMAC "
-                "signature verification, is also honored only when the request comes from one of "
-                "these proxies. "
+                "signature verification, is honored only when the request comes directly from one "
+                "of these proxies. "
                 "If empty (default), the manager falls back to manual X-Forwarded-For parsing and "
                 "accepts X-Forwarded-URL from any client, which is deprecated."
             ),

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -359,25 +359,11 @@ async def server_main(
             ),
         )
 
-        # Set up XForwardedStrict middleware if trusted proxies are configured.
-        # This must be inserted BEFORE auth middleware so that request.remote is
-        # resolved to the real client IP before authentication runs.
+        # Resolve forwarding headers only for requests arriving from these proxies.
         trusted_proxies = dep_resources.bootstrap.config_provider.config.manager.trusted_proxies
         root_app[TRUSTED_PROXY_NETWORKS_KEY] = parse_trusted_proxy_networks(trusted_proxies)
         if trusted_proxies:
-            from aiohttp_remotes import XForwardedStrict
-
-            xff_middleware = XForwardedStrict(
-                [trusted_proxies],
-                white_paths=root_app.get("auth_middleware_allowlist", []),
-            )
-            await xff_middleware.setup(root_app)
-            root_app["_trusted_proxies_enabled"] = True
-            log.info(
-                "XForwardedStrict middleware enabled with trusted proxies: {}", trusted_proxies
-            )
-        else:
-            root_app["_trusted_proxies_enabled"] = False
+            log.info("Trusting the forwarding headers set by proxies: {}", trusted_proxies)
 
         # Build and mount the API module tree.
         # Must happen before runner.setup() which freezes the application router.

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -62,6 +62,7 @@ from .api.rest.middleware import (
     build_auth_middleware,
     build_exception_middleware,
 )
+from .api.rest.middleware.auth import TRUSTED_PROXY_NETWORKS_KEY, parse_trusted_proxy_networks
 from .api.rest.routing import RouteRegistry
 from .config.bootstrap import BootstrapConfig
 from .config.unified import EventLoopType
@@ -362,6 +363,7 @@ async def server_main(
         # This must be inserted BEFORE auth middleware so that request.remote is
         # resolved to the real client IP before authentication runs.
         trusted_proxies = dep_resources.bootstrap.config_provider.config.manager.trusted_proxies
+        root_app[TRUSTED_PROXY_NETWORKS_KEY] = parse_trusted_proxy_networks(trusted_proxies)
         if trusted_proxies:
             from aiohttp_remotes import XForwardedStrict
 

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -34,6 +34,10 @@ from ai.backend.common.dto.manager.auth.request import (
     VerifyAuthRequest,
 )
 from ai.backend.manager.api.rest.auth.handler import AuthHandler
+from ai.backend.manager.api.rest.middleware.auth import (
+    TRUSTED_PROXY_NETWORKS_KEY,
+    parse_trusted_proxy_networks,
+)
 from ai.backend.manager.data.auth.types import AuthorizationResult, SSHKeypair
 from ai.backend.manager.dto.context import RequestCtx, UserContext
 from ai.backend.manager.models.user import UserRole, UserStatus
@@ -120,12 +124,21 @@ class TestGetMyIp:
     def _make_mock_request(
         xff: str | None = None,
         remote: str | None = None,
-        trusted_proxies_enabled: bool = False,
+        trusted_proxies: list[str] | None = None,
+        peer: str | None = None,
     ) -> MagicMock:
         mock_request = MagicMock(spec=web.Request)
         mock_request.headers.get.return_value = xff
         mock_request.remote = remote
-        mock_request.app.get.return_value = trusted_proxies_enabled
+        mock_request.config_dict = {
+            TRUSTED_PROXY_NETWORKS_KEY: parse_trusted_proxy_networks(trusted_proxies or [])
+        }
+        if peer is None:
+            mock_request.transport = None
+        else:
+            transport = MagicMock()
+            transport.get_extra_info.return_value = (peer, 54321)
+            mock_request.transport = transport
         return mock_request
 
     async def test_returns_client_ip_from_x_forwarded_for(
@@ -176,15 +189,15 @@ class TestGetMyIp:
         assert isinstance(data, dict)
         assert data["client_ip"] == "1.2.3.4"
 
-    async def test_returns_remote_when_trusted_proxies_enabled(
+    async def test_skips_trusted_hops_when_trusted_proxies_configured(
         self,
         handler: AuthHandler,
     ) -> None:
-        """When XForwardedStrict is active, use request.remote directly."""
+        """With trusted proxies, every trailing trusted hop is skipped."""
         mock_request = self._make_mock_request(
             xff="1.2.3.4, 10.0.0.1",
-            remote="1.2.3.4",
-            trusted_proxies_enabled=True,
+            trusted_proxies=["10.0.0.0/8"],
+            peer="10.0.0.2",
         )
         request_ctx = RequestCtx(request=mock_request)
 

--- a/tests/unit/manager/api/test_auth_trusted_proxy.py
+++ b/tests/unit/manager/api/test_auth_trusted_proxy.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from dateutil.tz import tzutc
+
+from ai.backend.common.exception import InvalidIpAddressValue
+from ai.backend.manager.api.rest.middleware import auth as auth_module
+from ai.backend.manager.api.rest.middleware.auth import (
+    FORWARDED_URL_HEADER,
+    TRUSTED_PROXY_NETWORKS_KEY,
+    is_from_trusted_proxy,
+    parse_trusted_proxy_networks,
+    sign_request,
+)
+
+SIGN_METHOD = "HMAC-SHA256"
+SECRET_KEY = "fake-secret-key"
+DEFAULT_HOST = "10.214.150.180:8081"
+DEFAULT_PATH = "/admin/gql"
+FORWARDED_URL = "https://example.invalid/proxied/admin/gql"
+TRUSTED_PROXY = "10.0.0.1"
+UNTRUSTED_PEER = "203.0.113.7"
+
+
+def _make_request(
+    *,
+    host: str = DEFAULT_HOST,
+    raw_path: str = DEFAULT_PATH,
+    forwarded_url: str | None = None,
+    peer: str | None = TRUSTED_PROXY,
+    trusted_proxies: list[str] | None = None,
+) -> web.Request:
+    date = datetime(2026, 8, 10, 3, 4, 5, tzinfo=tzutc())
+    state: dict[str, Any] = {"date": date, "raw_date": date.isoformat()}
+    headers = {"X-BackendAI-Version": "v8.20240915"}
+    if forwarded_url is not None:
+        headers[FORWARDED_URL_HEADER] = forwarded_url
+
+    request = MagicMock(spec=web.Request)
+    request.__getitem__.side_effect = state.__getitem__
+    request.headers = headers
+    request.method = "POST"
+    request.host = host
+    request.raw_path = raw_path
+    request.content_type = "application/json"
+    request.can_read_body = False
+    request.config_dict = {
+        TRUSTED_PROXY_NETWORKS_KEY: parse_trusted_proxy_networks(trusted_proxies or [])
+    }
+    if peer is None:
+        request.transport = None
+    else:
+        transport = MagicMock()
+        transport.get_extra_info.return_value = (peer, 54321)
+        request.transport = transport
+    return request
+
+
+@pytest.fixture(autouse=True)
+def reset_deprecation_warning() -> None:
+    auth_module._warn_forwarded_url_without_trusted_proxies.cache_clear()
+
+
+def test_parse_trusted_proxy_networks_accepts_bare_addresses_cidrs_and_wildcards() -> None:
+    networks = parse_trusted_proxy_networks(["10.0.0.1", "172.16.0.0/12", "10.1.*.*", "fd00::/8"])
+
+    assert [str(network) for network in networks] == [
+        "10.0.0.1/32",
+        "172.16.0.0/12",
+        "10.1.0.0/16",
+        "fd00::/8",
+    ]
+
+
+def test_parse_trusted_proxy_networks_rejects_invalid_value() -> None:
+    with pytest.raises(InvalidIpAddressValue):
+        parse_trusted_proxy_networks(["not-an-address"])
+
+
+def test_is_from_trusted_proxy_without_configuration() -> None:
+    request = _make_request(peer=TRUSTED_PROXY, trusted_proxies=[])
+
+    assert not is_from_trusted_proxy(request)
+
+
+def test_is_from_trusted_proxy_with_matching_peer() -> None:
+    request = _make_request(peer="10.1.2.3", trusted_proxies=["10.0.0.0/8"])
+
+    assert is_from_trusted_proxy(request)
+
+
+def test_is_from_trusted_proxy_with_unmatched_peer() -> None:
+    request = _make_request(peer=UNTRUSTED_PEER, trusted_proxies=["10.0.0.0/8"])
+
+    assert not is_from_trusted_proxy(request)
+
+
+def test_is_from_trusted_proxy_without_transport() -> None:
+    request = _make_request(peer=None, trusted_proxies=["10.0.0.0/8"])
+
+    assert not is_from_trusted_proxy(request)
+
+
+async def test_forwarded_url_is_ignored_from_untrusted_peer() -> None:
+    forwarded = _make_request(
+        forwarded_url=FORWARDED_URL,
+        peer=UNTRUSTED_PEER,
+        trusted_proxies=["10.0.0.0/8"],
+    )
+    plain = _make_request(peer=UNTRUSTED_PEER, trusted_proxies=["10.0.0.0/8"])
+
+    assert await sign_request(SIGN_METHOD, forwarded, SECRET_KEY) == await sign_request(
+        SIGN_METHOD, plain, SECRET_KEY
+    )
+
+
+async def test_forwarded_url_is_honored_from_trusted_peer() -> None:
+    forwarded = _make_request(
+        forwarded_url=FORWARDED_URL,
+        peer=TRUSTED_PROXY,
+        trusted_proxies=["10.0.0.0/8"],
+    )
+    upstream = _make_request(
+        host="example.invalid",
+        raw_path="/proxied/admin/gql",
+        peer=TRUSTED_PROXY,
+        trusted_proxies=["10.0.0.0/8"],
+    )
+
+    assert await sign_request(SIGN_METHOD, forwarded, SECRET_KEY) == await sign_request(
+        SIGN_METHOD, upstream, SECRET_KEY
+    )
+
+
+async def test_forwarded_url_is_honored_without_trusted_proxies_configured() -> None:
+    forwarded = _make_request(
+        forwarded_url=FORWARDED_URL,
+        peer=UNTRUSTED_PEER,
+        trusted_proxies=[],
+    )
+    upstream = _make_request(
+        host="example.invalid",
+        raw_path="/proxied/admin/gql",
+        peer=UNTRUSTED_PEER,
+        trusted_proxies=[],
+    )
+
+    assert await sign_request(SIGN_METHOD, forwarded, SECRET_KEY) == await sign_request(
+        SIGN_METHOD, upstream, SECRET_KEY
+    )
+
+
+async def test_deprecation_warning_is_logged_once_without_trusted_proxies(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger=auth_module.__spec__.name):
+        for _ in range(2):
+            await sign_request(
+                SIGN_METHOD,
+                _make_request(forwarded_url=FORWARDED_URL, trusted_proxies=[]),
+                SECRET_KEY,
+            )
+
+    warnings = [
+        record for record in caplog.records if "manager.trusted-proxies" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+async def test_no_warning_when_forwarded_url_is_absent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level("WARNING", logger=auth_module.__spec__.name):
+        await sign_request(SIGN_METHOD, _make_request(trusted_proxies=[]), SECRET_KEY)
+
+    assert not [
+        record for record in caplog.records if "manager.trusted-proxies" in record.getMessage()
+    ]

--- a/tests/unit/manager/api/test_auth_trusted_proxy.py
+++ b/tests/unit/manager/api/test_auth_trusted_proxy.py
@@ -13,6 +13,7 @@ from ai.backend.manager.api.rest.middleware import auth as auth_module
 from ai.backend.manager.api.rest.middleware.auth import (
     FORWARDED_URL_HEADER,
     TRUSTED_PROXY_NETWORKS_KEY,
+    extract_client_ip,
     is_from_trusted_proxy,
     parse_trusted_proxy_networks,
     sign_request,
@@ -32,6 +33,7 @@ def _make_request(
     host: str = DEFAULT_HOST,
     raw_path: str = DEFAULT_PATH,
     forwarded_url: str | None = None,
+    forwarded_for: str | None = None,
     peer: str | None = TRUSTED_PROXY,
     trusted_proxies: list[str] | None = None,
 ) -> web.Request:
@@ -40,10 +42,13 @@ def _make_request(
     headers = {"X-BackendAI-Version": "v8.20240915"}
     if forwarded_url is not None:
         headers[FORWARDED_URL_HEADER] = forwarded_url
+    if forwarded_for is not None:
+        headers["X-Forwarded-For"] = forwarded_for
 
     request = MagicMock(spec=web.Request)
     request.__getitem__.side_effect = state.__getitem__
     request.headers = headers
+    request.remote = peer
     request.method = "POST"
     request.host = host
     request.raw_path = raw_path
@@ -181,3 +186,71 @@ async def test_no_warning_when_forwarded_url_is_absent(
     assert not [
         record for record in caplog.records if "manager.trusted-proxies" in record.getMessage()
     ]
+
+
+class TestExtractClientIP:
+    """Client IP resolution over the X-Forwarded-For chain."""
+
+    def test_single_proxy_hop(self) -> None:
+        request = _make_request(
+            forwarded_for="203.0.113.9",
+            peer="10.0.0.1",
+            trusted_proxies=["10.0.0.0/8"],
+        )
+
+        assert extract_client_ip(request) == "203.0.113.9"
+
+    def test_multiple_trusted_hops(self) -> None:
+        request = _make_request(
+            forwarded_for="203.0.113.9, 10.0.0.5, 10.0.0.6",
+            peer="10.0.0.1",
+            trusted_proxies=["10.0.0.0/8"],
+        )
+
+        assert extract_client_ip(request) == "203.0.113.9"
+
+    def test_no_forwarded_for_falls_back_to_peer(self) -> None:
+        request = _make_request(peer="10.0.0.1", trusted_proxies=["10.0.0.0/8"])
+
+        assert extract_client_ip(request) == "10.0.0.1"
+
+    def test_forged_header_from_untrusted_peer_is_ignored(self) -> None:
+        request = _make_request(
+            forwarded_for="1.2.3.4",
+            peer=UNTRUSTED_PEER,
+            trusted_proxies=["10.0.0.0/8"],
+        )
+
+        assert extract_client_ip(request) == UNTRUSTED_PEER
+
+    def test_untrusted_hop_between_trusted_ones_wins(self) -> None:
+        request = _make_request(
+            forwarded_for="203.0.113.9, 198.51.100.4, 10.0.0.5",
+            peer="10.0.0.1",
+            trusted_proxies=["10.0.0.0/8"],
+        )
+
+        assert extract_client_ip(request) == "198.51.100.4"
+
+    def test_every_hop_trusted_returns_the_outermost(self) -> None:
+        request = _make_request(
+            forwarded_for="10.0.0.9, 10.0.0.5",
+            peer="10.0.0.1",
+            trusted_proxies=["10.0.0.0/8"],
+        )
+
+        assert extract_client_ip(request) == "10.0.0.9"
+
+    def test_without_trusted_proxies_takes_the_first_entry(self) -> None:
+        request = _make_request(
+            forwarded_for="203.0.113.9, 10.0.0.5",
+            peer="10.0.0.1",
+            trusted_proxies=[],
+        )
+
+        assert extract_client_ip(request) == "203.0.113.9"
+
+    def test_without_trusted_proxies_falls_back_to_remote(self) -> None:
+        request = _make_request(peer="10.0.0.1", trusted_proxies=[])
+
+        assert extract_client_ip(request) == "10.0.0.1"


### PR DESCRIPTION
## Summary

- `sign_request()` replaced the HMAC signature host and path with the client-supplied `X-Forwarded-URL` header without any trust check, so a client could choose the host its signature is bound to (defeating endpoint binding) and have the signature cover a path other than the one actually routed. The header is now honored only when the connection peer matches `manager.trusted-proxies`; an untrusted origin is ignored rather than rejected, so a misconfigured proxy cannot turn otherwise valid requests into hard failures.
- Enabling `manager.trusted-proxies` was itself unusable, which made that gate unreachable. `XForwardedStrict([trusted_proxies])` declares exactly **one** trusted hop regardless of how many entries the setting holds, and `remote_ip()` rejects any request whose hop count differs — so every request without exactly one `X-Forwarded-For` entry answered `400`, including direct calls and any deployment with two or more proxies in front. The middleware was also registered with `app.middlewares.append()`, placing it *inside* the auth middleware, so `request.remote` was still the peer address while authentication ran and `allowed_client_ip` was matched against the proxy.
- The middleware is dropped and the address is resolved where it is consumed: walk the `X-Forwarded-For` chain inwards from the connection peer and take the first address that is not a trusted proxy. Any hop count works, a request without the header keeps the peer address, and a client that forges the header while connecting directly is caught by its own peer address ending the walk.
- When `manager.trusted-proxies` is empty the previous behavior is kept byte-for-byte and a deprecation warning is logged once per process, so this is safe to backport.

## Test plan

- [x] `pants test tests/unit/manager/api/test_auth_trusted_proxy.py` — 19 unit tests: CIDR/wildcard parsing, trusted-peer decision, signature equivalence for honored vs ignored header, once-only deprecation warning, and client-IP resolution over 0/1/N hops including a forged header from an untrusted peer
- [x] `pants test tests/unit/manager/api/test_auth_params.py tests/unit/manager/api/auth::` — existing auth tests still pass
- [x] `pants fmt`, `pants lint`, `pants check`
- [x] Live verification against a local manager, HMAC-signed requests over three configurations:

  | request | `trusted-proxies` unset | peer **not** trusted | peer trusted |
  |---|---|---|---|
  | correctly signed, no forwarded headers | 200 | 200 | 200 |
  | injected `X-Forwarded-URL`, signed with the forwarded host+path | 200 (legacy, warns once) | **401** | 200 |
  | `./bai admin domain search` | 200 | 200 | 200 |

- [x] Client IP resolution against the live manager (`GET /auth/my-ip`, trusted `["127.0.0.1/32", "10.0.0.0/8"]`, peer `127.0.0.1`):

  | `X-Forwarded-For` | resolved |
  |---|---|
  | (none) | `127.0.0.1` |
  | `203.0.113.9` | `203.0.113.9` |
  | `203.0.113.9, 10.0.0.5, 10.0.0.6` | `203.0.113.9` |
  | `203.0.113.9, 198.51.100.4, 10.0.0.5` | `198.51.100.4` |
  | `1.2.3.4` forged from an untrusted peer | peer address, header ignored |

  On `main` the same configuration answered `400` to every one of these except the single-entry case.

Resolves BA-7252
