### PR TITLE
fix(BA-7323): define the roles table locally in RBAC role migrations (#13695)

### DIFF
--- a/changes/13695.fix.md
+++ b/changes/13695.fix.md
@@ -1,0 +1,1 @@
+Fix `alembic upgrade` aborting at the RBAC global-role migration with `CompileError: Unconsumed column names: status`, which blocked upgrades of any database created before that revision

--- a/src/ai/backend/manager/models/alembic/versions/09206ac04fd3_create_global_scope_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/09206ac04fd3_create_global_scope_roles.py
@@ -42,6 +42,10 @@ down_revision = "de1032a11cca"
 branch_labels = None
 depends_on = None
 
+# Metadata local to this revision so that the table snapshots below cannot be
+# altered by definitions living in other revisions.
+_local_metadata = sa.MetaData()
+
 
 class UserRole(enum.StrEnum):
     """
@@ -74,12 +78,49 @@ class Tables:
             extend_existing=True,
         )
 
+    @staticmethod
+    def get_roles_table() -> sa.Table:
+        """Snapshot of the ``roles`` schema at this revision: ``state`` was renamed to
+        ``status`` by 643deb439458 and ``source`` was added by 42feff246198."""
+        return sa.Table(
+            "roles",
+            _local_metadata,
+            IDColumn(),
+            sa.Column("name", sa.String(64), nullable=False),
+            sa.Column("description", sa.Text, nullable=True),
+            sa.Column("status", sa.VARCHAR(16), nullable=False, server_default="active"),
+            sa.Column("source", sa.VARCHAR(16), nullable=False, server_default="system"),
+            extend_existing=True,
+        )
+
+
+def _get_or_create_role(db_conn: Connection, name: str, source: str, status: str) -> uuid.UUID:
+    roles_table = Tables.get_roles_table()
+    role_id: uuid.UUID | None = db_conn.scalar(
+        sa.select(roles_table.c.id).where(
+            sa.and_(
+                roles_table.c.name == name,
+                roles_table.c.source == source,
+            )
+        )
+    )
+    if role_id is not None:
+        return role_id
+    created_id: uuid.UUID = db_conn.execute(
+        sa.insert(roles_table)
+        .values({"name": name, "source": source, "status": status})
+        .returning(roles_table.c.id)
+    ).scalar_one()
+    return created_id
+
 
 class RoleCreator:
     @classmethod
     def _create_superadmin_role(cls, db_conn: Connection) -> uuid.UUID:
         role_input = get_superadmin_role_creation_input()
-        role_id = PermissionUpdateUtil.get_or_create_role(db_conn, role_input)
+        role_id = _get_or_create_role(
+            db_conn, role_input.name, role_input.source, role_input.status
+        )
         permission_group_id, exist = PermissionUpdateUtil.get_or_create_global_permission_group(
             db_conn, role_id
         )
@@ -92,7 +133,9 @@ class RoleCreator:
     @classmethod
     def _create_monitor_role(cls, db_conn: Connection) -> uuid.UUID:
         role_input = get_monitor_role_creation_input()
-        role_id = PermissionUpdateUtil.get_or_create_role(db_conn, role_input)
+        role_id = _get_or_create_role(
+            db_conn, role_input.name, role_input.source, role_input.status
+        )
         permission_group_id, exist = PermissionUpdateUtil.get_or_create_global_permission_group(
             db_conn, role_id
         )

--- a/src/ai/backend/manager/models/alembic/versions/2c9000848b6e_backfill_missing_user_system_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/2c9000848b6e_backfill_missing_user_system_roles.py
@@ -25,7 +25,6 @@ from ai.backend.manager.models.rbac_models.migration.enums import (
     ScopeType,
 )
 from ai.backend.manager.models.rbac_models.migration.models import (
-    get_roles_table,
     get_user_roles_table,
     mapper_registry,
 )
@@ -39,7 +38,6 @@ from ai.backend.manager.models.rbac_models.migration.user import (
 )
 from ai.backend.manager.models.rbac_models.migration.utils import (
     insert_skip_on_conflict,
-    query_role_rows_by_name,
 )
 
 # revision identifiers, used by Alembic.
@@ -47,6 +45,23 @@ revision = "2c9000848b6e"
 down_revision = "4f08ccd6cb8e"
 branch_labels = None
 depends_on = None
+
+# Metadata local to this revision so that the table snapshots below cannot be
+# altered by definitions living in other revisions.
+_local_metadata = sa.MetaData()
+
+
+def _get_roles_table() -> sa.Table:
+    """Snapshot of the ``roles`` columns this revision touches."""
+    return sa.Table(
+        "roles",
+        _local_metadata,
+        IDColumn(),
+        sa.Column("name", sa.String(64), nullable=False),
+        sa.Column("status", sa.VARCHAR(16), nullable=False, server_default="active"),
+        sa.Column("source", sa.VARCHAR(16), nullable=False, server_default="system"),
+        extend_existing=True,
+    )
 
 
 def _get_permissions_table() -> sa.Table:
@@ -88,7 +103,7 @@ def _query_users_without_system_roles(
 ) -> Sequence[Row[Any]]:
     users_table = _get_users_table()
     user_roles_table = get_user_roles_table()
-    roles_table = get_roles_table()
+    roles_table = _get_roles_table()
     # Subquery: user_ids that already have a system role
     system_role_subq = (
         sa.select(user_roles_table.c.user_id)
@@ -111,7 +126,7 @@ def _query_users_without_system_roles(
 
 
 def _backfill_roles_and_permissions(db_conn: Connection, rows: Sequence[Row[Any]]) -> None:
-    roles_table = get_roles_table()
+    roles_table = _get_roles_table()
     from ai.backend.manager.models.rbac_models.migration.enums import RoleSource, RoleStatus
 
     # Create roles (skip if already exists by name)
@@ -124,7 +139,11 @@ def _backfill_roles_and_permissions(db_conn: Connection, rows: Sequence[Row[Any]
     insert_skip_on_conflict(db_conn, roles_table, role_inputs)
 
     # Resolve role IDs
-    role_rows = query_role_rows_by_name(db_conn, list(uuid_by_role_name.keys()))
+    role_rows = db_conn.execute(
+        sa.select(roles_table.c.id, roles_table.c.name).where(
+            roles_table.c.name.in_(list(uuid_by_role_name.keys()))
+        )
+    ).all()
     role_id_user_id_map: dict[uuid.UUID, uuid.UUID] = {
         r.id: uuid_by_role_name[r.name] for r in role_rows
     }

--- a/src/ai/backend/manager/models/alembic/versions/e3fb172166dc_backfill_project_member_roles.py
+++ b/src/ai/backend/manager/models/alembic/versions/e3fb172166dc_backfill_project_member_roles.py
@@ -39,12 +39,10 @@ from ai.backend.manager.models.rbac_models.migration.enums import (
 )
 from ai.backend.manager.models.rbac_models.migration.models import (
     get_association_scopes_entities_table,
-    get_roles_table,
     mapper_registry,
 )
 from ai.backend.manager.models.rbac_models.migration.utils import (
     insert_skip_on_conflict,
-    query_role_rows_by_name,
 )
 
 # revision identifiers, used by Alembic.
@@ -53,6 +51,10 @@ down_revision = "d8e4f2a1b3c7"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None
+
+# Metadata local to this revision so that the table snapshots below cannot be
+# altered by definitions living in other revisions.
+_local_metadata = sa.MetaData()
 
 
 # Snapshot of MEMBER_ACCESSIBLE_ENTITY_TYPES_IN_PROJECT at the time of writing.
@@ -74,6 +76,19 @@ _MEMBER_ACCESSIBLE_ENTITY_TYPES: tuple[str, ...] = (
 
 # Snapshot of OperationType.member_operations() — member roles only grant READ.
 _MEMBER_OPERATIONS: tuple[str, ...] = ("read",)
+
+
+def _get_roles_table() -> sa.Table:
+    """Snapshot of the ``roles`` columns this revision touches."""
+    return sa.Table(
+        "roles",
+        _local_metadata,
+        IDColumn(),
+        sa.Column("name", sa.String(64), nullable=False),
+        sa.Column("status", sa.VARCHAR(16), nullable=False, server_default="active"),
+        sa.Column("source", sa.VARCHAR(16), nullable=False, server_default="system"),
+        extend_existing=True,
+    )
 
 
 def _get_groups_table() -> sa.Table:
@@ -122,7 +137,7 @@ def _query_projects_missing_member_role(db_conn: Connection) -> Sequence[Row[Any
     convention for that project id.
     """
     groups_table = _get_groups_table()
-    roles_table = get_roles_table()
+    roles_table = _get_roles_table()
     assoc_table = get_association_scopes_entities_table()
 
     runtime_pattern = (
@@ -167,7 +182,7 @@ def _create_member_roles_for_projects(
     if not project_ids:
         return {}
 
-    roles_table = get_roles_table()
+    roles_table = _get_roles_table()
     role_inputs: list[dict[str, Any]] = []
     name_to_project: dict[str, uuid.UUID] = {}
     for project_id in project_ids:
@@ -183,7 +198,11 @@ def _create_member_roles_for_projects(
     # would not help here. The outer filter query is what keeps us idempotent.
     db_conn.execute(sa.insert(roles_table), role_inputs)
 
-    role_rows = query_role_rows_by_name(db_conn, list(name_to_project.keys()))
+    role_rows = db_conn.execute(
+        sa.select(roles_table.c.id, roles_table.c.name).where(
+            roles_table.c.name.in_(list(name_to_project.keys()))
+        )
+    ).all()
     project_to_role: dict[uuid.UUID, uuid.UUID] = {}
     for row in role_rows:
         resolved = name_to_project.get(row.name)
@@ -241,7 +260,7 @@ def _promote_legacy_member_roles_to_system(db_conn: Connection) -> None:
     updated, to avoid touching any unrelated custom role. The filter is
     idempotent: roles that are already ``system`` simply match zero rows.
     """
-    roles_table = get_roles_table()
+    roles_table = _get_roles_table()
     assoc_table = get_association_scopes_entities_table()
 
     legacy_scope_subq = (


### PR DESCRIPTION
This is an auto-generated backport of #13695 to the 26.4 release.