### PR TITLE
ci(BA-7311): warn when a backport-target pull request carries a migration

### DIFF
--- a/.github/scripts/check-backport-migration.sh
+++ b/.github/scripts/check-backport-migration.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Warn about a pull request that will be backported and also changes the
+# database schema. Such a migration is cherry-picked onto a release branch
+# while its `main` counterpart stays where it is, so both have to be
+# idempotent -- a requirement easy to miss while writing the migration and
+# expensive to notice after the backport has been opened.
+#
+#   check-backport-migration.sh --pr <number> [options]
+#
+#     --pr <number>     the pull request to check
+#     --title <t>       its title, which the `fix:` rule reads
+#     --body <b>        its body, which carries the `Backport:` trailer
+#     --labels <csv>    its labels, searched for the one below
+#     --base <ref>      the branch it is opened against
+#     --label <name>    the label a schema change carries, the one
+#                       `.github/labeler.yml` puts on an alembic revision
+#                       (default: require:db-migration)
+#     --registry <path> the maintained-version registry
+#                       (default: .github/maintained-versions.yml)
+#
+# Prints one line and exits 1 when the pull request is both; prints nothing
+# and exits 0 otherwise. Which release branches a pull request reaches is not
+# decided here -- `decide-backport-targets.sh` owns that rule and this script
+# asks it. Nothing is written and no comment is posted, so the decision can be
+# reproduced against your own checkout:
+#
+#   .github/scripts/check-backport-migration.sh --pr 13615 --base main \
+#     --title 'fix(BA-1234): ...' --labels 'require:db-migration'
+set -e
+
+usage() {
+  echo "Usage: $0 --pr <number> [options]"
+  echo "  --pr <number>     the pull request to check"
+  echo "  --title <t>       its title"
+  echo "  --body <b>        its body, carrying the 'Backport:' trailer"
+  echo "  --labels <csv>    its labels"
+  echo "  --base <ref>      the branch it is opened against"
+  echo "  --label <name>    the label a schema change carries"
+  echo "                    (default: require:db-migration)"
+  echo "  --registry <path> maintained-version registry"
+  echo "                    (default: .github/maintained-versions.yml)"
+}
+
+pr_number=""
+pr_title=""
+pr_body=""
+pr_labels=""
+pr_base=""
+# The label `.github/labeler.yml` puts on a pull request that adds an alembic
+# revision. Named here so that renaming it there is a one-line change.
+migration_label="require:db-migration"
+registry=".github/maintained-versions.yml"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) ;;
+    *) [ "$#" -ge 2 ] || { echo "Error: $1 requires a value" >&2; usage >&2; exit 2; } ;;
+  esac
+  case "$1" in
+    --pr) pr_number="$2"; shift ;;
+    --title) pr_title="$2"; shift ;;
+    --body) pr_body="$2"; shift ;;
+    --labels) pr_labels="$2"; shift ;;
+    --base) pr_base="$2"; shift ;;
+    --label) migration_label="$2"; shift ;;
+    --registry) registry="$2"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ -z "$pr_number" ]; then
+  echo "Error: --pr is required" >&2
+  usage >&2
+  exit 2
+fi
+if [ -z "$migration_label" ]; then
+  echo "Error: --label must not be empty" >&2
+  usage >&2
+  exit 2
+fi
+
+# The cheaper half of the question first: no schema change, nothing to warn
+# about, and the registry stays unread.
+case ",${pr_labels}," in
+  *",${migration_label},"*) ;;
+  *)
+    echo "#$pr_number carries no '$migration_label' label; no migration to backport." >&2
+    exit 0
+    ;;
+esac
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+status=0
+targets=$("$script_dir/decide-backport-targets.sh" \
+  --event pull_request \
+  --targets-only \
+  --pr "$pr_number" \
+  --title "$pr_title" \
+  --body "$pr_body" \
+  --labels "$pr_labels" \
+  --base "$pr_base" \
+  --registry "$registry") || status=$?
+
+# An undecidable target list -- a `Backport:` trailer naming a version nobody
+# maintains, say -- is worth the same look as a decided one, and silence here
+# would read as "no backport".
+if [ "$status" -ne 0 ]; then
+  echo "#$pr_number carries '$migration_label' and its backport targets could not be decided; see the reason logged above."
+  exit 1
+fi
+
+if [ -z "$targets" ]; then
+  echo "#$pr_number changes the schema but reaches no release branch." >&2
+  exit 0
+fi
+
+# One line, so that the caller can hand it to whatever its CI annotates with.
+echo "#$pr_number carries '$migration_label' and will be backported to ${targets// /, }. A migration that lands on both main and a release branch must be idempotent on each -- see src/ai/backend/manager/models/alembic/README.md."
+exit 1

--- a/.github/scripts/decide-backport-targets.sh
+++ b/.github/scripts/decide-backport-targets.sh
@@ -6,10 +6,10 @@
 #
 #   decide-backport-targets.sh --event <name> --pr <number> [options]
 #
-#     --event <name>            pull_request_target, a merged pull request whose
-#                               metadata the rules below decide from, or
-#                               issue_comment, a `/backport <version> ...`
-#                               comment naming the targets outright
+#     --event <name>            pull_request_target or pull_request, a pull
+#                               request whose metadata the rules below decide
+#                               from, or issue_comment, a `/backport <version>
+#                               ...` comment naming the targets outright
 #     --pr <number>             the pull request to back port
 #     --title <t>               its title, which the `fix:` rule reads
 #     --body <b>                its body, which carries the `Backport:` trailer
@@ -21,6 +21,11 @@
 #     --pr-author <login>       who the backport is assigned to
 #     --registry <path>         the maintained-version registry
 #                               (default: .github/maintained-versions.yml)
+#     --targets-only            print the target versions rather than the job
+#                               matrix, and answer for a pull request that has
+#                               not been merged yet -- no merge commit is
+#                               needed, no release branch is looked up and no
+#                               comment is posted
 #     --dry-run                 decide as usual, but report the pull request
 #                               comments instead of posting them
 #
@@ -53,6 +58,7 @@ usage() {
   echo "  --pr-author <login>       who the backport is assigned to"
   echo "  --registry <path>         maintained-version registry"
   echo "                            (default: .github/maintained-versions.yml)"
+  echo "  --targets-only            print the target versions, not the matrix"
   echo "  --dry-run                 report the pull request comments, post none"
 }
 
@@ -67,13 +73,14 @@ comment_body=""
 author_association=""
 pr_author_login=""
 registry=".github/maintained-versions.yml"
+targets_only=0
 dry_run=0
 
 while [ "$#" -gt 0 ]; do
-  # Every option but `--dry-run` takes a value; catching a missing one here
-  # keeps each branch below to a single assignment.
+  # Every flag-shaped option aside, each one takes a value; catching a missing
+  # one here keeps each branch below to a single assignment.
   case "$1" in
-    --dry-run|-h|--help) ;;
+    --targets-only|--dry-run|-h|--help) ;;
     *) [ "$#" -ge 2 ] || { echo "Error: $1 requires a value" >&2; usage >&2; exit 2; } ;;
   esac
   case "$1" in
@@ -88,6 +95,7 @@ while [ "$#" -gt 0 ]; do
     --author-association) author_association="$2"; shift ;;
     --pr-author) pr_author_login="$2"; shift ;;
     --registry) registry="$2"; shift ;;
+    --targets-only) targets_only=1 ;;
     --dry-run) dry_run=1 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -99,6 +107,12 @@ if [ -z "$event_name" ] || [ -z "$pr_number" ]; then
   echo "Error: --event and --pr are required" >&2
   usage >&2
   exit 2
+fi
+
+# The question `--targets-only` answers is asked of a pull request still open,
+# where a comment would be noise rather than a record of what was backported.
+if [ "$targets_only" -eq 1 ]; then
+  dry_run=1
 fi
 
 maintained=()   # versions the registry declares alive
@@ -179,7 +193,7 @@ fi
 if [ "$pr_base" != "main" ]; then
   skip_and_exit "#$pr_number targets '$pr_base' rather than 'main'; nothing to backport."
 fi
-if [ -z "$merge_commit" ]; then
+if [ "$targets_only" -eq 0 ] && [ -z "$merge_commit" ]; then
   skip_and_exit "#$pr_number has no merge commit; nothing to backport."
 fi
 
@@ -248,6 +262,11 @@ if [ ${#targets[@]} -gt 0 ]; then
   targets=("${sorted[@]}")
 fi
 echo "Backport targets of #$pr_number: ${targets[*]}" >&2
+if [ "$targets_only" -eq 1 ]; then
+  # Which of these have a release branch is left undecided: a caller asking
+  # about an open pull request wants the rule's answer, not today's remote.
+  emit_and_exit "${targets[*]}"
+fi
 if [ ${#targets[@]} -eq 0 ]; then
   emit_and_exit "[]"
 fi

--- a/.github/workflows/backport-migration-check.yml
+++ b/.github/workflows/backport-migration-check.yml
@@ -1,0 +1,45 @@
+name: backport-migration-check
+
+# Advisory only: this workflow is deliberately kept out of the required status
+# checks, so a red run asks a reviewer to look rather than blocking the merge.
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-backport-migration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the revision
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          sparse-checkout: .github
+      - name: Check whether a migration would be backported
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if ! warning=$(.github/scripts/check-backport-migration.sh \
+            --pr "$PR_NUMBER" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --labels "$PR_LABELS" \
+            --base "$PR_BASE"); then
+            if [ -n "$warning" ]; then
+              echo "::warning title=Backport carries a migration::$warning"
+            fi
+            exit 1
+          fi

--- a/changes/13665.misc.md
+++ b/changes/13665.misc.md
@@ -1,0 +1,1 @@
+Warn on a pull request that would backport a database migration to a release branch, where the migration has to be idempotent on both branches


### PR DESCRIPTION
## Summary
- Add an advisory `backport-migration-check` workflow that fails when a pull request both carries `require:db-migration` and would be backported to a release branch.
- Keep it out of the required status checks: the red run asks a reviewer to confirm the migration is idempotent on both branches, it does not block the merge.
- Add `--targets-only` to `decide-backport-targets.sh` so the backport rule stays in one place and can also answer for a pull request that has not been merged yet.

## Test plan
- [x] Hand-run against the real `.github/maintained-versions.yml`: `fix:` + label, `Backport: 26.4` + label, `Backport: none`, non-`fix:`, release-branch base, label substring near-miss, unmaintained trailer version, missing `--pr`.
- [x] `decide-backport-targets.sh` merge-time path unchanged (no merge commit still skips).
- [x] Confirm the check reports as expected on this pull request itself.

Resolves BA-7311

🤖 Generated with [Claude Code](https://claude.com/claude-code)