### PR TITLE
refactor(BA-7318): type message queue payloads as anycast/broadcast models

### DIFF
--- a/changes/13679.enhance.md
+++ b/changes/13679.enhance.md
@@ -1,0 +1,1 @@
+Type the message queue payloads as separate anycast and broadcast models, and validate received messages instead of casting them

--- a/src/ai/backend/common/clients/valkey_client/valkey_stream/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_stream/client.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Self, cast
+from typing import Self, cast
 
 from glide import (
     Batch,
@@ -19,8 +19,11 @@ from ai.backend.common.clients.valkey_client.client import (
     create_valkey_client,
 )
 from ai.backend.common.exception import BackendAIError
-from ai.backend.common.json import dump_json, load_json
-from ai.backend.common.message_queue.types import BroadcastPayload
+from ai.backend.common.message_queue.payload import (
+    AnycastPayload,
+    BroadcastPayload,
+    CachedBroadcastPayload,
+)
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
     BackoffStrategy,
@@ -211,7 +214,7 @@ class ValkeyStreamClient:
     async def enqueue_stream_message(
         self,
         stream_key: str,
-        payload: Mapping[bytes, bytes],
+        payload: AnycastPayload,
     ) -> None:
         """
         Enqueue a message to the Valkey stream.
@@ -220,7 +223,7 @@ class ValkeyStreamClient:
         :param payload: The message payload to add to the stream.
         :raises: GlideClientError if the message cannot be added.
         """
-        values = [(k, v) for k, v in payload.items()]
+        values = [(k, v) for k, v in payload.to_stream_fields().items()]
         async with self._client.client() as conn:
             await conn.xadd(
                 stream_key,
@@ -236,7 +239,7 @@ class ValkeyStreamClient:
         stream_key: str,
         group_name: str,
         message_id: bytes,
-        payload: Mapping[bytes, bytes],
+        payload: AnycastPayload,
     ) -> None:
         """
         Requeue a message in the consumer group.
@@ -249,7 +252,7 @@ class ValkeyStreamClient:
         """
         tx = self._create_batch()
         tx.xack(stream_key, group_name, [message_id])
-        values = [(k, v) for k, v in payload.items()]
+        values = [(k, v) for k, v in payload.to_stream_fields().items()]
         tx.xadd(
             stream_key,
             cast(list[tuple[str | bytes, str | bytes]], values),
@@ -307,25 +310,24 @@ class ValkeyStreamClient:
     async def broadcast(
         self,
         channel: str,
-        payload: Mapping[str, Any],
+        payload: BroadcastPayload,
     ) -> None:
         """
         Broadcast a message to a channel.
 
         :param channel: The channel to broadcast the message to.
-        :param payload: The payload of the message.
+        :param payload: The message payload to publish.
         :raises: GlideClientError if the message cannot be broadcasted.
         """
-        message = dump_json(payload)
         async with self._client.client() as conn:
-            await conn.publish(message=message, channel=channel)
+            await conn.publish(message=payload.to_json(), channel=channel)
 
     @valkey_stream_resilience.apply()
     async def broadcast_with_cache(
         self,
         channel: str,
         cache_id: str,
-        payload: Mapping[str, str],
+        payload: BroadcastPayload,
         expiry_seconds: int = _DEFAULT_CACHE_EXPIRATION,
     ) -> None:
         """
@@ -333,11 +335,11 @@ class ValkeyStreamClient:
 
         :param channel: The channel to broadcast the message to.
         :param cache_id: The ID for caching the message.
-        :param payload: The payload of the message.
+        :param payload: The message payload to publish.
         :param expiry_seconds: The expiration time for the cached message in seconds.
         :raises: GlideClientError if the message cannot be broadcasted or cached.
         """
-        message = dump_json(payload)
+        message = payload.to_json()
         tx = self._create_batch()
         tx.set(key=cache_id, value=message, expiry=ExpirySet(ExpiryType.SEC, expiry_seconds))
         tx.publish(
@@ -351,32 +353,32 @@ class ValkeyStreamClient:
     async def fetch_cached_broadcast_message(
         self,
         cache_id: str,
-    ) -> Mapping[str, str] | None:
+    ) -> BroadcastPayload | None:
         """
         Fetch a cached broadcast message by its ID.
 
         :param cache_id: The ID of the cached message.
         :return: The cached message payload or None if not found.
+        :raises: InvalidMessagePayloadError if the cached message is malformed.
         """
         async with self._client.client() as conn:
             result = await conn.get(cache_id)
         if not result:
             return None
-        payload = load_json(result)
-        return cast(Mapping[str, str], payload)
+        return BroadcastPayload.from_json(result)
 
     @valkey_stream_resilience.apply()
     async def broadcast_batch(
         self,
         channel: str,
-        events: list[BroadcastPayload],
+        events: list[CachedBroadcastPayload],
         expiry_seconds: int = _DEFAULT_CACHE_EXPIRATION,
     ) -> None:
         """
         Broadcast multiple messages to a channel in a batch with optional caching.
 
         :param channel: The channel to broadcast the messages to.
-        :param events: List of BroadcastPayload objects containing payload and optional cache_id.
+        :param events: List of payloads to publish, each with an optional cache_id.
         :param expiry_seconds: The expiration time for the cached messages in seconds.
         :raises: GlideClientError if the messages cannot be broadcasted or cached.
         """
@@ -385,7 +387,7 @@ class ValkeyStreamClient:
 
         tx = self._create_batch()
         for event in events:
-            message = dump_json(event.payload)
+            message = event.payload.to_json()
             # Only set cache if cache_id is provided
             if event.cache_id:
                 tx.set(
@@ -403,16 +405,17 @@ class ValkeyStreamClient:
     @valkey_stream_resilience.apply()
     async def receive_broadcast_message(
         self,
-    ) -> Mapping[str, str]:
+    ) -> BroadcastPayload:
         """
         Receive a broadcast message from a channel.
         This method blocks until a message is received.
 
         :return: The payload of the received message.
+        :raises: InvalidMessagePayloadError if the received message is malformed.
         """
         async with self._client.client() as conn:
             message = await conn.get_pubsub_message()
-        return cast(Mapping[str, str], load_json(message.message))
+        return BroadcastPayload.from_json(cast(bytes | str, message.message))
 
     def _create_batch(self, is_atomic: bool = False) -> Batch:
         """

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -24,17 +24,14 @@ from aiotools.taskgroup.types import AsyncExceptionHandler
 
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
-from ai.backend.common.message_queue.queue import AbstractMessageQueue
-from ai.backend.common.message_queue.types import (
-    BroadcastMessage,
+from ai.backend.common.message_queue.message import MessageId, MQMessage
+from ai.backend.common.message_queue.payload import (
+    AnycastPayload,
     BroadcastPayload,
-    MessageId,
-    MessageMetadata,
-    MessagePayload,
-    MQMessage,
-    deserialize_event_name_for_anycast,
-    deserialize_event_name_for_broadcast,
+    CachedBroadcastPayload,
 )
+from ai.backend.common.message_queue.queue import AbstractMessageQueue
+from ai.backend.common.message_queue.types import MessageMetadata
 from ai.backend.common.types import (
     AgentId,
 )
@@ -578,7 +575,7 @@ class EventDispatcher(EventDispatcherGroup):
         self,
         mq_msg: MQMessage,
     ) -> None:
-        event_name = deserialize_event_name_for_anycast(mq_msg.payload)
+        event_name = mq_msg.payload.name
         consumer_handlers = self._consumers.get(event_name)
         post_callback = _ConsumerPostCallback(
             mq_msg.msg_id,
@@ -590,38 +587,39 @@ class EventDispatcher(EventDispatcherGroup):
             return
         if self._log_events:
             log.debug("DISPATCH_CONSUMERS(ev:{})", event_name)
-        msg_payload = MessagePayload.from_anycast(mq_msg.payload)
+        payload = mq_msg.payload
+        args = payload.decode_args()
         for consumer in consumer_handlers.copy():
             self._consumer_taskgroup.create_task(
                 self._handle(
                     consumer,
-                    AgentId(msg_payload.source),
-                    msg_payload.args,
+                    AgentId(payload.source),
+                    args,
                     [post_callback],
-                    msg_payload.metadata,
+                    payload.metadata,
                 ),
             )
             await asyncio.sleep(0)
 
     async def _dispatch_subscribers(
         self,
-        broadcast_msg: BroadcastMessage,
+        payload: BroadcastPayload,
     ) -> None:
-        event_name = deserialize_event_name_for_broadcast(broadcast_msg.payload)
+        event_name = payload.name
         subscriber_handlers = self._subscribers.get(event_name)
         if not subscriber_handlers:
             return
         if self._log_events:
             log.debug("DISPATCH_SUBSCRIBERS(ev:{})", event_name)
-        msg_payload = MessagePayload.from_broadcast(broadcast_msg.payload)
+        args = payload.decode_args()
         for subscriber in subscriber_handlers.copy():
             self._subscriber_taskgroup.create_task(
                 self._handle(
                     subscriber,
-                    AgentId(msg_payload.source),
-                    msg_payload.args,
+                    AgentId(payload.source),
+                    args,
                     tuple(),
-                    msg_payload.metadata,
+                    payload.metadata,
                 ),
             )
             await asyncio.sleep(0)
@@ -647,7 +645,7 @@ class EventDispatcher(EventDispatcherGroup):
             if self._closed:
                 return
             try:
-                await self._dispatch_subscribers(cast(BroadcastMessage, msg))
+                await self._dispatch_subscribers(cast(BroadcastPayload, msg))
             except Exception as e:
                 log.exception(
                     "EventDispatcher._subscribe_loop: unexpected-error, {}",
@@ -699,13 +697,13 @@ class EventProducer:
             user=user,
             triggered_user=triggered,
         )
-        raw_event = MessagePayload(
+        payload = AnycastPayload.from_event_args(
             name=event.event_name(),
             source=source,
             args=event.serialize(),
             metadata=metadata,
-        ).serialize_anycast()
-        await self._msg_queue.send(raw_event)
+        )
+        await self._msg_queue.send(payload)
 
     async def broadcast_event(
         self,
@@ -726,13 +724,13 @@ class EventProducer:
             user=user,
             triggered_user=triggered,
         )
-        raw_event = MessagePayload(
+        payload = BroadcastPayload.from_event_args(
             name=event.event_name(),
             source=source,
             args=event.serialize(),
             metadata=metadata,
-        ).serialize_broadcast()
-        await self._msg_queue.broadcast(raw_event)
+        )
+        await self._msg_queue.broadcast(payload)
 
     async def broadcast_event_with_cache(
         self,
@@ -752,16 +750,15 @@ class EventProducer:
             user=user,
             triggered_user=triggered,
         )
-        # I want to receive MessagePayload as an argument in anycast and broadcast, but changing it would require changes in other places, so I'll leave it as is for now.
-        raw_event = MessagePayload(
+        payload = BroadcastPayload.from_event_args(
             name=event.event_name(),
             source=str(self._source),
             args=event.serialize(),
             metadata=metadata,
-        ).serialize_broadcast()
+        )
         await self._msg_queue.broadcast_with_cache(
             cache_id,
-            raw_event,
+            payload,
         )
 
     async def broadcast_events_batch(
@@ -787,18 +784,17 @@ class EventProducer:
             triggered_user=triggered,
         )
 
-        # Convert events to BroadcastPayload objects
-        broadcast_payloads: list[BroadcastPayload] = []
+        broadcast_payloads: list[CachedBroadcastPayload] = []
         for event in events:
-            raw_event = MessagePayload(
+            payload = BroadcastPayload.from_event_args(
                 name=event.event_name(),
                 source=str(self._source),
                 args=event.serialize(),
                 metadata=metadata,
-            ).serialize_broadcast()
+            )
             broadcast_payloads.append(
-                BroadcastPayload(
-                    payload=raw_event,
+                CachedBroadcastPayload(
+                    payload=payload,
                     cache_id=event.cache_id(),  # Get cache_id from event
                 )
             )

--- a/src/ai/backend/common/events/fetcher.py
+++ b/src/ai/backend/common/events/fetcher.py
@@ -1,6 +1,5 @@
 from ai.backend.common.events.types import AbstractBroadcastEvent
 from ai.backend.common.message_queue.queue import AbstractMessageQueue
-from ai.backend.common.message_queue.types import MessagePayload
 
 
 class EventFetcher:
@@ -20,5 +19,4 @@ class EventFetcher:
         payload = await self._msg_queue.fetch_cached_broadcast_message(cache_id)
         if payload is None:
             return None
-        message_payload = MessagePayload.from_broadcast(payload)
-        return AbstractBroadcastEvent.deserialize_from_wrapper(message_payload)
+        return AbstractBroadcastEvent.deserialize_from_wrapper(payload)

--- a/src/ai/backend/common/events/types.py
+++ b/src/ai/backend/common/events/types.py
@@ -2,7 +2,7 @@ import enum
 from abc import ABC, abstractmethod
 from typing import Self, final, override
 
-from ai.backend.common.message_queue.types import MessagePayload
+from ai.backend.common.message_queue.payload import BroadcastPayload
 
 from .user_event.user_event import UserEvent
 
@@ -144,14 +144,14 @@ class AbstractBroadcastEvent(AbstractEvent):
             return
 
     @classmethod
-    def deserialize_from_wrapper(cls, payload: MessagePayload) -> "AbstractBroadcastEvent":
+    def deserialize_from_wrapper(cls, payload: BroadcastPayload) -> "AbstractBroadcastEvent":
         """
-        Deserialize the event from event wrapper mapping.
+        Deserialize the event from its broadcast payload.
         """
         event_class = cls._register_dict.get(payload.name)
         if not event_class:
             raise ValueError(f"Event class for name {payload.name} not found")
-        return event_class.deserialize(payload.args)
+        return event_class.deserialize(payload.decode_args())
 
     @classmethod
     @override

--- a/src/ai/backend/common/message_queue/AGENTS.md
+++ b/src/ai/backend/common/message_queue/AGENTS.md
@@ -11,10 +11,15 @@ Abstraction over Redis streams (anycast) and pub/sub (broadcast). Prefer `RedisQ
 
 - **Consumers must call `done(msg_id)` after handling** — otherwise the message is redelivered after the idle timeout, then discarded past max retries.
 - Subscribers do not ack (broadcast may be lost by design).
-- Anycast payload is `dict[bytes, bytes]`; broadcast payload is `dict[str, str]`. Do not mix.
+- Anycast carries `AnycastPayload`, broadcast carries `BroadcastPayload`. Do not mix, and do not hand-build the wire mapping — the payload models own the encoding.
+- Decode received messages with `from_stream_fields()` / `from_json()`; they raise `InvalidMessagePayloadError` instead of failing later at field access.
 - Configure only the streams/channels you use (`consume_stream_keys=None` / `subscribe_channels=None`) to avoid idle background loops.
 - Always `await close()` the queue/components to avoid connection and task leaks.
 
-## Types (`types.py`)
+## Types
 
-`MQMessage` (anycast), `BroadcastMessage` (broadcast), `MessagePayload` (high-level, used by the events system). When relaying, preserve `MessageMetadata` (request_id/user) via `apply_context()`.
+| Module | Holds |
+|--------|-------|
+| `payload.py` | The payloads: `MessagePayload` base (`name`, `source`, `body`, `metadata`), `AnycastPayload` (adds `retry_count` + stream-field codec), `BroadcastPayload` (adds the JSON codec), `CachedBroadcastPayload` (a broadcast payload plus its `cache_id`, for `broadcast_batch()`) |
+| `message.py` | What a consumer receives: `MQMessage` (anycast payload + the stream entry id needed to ack it, `retry()`) and `MessageId` |
+| `types.py` | `MessageMetadata` — when relaying, preserve it (request_id/user) via `apply_context()` |

--- a/src/ai/backend/common/message_queue/abc/anycaster.py
+++ b/src/ai/backend/common/message_queue/abc/anycaster.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from ai.backend.common.message_queue.payload import AnycastPayload
+
 
 class AbstractAnycaster(ABC):
     """
@@ -10,12 +12,12 @@ class AbstractAnycaster(ABC):
     """
 
     @abstractmethod
-    async def anycast(self, payload: dict[bytes, bytes]) -> None:
+    async def anycast(self, payload: AnycastPayload) -> None:
         """
         Send a message to the anycast queue.
 
         Args:
-            payload: Message payload as a dict of bytes
+            payload: Message payload as an anycast envelope
 
         Raises:
             RuntimeError: If the component is closed

--- a/src/ai/backend/common/message_queue/abc/broadcaster.py
+++ b/src/ai/backend/common/message_queue/abc/broadcaster.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
-from typing import Any
 
-from ai.backend.common.message_queue.types import BroadcastPayload
+from ai.backend.common.message_queue.payload import BroadcastPayload, CachedBroadcastPayload
 
 
 class AbstractBroadcaster(ABC):
@@ -14,12 +12,12 @@ class AbstractBroadcaster(ABC):
     """
 
     @abstractmethod
-    async def broadcast(self, payload: Mapping[str, Any]) -> None:
+    async def broadcast(self, payload: BroadcastPayload) -> None:
         """
         Broadcast a message to all subscribers.
 
         Args:
-            payload: Message payload as a mapping
+            payload: Message payload as a broadcast envelope
 
         Raises:
             RuntimeError: If the component is closed
@@ -27,13 +25,13 @@ class AbstractBroadcaster(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def broadcast_with_cache(self, cache_id: str, payload: Mapping[str, str]) -> None:
+    async def broadcast_with_cache(self, cache_id: str, payload: BroadcastPayload) -> None:
         """
         Broadcast a message with caching support.
 
         Args:
             cache_id: Unique identifier for caching the message
-            payload: Message payload as string mapping
+            payload: Message payload as a broadcast envelope
 
         Raises:
             RuntimeError: If the component is closed
@@ -41,7 +39,7 @@ class AbstractBroadcaster(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def fetch_cached_broadcast_message(self, cache_id: str) -> Mapping[str, str] | None:
+    async def fetch_cached_broadcast_message(self, cache_id: str) -> BroadcastPayload | None:
         """
         Retrieve a cached broadcast message.
 
@@ -57,7 +55,7 @@ class AbstractBroadcaster(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def broadcast_batch(self, events: list[BroadcastPayload]) -> None:
+    async def broadcast_batch(self, events: list[CachedBroadcastPayload]) -> None:
         """
         Broadcast multiple messages in a batch.
 

--- a/src/ai/backend/common/message_queue/abc/consumer.py
+++ b/src/ai/backend/common/message_queue/abc/consumer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 
-from ai.backend.common.message_queue.types import MessageId, MQMessage
+from ai.backend.common.message_queue.message import MessageId, MQMessage
 
 
 class AbstractConsumer(ABC):

--- a/src/ai/backend/common/message_queue/abc/queue.py
+++ b/src/ai/backend/common/message_queue/abc/queue.py
@@ -4,14 +4,13 @@ Use `ai.backend.common.message_queue.abc.{anycaster,broadcaster,consumer,subscri
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import AsyncGenerator, Mapping
-from typing import Any
+from collections.abc import AsyncGenerator
 
-from ai.backend.common.message_queue.types import (
-    BroadcastMessage,
+from ai.backend.common.message_queue.message import MessageId, MQMessage
+from ai.backend.common.message_queue.payload import (
+    AnycastPayload,
     BroadcastPayload,
-    MessageId,
-    MQMessage,
+    CachedBroadcastPayload,
 )
 
 
@@ -19,7 +18,7 @@ class AbstractMessageQueue(ABC):
     @abstractmethod
     async def send(
         self,
-        payload: dict[bytes, bytes],
+        payload: AnycastPayload,
     ) -> None:
         """
         Send a message to the queue.
@@ -33,7 +32,7 @@ class AbstractMessageQueue(ABC):
     @abstractmethod
     async def broadcast(
         self,
-        payload: Mapping[str, Any],
+        payload: BroadcastPayload,
     ) -> None:
         """
         Broadcast a message to all subscribers of the channel.
@@ -47,7 +46,7 @@ class AbstractMessageQueue(ABC):
     async def broadcast_with_cache(
         self,
         cache_id: str,
-        payload: Mapping[str, str],
+        payload: BroadcastPayload,
     ) -> None:
         """
         Broadcast a message to all subscribers of the channel with cache.
@@ -59,7 +58,7 @@ class AbstractMessageQueue(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def fetch_cached_broadcast_message(self, cache_id: str) -> Mapping[str, str] | None:
+    async def fetch_cached_broadcast_message(self, cache_id: str) -> BroadcastPayload | None:
         """
         Fetch a cached broadcast message by cache_id.
         This method retrieves the cached message from the broadcast channel.
@@ -70,7 +69,7 @@ class AbstractMessageQueue(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def broadcast_batch(self, events: list[BroadcastPayload]) -> None:
+    async def broadcast_batch(self, events: list[CachedBroadcastPayload]) -> None:
         """
         Broadcast multiple messages in a batch with optional caching.
         This method broadcasts multiple messages to all subscribers.
@@ -95,7 +94,7 @@ class AbstractMessageQueue(ABC):
     @abstractmethod
     async def subscribe_queue(
         self,
-    ) -> AsyncGenerator[BroadcastMessage, None]:
+    ) -> AsyncGenerator[BroadcastPayload, None]:
         """
         Subscribe to messages from the queue.
         This method will block until a message is available.

--- a/src/ai/backend/common/message_queue/abc/subscriber.py
+++ b/src/ai/backend/common/message_queue/abc/subscriber.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import AsyncGenerator
 
-from ai.backend.common.message_queue.types import BroadcastMessage
+from ai.backend.common.message_queue.payload import BroadcastPayload
 
 
 class AbstractSubscriber(ABC):
@@ -13,7 +13,7 @@ class AbstractSubscriber(ABC):
     """
 
     @abstractmethod
-    async def subscribe_queue(self) -> AsyncGenerator[BroadcastMessage, None]:
+    async def subscribe_queue(self) -> AsyncGenerator[BroadcastPayload, None]:
         """
         Subscribe to broadcast messages.
 
@@ -21,7 +21,7 @@ class AbstractSubscriber(ABC):
         Unlike consumer messages, broadcast messages don't require acknowledgment.
 
         Yields:
-            BroadcastMessage: Broadcast messages from subscribed channels
+            BroadcastPayload: Broadcast messages from subscribed channels
 
         Raises:
             RuntimeError: If the component is closed

--- a/src/ai/backend/common/message_queue/exceptions.py
+++ b/src/ai/backend/common/message_queue/exceptions.py
@@ -1,0 +1,26 @@
+from typing import override
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class InvalidMessagePayloadError(BackendAIError):
+    """
+    Raised when a received message does not conform to the message envelope contract.
+    """
+
+    error_type = "https://api.backend.ai/probs/invalid-message-payload"
+    error_title = "Invalid Message Payload"
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.MESSAGE_QUEUE,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
+        )

--- a/src/ai/backend/common/message_queue/hiredis_queue.py
+++ b/src/ai/backend/common/message_queue/hiredis_queue.py
@@ -3,19 +3,20 @@ import hashlib
 import logging
 import socket
 from collections.abc import AsyncGenerator, Mapping
-from typing import Any, cast, override
+from typing import Any, override
 
 import hiredis
 from aiotools.server import process_index
 
-from ai.backend.common.json import dump_json, load_json
 from ai.backend.common.message_queue.redis_queue import RedisMQArgs
 from ai.backend.common.redis_client import RedisConnection
 from ai.backend.common.types import RedisTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
+from .exceptions import InvalidMessagePayloadError
+from .message import MessageId, MQMessage
+from .payload import AnycastPayload, BroadcastPayload, CachedBroadcastPayload
 from .queue import AbstractMessageQueue
-from .types import BroadcastMessage, BroadcastPayload, MessageId, MQMessage
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -25,7 +26,7 @@ _DEFAULT_QUEUE_MAX_LEN = 128
 _DEFAULT_AUTO_RECONNECT_INTERVAL = 5  # seconds
 
 
-def _make_pieces(payload: dict[bytes, bytes]) -> list[bytes]:
+def _make_pieces(payload: Mapping[bytes, bytes]) -> list[bytes]:
     pieces = []
     for k, v in payload.items():
         pieces.append(k)
@@ -33,11 +34,15 @@ def _make_pieces(payload: dict[bytes, bytes]) -> list[bytes]:
     return pieces
 
 
+def _make_payload(messages: list[bytes]) -> dict[bytes, bytes]:
+    return {messages[i]: messages[i + 1] for i in range(0, len(messages), 2)}
+
+
 class HiRedisQueue(AbstractMessageQueue):
     _target: RedisTarget
     _db: int
     _consume_queue: asyncio.Queue[MQMessage]
-    _subscribe_queue: asyncio.Queue[BroadcastMessage]
+    _subscribe_queue: asyncio.Queue[BroadcastPayload]
     _anycast_stream_key: str
     _broadcast_channel: str
     _group_name: str
@@ -73,9 +78,9 @@ class HiRedisQueue(AbstractMessageQueue):
             )
 
     @override
-    async def send(self, payload: dict[bytes, bytes]) -> None:
+    async def send(self, payload: AnycastPayload) -> None:
         async with RedisConnection(self._target, db=self._db) as client:
-            pieces = _make_pieces(payload)
+            pieces = _make_pieces(payload.to_stream_fields())
             await client.execute([
                 "XADD",
                 self._anycast_stream_key,
@@ -86,9 +91,9 @@ class HiRedisQueue(AbstractMessageQueue):
             ])
 
     @override
-    async def broadcast(self, payload: Mapping[str, str]) -> None:
+    async def broadcast(self, payload: BroadcastPayload) -> None:
         async with RedisConnection(self._target, db=self._db) as client:
-            payload_bytes = dump_json(payload)
+            payload_bytes = payload.to_json()
             await client.execute([
                 "PUBLISH",
                 self._broadcast_channel,
@@ -96,9 +101,9 @@ class HiRedisQueue(AbstractMessageQueue):
             ])
 
     @override
-    async def broadcast_with_cache(self, cache_id: str, payload: Mapping[str, str]) -> None:
+    async def broadcast_with_cache(self, cache_id: str, payload: BroadcastPayload) -> None:
         async with RedisConnection(self._target, db=self._db) as client:
-            payload_bytes = dump_json(payload)
+            payload_bytes = payload.to_json()
             await client.pipeline([
                 [
                     "SET",
@@ -118,17 +123,17 @@ class HiRedisQueue(AbstractMessageQueue):
             ])
 
     @override
-    async def fetch_cached_broadcast_message(self, cache_id: str) -> Mapping[str, str] | None:
+    async def fetch_cached_broadcast_message(self, cache_id: str) -> BroadcastPayload | None:
         if self._closed:
             raise RuntimeError("Queue is closed")
         async with RedisConnection(self._target, db=self._db) as client:
             reply = await client.execute(["GET", cache_id])
             if reply is None:
                 return None
-            return cast(Mapping[str, str] | None, load_json(reply))
+            return BroadcastPayload.from_json(reply)
 
     @override
-    async def broadcast_batch(self, events: list[BroadcastPayload]) -> None:
+    async def broadcast_batch(self, events: list[CachedBroadcastPayload]) -> None:
         """
         Broadcast multiple messages in a batch with optional caching.
         This method broadcasts multiple messages to all subscribers.
@@ -141,7 +146,7 @@ class HiRedisQueue(AbstractMessageQueue):
         async with RedisConnection(self._target, db=self._db) as client:
             pipeline_commands: list[list[str | bytes | int]] = []
             for event in events:
-                payload_bytes: bytes = dump_json(event.payload)
+                payload_bytes: bytes = event.payload.to_json()
                 # Only add cache commands if cache_id is provided
                 if event.cache_id:
                     pipeline_commands.extend([
@@ -182,7 +187,7 @@ class HiRedisQueue(AbstractMessageQueue):
             except asyncio.CancelledError:
                 break
 
-    async def subscribe_queue(self) -> AsyncGenerator[BroadcastMessage, None]:  # type: ignore
+    async def subscribe_queue(self) -> AsyncGenerator[BroadcastPayload, None]:  # type: ignore
         while not self._closed:
             try:
                 yield await self._subscribe_queue.get()
@@ -249,21 +254,23 @@ class HiRedisQueue(AbstractMessageQueue):
                 return autoclaim_start_id, False
             for stream_msg in reply.values():
                 for msg_id, messages in stream_msg:
-                    payload = {}
-                    for i in range(0, len(messages), 2):
-                        key = messages[i]
-                        value = messages[i + 1]
-                        payload[key] = value
-                    msg = MQMessage(msg_id, payload)
-                    if msg.retry():
-                        await self._retry_message(stream_key, msg)
+                    try:
+                        payload = AnycastPayload.from_stream_fields(_make_payload(messages))
+                    except InvalidMessagePayloadError as e:
+                        # A malformed message can never be handled, so discard it right away.
+                        log.warning("Discarding malformed message {}: {}", msg_id, e)
+                        await self._done(stream_key, msg_id)
+                        continue
+                    retried = MQMessage(msg_id=msg_id, payload=payload).retry()
+                    if retried is not None:
+                        await self._retry_message(stream_key, retried)
                     else:
                         # discard the message
                         await self._done(stream_key, msg_id)
         return autoclaim_start_id, True
 
     async def _retry_message(self, stream_key: str, message: MQMessage) -> None:
-        pieces = _make_pieces(message.payload)
+        pieces = _make_pieces(message.payload.to_stream_fields())
         async with RedisConnection(self._target, db=self._db) as client:
             await client.pipeline([
                 [
@@ -316,13 +323,13 @@ class HiRedisQueue(AbstractMessageQueue):
                 return
             for stream_msg in reply.values():
                 for msg_id, messages in stream_msg:
-                    payload = {}
-                    for i in range(0, len(messages), 2):
-                        key = messages[i]
-                        value = messages[i + 1]
-                        payload[key] = value
-                    msg = MQMessage(msg_id, payload)
-                    await self._consume_queue.put(msg)
+                    try:
+                        payload = AnycastPayload.from_stream_fields(_make_payload(messages))
+                    except InvalidMessagePayloadError as e:
+                        # Leave it unacked: the auto-claim loop discards it once retries run out.
+                        log.warning("Skipping malformed message {}: {}", msg_id, e)
+                        continue
+                    await self._consume_queue.put(MQMessage(msg_id=msg_id, payload=payload))
 
     async def _read_broadcast_messages_loop(self, subscribe_channels: set[str]) -> None:
         log.info("Starting broadcast messages reading loop for channels: {}", subscribe_channels)
@@ -345,12 +352,12 @@ class HiRedisQueue(AbstractMessageQueue):
                     log.debug("Invalid reply from subscribe: {}", reply)
                     continue
                 _, channel, payload_bytes = reply
-                payload = load_json(payload_bytes)
-                await self._subscribe_queue.put(
-                    BroadcastMessage(
-                        payload=payload,
-                    )
-                )
+                try:
+                    payload = BroadcastPayload.from_json(payload_bytes)
+                except InvalidMessagePayloadError as e:
+                    log.warning("Dropping malformed broadcast message: {}", e)
+                    continue
+                await self._subscribe_queue.put(payload)
 
     async def _failover_consumer(self, e: hiredis.HiredisError) -> None:
         # If the group does not exist, create it

--- a/src/ai/backend/common/message_queue/message.py
+++ b/src/ai/backend/common/message_queue/message.py
@@ -1,0 +1,28 @@
+from typing import Final, Self
+
+from pydantic import BaseModel, ConfigDict
+
+from .payload import AnycastPayload
+
+_DEFAULT_MAX_RETRIES: Final[int] = 3
+
+type MessageId = bytes
+
+
+class MQMessage(BaseModel):
+    """An anycast payload together with the stream entry id needed to ack it."""
+
+    model_config = ConfigDict(frozen=True)
+
+    msg_id: MessageId
+    payload: AnycastPayload
+
+    def retry(self) -> Self | None:
+        """
+        Return a copy of the message carrying an incremented retry count.
+        Returns None once the message has been retried more than the maximum number
+        of times, meaning it should be discarded.
+        """
+        if self.payload.retry_count > _DEFAULT_MAX_RETRIES:
+            return None
+        return self.model_copy(update={"payload": self.payload.increment_retry()})

--- a/src/ai/backend/common/message_queue/payload.py
+++ b/src/ai/backend/common/message_queue/payload.py
@@ -1,0 +1,156 @@
+import base64
+import binascii
+from collections.abc import Mapping
+from typing import Any, Final, Self, cast
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from ai.backend.common import msgpack
+from ai.backend.common.json import dump_json, load_json
+
+from .exceptions import InvalidMessagePayloadError
+from .types import MessageMetadata
+
+# Wire field names. The body is still carried as "args" until the producers cut over to JSON.
+_NAME_FIELD: Final[str] = "name"
+_SOURCE_FIELD: Final[str] = "source"
+_BODY_FIELD: Final[str] = "args"
+_METADATA_FIELD: Final[str] = "metadata"
+_RETRY_COUNT_FIELD: Final[str] = "_retry_count"
+
+# Errors any wire decoding may raise before the model itself is validated.
+_DECODE_ERRORS: Final = (KeyError, TypeError, ValueError, ValidationError)
+
+
+class MessagePayload(BaseModel):
+    """
+    The fields every message carries, regardless of delivery mode.
+
+    `body` is opaque to this layer: it holds the serialized event arguments and is
+    neither inspected nor decoded here.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    source: str
+    body: bytes
+    metadata: MessageMetadata | None = None
+
+    @classmethod
+    def from_event_args(
+        cls,
+        *,
+        name: str,
+        source: str,
+        args: tuple[Any, ...],
+        metadata: MessageMetadata | None = None,
+    ) -> Self:
+        """
+        Build a payload out of the serializable arguments of an event.
+        """
+        return cls(name=name, source=source, body=msgpack.packb(args), metadata=metadata)
+
+    def decode_args(self) -> tuple[Any, ...]:
+        """
+        Decode the event arguments carried by the body.
+        """
+        return cast(tuple[Any, ...], msgpack.unpackb(self.body))
+
+
+class AnycastPayload(MessagePayload):
+    """
+    A payload delivered to exactly one consumer.
+
+    `retry_count` is transport-level redelivery state maintained by the auto-claim
+    path. It lives only here because broadcast has no ack path.
+    """
+
+    retry_count: int = 0
+
+    def to_stream_fields(self) -> dict[bytes, bytes]:
+        """
+        Render the payload as the field mapping of a stream entry.
+        """
+        fields = {
+            _NAME_FIELD.encode(): self.name.encode("utf-8"),
+            _SOURCE_FIELD.encode(): self.source.encode("utf-8"),
+            _BODY_FIELD.encode(): self.body,
+        }
+        if self.metadata is not None:
+            fields[_METADATA_FIELD.encode()] = self.metadata.serialize()
+        if self.retry_count:
+            fields[_RETRY_COUNT_FIELD.encode()] = str(self.retry_count).encode("utf-8")
+        return fields
+
+    @classmethod
+    def from_stream_fields(cls, fields: Mapping[bytes, bytes]) -> Self:
+        """
+        Build a payload out of the field mapping of a stream entry.
+
+        Raises:
+            InvalidMessagePayloadError: If the entry does not match the payload schema
+        """
+        raw_metadata = fields.get(_METADATA_FIELD.encode())
+        raw_retry_count = fields.get(_RETRY_COUNT_FIELD.encode())
+        try:
+            return cls(
+                name=fields[_NAME_FIELD.encode()].decode("utf-8"),
+                source=fields[_SOURCE_FIELD.encode()].decode("utf-8"),
+                body=fields[_BODY_FIELD.encode()],
+                metadata=MessageMetadata.deserialize(raw_metadata) if raw_metadata else None,
+                retry_count=int(raw_retry_count) if raw_retry_count else 0,
+            )
+        except _DECODE_ERRORS as e:
+            raise InvalidMessagePayloadError(f"Malformed anycast message: {e}") from e
+
+    def increment_retry(self) -> Self:
+        return self.model_copy(update={"retry_count": self.retry_count + 1})
+
+
+class BroadcastPayload(MessagePayload):
+    """
+    A payload delivered to every subscriber. There is no ack, hence no retry state.
+    """
+
+    def to_json(self) -> bytes:
+        """
+        Render the payload as the JSON message published to a channel.
+        """
+        fields = {
+            _NAME_FIELD: self.name,
+            _SOURCE_FIELD: self.source,
+            _BODY_FIELD: base64.b64encode(self.body).decode("ascii"),
+        }
+        if self.metadata is not None:
+            fields[_METADATA_FIELD] = self.metadata.serialize().decode("utf-8")
+        return dump_json(fields)
+
+    @classmethod
+    def from_json(cls, data: str | bytes) -> Self:
+        """
+        Build a payload out of a JSON message received from a channel.
+
+        Raises:
+            InvalidMessagePayloadError: If the message does not match the payload schema
+        """
+        try:
+            fields = load_json(data)
+            raw_metadata = fields.get(_METADATA_FIELD)
+            return cls(
+                name=fields[_NAME_FIELD],
+                source=fields[_SOURCE_FIELD],
+                body=base64.b64decode(fields[_BODY_FIELD], validate=True),
+                metadata=MessageMetadata.deserialize(raw_metadata) if raw_metadata else None,
+            )
+        except (*_DECODE_ERRORS, binascii.Error, AttributeError) as e:
+            raise InvalidMessagePayloadError(f"Malformed broadcast message: {e}") from e
+
+
+class CachedBroadcastPayload(BaseModel):
+    """A broadcast payload, cached under `cache_id` when one is given."""
+
+    model_config = ConfigDict(frozen=True)
+
+    payload: BroadcastPayload
+    cache_id: str | None = None

--- a/src/ai/backend/common/message_queue/redis_queue/anycaster.py
+++ b/src/ai/backend/common/message_queue/redis_queue/anycaster.py
@@ -5,6 +5,7 @@ from typing import Self, override
 
 from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyStreamClient
 from ai.backend.common.message_queue.abc import AbstractAnycaster
+from ai.backend.common.message_queue.payload import AnycastPayload
 from ai.backend.common.types import RedisTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
@@ -59,7 +60,7 @@ class RedisAnycaster(AbstractAnycaster):
         return cls(client, stream_key)
 
     @override
-    async def anycast(self, payload: dict[bytes, bytes]) -> None:
+    async def anycast(self, payload: AnycastPayload) -> None:
         """
         Send a message to the anycast stream.
 
@@ -68,7 +69,7 @@ class RedisAnycaster(AbstractAnycaster):
         message will be added to the end of the stream.
 
         Args:
-            payload: Message payload as a dictionary of bytes
+            payload: Message payload as an anycast envelope
 
         Raises:
             MessageQueueClosedError: If the anycaster is closed

--- a/src/ai/backend/common/message_queue/redis_queue/broadcaster.py
+++ b/src/ai/backend/common/message_queue/redis_queue/broadcaster.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
-from typing import Any, Self, override
+from typing import Self, override
 
 from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyStreamClient
 from ai.backend.common.message_queue.abc import AbstractBroadcaster
-from ai.backend.common.message_queue.types import BroadcastPayload
+from ai.backend.common.message_queue.payload import BroadcastPayload, CachedBroadcastPayload
 from ai.backend.common.types import RedisTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
@@ -60,7 +59,7 @@ class RedisBroadcaster(AbstractBroadcaster):
         return cls(client, channel)
 
     @override
-    async def broadcast(self, payload: Mapping[str, Any]) -> None:
+    async def broadcast(self, payload: BroadcastPayload) -> None:
         """
         Broadcast a message to all subscribers.
 
@@ -68,7 +67,7 @@ class RedisBroadcaster(AbstractBroadcaster):
         Messages are not guaranteed to be delivered (fire-and-forget).
 
         Args:
-            payload: Message payload as a mapping
+            payload: Message payload as a broadcast envelope
 
         Raises:
             MessageQueueClosedError: If the broadcaster is closed
@@ -80,7 +79,7 @@ class RedisBroadcaster(AbstractBroadcaster):
         log.debug("Message broadcasted to channel {}", self._channel)
 
     @override
-    async def broadcast_with_cache(self, cache_id: str, payload: Mapping[str, str]) -> None:
+    async def broadcast_with_cache(self, cache_id: str, payload: BroadcastPayload) -> None:
         """
         Broadcast a message with caching support.
 
@@ -89,7 +88,7 @@ class RedisBroadcaster(AbstractBroadcaster):
 
         Args:
             cache_id: Unique identifier for caching the message
-            payload: Message payload as string mapping
+            payload: Message payload as a broadcast envelope
 
         Raises:
             MessageQueueClosedError: If the broadcaster is closed
@@ -103,7 +102,7 @@ class RedisBroadcaster(AbstractBroadcaster):
         )
 
     @override
-    async def fetch_cached_broadcast_message(self, cache_id: str) -> Mapping[str, str] | None:
+    async def fetch_cached_broadcast_message(self, cache_id: str) -> BroadcastPayload | None:
         """
         Retrieve a cached broadcast message.
 
@@ -118,20 +117,21 @@ class RedisBroadcaster(AbstractBroadcaster):
 
         Raises:
             MessageQueueClosedError: If the broadcaster is closed
+            InvalidMessagePayloadError: If the cached message is malformed
         """
         if self._closed:
             raise MessageQueueClosedError("Broadcaster is closed")
 
-        message = await self._client.fetch_cached_broadcast_message(cache_id)
+        payload = await self._client.fetch_cached_broadcast_message(cache_id)
         log.debug(
             "Fetched cached message for cache_id {}: {}",
             cache_id,
-            "found" if message else "not found",
+            "found" if payload else "not found",
         )
-        return message
+        return payload
 
     @override
-    async def broadcast_batch(self, events: list[BroadcastPayload]) -> None:
+    async def broadcast_batch(self, events: list[CachedBroadcastPayload]) -> None:
         """
         Broadcast multiple messages in a batch.
 

--- a/src/ai/backend/common/message_queue/redis_queue/consumer.py
+++ b/src/ai/backend/common/message_queue/redis_queue/consumer.py
@@ -16,7 +16,9 @@ from aiotools.server import process_index
 from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyStreamClient
 from ai.backend.common.defs import REDIS_STREAM_DB
 from ai.backend.common.message_queue.abc import AbstractConsumer
-from ai.backend.common.message_queue.types import MessageId, MQMessage
+from ai.backend.common.message_queue.exceptions import InvalidMessagePayloadError
+from ai.backend.common.message_queue.message import MessageId, MQMessage
+from ai.backend.common.message_queue.payload import AnycastPayload
 from ai.backend.common.types import RedisTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
@@ -290,8 +292,13 @@ class RedisConsumer(AbstractConsumer):
             return
 
         for msg in payload:
-            mq_msg = MQMessage(msg_id=msg.msg_id, payload={**msg.payload})
-            await self._consume_queue.put(mq_msg)
+            try:
+                anycast_payload = AnycastPayload.from_stream_fields(msg.payload)
+            except InvalidMessagePayloadError as e:
+                # Leave it unacked: the auto-claim loop discards it once retries run out.
+                log.warning("Skipping malformed message {}: {}", msg.msg_id, e)
+                continue
+            await self._consume_queue.put(MQMessage(msg_id=msg.msg_id, payload=anycast_payload))
 
     async def _auto_claim_loop(
         self, stream_key: str, autoclaim_start_id: str, autoclaim_idle_timeout: int
@@ -362,12 +369,19 @@ class RedisConsumer(AbstractConsumer):
             return autoclaim_start_id, False
 
         for msg in message.messages:
-            mq_msg = MQMessage(msg.msg_id, {**msg.payload})
-            if mq_msg.retry():
-                await self._retry_message(stream_key, mq_msg)
+            try:
+                payload = AnycastPayload.from_stream_fields(msg.payload)
+            except InvalidMessagePayloadError as e:
+                # A malformed message can never be handled, so discard it right away.
+                log.warning("Discarding malformed message {}: {}", msg.msg_id, e)
+                await self._client.done_stream_message(stream_key, self._group_name, msg.msg_id)
+                continue
+            retried = MQMessage(msg_id=msg.msg_id, payload=payload).retry()
+            if retried is not None:
+                await self._retry_message(stream_key, retried)
                 continue
             # Discard the message if retry limit exceeded
-            await self._client.done_stream_message(stream_key, self._group_name, mq_msg.msg_id)
+            await self._client.done_stream_message(stream_key, self._group_name, msg.msg_id)
 
         return autoclaim_start_id, len(message.messages) > 0
 

--- a/src/ai/backend/common/message_queue/redis_queue/queue.py
+++ b/src/ai/backend/common/message_queue/redis_queue/queue.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Any, Self, override
+from typing import Self, override
 
 from ai.backend.common.message_queue.abc import (
     AbstractAnycaster,
@@ -11,11 +11,11 @@ from ai.backend.common.message_queue.abc import (
     AbstractSubscriber,
 )
 from ai.backend.common.message_queue.abc.queue import AbstractMessageQueue
-from ai.backend.common.message_queue.types import (
-    BroadcastMessage,
+from ai.backend.common.message_queue.message import MessageId, MQMessage
+from ai.backend.common.message_queue.payload import (
+    AnycastPayload,
     BroadcastPayload,
-    MessageId,
-    MQMessage,
+    CachedBroadcastPayload,
 )
 from ai.backend.common.types import RedisTarget
 
@@ -104,7 +104,7 @@ class RedisQueue(AbstractMessageQueue):
     # Anycaster methods
 
     @override
-    async def send(self, payload: dict[bytes, bytes]) -> None:
+    async def send(self, payload: AnycastPayload) -> None:
         """
         Send a message to the anycast queue.
         If the queue is full, the oldest message will be removed.
@@ -115,7 +115,7 @@ class RedisQueue(AbstractMessageQueue):
     # Broadcaster methods
 
     @override
-    async def broadcast(self, payload: Mapping[str, Any]) -> None:
+    async def broadcast(self, payload: BroadcastPayload) -> None:
         """
         Broadcast a message to all subscribers.
         The message will be delivered to all subscribers.
@@ -123,7 +123,7 @@ class RedisQueue(AbstractMessageQueue):
         await self._broadcaster.broadcast(payload)
 
     @override
-    async def broadcast_with_cache(self, cache_id: str, payload: Mapping[str, str]) -> None:
+    async def broadcast_with_cache(self, cache_id: str, payload: BroadcastPayload) -> None:
         """
         Broadcast a message to all subscribers with cache.
         The message will be delivered to all subscribers.
@@ -131,7 +131,7 @@ class RedisQueue(AbstractMessageQueue):
         await self._broadcaster.broadcast_with_cache(cache_id, payload)
 
     @override
-    async def fetch_cached_broadcast_message(self, cache_id: str) -> Mapping[str, str] | None:
+    async def fetch_cached_broadcast_message(self, cache_id: str) -> BroadcastPayload | None:
         """
         Fetch a cached broadcast message by cache_id.
         This method retrieves the cached message from the broadcast channel.
@@ -139,7 +139,7 @@ class RedisQueue(AbstractMessageQueue):
         return await self._broadcaster.fetch_cached_broadcast_message(cache_id)
 
     @override
-    async def broadcast_batch(self, events: list[BroadcastPayload]) -> None:
+    async def broadcast_batch(self, events: list[CachedBroadcastPayload]) -> None:
         """
         Broadcast multiple messages in a batch with optional caching.
         This method broadcasts multiple messages to all subscribers.
@@ -174,7 +174,7 @@ class RedisQueue(AbstractMessageQueue):
     # Subscriber methods
 
     @override
-    async def subscribe_queue(self) -> AsyncGenerator[BroadcastMessage, None]:  # type: ignore
+    async def subscribe_queue(self) -> AsyncGenerator[BroadcastPayload, None]:  # type: ignore
         """
         Subscribe to broadcast messages.
         """

--- a/src/ai/backend/common/message_queue/redis_queue/subscriber.py
+++ b/src/ai/backend/common/message_queue/redis_queue/subscriber.py
@@ -9,7 +9,8 @@ import glide
 
 from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyStreamClient
 from ai.backend.common.message_queue.abc import AbstractSubscriber
-from ai.backend.common.message_queue.types import BroadcastMessage
+from ai.backend.common.message_queue.exceptions import InvalidMessagePayloadError
+from ai.backend.common.message_queue.payload import BroadcastPayload
 from ai.backend.common.types import RedisTarget
 from ai.backend.logging.utils import BraceStyleAdapter
 
@@ -25,7 +26,7 @@ class RedisSubscriber(AbstractSubscriber):
     """
 
     _client: ValkeyStreamClient
-    _subscribe_queue: asyncio.Queue[BroadcastMessage]
+    _subscribe_queue: asyncio.Queue[BroadcastPayload]
     _channels: set[str]
     _closed: bool
     _loop_task: asyncio.Task[Any] | None
@@ -68,7 +69,7 @@ class RedisSubscriber(AbstractSubscriber):
         return cls(client, channels)
 
     @override
-    async def subscribe_queue(self) -> AsyncGenerator[BroadcastMessage, None]:  # type: ignore[override]
+    async def subscribe_queue(self) -> AsyncGenerator[BroadcastPayload, None]:  # type: ignore[override]
         """
         Subscribe to broadcast messages.
 
@@ -77,7 +78,7 @@ class RedisSubscriber(AbstractSubscriber):
         acknowledgment.
 
         Yields:
-            BroadcastMessage: Broadcast messages from subscribed channels
+            BroadcastPayload: Broadcast messages from subscribed channels
 
         Raises:
             RuntimeError: If the subscriber is closed
@@ -131,7 +132,13 @@ class RedisSubscriber(AbstractSubscriber):
     async def _read_broadcast_messages(self) -> None:
         """
         Read broadcast messages and put them in the subscribe queue.
+
+        A message that does not conform to the broadcast envelope is dropped: there is
+        no ack path to retry it on, and it would otherwise fail later at field access.
         """
-        payload = await self._client.receive_broadcast_message()
-        msg = BroadcastMessage(payload)
-        await self._subscribe_queue.put(msg)
+        try:
+            payload = await self._client.receive_broadcast_message()
+        except InvalidMessagePayloadError as e:
+            log.warning("Dropping malformed broadcast message: {}", e)
+            return
+        await self._subscribe_queue.put(payload)

--- a/src/ai/backend/common/message_queue/types.py
+++ b/src/ai/backend/common/message_queue/types.py
@@ -1,58 +1,13 @@
-import base64
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from typing import Self, cast
+from typing import Self
 
-from ai.backend.common import msgpack
 from ai.backend.common.contexts.request_id import with_request_id
 from ai.backend.common.contexts.user import with_triggered_user, with_user
 from ai.backend.common.data.user.types import UserData
 from ai.backend.common.json import dump_json, load_json
 from ai.backend.logging.utils import with_log_context_fields
-
-_DEFAULT_RETRY_FIELD = b"_retry_count"
-_DEFAULT_MAX_RETRIES = 3
-
-type MessageId = bytes
-
-
-@dataclass
-class BroadcastPayload:
-    """Payload data for broadcasting with optional cache."""
-
-    payload: Mapping[str, str]
-    cache_id: str | None = None
-
-
-@dataclass
-class BroadcastMessage:
-    payload: Mapping[str, str]
-
-
-@dataclass
-class MQMessage:
-    msg_id: MessageId
-    payload: dict[bytes, bytes]
-
-    def retry(self) -> bool:
-        """
-        Retry the message.
-        If the message has been retried more than the maximum number of retries,
-        the message will be discarded.
-        The retry count is stored in the message payload.
-        """
-        if self._retry_count() > _DEFAULT_MAX_RETRIES:
-            return False
-        self.payload[_DEFAULT_RETRY_FIELD] = str(self._retry_count() + 1).encode("utf-8")
-        return True
-
-    def _retry_count(self) -> int:
-        """
-        Get the retry count of the message.
-        The retry count is the number of times the message has been re-delivered.
-        """
-        return int(self.payload.get(_DEFAULT_RETRY_FIELD, b"0"))
 
 
 @dataclass
@@ -103,80 +58,3 @@ class MessageMetadata:
             if log_fields:
                 stack.enter_context(with_log_context_fields(log_fields))
             yield
-
-
-def deserialize_event_name_for_anycast(payload: Mapping[bytes, bytes]) -> str:
-    return payload[b"name"].decode("utf-8")
-
-
-def deserialize_event_name_for_broadcast(payload: Mapping[str, str]) -> str:
-    return payload["name"]
-
-
-@dataclass
-class MessagePayload:
-    name: str
-    source: str
-    args: tuple[bytes, ...]
-    metadata: MessageMetadata | None = None
-
-    def serialize_anycast(self) -> dict[bytes, bytes]:
-        """
-        Serialize the message payload to a dictionary.
-        """
-        result = {
-            b"name": self.name.encode(),
-            b"source": self.source.encode(),
-            b"args": msgpack.packb(self.args),
-        }
-        if self.metadata:
-            result[b"metadata"] = self.metadata.serialize()
-        return result
-
-    def serialize_broadcast(self) -> dict[str, str]:
-        """
-        Serialize the message payload to a dictionary.
-        The keys are bytes and the values are bytes.
-        """
-        args = base64.b64encode(msgpack.packb(self.args)).decode("ascii")
-        result = {
-            "name": self.name,
-            "source": self.source,
-            "args": args,
-        }
-        if self.metadata:
-            result["metadata"] = self.metadata.serialize().decode("utf-8")
-        return result
-
-    @classmethod
-    def from_anycast(cls, payload: Mapping[bytes, bytes]) -> Self:
-        """
-        Deserialize the message payload from a dictionary.
-        The keys are bytes and the values are bytes.
-        """
-        metadata = None
-        if b"metadata" in payload:
-            metadata = MessageMetadata.deserialize(payload[b"metadata"])
-        return cls(
-            name=deserialize_event_name_for_anycast(payload),
-            source=payload[b"source"].decode("utf-8"),
-            args=cast(tuple[bytes, ...], msgpack.unpackb(payload[b"args"])),
-            metadata=metadata,
-        )
-
-    @classmethod
-    def from_broadcast(cls, payload: Mapping[str, str]) -> Self:
-        """
-        Deserialize the message payload from a dictionary.
-        The keys are bytes and the values are bytes.
-        """
-        args_bytes = base64.b64decode(payload["args"])
-        metadata = None
-        if "metadata" in payload:
-            metadata = MessageMetadata.deserialize(payload["metadata"])
-        return cls(
-            name=deserialize_event_name_for_broadcast(payload),
-            source=payload["source"],
-            args=cast(tuple[bytes, ...], msgpack.unpackb(args_bytes)),
-            metadata=metadata,
-        )

--- a/tests/unit/common/clients/valkey_client/test_valkey_stream_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_stream_client.py
@@ -6,79 +6,55 @@ import random
 from ai.backend.common.clients.valkey_client.valkey_stream.client import (
     ValkeyStreamClient,
 )
+from ai.backend.common.message_queue.payload import AnycastPayload, BroadcastPayload
+
+
+def _anycast_payload() -> AnycastPayload:
+    return AnycastPayload(name="test-event", source="i-test", body=b"body")
+
+
+def _broadcast_payload() -> BroadcastPayload:
+    return BroadcastPayload(name="test-event", source="i-test", body=b"body")
 
 
 async def test_valkey_stream_anycast(test_valkey_stream: ValkeyStreamClient) -> None:
     test_stream = f"test-stream-{random.randint(1000, 9999)}"
     test_group = f"test-group-{random.randint(1000, 9999)}"
+    payload = _anycast_payload()
     await test_valkey_stream.make_consumer_group(test_stream, test_group)
-    await test_valkey_stream.enqueue_stream_message(
-        test_stream,
-        {
-            b"key1": b"value1",
-            b"key2": b"value2",
-        },
-    )
+    await test_valkey_stream.enqueue_stream_message(test_stream, payload)
     values = await test_valkey_stream.read_consumer_group(test_stream, test_group, "test-consumer")
     assert values is not None
     assert len(values) == 1
-    assert values[0].payload == {
-        b"key1": b"value1",
-        b"key2": b"value2",
-    }
+    assert AnycastPayload.from_stream_fields(values[0].payload) == payload
     await test_valkey_stream.done_stream_message("test-stream", "test-group", values[0].msg_id)
 
 
 async def test_valkey_stream_broadcast(test_valkey_stream: ValkeyStreamClient) -> None:
-    await test_valkey_stream.broadcast(
-        "test-broadcast",
-        {
-            "key1": "value1",
-            "key2": "value2",
-        },
-    )
-    values = await test_valkey_stream.receive_broadcast_message()
-    assert values == {
-        "key1": "value1",
-        "key2": "value2",
-    }
+    payload = _broadcast_payload()
+    await test_valkey_stream.broadcast("test-broadcast", payload)
+    received = await test_valkey_stream.receive_broadcast_message()
+    assert received == payload
 
 
 async def test_valkey_stream_broadcast_with_cache(test_valkey_stream: ValkeyStreamClient) -> None:
     cache_id = f"test-cache-{random.randint(1000, 9999)}"
-    await test_valkey_stream.broadcast_with_cache(
-        "test-broadcast",
-        cache_id,
-        {
-            "key1": "value1",
-            "key2": "value2",
-        },
-    )
-    values = await test_valkey_stream.receive_broadcast_message()
-    assert values == {
-        "key1": "value1",
-        "key2": "value2",
-    }
-    cached_values = await test_valkey_stream.fetch_cached_broadcast_message(cache_id)
-    assert cached_values is not None, "Cached values should not be None"
-    assert cached_values == {
-        "key1": "value1",
-        "key2": "value2",
-    }, "Cached values should match the broadcasted values"
+    payload = _broadcast_payload()
+    await test_valkey_stream.broadcast_with_cache("test-broadcast", cache_id, payload)
+    received = await test_valkey_stream.receive_broadcast_message()
+    assert received == payload
+    cached = await test_valkey_stream.fetch_cached_broadcast_message(cache_id)
+    assert cached is not None, "Cached message should not be None"
+    assert cached == payload, "Cached message should match the broadcasted one"
 
 
 async def test_valkey_stream_auto_claim(test_valkey_stream: ValkeyStreamClient) -> None:
     test_stream = f"test-stream-{random.randint(1000, 9999)}"
     test_group = f"test-group-{random.randint(1000, 9999)}"
+    payload = _anycast_payload()
 
     await test_valkey_stream.make_consumer_group(test_stream, test_group)
-    await test_valkey_stream.enqueue_stream_message(
-        test_stream,
-        {
-            b"key1": b"value1",
-            b"key2": b"value2",
-        },
-    )
+    await test_valkey_stream.enqueue_stream_message(test_stream, payload)
     await test_valkey_stream.read_consumer_group(test_stream, test_group, "test-consumer")
     await asyncio.sleep(0.1)  # Ensure the message is available for auto claim
     # Auto claim the message
@@ -92,10 +68,7 @@ async def test_valkey_stream_auto_claim(test_valkey_stream: ValkeyStreamClient) 
     )
     assert auto_claimed is not None, "Auto claim should return a result"
     assert len(auto_claimed.messages) == 1, "One message should be available for auto claim"
-    assert auto_claimed.messages[0].payload == {
-        b"key1": b"value1",
-        b"key2": b"value2",
-    }
+    assert AnycastPayload.from_stream_fields(auto_claimed.messages[0].payload) == payload
     # Acknowledge the auto claimed message
     await test_valkey_stream.done_stream_message(
         test_stream, test_group, auto_claimed.messages[0].msg_id

--- a/tests/unit/common/events/test_dispatcher.py
+++ b/tests/unit/common/events/test_dispatcher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any, override
@@ -16,10 +15,8 @@ from ai.backend.common.events.types import (
     EventDomain,
 )
 from ai.backend.common.events.user_event.user_event import UserEvent
-from ai.backend.common.message_queue.types import (
-    BroadcastMessage,
-    MQMessage,
-)
+from ai.backend.common.message_queue.message import MQMessage
+from ai.backend.common.message_queue.payload import AnycastPayload, BroadcastPayload
 from ai.backend.common.types import AgentId
 
 
@@ -90,22 +87,19 @@ class DummyBroadcastEvent(AbstractBroadcastEvent):
 def _make_anycast_mq_message(event: AbstractAnycastEvent) -> MQMessage:
     return MQMessage(
         msg_id=b"test-msg-id",
-        payload={
-            b"name": event.event_name().encode("utf-8"),
-            b"source": b"i-test",
-            b"args": msgpack.packb(event.serialize()),
-        },
+        payload=AnycastPayload(
+            name=event.event_name(),
+            source="i-test",
+            body=msgpack.packb(event.serialize()),
+        ),
     )
 
 
-def _make_broadcast_message(event: AbstractBroadcastEvent) -> BroadcastMessage:
-    args = base64.b64encode(msgpack.packb(event.serialize())).decode("ascii")
-    return BroadcastMessage(
-        payload={
-            "name": event.event_name(),
-            "source": "i-test",
-            "args": args,
-        },
+def _make_broadcast_payload(event: AbstractBroadcastEvent) -> BroadcastPayload:
+    return BroadcastPayload(
+        name=event.event_name(),
+        source="i-test",
+        body=msgpack.packb(event.serialize()),
     )
 
 
@@ -115,7 +109,7 @@ class StubMessageQueue:
     def __init__(
         self,
         anycast_messages: list[MQMessage] | None = None,
-        broadcast_messages: list[BroadcastMessage] | None = None,
+        broadcast_messages: list[BroadcastPayload] | None = None,
     ) -> None:
         self._anycast_messages = anycast_messages or []
         self._broadcast_messages = broadcast_messages or []
@@ -125,7 +119,7 @@ class StubMessageQueue:
         for msg in self._anycast_messages:
             yield msg
 
-    async def subscribe_queue(self) -> AsyncGenerator[BroadcastMessage, None]:
+    async def subscribe_queue(self) -> AsyncGenerator[BroadcastPayload, None]:
         for msg in self._broadcast_messages:
             yield msg
 
@@ -204,7 +198,7 @@ class TestDispatchSubscribers:
     @pytest.fixture
     def mq(self) -> StubMessageQueue:
         return StubMessageQueue(
-            broadcast_messages=[_make_broadcast_message(DummyBroadcastEvent(value=7))],
+            broadcast_messages=[_make_broadcast_payload(DummyBroadcastEvent(value=7))],
         )
 
     @pytest.fixture

--- a/tests/unit/common/message_queue/test_redis_queue.py
+++ b/tests/unit/common/message_queue/test_redis_queue.py
@@ -6,8 +6,9 @@ import pytest
 
 from ai.backend.common import redis_helper
 from ai.backend.common.defs import REDIS_STREAM_DB
+from ai.backend.common.message_queue.message import MQMessage
+from ai.backend.common.message_queue.payload import AnycastPayload, BroadcastPayload
 from ai.backend.common.message_queue.redis_queue import RedisMQArgs, RedisQueue
-from ai.backend.common.message_queue.types import BroadcastMessage, MQMessage
 from ai.backend.common.types import (
     HostPortPair,
     RedisConnectionInfo,
@@ -87,7 +88,7 @@ async def redis_queue(
 
 async def test_send_and_consume(redis_queue: RedisQueue) -> None:
     # Test message sending and consuming
-    test_payload = {b"key": b"value", b"key2": b"value2"}
+    test_payload = AnycastPayload(name="test-event", source="i-test", body=b"body")
 
     # Send message
     await redis_queue.send(test_payload)
@@ -102,10 +103,10 @@ async def test_send_and_consume(redis_queue: RedisQueue) -> None:
 
 async def test_subscribe(redis_queue: RedisQueue) -> None:
     # Test message subscription
-    test_payload = {"key": "value", "key2": "value2"}
+    test_payload = BroadcastPayload(name="test-event", source="i-test", body=b"body")
 
     # Create task to subscribe
-    received_messages: list[BroadcastMessage] = []
+    received_messages: list[BroadcastPayload] = []
 
     async def subscriber() -> None:
         async for message in redis_queue.subscribe_queue():
@@ -123,15 +124,15 @@ async def test_subscribe(redis_queue: RedisQueue) -> None:
     await asyncio.wait_for(subscriber_task, timeout=5)
 
     assert len(received_messages) == 1
-    assert received_messages[0].payload == test_payload
+    assert received_messages[0] == test_payload
 
 
 async def test_broadcast_with_cache(redis_queue: RedisQueue) -> None:
     # Test broadcasting with cache
-    test_payload = {"key": "value", "key2": "value2"}
+    test_payload = BroadcastPayload(name="test-event", source="i-test", body=b"body")
     cache_id = f"test-cache-id-{random.randint(1000, 9999)}"
 
-    received_messages: list[BroadcastMessage] = []
+    received_messages: list[BroadcastPayload] = []
 
     async def subscriber() -> None:
         async for message in redis_queue.subscribe_queue():
@@ -149,7 +150,7 @@ async def test_broadcast_with_cache(redis_queue: RedisQueue) -> None:
     await asyncio.wait_for(subscriber_task, timeout=5)
 
     assert len(received_messages) == 1
-    assert received_messages[0].payload == test_payload
+    assert received_messages[0] == test_payload
 
     # Fetch cached message
     cached_message = await redis_queue.fetch_cached_broadcast_message(cache_id)
@@ -159,7 +160,7 @@ async def test_broadcast_with_cache(redis_queue: RedisQueue) -> None:
 
 async def test_done(redis_queue: RedisQueue) -> None:
     # Test message acknowledgment
-    test_payload = {b"key": b"value"}
+    test_payload = AnycastPayload(name="test-event", source="i-test", body=b"body")
 
     # Send message
     await redis_queue.send(test_payload)


### PR DESCRIPTION
## Summary

- Replace the untyped payload mappings on the message queue interfaces with Pydantic models: a shared `MessagePayload` base (`name`, `source`, `body`, `metadata`), `AnycastPayload` adding the transport-level `retry_count`, and `BroadcastPayload` carrying the JSON codec. Retry state can no longer reach the broadcast path, and a missing or misspelled field is now a type error instead of a runtime `KeyError`.
- Validate received messages instead of casting them. `ValkeyStreamClient.receive_broadcast_message()` / `fetch_cached_broadcast_message()` no longer `cast(Mapping[str, str], load_json(...))`; a malformed message raises `InvalidMessagePayloadError` and is skipped (stream read), ack-discarded (auto-claim), or dropped (broadcast) instead of failing later at field access — the failure shape behind BA-5659.
- Keep `ValkeyStreamClient` schema-agnostic by transporting opaque serialized messages, which also resolves `broadcast()` taking `Mapping[str, Any]` while every sibling method took `Mapping[str, str]`. `MQMessage.retry()` now returns a copy instead of mutating the payload dict in place.

Both implementations are covered: `redis_queue/` and the still-wired legacy `hiredis_queue.py`.

The wire format is unchanged (anycast fields `name`/`source`/`args`/`metadata`/`_retry_count`; broadcast JSON with base64 `args` and `metadata` as an embedded JSON string), so this does not depend on the JSON producer cutover — that migration only changes how the body is encoded.

## Test plan

- [x] `pants check ::`
- [x] `pants test tests/unit/common/message_queue:: tests/unit/common/events:: tests/unit/common/clients/valkey_client::`
- [x] Anycast round trip on a live manager/agent pair: event produced, consumed, acked
- [x] Broadcast round trip including a cached event fetched by a late subscriber
- [x] Redelivery path: an unacked message is auto-claimed, retried, and discarded past the retry limit

Resolves BA-7318

🤖 Generated with [Claude Code](https://claude.com/claude-code)