### PR TITLE
fix(BA-7258): wait longer than the kernel runner for a start-service reply (#13684)

### DIFF
--- a/changes/13684.fix.md
+++ b/changes/13684.fix.md
@@ -1,0 +1,1 @@
+Fix interactive app launches (jupyter, vscode, ...) intermittently failing with HTTP 500 when the app took more than 10 seconds to open its port, by making the agent wait for the kernel runner's verdict rather than giving up before the runner does.

--- a/src/ai/backend/agent/kernel.py
+++ b/src/ai/backend/agent/kernel.py
@@ -75,6 +75,10 @@ __all__ = ["KernelOwnershipData"]
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
+# Must exceed the launch timeout that ai.backend.kernel.base grants a service port, which cannot
+# be imported here because that package runs inside the container.
+SERVICE_START_REPLY_TIMEOUT_SEC = 35.0
+
 # msg types visible to the API client.
 # (excluding control signals such as 'finished' and 'waiting-input'
 # since they are passed as separate status field.)
@@ -952,7 +956,7 @@ class AbstractCodeRunner(aobject, metaclass=ABCMeta):
             _dump_json_bytes(service_info),
         ])
         try:
-            with timeout(10):
+            with timeout(SERVICE_START_REPLY_TIMEOUT_SEC):
                 result = await self.service_queue.get()
             self.service_queue.task_done()
             return cast(dict[str, Any], load_json(result))

--- a/src/ai/backend/kernel/base.py
+++ b/src/ai/backend/kernel/base.py
@@ -52,6 +52,8 @@ log = BraceStyleAdapter(logger)
 
 TReturn = TypeVar("TReturn")
 
+DEFAULT_SERVICE_LAUNCH_TIMEOUT_SEC = 30.0
+
 
 class FailureSentinel(enum.Enum):
     TOKEN = 0
@@ -871,7 +873,7 @@ class BaseRunner(metaclass=ABCMeta):
         service_info: Mapping[str, Any],
         *,
         cwd: str | None = None,
-        launch_timeout: float | None = 30.0,
+        launch_timeout: float | None = DEFAULT_SERVICE_LAUNCH_TIMEOUT_SEC,
     ) -> dict[str, Any]:
         error_reason = None
         try:

--- a/tests/unit/agent/test_service_launch_timeout.py
+++ b/tests/unit/agent/test_service_launch_timeout.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from ai.backend.agent.kernel import SERVICE_START_REPLY_TIMEOUT_SEC as AGENT_REPLY_TIMEOUT_SEC
+from ai.backend.kernel.base import DEFAULT_SERVICE_LAUNCH_TIMEOUT_SEC as KRUNNER_LAUNCH_TIMEOUT_SEC
+
+
+def test_the_reply_timeout_outlasts_the_kernel_runner() -> None:
+    assert AGENT_REPLY_TIMEOUT_SEC > KRUNNER_LAUNCH_TIMEOUT_SEC


### PR DESCRIPTION
This is an auto-generated backport of #13684 to the 26.4 release.