### PR TITLE
refactor(BA-7225): remove unreferenced ORM relationships from row classes

### DIFF
--- a/changes/13669.enhance.md
+++ b/changes/13669.enhance.md
@@ -1,0 +1,1 @@
+Remove unreferenced SQLAlchemy ORM relationships from the user, group, session, keypair, vfolder, agent, and endpoint row models

--- a/src/ai/backend/manager/models/agent/row.py
+++ b/src/ai/backend/manager/models/agent/row.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, cast, override
+from typing import Any, cast, override
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
@@ -39,7 +39,6 @@ from ai.backend.manager.models.base import (
     EnumType,
     ResourceSlotColumn,
 )
-from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.rbac import (
     AbstractPermissionContext,
@@ -54,9 +53,6 @@ from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.resource_slot import AgentResourceRow
 from ai.backend.manager.models.types import QueryCondition
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, execute_with_txn_retry
-
-if TYPE_CHECKING:
-    from ai.backend.manager.models.scaling_group import ScalingGroupRow
 
 __all__: Sequence[str] = (
     "AgentRow",
@@ -136,13 +132,7 @@ class AgentRow(Base):
         default=False,
     )
 
-    kernels: Mapped[list[KernelRow]] = relationship("KernelRow", back_populates="agent_row")
     agent_resource_rows: Mapped[list[AgentResourceRow]] = relationship("AgentResourceRow")
-    scaling_group_row: Mapped[ScalingGroupRow] = relationship(
-        "ScalingGroupRow",
-        back_populates="agents",
-        foreign_keys="[AgentRow.scaling_group]",
-    )
 
     def actual_occupied_slots(self) -> ResourceSlot:
         occupied = ResourceSlot()

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -83,9 +83,6 @@ from ai.backend.manager.models.routing import RouteStatus
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.deployment.creator import DeploymentCreator
-    from ai.backend.manager.models.deployment_auto_scaling_policy import (
-        DeploymentAutoScalingPolicyRow,
-    )
     from ai.backend.manager.models.deployment_policy import DeploymentPolicyRow
     from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
     from ai.backend.manager.models.replica_group import ReplicaGroupRow
@@ -107,12 +104,6 @@ def _get_endpoint_tokens_join_condition() -> Any:
     from ai.backend.manager.models.endpoint import EndpointTokenRow
 
     return foreign(EndpointTokenRow.endpoint) == EndpointRow.id
-
-
-def _get_endpoint_revisions_join_condition() -> Any:
-    from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
-
-    return EndpointRow.id == foreign(DeploymentRevisionRow.endpoint)
 
 
 def _get_primary_replica_group_join_condition() -> sa.ColumnElement[bool]:
@@ -138,14 +129,6 @@ def _get_deploying_revision_join_condition() -> sa.ColumnElement[bool]:
     from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 
     return foreign(EndpointRow.deploying_revision_id) == DeploymentRevisionRow.id
-
-
-def _get_endpoint_auto_scaling_policy_join_condition() -> Any:
-    from ai.backend.manager.models.deployment_auto_scaling_policy import (
-        DeploymentAutoScalingPolicyRow,
-    )
-
-    return EndpointRow.id == foreign(DeploymentAutoScalingPolicyRow.endpoint)
 
 
 def _get_deployment_policy_join_condition() -> Any:
@@ -291,9 +274,6 @@ class EndpointRow(Base):
         back_populates="endpoint_row",
         primaryjoin=_get_endpoint_tokens_join_condition,
     )
-    endpoint_auto_scaling_rules: Mapped[list[EndpointAutoScalingRuleRow]] = relationship(
-        "EndpointAutoScalingRuleRow", back_populates="endpoint_row"
-    )
     created_user_row: Mapped[UserRow | None] = relationship(
         "UserRow",
         foreign_keys=[created_user],
@@ -305,11 +285,6 @@ class EndpointRow(Base):
         primaryjoin=_get_session_owner_row_join_condition,
     )
 
-    revisions: Mapped[list[DeploymentRevisionRow]] = relationship(
-        "DeploymentRevisionRow",
-        primaryjoin=_get_endpoint_revisions_join_condition,
-        order_by="DeploymentRevisionRow.revision_number.desc()",
-    )
     primary_replica_group_row: Mapped[ReplicaGroupRow | None] = relationship(
         "ReplicaGroupRow",
         primaryjoin=_get_primary_replica_group_join_condition,
@@ -339,12 +314,6 @@ class EndpointRow(Base):
         "DeploymentRevisionRow",
         primaryjoin=_get_deploying_revision_join_condition,
         viewonly=True,
-        uselist=False,
-    )
-
-    auto_scaling_policy: Mapped[DeploymentAutoScalingPolicyRow | None] = relationship(
-        "DeploymentAutoScalingPolicyRow",
-        primaryjoin=_get_endpoint_auto_scaling_policy_join_condition,
         uselist=False,
     )
 
@@ -719,8 +688,9 @@ class EndpointRow(Base):
     def to_data(self) -> EndpointData:
         """Convert to EndpointData.
 
-        Requires revisions and revisions.image_row to be eagerly loaded
-        via selectinload for revision field population.
+        Requires ``current_revision_row`` / ``deploying_revision_row`` and
+        their ``image_row`` to be eagerly loaded via selectinload for
+        revision field population.
         ``_find_active_revision`` prefers ``current_revision`` and falls
         back to ``deploying_revision`` so the projection reflects the
         spec currently being deployed during the initial DEPLOYING
@@ -1080,9 +1050,7 @@ class EndpointAutoScalingRuleRow(Base):
         nullable=False,
     )
 
-    endpoint_row: Mapped[EndpointRow] = relationship(
-        "EndpointRow", back_populates="endpoint_auto_scaling_rules", lazy="joined"
-    )
+    endpoint_row: Mapped[EndpointRow] = relationship("EndpointRow", lazy="joined")
 
     @classmethod
     async def list(

--- a/src/ai/backend/manager/models/group/row.py
+++ b/src/ai/backend/manager/models/group/row.py
@@ -72,29 +72,11 @@ from ai.backend.manager.models.types import (
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, execute_with_txn_retry
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.domain import DomainRow
-    from ai.backend.manager.models.kernel import KernelRow
-    from ai.backend.manager.models.network import NetworkRow
     from ai.backend.manager.models.rbac import ContainerRegistryScope
     from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
     from ai.backend.manager.models.scaling_group import ScalingGroupForProjectRow
-    from ai.backend.manager.models.session import SessionRow
-    from ai.backend.manager.models.user import UserRow
-    from ai.backend.manager.models.vfolder import VFolderRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-
-def _get_networks_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.network import NetworkRow
-
-    return GroupRow.id == foreign(NetworkRow.project)
-
-
-def _get_vfolder_rows_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.vfolder import VFolderRow
-
-    return GroupRow.id == foreign(VFolderRow.group)
 
 
 def _get_association_container_registries_groups_join_condition() -> sa.ColumnElement[bool]:
@@ -153,9 +135,6 @@ class AssocGroupUserRow(Base):
         sa.ForeignKey("groups.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
     )
-
-    user: Mapped[UserRow] = relationship("UserRow", back_populates="groups")
-    group: Mapped[GroupRow] = relationship("GroupRow", back_populates="users")
 
 
 # DEPRECATED: scheduled for sunset; project membership lives in
@@ -220,26 +199,11 @@ class GroupRow(LifecycleTimestampsMixin, Base):
     )
 
     # Relationships (defined with deferred join conditions to avoid circular imports)
-    sessions: Mapped[list[SessionRow]] = relationship("SessionRow", back_populates="group")
-    domain: Mapped[DomainRow] = relationship("DomainRow")
     sgroup_for_groups_rows: Mapped[list[ScalingGroupForProjectRow]] = relationship(
         "ScalingGroupForProjectRow"
     )
-    users: Mapped[list[AssocGroupUserRow]] = relationship(
-        "AssocGroupUserRow", back_populates="group"
-    )
+    users: Mapped[list[AssocGroupUserRow]] = relationship("AssocGroupUserRow")
     resource_policy_row: Mapped[ProjectResourcePolicyRow] = relationship("ProjectResourcePolicyRow")
-    kernels: Mapped[list[KernelRow]] = relationship("KernelRow", back_populates="group_row")
-    networks: Mapped[list[NetworkRow]] = relationship(
-        "NetworkRow",
-        back_populates="project_row",
-        primaryjoin=_get_networks_join_condition,
-    )
-    vfolder_rows: Mapped[list[VFolderRow]] = relationship(
-        "VFolderRow",
-        back_populates="group_row",
-        primaryjoin=_get_vfolder_rows_join_condition,
-    )
     association_container_registries_groups_rows: Mapped[
         list[AssociationContainerRegistriesGroupsRow]
     ] = relationship(

--- a/src/ai/backend/manager/models/kernel/row.py
+++ b/src/ai/backend/manager/models/kernel/row.py
@@ -435,12 +435,11 @@ class KernelRow(CreatedAtMixin, Base):
         "ImageRow",
         foreign_keys="KernelRow.image_id",
     )
-    agent_row: Mapped[AgentRow | None] = relationship("AgentRow", back_populates="kernels")
-    group_row: Mapped[GroupRow] = relationship("GroupRow", back_populates="kernels")
+    agent_row: Mapped[AgentRow | None] = relationship("AgentRow")
+    group_row: Mapped[GroupRow] = relationship("GroupRow")
     user_row: Mapped[UserRow] = relationship(
         "UserRow",
         primaryjoin=_get_user_row_join_condition,
-        back_populates="kernels",
         foreign_keys="KernelRow.user_uuid",
     )
 

--- a/src/ai/backend/manager/models/keypair/row.py
+++ b/src/ai/backend/manager/models/keypair/row.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.backends import default_backend as crypto_default_backe
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
-from sqlalchemy.orm import Mapped, foreign, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql.expression import false
 
 from ai.backend.common import msgpack
@@ -29,7 +29,6 @@ from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 if TYPE_CHECKING:
     from ai.backend.manager.models.resource_policy import KeyPairResourcePolicyRow
     from ai.backend.manager.models.scaling_group import ScalingGroupForKeypairsRow
-    from ai.backend.manager.models.session import SessionRow
     from ai.backend.manager.models.user import UserRow
 
 __all__: Sequence[str] = (
@@ -44,13 +43,6 @@ __all__: Sequence[str] = (
 
 
 MAXIMUM_DOTFILE_SIZE = 64 * 1024  # 61 KiB
-
-
-# Defined for avoiding circular import
-def _get_session_row_join_condition() -> sa.ColumnElement[bool]:
-    from ai.backend.manager.models.session import SessionRow
-
-    return KeyPairRow.access_key == foreign(SessionRow.access_key)
 
 
 class KeyPairRow(LifecycleTimestampsMixin, Base):
@@ -99,11 +91,6 @@ class KeyPairRow(LifecycleTimestampsMixin, Base):
     )
 
     # Relationships
-    sessions: Mapped[list[SessionRow]] = relationship(
-        "SessionRow",
-        primaryjoin=_get_session_row_join_condition,
-        foreign_keys="SessionRow.access_key",
-    )
     resource_policy_row: Mapped[KeyPairResourcePolicyRow] = relationship("KeyPairResourcePolicyRow")
     sgroup_for_keypairs_rows: Mapped[list[ScalingGroupForKeypairsRow]] = relationship(
         "ScalingGroupForKeypairsRow",

--- a/src/ai/backend/manager/models/network/row.py
+++ b/src/ai/backend/manager/models/network/row.py
@@ -70,7 +70,6 @@ class NetworkRow(LifecycleTimestampsMixin, Base):
 
     project_row: Mapped[GroupRow] = relationship(
         "GroupRow",
-        back_populates="networks",
         primaryjoin=_get_project_join_condition,
     )
     domain_row: Mapped[DomainRow] = relationship(

--- a/src/ai/backend/manager/models/routing/row.py
+++ b/src/ai/backend/manager/models/routing/row.py
@@ -156,7 +156,7 @@ class RoutingRow(Base):
 
     endpoint_row: Mapped[EndpointRow] = relationship("EndpointRow", back_populates="routings")
     session_row: Mapped[SessionRow | None] = relationship(
-        "SessionRow", back_populates="routing", foreign_keys="RoutingRow.session"
+        "SessionRow", foreign_keys="RoutingRow.session"
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/scaling_group/row.py
+++ b/src/ai/backend/manager/models/scaling_group/row.py
@@ -305,7 +305,6 @@ class ScalingGroupRow(CreatedAtMixin, Base):
 
     agents: Mapped[list[AgentRow]] = relationship(
         "AgentRow",
-        back_populates="scaling_group_row",
         foreign_keys="[AgentRow.scaling_group]",
     )
 

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -104,7 +104,6 @@ from ai.backend.manager.models.rbac import (
 )
 from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.resource_slot import ResourceAllocationRow
-from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.types import (
     QueryCondition,
     QueryOption,
@@ -116,8 +115,6 @@ from ai.backend.manager.models.utils import (
 )
 
 if TYPE_CHECKING:
-    from ai.backend.manager.models.domain import DomainRow
-    from ai.backend.manager.models.scaling_group import ScalingGroupRow
     from ai.backend.manager.models.user import UserRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -352,12 +349,6 @@ ALLOWED_IMAGE_ROLES_FOR_SESSION_TYPE: Mapping[SessionTypes, tuple[str, ...]] = {
 
 
 # Defined for avoiding circular import
-def _get_keypair_row_join_condition() -> sa.sql.elements.ColumnElement[Any]:
-    from ai.backend.manager.models.keypair import KeyPairRow
-
-    return KeyPairRow.access_key == foreign(SessionRow.access_key)
-
-
 def _get_user_row_join_condition() -> sa.sql.elements.ColumnElement[Any]:
     from ai.backend.manager.models.user import UserRow
 
@@ -463,10 +454,6 @@ class SessionRow(CreatedAtMixin, Base):
     scaling_group_name: Mapped[str] = mapped_column(
         "scaling_group_name", sa.ForeignKey("scaling_groups.name"), index=True, nullable=False
     )
-    scaling_group: Mapped[ScalingGroupRow] = relationship(
-        "ScalingGroupRow",
-        foreign_keys=[scaling_group_name],
-    )
     target_sgroup_names: Mapped[list[str] | None] = mapped_column(
         "target_sgroup_names",
         sa.ARRAY(sa.String(length=64)),
@@ -484,21 +471,16 @@ class SessionRow(CreatedAtMixin, Base):
         index=True,
         nullable=False,
     )
-    domain: Mapped[DomainRow] = relationship(
-        "DomainRow",
-        foreign_keys=[domain_name],
-    )
     group_id: Mapped[UUID] = mapped_column(
         "group_id", GUID, sa.ForeignKey("groups.id"), nullable=False
     )
-    group: Mapped[GroupRow] = relationship("GroupRow", back_populates="sessions")
+    group: Mapped[GroupRow] = relationship("GroupRow")
     user_uuid: Mapped[UUID] = mapped_column(
         "user_uuid", GUID, server_default=sa.text("uuid_generate_v4()"), nullable=False
     )
     user: Mapped[UserRow] = relationship(
         "UserRow",
         primaryjoin=_get_user_row_join_condition,
-        back_populates="sessions",
         foreign_keys=[user_uuid],
     )
 
@@ -653,10 +635,6 @@ class SessionRow(CreatedAtMixin, Base):
             name="fk_sessions_replica_id_routings",
         ),
         nullable=True,
-    )
-
-    routing: Mapped[list[RoutingRow]] = relationship(
-        "RoutingRow", back_populates="session_row", foreign_keys="RoutingRow.session"
     )
 
     __table_args__ = (

--- a/src/ai/backend/manager/models/user/row.py
+++ b/src/ai/backend/manager/models/user/row.py
@@ -46,13 +46,8 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine, execute_with_
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.domain import DomainRow
-    from ai.backend.manager.models.group import AssocGroupUserRow
-    from ai.backend.manager.models.kernel import KernelRow
     from ai.backend.manager.models.keypair import KeyPairRow
-    from ai.backend.manager.models.rbac_models import UserRoleRow
     from ai.backend.manager.models.resource_policy import UserResourcePolicyRow
-    from ai.backend.manager.models.session import SessionRow
-    from ai.backend.manager.models.vfolder import VFolderRow
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -81,40 +76,10 @@ INACTIVE_USER_STATUSES = (
 
 
 # Defined for avoiding circular import
-def _get_session_row_join_condition() -> Any:
-    from ai.backend.manager.models.session import SessionRow
-
-    return UserRow.uuid == foreign(SessionRow.user_uuid)
-
-
-def _get_kernel_row_join_condition() -> Any:
-    from ai.backend.manager.models.kernel import KernelRow
-
-    return UserRow.uuid == foreign(KernelRow.user_uuid)
-
-
-def _get_vfolder_rows_join_condition() -> Any:
-    from ai.backend.manager.models.vfolder import VFolderRow
-
-    return UserRow.uuid == foreign(VFolderRow.user)
-
-
-def _get_role_assignments_join_condition() -> Any:
-    from ai.backend.manager.models.rbac_models import UserRoleRow
-
-    return UserRow.uuid == foreign(UserRoleRow.user_id)
-
-
 def _get_domain_join_condition() -> Any:
     from ai.backend.manager.models.domain import DomainRow
 
     return DomainRow.name == foreign(UserRow.domain_name)
-
-
-def _get_groups_join_condition() -> Any:
-    from ai.backend.manager.models.group import AssocGroupUserRow
-
-    return foreign(AssocGroupUserRow.user_id) == UserRow.uuid
 
 
 def _get_resource_policy_join_condition() -> Any:
@@ -228,23 +193,8 @@ class UserRow(LifecycleTimestampsMixin, Base):
     )
 
     # Relationships
-    sessions: Mapped[list[SessionRow]] = relationship(
-        "SessionRow",
-        back_populates="user",
-        primaryjoin=_get_session_row_join_condition,
-        foreign_keys="SessionRow.user_uuid",
-    )
-    kernels: Mapped[list[KernelRow]] = relationship(
-        "KernelRow",
-        back_populates="user_row",
-        primaryjoin=_get_kernel_row_join_condition,
-        foreign_keys="KernelRow.user_uuid",
-    )
     domain: Mapped[DomainRow | None] = relationship(
         "DomainRow", primaryjoin=_get_domain_join_condition
-    )
-    groups: Mapped[list[AssocGroupUserRow]] = relationship(
-        "AssocGroupUserRow", back_populates="user", primaryjoin=_get_groups_join_condition
     )
     resource_policy_row: Mapped[UserResourcePolicyRow] = relationship(
         "UserResourcePolicyRow",
@@ -261,17 +211,6 @@ class UserRow(LifecycleTimestampsMixin, Base):
         "KeyPairRow",
         primaryjoin=_get_main_keypair_join_condition,
         foreign_keys="UserRow.main_access_key",
-    )
-
-    vfolder_rows: Mapped[list[VFolderRow]] = relationship(
-        "VFolderRow",
-        back_populates="user_row",
-        primaryjoin=_get_vfolder_rows_join_condition,
-    )
-
-    role_assignments: Mapped[list[UserRoleRow]] = relationship(
-        "UserRoleRow",
-        primaryjoin=_get_role_assignments_join_condition,
     )
 
     @classmethod

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -377,19 +377,11 @@ class VFolderRow(LifecycleTimestampsMixin, Base):
     # Relationships
     user_row: Mapped[UserRow | None] = relationship(
         "UserRow",
-        back_populates="vfolder_rows",
         primaryjoin=_get_user_row_join_condition,
     )
     group_row: Mapped[GroupRow | None] = relationship(
         "GroupRow",
-        back_populates="vfolder_rows",
         primaryjoin=_get_group_row_join_condition,
-    )
-    permission_rows: Mapped[list[VFolderPermissionRow]] = relationship(
-        "VFolderPermissionRow", back_populates="vfolder_row"
-    )
-    invitation_rows: Mapped[list[VFolderInvitationRow]] = relationship(
-        "VFolderInvitationRow", back_populates="vfolder_row"
     )
 
     @classmethod
@@ -497,7 +489,7 @@ class VFolderInvitationRow(LifecycleTimestampsMixin, Base):
     )
 
     # Relationships
-    vfolder_row: Mapped[VFolderRow] = relationship("VFolderRow", back_populates="invitation_rows")
+    vfolder_row: Mapped[VFolderRow] = relationship("VFolderRow")
 
 
 # NOTE: Deprecated legacy table reference for backward compatibility.
@@ -523,9 +515,6 @@ class VFolderPermissionRow(Base):
     user: Mapped[uuid.UUID] = mapped_column(
         "user", GUID, sa.ForeignKey("users.uuid"), nullable=False
     )
-
-    # Relationships
-    vfolder_row: Mapped[VFolderRow] = relationship("VFolderRow", back_populates="permission_rows")
 
 
 # NOTE: Deprecated legacy table reference for backward compatibility.


### PR DESCRIPTION
## Summary

- Remove `relationship()` definitions that have no remaining references from the user, group, session, keypair, vfolder, agent, and endpoint row modules, together with their `primaryjoin` helpers and now-dead `TYPE_CHECKING` imports. `AssocGroupUserRow` and `VFolderPermissionRow` are left with no relationships at all.
- Where the other side of a pair is still in use, only its `back_populates` is dropped: `kernel` (`user_row`/`group_row`/`agent_row`), `session` (`user`/`group`), `vfolder` (`user_row`/`group_row`/`VFolderInvitationRow.vfolder_row`), `group` (`users`), `scaling_group` (`agents`), `network` (`project_row`), `routing` (`session_row`), `endpoint` (`EndpointAutoScalingRuleRow.endpoint_row`).
- `EndpointTokenRow.endpoint_row` was listed in the issue but is still eagerly loaded via `selectinload` (`endpoint/row.py`), as is its `EndpointRow.tokens` counterpart, so both stay with their `back_populates` intact.

Removed, by module: `user` (`sessions`, `kernels`, `groups`, `vfolder_rows`, `role_assignments`), `group` (`AssocGroupUserRow.user`/`group`, `GroupRow.sessions`/`domain`/`kernels`/`networks`/`vfolder_rows`), `session` (`scaling_group`, `domain`, `routing`), `keypair` (`sessions`), `vfolder` (`VFolderRow.permission_rows`/`invitation_rows`, `VFolderPermissionRow.vfolder_row`), `agent` (`kernels`, `scaling_group_row`), `endpoint` (`revisions`, `auto_scaling_policy`, `endpoint_auto_scaling_rules`).

The issue's `session (access_key_row)` item was already gone as a relationship; only its orphaned `_get_keypair_row_join_condition` helper remained, and that is removed here. `EndpointRow.to_data`'s docstring named the removed `revisions` attribute; it now names the relationships the projection actually reads (`current_revision_row` / `deploying_revision_row`).

## Test plan

- [x] Repo-wide reference sweep over all removed attributes across `src/` and `tests/` — class-qualified, instance-attribute, and constructor-kwarg forms; no remaining readers or loader options. Matches for `SessionRow.scaling_group`/`domain`, `GroupRow.domain`, and `AssocGroupUserRow.user`/`group` were all column prefixes (`scaling_group_name`, `domain_name`, `user_id`, `group_id`).
- [x] Import every `manager/models` module and run `sqlalchemy.orm.configure_mappers()` — passes, so no `back_populates` pair is left dangling
- [x] CI: `pants check` and `pants test`

Resolves BA-7225