### PR TITLE
refactor(BA-7224): remove unreferenced ORM relationships from row classes

### DIFF
--- a/changes/13667.enhance.md
+++ b/changes/13667.enhance.md
@@ -1,0 +1,1 @@
+Remove unreferenced SQLAlchemy ORM relationships from the artifact, storage, container registry, RBAC, and deployment row models

--- a/src/ai/backend/manager/models/artifact/row.py
+++ b/src/ai/backend/manager/models/artifact/row.py
@@ -84,21 +84,18 @@ class ArtifactRow(Base):
 
     huggingface_registry: Mapped[HuggingFaceRegistryRow] = relationship(
         "HuggingFaceRegistryRow",
-        back_populates="artifacts",
         primaryjoin=lambda: foreign(ArtifactRow.registry_id) == HuggingFaceRegistryRow.id,
-        overlaps="reservoir_registry,artifacts",
+        overlaps="reservoir_registry",
     )
 
     reservoir_registry: Mapped[ReservoirRegistryRow] = relationship(
         "ReservoirRegistryRow",
-        back_populates="artifacts",
         primaryjoin=lambda: foreign(ArtifactRow.registry_id) == ReservoirRegistryRow.id,
-        overlaps="huggingface_registry,artifacts",
+        overlaps="huggingface_registry",
     )
 
     revision_rows: Mapped[list[ArtifactRevisionRow]] = relationship(
         "ArtifactRevisionRow",
-        back_populates="artifact",
         primaryjoin=_get_artifact_revision_join_cond,
     )
 

--- a/src/ai/backend/manager/models/artifact_revision/row.py
+++ b/src/ai/backend/manager/models/artifact_revision/row.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, override
+from typing import Any, override
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.artifact.types import VerificationStepResult
 from ai.backend.common.data.storage.registries.types import ModelData
@@ -21,29 +21,9 @@ from ai.backend.manager.models.base import (
     Base,
 )
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.artifact import ArtifactRow
-    from ai.backend.manager.models.association_artifacts_storages import (
-        AssociationArtifactsStorageRow,
-    )
-
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = ("ArtifactRevisionRow",)
-
-
-def _get_artifact_join_cond() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.artifact import ArtifactRow
-
-    return foreign(ArtifactRevisionRow.artifact_id) == ArtifactRow.id
-
-
-def _get_association_artifacts_storages_join_cond() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.association_artifacts_storages import (
-        AssociationArtifactsStorageRow,
-    )
-
-    return ArtifactRevisionRow.id == foreign(AssociationArtifactsStorageRow.artifact_revision_id)
 
 
 class ArtifactRevisionRow(Base):
@@ -98,21 +78,6 @@ class ArtifactRevisionRow(Base):
     )
     verification_result: Mapped[dict[str, Any] | None] = mapped_column(
         "verification_result", sa.JSON(none_as_null=True), nullable=True, default=None
-    )
-
-    artifact: Mapped[ArtifactRow] = relationship(
-        "ArtifactRow",
-        back_populates="revision_rows",
-        primaryjoin=_get_artifact_join_cond,
-        viewonly=True,
-    )
-
-    association_artifacts_storages_rows: Mapped[list[AssociationArtifactsStorageRow]] = (
-        relationship(
-            "AssociationArtifactsStorageRow",
-            back_populates="artifact_revision_row",
-            primaryjoin=_get_association_artifacts_storages_join_cond,
-        )
     )
 
     @override

--- a/src/ai/backend/manager/models/association_artifacts_storages/row.py
+++ b/src/ai/backend/manager/models/association_artifacts_storages/row.py
@@ -3,40 +3,16 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.base import GUID, Base
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
-    from ai.backend.manager.models.object_storage import ObjectStorageRow
-    from ai.backend.manager.models.vfs_storage import VFSStorageRow
-
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__: Sequence[str] = ("AssociationArtifactsStorageRow",)
-
-
-def _get_association_artifact_join_cond() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
-
-    return ArtifactRevisionRow.id == foreign(AssociationArtifactsStorageRow.artifact_revision_id)
-
-
-def _get_association_object_storage_join_cond() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.object_storage import ObjectStorageRow
-
-    return ObjectStorageRow.id == foreign(AssociationArtifactsStorageRow.storage_namespace_id)
-
-
-def _get_association_vfs_storage_join_cond() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.vfs_storage import VFSStorageRow
-
-    return VFSStorageRow.id == foreign(AssociationArtifactsStorageRow.storage_namespace_id)
 
 
 class AssociationArtifactsStorageRow(Base):
@@ -64,25 +40,3 @@ class AssociationArtifactsStorageRow(Base):
         nullable=False,
     )
     storage_type: Mapped[str] = mapped_column("storage_type", sa.String, nullable=False)
-
-    artifact_revision_row: Mapped[ArtifactRevisionRow] = relationship(
-        "ArtifactRevisionRow",
-        back_populates="association_artifacts_storages_rows",
-        primaryjoin=_get_association_artifact_join_cond,
-    )
-
-    # only valid when storage_type is "object_storage"
-    object_storage_row: Mapped[ObjectStorageRow | None] = relationship(
-        "ObjectStorageRow",
-        back_populates="association_artifacts_storages_rows",
-        primaryjoin=_get_association_object_storage_join_cond,
-        overlaps="vfs_storage_row",
-    )
-
-    # only valid when storage_type is "vfs"
-    vfs_storage_row: Mapped[VFSStorageRow | None] = relationship(
-        "VFSStorageRow",
-        back_populates="association_artifacts_storages_rows",
-        primaryjoin=_get_association_vfs_storage_join_cond,
-        overlaps="object_storage_row",
-    )

--- a/src/ai/backend/manager/models/association_container_registries_groups/row.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups/row.py
@@ -3,33 +3,16 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.models.base import GUID, Base
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.container_registry import ContainerRegistryRow
-    from ai.backend.manager.models.group import GroupRow
-
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__: Sequence[str] = ("AssociationContainerRegistriesGroupsRow",)
-
-
-def _get_container_registry_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.container_registry import ContainerRegistryRow
-
-    return ContainerRegistryRow.id == foreign(AssociationContainerRegistriesGroupsRow.registry_id)
-
-
-def _get_group_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.group import GroupRow
-
-    return GroupRow.id == foreign(AssociationContainerRegistriesGroupsRow.group_id)
 
 
 class AssociationContainerRegistriesGroupsRow(Base):
@@ -51,16 +34,4 @@ class AssociationContainerRegistriesGroupsRow(Base):
         "group_id",
         GUID,
         nullable=False,
-    )
-
-    container_registry_row: Mapped[ContainerRegistryRow] = relationship(
-        "ContainerRegistryRow",
-        back_populates="association_container_registries_groups_rows",
-        primaryjoin=_get_container_registry_join_condition,
-    )
-
-    group_row: Mapped[GroupRow] = relationship(
-        "GroupRow",
-        back_populates="association_container_registries_groups_rows",
-        primaryjoin=_get_group_join_condition,
     )

--- a/src/ai/backend/manager/models/container_registry/row.py
+++ b/src/ai/backend/manager/models/container_registry/row.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     from ai.backend.manager.models.association_container_registries_groups import (
         AssociationContainerRegistriesGroupsRow,
     )
-    from ai.backend.manager.models.image import ImageRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -99,12 +98,6 @@ class ContainerRegistryValidator:
                 pass
 
 
-def _get_image_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.image import ImageRow
-
-    return ContainerRegistryRow.id == foreign(ImageRow.registry_id)
-
-
 def _get_association_join_condition() -> sa.ColumnElement[bool]:
     from ai.backend.manager.models.association_container_registries_groups import (
         AssociationContainerRegistriesGroupsRow,
@@ -146,17 +139,10 @@ class ContainerRegistryRow(Base):
         "extra", sa.JSON, nullable=True, default=None
     )
 
-    image_rows: Mapped[list[ImageRow]] = relationship(
-        "ImageRow",
-        back_populates="registry_row",
-        primaryjoin=_get_image_join_condition,
-    )
-
     association_container_registries_groups_rows: Mapped[
         list[AssociationContainerRegistriesGroupsRow]
     ] = relationship(
         "AssociationContainerRegistriesGroupsRow",
-        back_populates="container_registry_row",
         primaryjoin=_get_association_join_condition,
     )
 

--- a/src/ai/backend/manager/models/deployment_auto_scaling_policy/row.py
+++ b/src/ai/backend/manager/models/deployment_auto_scaling_policy/row.py
@@ -4,11 +4,10 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.types import AutoScalingMetricComparator, AutoScalingMetricSource
@@ -21,18 +20,9 @@ from ai.backend.manager.models.base import (
 )
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.endpoint import EndpointRow
-
 __all__ = ("DeploymentAutoScalingPolicyRow",)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-def _get_endpoint_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.endpoint import EndpointRow
-
-    return foreign(DeploymentAutoScalingPolicyRow.endpoint) == EndpointRow.id
 
 
 class DeploymentAutoScalingPolicyRow(LifecycleTimestampsMixin, Base):
@@ -99,14 +89,6 @@ class DeploymentAutoScalingPolicyRow(LifecycleTimestampsMixin, Base):
     )
     last_scaled_at: Mapped[datetime | None] = mapped_column(
         "last_scaled_at", sa.DateTime(timezone=True), nullable=True
-    )
-
-    # Relationships (without FK constraints)
-    endpoint_row: Mapped[EndpointRow] = relationship(
-        "EndpointRow",
-        back_populates="auto_scaling_policy",
-        primaryjoin=_get_endpoint_join_condition,
-        uselist=False,
     )
 
     def to_data(self) -> DeploymentAutoScalingPolicyData:

--- a/src/ai/backend/manager/models/deployment_policy/row.py
+++ b/src/ai/backend/manager/models/deployment_policy/row.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.identifier.deployment import DeploymentID
@@ -20,9 +19,6 @@ from ai.backend.manager.models.base import (
     StrEnumType,
 )
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.endpoint import EndpointRow
 
 __all__ = ("DeploymentPolicyRow",)
 
@@ -68,13 +64,6 @@ class DeploymentPolicyRow(LifecycleTimestampsMixin, Base):
         pgsql.JSONB(),
         nullable=False,
         server_default="{}",
-    )
-
-    endpoint_row: Mapped[EndpointRow | None] = relationship(
-        "EndpointRow",
-        back_populates="deployment_policy",
-        foreign_keys=[endpoint],
-        uselist=False,
     )
 
     def to_data(self) -> DeploymentPolicyData:

--- a/src/ai/backend/manager/models/deployment_revision/row.py
+++ b/src/ai/backend/manager/models/deployment_revision/row.py
@@ -44,21 +44,13 @@ from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 from ai.backend.manager.models.runtime_variant_preset.types import RuntimeVariantPresetValueEntry
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.endpoint import EndpointRow
     from ai.backend.manager.models.image import ImageRow
     from ai.backend.manager.models.resource_slot.row import DeploymentRevisionResourceSlotRow
-    from ai.backend.manager.models.routing import RoutingRow
     from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
 
 __all__ = ("DeploymentRevisionRow",)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-def _get_endpoint_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.endpoint import EndpointRow
-
-    return foreign(DeploymentRevisionRow.endpoint) == EndpointRow.id
 
 
 def _get_image_join_condition() -> sa.sql.elements.ColumnElement[Any]:
@@ -71,12 +63,6 @@ def _get_runtime_variant_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
 
     return foreign(DeploymentRevisionRow.runtime_variant_id) == RuntimeVariantRow.id
-
-
-def _get_routings_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.routing import RoutingRow
-
-    return DeploymentRevisionRow.id == foreign(RoutingRow.revision)
 
 
 class DeploymentRevisionRow(CreatedAtMixin, Base):
@@ -248,11 +234,6 @@ class DeploymentRevisionRow(CreatedAtMixin, Base):
         lazy="selectin",
     )
 
-    endpoint_row: Mapped[EndpointRow] = relationship(
-        "EndpointRow",
-        back_populates="revisions",
-        primaryjoin=_get_endpoint_join_condition,
-    )
     image_row: Mapped[ImageRow] = relationship(
         "ImageRow",
         primaryjoin=_get_image_join_condition,
@@ -262,11 +243,6 @@ class DeploymentRevisionRow(CreatedAtMixin, Base):
         primaryjoin=_get_runtime_variant_join_condition,
         lazy="joined",
         innerjoin=True,
-    )
-    routings: Mapped[list[RoutingRow]] = relationship(
-        "RoutingRow",
-        primaryjoin=_get_routings_join_condition,
-        viewonly=True,
     )
 
     def to_data(self) -> ModelRevisionData:

--- a/src/ai/backend/manager/models/deployment_revision_preset/row.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/row.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.config import ModelDefinition
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
@@ -29,9 +27,6 @@ from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 from ai.backend.manager.models.runtime_variant_preset.types import (
     RuntimeVariantPresetValueEntry,
 )
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
 
 __all__ = ("DeploymentRevisionPresetRow",)
 
@@ -110,12 +105,6 @@ class DeploymentRevisionPresetRow(LifecycleTimestampsMixin, Base):
         pgsql.JSONB(),
         nullable=False,
         server_default=sa.text("'{}'::jsonb"),
-    )
-
-    resource_slot_rows: Mapped[list[PresetResourceSlotRow]] = relationship(
-        "PresetResourceSlotRow",
-        cascade="all, delete-orphan",
-        lazy="selectin",
     )
 
     def to_data(self) -> DeploymentRevisionPresetData:

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -307,7 +307,6 @@ class EndpointRow(Base):
 
     revisions: Mapped[list[DeploymentRevisionRow]] = relationship(
         "DeploymentRevisionRow",
-        back_populates="endpoint_row",
         primaryjoin=_get_endpoint_revisions_join_condition,
         order_by="DeploymentRevisionRow.revision_number.desc()",
     )
@@ -345,14 +344,12 @@ class EndpointRow(Base):
 
     auto_scaling_policy: Mapped[DeploymentAutoScalingPolicyRow | None] = relationship(
         "DeploymentAutoScalingPolicyRow",
-        back_populates="endpoint_row",
         primaryjoin=_get_endpoint_auto_scaling_policy_join_condition,
         uselist=False,
     )
 
     deployment_policy: Mapped[DeploymentPolicyRow | None] = relationship(
         "DeploymentPolicyRow",
-        back_populates="endpoint_row",
         primaryjoin=_get_deployment_policy_join_condition,
         uselist=False,
     )

--- a/src/ai/backend/manager/models/group/row.py
+++ b/src/ai/backend/manager/models/group/row.py
@@ -228,9 +228,7 @@ class GroupRow(LifecycleTimestampsMixin, Base):
     users: Mapped[list[AssocGroupUserRow]] = relationship(
         "AssocGroupUserRow", back_populates="group"
     )
-    resource_policy_row: Mapped[ProjectResourcePolicyRow] = relationship(
-        "ProjectResourcePolicyRow", back_populates="projects"
-    )
+    resource_policy_row: Mapped[ProjectResourcePolicyRow] = relationship("ProjectResourcePolicyRow")
     kernels: Mapped[list[KernelRow]] = relationship("KernelRow", back_populates="group_row")
     networks: Mapped[list[NetworkRow]] = relationship(
         "NetworkRow",
@@ -246,7 +244,6 @@ class GroupRow(LifecycleTimestampsMixin, Base):
         list[AssociationContainerRegistriesGroupsRow]
     ] = relationship(
         "AssociationContainerRegistriesGroupsRow",
-        back_populates="group_row",
         primaryjoin=_get_association_container_registries_groups_join_condition,
     )
 

--- a/src/ai/backend/manager/models/huggingface_registry/row.py
+++ b/src/ai/backend/manager/models/huggingface_registry/row.py
@@ -16,18 +16,11 @@ from ai.backend.manager.models.base import (
 )
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.artifact import ArtifactRow
     from ai.backend.manager.models.artifact_registries import ArtifactRegistryRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = ("HuggingFaceRegistryRow",)
-
-
-def _get_registry_artifact_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.artifact import ArtifactRow
-
-    return HuggingFaceRegistryRow.id == foreign(ArtifactRow.registry_id)
 
 
 def _get_registry_meta_join_condition() -> sa.ColumnElement[bool]:
@@ -45,12 +38,6 @@ class HuggingFaceRegistryRow(Base):
     url: Mapped[str] = mapped_column("url", sa.String, nullable=False)
     token: Mapped[str | None] = mapped_column("token", sa.String, nullable=True, default=None)
 
-    artifacts: Mapped[list[ArtifactRow]] = relationship(
-        "ArtifactRow",
-        back_populates="huggingface_registry",
-        primaryjoin=_get_registry_artifact_join_condition,
-        viewonly=True,
-    )
     meta: Mapped[ArtifactRegistryRow | None] = relationship(
         "ArtifactRegistryRow",
         back_populates="huggingface_registries",

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -224,7 +224,6 @@ class ImageRow(CreatedAtMixin, Base):
     # sessions = relationship("SessionRow", back_populates="image_row")
     registry_row = relationship(
         "ContainerRegistryRow",
-        back_populates="image_rows",
         primaryjoin=_get_container_registry_join_condition,
     )
 

--- a/src/ai/backend/manager/models/keypair/row.py
+++ b/src/ai/backend/manager/models/keypair/row.py
@@ -104,9 +104,7 @@ class KeyPairRow(LifecycleTimestampsMixin, Base):
         primaryjoin=_get_session_row_join_condition,
         foreign_keys="SessionRow.access_key",
     )
-    resource_policy_row: Mapped[KeyPairResourcePolicyRow] = relationship(
-        "KeyPairResourcePolicyRow", back_populates="keypairs"
-    )
+    resource_policy_row: Mapped[KeyPairResourcePolicyRow] = relationship("KeyPairResourcePolicyRow")
     sgroup_for_keypairs_rows: Mapped[list[ScalingGroupForKeypairsRow]] = relationship(
         "ScalingGroupForKeypairsRow",
     )

--- a/src/ai/backend/manager/models/object_storage/row.py
+++ b/src/ai/backend/manager/models/object_storage/row.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import TYPE_CHECKING, override
+from typing import override
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.object_storage.types import ObjectStorageData
@@ -14,29 +14,9 @@ from ai.backend.manager.models.base import (
     Base,
 )
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.association_artifacts_storages import (
-        AssociationArtifactsStorageRow,
-    )
-    from ai.backend.manager.models.storage_namespace import StorageNamespaceRow
-
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = ("ObjectStorageRow",)
-
-
-def _get_object_storage_association_artifact_join_cond() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.association_artifacts_storages import (
-        AssociationArtifactsStorageRow,
-    )
-
-    return ObjectStorageRow.id == foreign(AssociationArtifactsStorageRow.storage_namespace_id)
-
-
-def _get_object_storage_namespace_join_cond() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.storage_namespace import StorageNamespaceRow
-
-    return foreign(StorageNamespaceRow.storage_id) == ObjectStorageRow.id
 
 
 class ObjectStorageRow(Base):
@@ -72,20 +52,6 @@ class ObjectStorageRow(Base):
         "region",
         sa.String,
         nullable=True,
-    )
-
-    association_artifacts_storages_rows: Mapped[list[AssociationArtifactsStorageRow]] = (
-        relationship(
-            "AssociationArtifactsStorageRow",
-            back_populates="object_storage_row",
-            primaryjoin=_get_object_storage_association_artifact_join_cond,
-            overlaps="vfs_storage_row",
-        )
-    )
-    namespace_rows: Mapped[list[StorageNamespaceRow]] = relationship(
-        "StorageNamespaceRow",
-        back_populates="object_storage_row",
-        primaryjoin=_get_object_storage_namespace_join_cond,
     )
 
     @override

--- a/src/ai/backend/manager/models/rbac_models/permission/object_permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/object_permission.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.manager.data.permission.id import ObjectId
 from ai.backend.manager.data.permission.object_permission import ObjectPermissionData
@@ -17,29 +17,6 @@ from ai.backend.manager.models.base import (
     Base,
     StrEnumType,
 )
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-        AssociationScopesEntitiesRow,
-    )
-    from ai.backend.manager.models.rbac_models.role import RoleRow
-
-
-def _get_role_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.rbac_models.role import RoleRow
-
-    return RoleRow.id == foreign(ObjectPermissionRow.role_id)
-
-
-def _get_scope_association_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-        AssociationScopesEntitiesRow,
-    )
-
-    return sa.and_(
-        ObjectPermissionRow.entity_type == foreign(AssociationScopesEntitiesRow.entity_type),
-        ObjectPermissionRow.entity_id == foreign(AssociationScopesEntitiesRow.entity_id),
-    )
 
 
 class ObjectPermissionRow(Base):
@@ -69,19 +46,6 @@ class ObjectPermissionRow(Base):
     )  # e.g., "project_id", "user_id" etc.
     operation: Mapped[OperationType] = mapped_column(
         "operation", StrEnumType(OperationType, length=32), nullable=False
-    )
-
-    role_row: Mapped[RoleRow | None] = relationship(
-        "RoleRow",
-        back_populates="object_permission_rows",
-        primaryjoin=_get_role_join_condition,
-        viewonly=True,
-    )
-    scope_association_rows: Mapped[list[AssociationScopesEntitiesRow]] = relationship(
-        "AssociationScopesEntitiesRow",
-        primaryjoin=_get_scope_association_join_condition,
-        viewonly=True,
-        uselist=True,
     )
 
     def object_id(self) -> ObjectId:

--- a/src/ai/backend/manager/models/rbac_models/role.py
+++ b/src/ai/backend/manager/models/rbac_models/role.py
@@ -31,13 +31,6 @@ from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 if TYPE_CHECKING:
     from .permission.object_permission import ObjectPermissionRow
-    from .user_role import UserRoleRow
-
-
-def _get_mapped_user_role_rows_join_condition() -> sa.ColumnElement[bool]:
-    from .user_role import UserRoleRow
-
-    return RoleRow.id == foreign(UserRoleRow.role_id)
 
 
 def _get_object_permission_rows_join_condition() -> sa.ColumnElement[bool]:
@@ -80,14 +73,8 @@ class RoleRow(LifecycleTimestampsMixin, Base):
         "deleted_at", sa.DateTime(timezone=True), nullable=True
     )
 
-    mapped_user_role_rows: Mapped[list[UserRoleRow]] = relationship(
-        "UserRoleRow",
-        back_populates="role_row",
-        primaryjoin=_get_mapped_user_role_rows_join_condition,
-    )
     object_permission_rows: Mapped[list[ObjectPermissionRow]] = relationship(
         "ObjectPermissionRow",
-        back_populates="role_row",
         primaryjoin=_get_object_permission_rows_join_condition,
         viewonly=True,
     )

--- a/src/ai/backend/manager/models/rbac_models/user_role.py
+++ b/src/ai/backend/manager/models/rbac_models/user_role.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import (
-    TYPE_CHECKING,
-)
 
 import sqlalchemy as sa
 from sqlalchemy.orm import (
     Mapped,
-    foreign,
     mapped_column,
-    relationship,
 )
 
 from ai.backend.manager.data.permission.role import (
@@ -22,23 +17,6 @@ from ai.backend.manager.models.base import (
     GUID,
     Base,
 )
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.user import UserRow
-
-    from .role import RoleRow
-
-
-def _get_role_row_join_condition() -> sa.ColumnElement[bool]:
-    from .role import RoleRow
-
-    return RoleRow.id == foreign(UserRoleRow.role_id)
-
-
-def _get_user_row_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.user import UserRow
-
-    return UserRow.uuid == foreign(UserRoleRow.user_id)
 
 
 class UserRoleRow(Base):
@@ -65,17 +43,6 @@ class UserRoleRow(Base):
     )  # Null if granted by system
     granted_at: Mapped[datetime] = mapped_column(
         "granted_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
-    )
-
-    role_row: Mapped[RoleRow | None] = relationship(
-        "RoleRow",
-        back_populates="mapped_user_role_rows",
-        primaryjoin=_get_role_row_join_condition,
-    )
-    user_row: Mapped[UserRow | None] = relationship(
-        "UserRow",
-        back_populates="role_assignments",
-        primaryjoin=_get_user_row_join_condition,
     )
 
     def to_data(self) -> UserRoleAssignmentData:

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.identifier.deployment import DeploymentID
 from ai.backend.common.identifier.deployment_revision import DeploymentRevisionID
@@ -23,38 +22,9 @@ from ai.backend.manager.views.replica_group import (
     ReplicaGroupScalingSchedulingView,
 )
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
-    from ai.backend.manager.models.endpoint import EndpointRow
-    from ai.backend.manager.models.routing import RoutingRow
-
 __all__ = ("ReplicaGroupRow",)
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-def _get_deployment_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.endpoint import EndpointRow
-
-    return foreign(ReplicaGroupRow.deployment_id) == EndpointRow.id
-
-
-def _get_replicas_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.routing import RoutingRow
-
-    return ReplicaGroupRow.id == foreign(RoutingRow.replica_group_id)
-
-
-def _get_current_revision_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
-
-    return foreign(ReplicaGroupRow.current_revision_id) == DeploymentRevisionRow.id
-
-
-def _get_target_revision_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
-
-    return foreign(ReplicaGroupRow.target_revision_id) == DeploymentRevisionRow.id
 
 
 class ReplicaGroupRow(LifecycleTimestampsMixin, Base):
@@ -153,29 +123,6 @@ class ReplicaGroupRow(LifecycleTimestampsMixin, Base):
         "rollout",
         PydanticColumn(ReplicaGroupRolloutSpec),
         nullable=False,
-    )
-
-    endpoint_row: Mapped[EndpointRow] = relationship(
-        "EndpointRow",
-        primaryjoin=_get_deployment_join_condition,
-        viewonly=True,
-    )
-    replicas: Mapped[list[RoutingRow]] = relationship(
-        "RoutingRow",
-        primaryjoin=_get_replicas_join_condition,
-        viewonly=True,
-    )
-    current_revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
-        "DeploymentRevisionRow",
-        primaryjoin=_get_current_revision_join_condition,
-        viewonly=True,
-        uselist=False,
-    )
-    target_revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
-        "DeploymentRevisionRow",
-        primaryjoin=_get_target_revision_join_condition,
-        viewonly=True,
-        uselist=False,
     )
 
     def to_deploy_scheduling_view(self) -> ReplicaGroupDeploySchedulingView:

--- a/src/ai/backend/manager/models/reservoir_registry/row.py
+++ b/src/ai/backend/manager/models/reservoir_registry/row.py
@@ -16,18 +16,11 @@ from ai.backend.manager.models.base import (
 )
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.artifact import ArtifactRow
     from ai.backend.manager.models.artifact_registries import ArtifactRegistryRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = ("ReservoirRegistryRow",)
-
-
-def _get_registry_artifact_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.artifact import ArtifactRow
-
-    return ReservoirRegistryRow.id == foreign(ArtifactRow.registry_id)
 
 
 def _get_registry_meta_join_condition() -> sa.ColumnElement[bool]:
@@ -47,12 +40,6 @@ class ReservoirRegistryRow(Base):
     secret_key: Mapped[str] = mapped_column("secret_key", sa.String, nullable=False)
     api_version: Mapped[str] = mapped_column("api_version", sa.String, nullable=False)
 
-    artifacts: Mapped[list[ArtifactRow]] = relationship(
-        "ArtifactRow",
-        back_populates="reservoir_registry",
-        primaryjoin=_get_registry_artifact_join_condition,
-        viewonly=True,
-    )
     meta: Mapped[ArtifactRegistryRow | None] = relationship(
         "ArtifactRegistryRow",
         back_populates="reservoir_registries",

--- a/src/ai/backend/manager/models/resource_policy/row.py
+++ b/src/ai/backend/manager/models/resource_policy/row.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Self
+from typing import Self
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.defs.session import SESSION_PRIORITY_MAX, SESSION_PRIORITY_MIN
 from ai.backend.common.types import (
@@ -24,11 +24,6 @@ from ai.backend.manager.models.base import (
     VFolderHostPermissionColumn,
 )
 from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.group import GroupRow
-    from ai.backend.manager.models.keypair import KeyPairRow
-    from ai.backend.manager.models.user import UserRow
 
 __all__: Sequence[str] = (
     "DefaultForUnspecified",
@@ -92,10 +87,6 @@ class KeyPairResourcePolicyRow(CreatedAtMixin, Base):
     # TODO: implement with a many-to-many association table
     # allowed_scaling_groups: Mapped[list[str]] = mapped_column(sa.Array(sa.String), nullable=False)
 
-    keypairs: Mapped[list[KeyPairRow]] = relationship(
-        "KeyPairRow", back_populates="resource_policy_row"
-    )
-
     def to_dataclass(
         self,
     ) -> KeyPairResourcePolicyData:
@@ -140,8 +131,6 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
     max_concurrent_logins: Mapped[int | None] = mapped_column(
         "max_concurrent_logins", sa.Integer(), nullable=True, default=None
     )
-
-    users: Mapped[list[UserRow]] = relationship("UserRow", back_populates="resource_policy_row")
 
     def __init__(
         self,
@@ -199,10 +188,6 @@ class ProjectResourcePolicyRow(CreatedAtMixin, Base):
     )
     max_network_count: Mapped[int] = mapped_column(
         "max_network_count", sa.Integer(), nullable=False
-    )
-
-    projects: Mapped[list[GroupRow]] = relationship(
-        "GroupRow", back_populates="resource_policy_row"
     )
 
     def __init__(

--- a/src/ai/backend/manager/models/resource_preset/row.py
+++ b/src/ai/backend/manager/models/resource_preset/row.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Callable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Self
+from typing import Any, Self
 from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql.dml import Delete, Update
 from sqlalchemy.sql.selectable import Select
 
@@ -20,9 +20,6 @@ from ai.backend.manager.models.base import (
     Base,
     ResourceSlotColumn,
 )
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.scaling_group import ScalingGroupRow
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.manager.models"))
 
@@ -45,12 +42,6 @@ def filter_by_id(id: UUID) -> Callable[[WhereableStatement[Any]], WhereableState
 type QueryOption = Callable[[WhereableStatement[Any]], WhereableStatement[Any]]
 
 
-def _get_scaling_group_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.scaling_group import ScalingGroupRow
-
-    return ScalingGroupRow.name == foreign(ResourcePresetRow.scaling_group_name)
-
-
 class ResourcePresetRow(Base):
     __tablename__ = "resource_presets"
     id: Mapped[uuid.UUID] = mapped_column(
@@ -68,11 +59,6 @@ class ResourcePresetRow(Base):
     scaling_group_name: Mapped[str | None] = mapped_column(
         "scaling_group_name", sa.String(length=64), nullable=True, server_default=sa.null()
     )
-    scaling_group_row: Mapped[ScalingGroupRow | None] = relationship(
-        "ScalingGroupRow",
-        primaryjoin=_get_scaling_group_join_condition,
-    )
-
     __table_args__ = (
         sa.Index(
             "ix_resource_presets_name_null_scaling_group_name",

--- a/src/ai/backend/manager/models/routing/row.py
+++ b/src/ai/backend/manager/models/routing/row.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship, selectinload
+from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
 
 from ai.backend.common.config import ModelHealthCheck
 from ai.backend.common.identifier.deployment import DeploymentID
@@ -34,9 +34,7 @@ from ai.backend.manager.models.base import (
 )
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
     from ai.backend.manager.models.endpoint import EndpointRow
-    from ai.backend.manager.models.replica_group import ReplicaGroupRow
     from ai.backend.manager.models.session import SessionRow
 
 
@@ -44,18 +42,6 @@ __all__ = ("RouteStatus", "RoutingRow")
 
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-def _get_deployment_revision_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
-
-    return RoutingRow.revision == DeploymentRevisionRow.id
-
-
-def _get_replica_group_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.replica_group import ReplicaGroupRow
-
-    return foreign(RoutingRow.replica_group_id) == ReplicaGroupRow.id
 
 
 class RoutingRow(Base):
@@ -171,17 +157,6 @@ class RoutingRow(Base):
     endpoint_row: Mapped[EndpointRow] = relationship("EndpointRow", back_populates="routings")
     session_row: Mapped[SessionRow | None] = relationship(
         "SessionRow", back_populates="routing", foreign_keys="RoutingRow.session"
-    )
-    revision_row: Mapped[DeploymentRevisionRow | None] = relationship(
-        "DeploymentRevisionRow",
-        primaryjoin=_get_deployment_revision_join_condition,
-        foreign_keys="RoutingRow.revision",
-        viewonly=True,
-    )
-    replica_group_row: Mapped[ReplicaGroupRow | None] = relationship(
-        "ReplicaGroupRow",
-        primaryjoin=_get_replica_group_join_condition,
-        viewonly=True,
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/runtime_variant_preset/row.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/row.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
     PresetTarget,
@@ -23,16 +22,7 @@ from ai.backend.manager.data.runtime_variant_preset.types import (
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
-
 __all__ = ("RuntimeVariantPresetRow",)
-
-
-def _get_runtime_variant_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
-
-    return foreign(RuntimeVariantPresetRow.runtime_variant) == RuntimeVariantRow.id
 
 
 class RuntimeVariantPresetRow(LifecycleTimestampsMixin, Base):
@@ -74,11 +64,6 @@ class RuntimeVariantPresetRow(LifecycleTimestampsMixin, Base):
     # separate ``ui_type`` column has been folded into this JSONB.
     ui_option: Mapped[UIOption | None] = mapped_column(
         "ui_option", PydanticColumn(UIOption), nullable=True
-    )
-
-    runtime_variant_row: Mapped[RuntimeVariantRow] = relationship(
-        "RuntimeVariantRow",
-        primaryjoin=_get_runtime_variant_join_condition,
     )
 
     @staticmethod

--- a/src/ai/backend/manager/models/service_catalog/row.py
+++ b/src/ai/backend/manager/models/service_catalog/row.py
@@ -72,7 +72,6 @@ class ServiceCatalogRow(Base):
 
     endpoints: Mapped[list[ServiceCatalogEndpointRow]] = relationship(
         "ServiceCatalogEndpointRow",
-        back_populates="service",
         cascade="all, delete-orphan",
     )
 
@@ -111,11 +110,6 @@ class ServiceCatalogEndpointRow(Base):
     protocol: Mapped[str] = mapped_column("protocol", sa.String(length=16), nullable=False)
     metadata_: Mapped[dict[str, Any]] = mapped_column(
         "metadata", JSONB, nullable=True, server_default=sa.text("'{}'::jsonb")
-    )
-
-    service: Mapped[ServiceCatalogRow] = relationship(
-        "ServiceCatalogRow",
-        back_populates="endpoints",
     )
 
     __table_args__ = (

--- a/src/ai/backend/manager/models/storage_namespace/row.py
+++ b/src/ai/backend/manager/models/storage_namespace/row.py
@@ -47,7 +47,6 @@ class StorageNamespaceRow(Base):
 
     object_storage_row: Mapped[ObjectStorageRow] = relationship(
         "ObjectStorageRow",
-        back_populates="namespace_rows",
         primaryjoin=_get_storage_namespace_join_cond,
     )
 

--- a/src/ai/backend/manager/models/user/row.py
+++ b/src/ai/backend/manager/models/user/row.py
@@ -248,7 +248,6 @@ class UserRow(LifecycleTimestampsMixin, Base):
     )
     resource_policy_row: Mapped[UserResourcePolicyRow] = relationship(
         "UserResourcePolicyRow",
-        back_populates="users",
         primaryjoin=_get_resource_policy_join_condition,
     )
     keypairs: Mapped[list[KeyPairRow]] = relationship(
@@ -272,7 +271,6 @@ class UserRow(LifecycleTimestampsMixin, Base):
 
     role_assignments: Mapped[list[UserRoleRow]] = relationship(
         "UserRoleRow",
-        back_populates="user_row",
         primaryjoin=_get_role_assignments_join_condition,
     )
 

--- a/src/ai/backend/manager/models/vfs_storage/row.py
+++ b/src/ai/backend/manager/models/vfs_storage/row.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, override
+from typing import override
 
 import sqlalchemy as sa
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.vfs_storage.types import VFSStorageData
@@ -15,22 +15,9 @@ from ai.backend.manager.models.base import (
     Base,
 )
 
-if TYPE_CHECKING:
-    from ai.backend.manager.models.association_artifacts_storages import (
-        AssociationArtifactsStorageRow,
-    )
-
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 __all__ = ("VFSStorageRow",)
-
-
-def _get_vfs_storage_association_artifact_join_cond() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.association_artifacts_storages import (
-        AssociationArtifactsStorageRow,
-    )
-
-    return VFSStorageRow.id == foreign(AssociationArtifactsStorageRow.storage_namespace_id)
 
 
 class VFSStorageRow(Base):
@@ -48,15 +35,6 @@ class VFSStorageRow(Base):
     name: Mapped[str] = mapped_column("name", sa.String, index=True, unique=True, nullable=False)
     host: Mapped[str] = mapped_column("host", sa.String, nullable=False)
     base_path: Mapped[str] = mapped_column("base_path", sa.String, nullable=False)
-
-    association_artifacts_storages_rows: Mapped[list[AssociationArtifactsStorageRow]] = (
-        relationship(
-            "AssociationArtifactsStorageRow",
-            back_populates="vfs_storage_row",
-            primaryjoin=_get_vfs_storage_association_artifact_join_cond,
-            overlaps="association_artifacts_storages_rows,object_storage_row",
-        )
-    )
 
     @override
     def __str__(self) -> str:


### PR DESCRIPTION
## Summary

- Remove `relationship()` definitions that have no remaining references from the artifact, storage, container registry, RBAC, and deployment row modules, together with their `primaryjoin` helpers and now-dead `TYPE_CHECKING` imports.
- Where the other side of a pair is still in use, only its `back_populates` is dropped (`artifact`, `storage_namespace`, `container_registry`, `group`, `image`, `user`, `keypair`, `rbac_models/role`, `endpoint`, `service_catalog`). Stale `overlaps="...,artifacts"` entries on `ArtifactRow` are trimmed accordingly.
- `ModelCardRow.resource_requirement_rows` was listed in the issue but is still in use — the model card creator writes through it and `to_data()` reads it — so it stays.

Removed, by module: `artifact_revision` (`artifact`, `association_artifacts_storages_rows`), `association_artifacts_storages` (all 3), `association_container_registries_groups` (both), `container_registry` (`image_rows`), `object_storage` (both), `vfs_storage`, `huggingface_registry`/`reservoir_registry` (`artifacts`; `meta` kept), `rbac_models` (`UserRoleRow.role_row`/`user_row`, `RoleRow.mapped_user_role_rows`, `ObjectPermissionRow.role_row`/`scope_association_rows`), `replica_group` (all 4), `routing` (`replica_group_row`, `revision_row`), `deployment_auto_scaling_policy`, `deployment_policy`, `deployment_revision` (`endpoint_row`, `routings`), `deployment_revision_preset`, `resource_policy` (`keypairs`, `users`, `projects`), `resource_preset`, `runtime_variant_preset`, `service_catalog` (`ServiceCatalogEndpointRow.service`).

Dropping the ORM-level `cascade="all, delete-orphan"` on `DeploymentRevisionPresetRow.resource_slot_rows` does not change delete behavior: `preset_resource_slots.preset_id` carries a DB-level `ON DELETE CASCADE`, and deletion is driven explicitly by `PresetResourceSlotBatchPurgerSpec`.

## Test plan

- [x] Repo-wide reference sweep over all 35 removed attributes across `src/` and `tests/` — no remaining readers or loader options
- [x] Import every `manager/models` module and run `sqlalchemy.orm.configure_mappers()` — passes, so no `back_populates` pair is left dangling
- [x] CI: `pants check` and `pants test`

Resolves BA-7224