### PR TITLE
feat(BA-7264): build service images from a shared backend.ai-base image

### DIFF
--- a/changes/docker-base-image.feature.md
+++ b/changes/docker-base-image.feature.md
@@ -1,0 +1,1 @@
+Build the published service images from a shared `backend.ai-base` image installing every backend.ai package once (defined in `docker-bake.hcl`), and start them via the `backend.ai <alias> start-server` CLI entry points

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,161 @@
+# Bake definition for the published lablup/backend.ai-* service images.
+#
+# All seven service dockerfiles start FROM the shared (unpublished) base image
+# backend.ai-base:${PKGVER}, which installs every backend.ai package once.
+# The `contexts` wiring below resolves that FROM reference to the `base`
+# target inside the same build, so the base never needs to exist in a
+# registry or the local image store — bake builds it (per platform) and feeds
+# it to the service targets.
+#
+# CI (.github/workflows/docker-images.yml) runs the `default` group with
+# --push.  Local usage:
+#   PKGVER=$(python3 scripts/normalize-version.py "$(cat VERSION)") \
+#   PYTHON_VERSION=<ver from pants.toml> \
+#   docker buildx bake backend.ai-manager --set '*.platform=linux/arm64' --load
+#
+# The service target names MUST stay in sync with PUBLISHABLE_SERVICES in
+# scripts/list-dockerfiles.sh — the workflow's prepare job fails on drift.
+
+variable "PYTHON_VERSION" {
+  default = ""
+}
+variable "PKGVER" {
+  default = ""
+}
+variable "REGISTRY" {
+  default = "lablup"
+}
+# Set to true only for final (non-prerelease) releases; moves the `latest` tag.
+variable "TAG_LATEST" {
+  default = false
+}
+variable "REVISION" {
+  default = ""
+}
+
+group "default" {
+  targets = [
+    "backend_ai-manager",
+    "backend_ai-agent",
+    "backend_ai-webserver",
+    "backend_ai-storage-proxy",
+    "backend_ai-client",
+    "backend_ai-appproxy-coordinator",
+    "backend_ai-appproxy-worker",
+  ]
+}
+
+# Shared base image: built as a dependency of the service targets, never
+# pushed.  Carries all backend.ai packages so the service layers are thin and
+# every image shares the same (cacheable) heavy layer.
+target "base" {
+  context    = "."
+  dockerfile = "docker/backend.ai-base.dockerfile"
+  args = {
+    PYTHON_VERSION = PYTHON_VERSION
+    PKGVER         = PKGVER
+  }
+  platforms  = ["linux/amd64", "linux/arm64"]
+  cache-from = ["type=gha,scope=backend.ai-base"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-base"]
+}
+
+target "_service" {
+  context = "."
+  args = {
+    PKGVER = PKGVER
+  }
+  contexts = {
+    "backend.ai-base:${PKGVER}" = "target:base"
+  }
+  platforms = ["linux/amd64", "linux/arm64"]
+  attest = [
+    "type=provenance,mode=max",
+    "type=sbom",
+  ]
+  labels = {
+    "org.opencontainers.image.source"   = "https://github.com/lablup/backend.ai"
+    "org.opencontainers.image.version"  = PKGVER
+    "org.opencontainers.image.revision" = REVISION
+  }
+}
+
+# One target per published image.  Target names use `_` in place of the `.`
+# of the image name (bake target names cannot contain dots); the drift check
+# in the workflow maps them back.
+target "backend_ai-manager" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-manager.Dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-manager:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-manager:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-manager"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-manager"]
+}
+
+target "backend_ai-agent" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-agent.dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-agent:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-agent:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-agent"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-agent"]
+}
+
+target "backend_ai-webserver" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-webserver.dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-webserver:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-webserver:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-webserver"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-webserver"]
+}
+
+target "backend_ai-storage-proxy" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-storage-proxy.dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-storage-proxy:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-storage-proxy:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-storage-proxy"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-storage-proxy"]
+}
+
+target "backend_ai-client" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-client.dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-client:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-client:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-client"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-client"]
+}
+
+target "backend_ai-appproxy-coordinator" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-appproxy-coordinator.dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-appproxy-coordinator:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-appproxy-coordinator:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-appproxy-coordinator"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-appproxy-coordinator"]
+}
+
+target "backend_ai-appproxy-worker" {
+  inherits   = ["_service"]
+  dockerfile = "docker/backend.ai-appproxy-worker.dockerfile"
+  tags = concat(
+    ["${REGISTRY}/backend.ai-appproxy-worker:${PKGVER}"],
+    TAG_LATEST ? ["${REGISTRY}/backend.ai-appproxy-worker:latest"] : [],
+  )
+  cache-from = ["type=gha,scope=backend.ai-appproxy-worker"]
+  cache-to   = ["type=gha,mode=max,scope=backend.ai-appproxy-worker"]
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,12 +1,26 @@
 # `docker/` — Service and infra images
 
 The `backend.ai-*` dockerfiles in this directory are built and published to
-Docker Hub for every release tag by `.github/workflows/docker-images.yml`
-(matrix from `scripts/list-dockerfiles.sh --service`), multi-arch
-(`linux/amd64` + `linux/arm64`). The remaining dockerfiles are runtime helper
-images and are not published.
+Docker Hub for every release tag by `.github/workflows/docker-images.yml` in a
+single `docker buildx bake` run (`docker-bake.hcl` at the repository root),
+multi-arch (`linux/amd64` + `linux/arm64`).
+`scripts/list-dockerfiles.sh` stays the publishing allowlist — the workflow
+fails when it and the bake targets drift apart
+(`scripts/check-bake-targets.sh`). The remaining dockerfiles are runtime
+helper images and are not published.
 
 ## Published images
+
+All published images are thin layers over a shared, **unpublished** base image
+(`backend.ai-base.dockerfile`) that installs every backend.ai package once:
+
+- Every image contains **all** backend.ai packages and the full `backend.ai`
+  CLI; the images differ only in their default command, prepared directories,
+  and service extras (e.g. the agent's Docker CLI and entrypoint).
+- A host running several services downloads the shared base layers once; the
+  per-service layers are a few KB.
+- The same-version rule below is structural: one base build feeds all seven
+  images of a release.
 
 | Dockerfile | Docker Hub | Role |
 |---|---|---|
@@ -25,9 +39,22 @@ images and are not published.
 | `<version>` (e.g. `26.9.0`, `26.9.0rc1`) | The normalized package version of the release tag that built the image |
 | `latest` | Applied to **any** final (non-prerelease) release — never moved by rc/alpha/beta releases. This includes hotfixes cut from older release branches, so `latest` can move *backwards*; pin explicit versions in production |
 
-All images take the same build-arg contract: `PYTHON_VERSION` (from
-`pants.toml`) and `PKGVER` (normalized `VERSION`), and install the release
-wheels staged in `dist/` with the build context at the repository root.
+**Build contract.** The base image takes `PYTHON_VERSION` (from `pants.toml`)
+and `PKGVER` (normalized `VERSION`) and installs the release wheels staged in
+`dist/` (falling back to PyPI for a version already released there); the
+service dockerfiles take only `PKGVER` and start
+`FROM backend.ai-base:${PKGVER}`. Always build through bake — it builds the
+base as an in-run dependency of the service targets (via a named build
+context), so the base never needs to be pre-built or pushed anywhere:
+
+```sh
+PYTHON_VERSION=<ver from pants.toml> \
+PKGVER=$(python3 scripts/normalize-version.py "$(cat VERSION)") \
+  docker buildx bake backend_ai-manager --set '*.platform=linux/arm64' --load
+```
+
+(Bake target names replace the `.` of the image name with `_`; the build
+context is the repository root.)
 
 **Run every `lablup/backend.ai-*` image in one deployment at the SAME version.**
 The components exchange serialized messages over the shared Redis/Valkey event

--- a/docker/backend.ai-agent.dockerfile
+++ b/docker/backend.ai-agent.dockerfile
@@ -1,22 +1,9 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-agent.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
-ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION} AS builder
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-agent --set '*.platform=linux/amd64' --load
 ARG PKGVER
-COPY ./dist /dist
-COPY ./requirements.txt /requirements.txt
-# Install dependencies from requirements.txt to respect version constraints
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir -r /requirements.txt
-# Install backend.ai packages from /dist (these are not in requirements.txt or PyPI)
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-agent==${PKGVER} --find-links=/dist --no-deps
-
-FROM python:${PYTHON_VERSION}
-ENV PYTHONUNBUFFERED=1
-COPY --from=builder /wheels /wheels
-COPY ./dist /dist
-# Install all wheels (looking in /dist for backend.ai packages) and drop the
-# wheel/dist inputs in the same layer to keep the image slim
-RUN pip install --no-cache-dir --find-links=/dist /wheels/*.whl && rm -rf /wheels /dist
+FROM backend.ai-base:${PKGVER}
 
 # Docker CLI for DooD: the agent shells out to `docker load` / `docker exec`
 # against the host daemon socket. The binary is statically linked, so copying
@@ -39,4 +26,4 @@ WORKDIR /app
 COPY --chmod=0755 ./docker/backend.ai-agent-entrypoint.sh /app/entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["python", "-m", "ai.backend.agent.server", "-f", "/etc/backend.ai/agent.toml"]
+CMD ["backend.ai", "ag", "start-server", "-f", "/etc/backend.ai/agent.toml"]

--- a/docker/backend.ai-appproxy-coordinator.dockerfile
+++ b/docker/backend.ai-appproxy-coordinator.dockerfile
@@ -1,5 +1,7 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-appproxy-coordinator.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-appproxy-coordinator --set '*.platform=linux/amd64' --load
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION} AS builder
 ARG PKGVER
@@ -14,7 +16,7 @@ FROM python:${PYTHON_VERSION}
 COPY --from=builder /wheels /wheels
 COPY ./dist /dist
 # Install all wheels and also look in /dist for backend.ai packages
-RUN pip install --no-cache-dir --find-links=/dist /wheels/*.whl && rm -rf /wheels /dist
+RUN pip install --no-cache-dir --find-links=/dist /wheels/*.whl
 
 # Create necessary directories
 RUN mkdir -p /var/log/backend.ai /etc/backend.ai
@@ -22,4 +24,4 @@ RUN mkdir -p /var/log/backend.ai /etc/backend.ai
 # Set working directory
 WORKDIR /app
 
-CMD ["python", "-m", "ai.backend.appproxy.coordinator.server", "-f", "/etc/backend.ai/proxy-coordinator.toml"]
+CMD ["backend.ai", "app-proxy-coordinator", "start-server", "-f", "/etc/backend.ai/proxy-coordinator.toml"]

--- a/docker/backend.ai-appproxy-worker.dockerfile
+++ b/docker/backend.ai-appproxy-worker.dockerfile
@@ -1,20 +1,9 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-appproxy-worker.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
-ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION} AS builder
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-appproxy-worker --set '*.platform=linux/amd64' --load
 ARG PKGVER
-COPY ./dist /dist
-COPY ./requirements.txt /requirements.txt
-# Install dependencies from requirements.txt to respect version constraints
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir -r /requirements.txt
-# Install backend.ai packages from /dist (these are not in requirements.txt or PyPI)
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-appproxy-worker==${PKGVER} --find-links=/dist --no-deps
-
-FROM python:${PYTHON_VERSION}
-COPY --from=builder /wheels /wheels
-COPY ./dist /dist
-# Install all wheels and also look in /dist for backend.ai packages
-RUN pip install --no-cache-dir --find-links=/dist /wheels/*.whl && rm -rf /wheels /dist
+FROM lablup/backend.ai-base:${PKGVER}
 
 # Create necessary directories
 RUN mkdir -p /var/log/backend.ai /etc/backend.ai
@@ -22,4 +11,4 @@ RUN mkdir -p /var/log/backend.ai /etc/backend.ai
 # Set working directory
 WORKDIR /app
 
-CMD ["python", "-m", "ai.backend.appproxy.worker.server", "-f", "/etc/backend.ai/proxy-worker.toml"]
+CMD ["backend.ai", "app-proxy-worker", "start-server", "-f", "/etc/backend.ai/proxy-worker.toml"]

--- a/docker/backend.ai-base.dockerfile
+++ b/docker/backend.ai-base.dockerfile
@@ -1,0 +1,33 @@
+# Build context MUST be the repository root (the paths below are context-relative):
+#   docker build -f docker/backend.ai-base.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
+ARG PYTHON_VERSION
+FROM python:${PYTHON_VERSION} AS builder
+ARG PKGVER
+
+# Install dependencies from requirements.txt to respect version constraints
+COPY ./requirements.txt /requirements.txt
+RUN pip wheel --wheel-dir=/wheels --no-cache-dir -r /requirements.txt
+
+# Install the backend.ai packages from /dist (these are not in
+# requirements.txt).  Resolving them JOINTLY with -r requirements.txt keeps
+# the dependency versions consistent with the step above by construction
+# (`-c` would be the usual tool, but pip rejects constraints entries carrying
+# extras, which requirements.txt has); the step above still exists so the
+# heavy dependency download is a layer that caches independently of dist/,
+# and --find-links=/wheels lets this resolve reuse its wheels.
+COPY ./dist /dist
+RUN pip wheel --wheel-dir=/wheels --no-cache-dir \
+    --find-links=/wheels --find-links=/dist \
+    -r /requirements.txt \
+    backend.ai-manager==${PKGVER} \
+    backend.ai-agent==${PKGVER} \
+    backend.ai-webserver==${PKGVER} \
+    backend.ai-storage-proxy==${PKGVER} \
+    backend.ai-client==${PKGVER} \
+    backend.ai-appproxy-coordinator==${PKGVER} \
+    backend.ai-appproxy-worker==${PKGVER}
+
+FROM python:${PYTHON_VERSION}
+ENV PYTHONUNBUFFERED=1
+RUN --mount=type=bind,from=builder,source=/wheels,target=/wheels \
+    pip install --no-cache-dir /wheels/*.whl

--- a/docker/backend.ai-client.dockerfile
+++ b/docker/backend.ai-client.dockerfile
@@ -1,11 +1,7 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-client.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
-ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION} AS builder
-ARG PKGVER
-COPY ./dist /dist
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-client==${PKGVER} --find-links=/dist
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-client --set '*.platform=linux/amd64' --load
 
-FROM python:${PYTHON_VERSION}
-COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels /dist
+ARG PKGVER
+FROM lablup/backend.ai-base:${PKGVER}

--- a/docker/backend.ai-manager-entrypoint.sh
+++ b/docker/backend.ai-manager-entrypoint.sh
@@ -24,4 +24,4 @@ mkdir -p /var/log/backend.ai
 mkdir -p /tmp/backend.ai/ipc
 
 echo "=== Manager server starting ==="
-exec python -m ai.backend.manager.server --config /etc/backend.ai/manager.toml
+exec backend.ai mgr start-server --config /etc/backend.ai/manager.toml

--- a/docker/backend.ai-manager.Dockerfile
+++ b/docker/backend.ai-manager.Dockerfile
@@ -1,20 +1,9 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-manager.Dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
-ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION} AS builder
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-manager --set '*.platform=linux/amd64' --load
 ARG PKGVER
-COPY ./dist /dist
-COPY ./requirements.txt /requirements.txt
-# Install dependencies from requirements.txt to respect version constraints
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir -r /requirements.txt
-# Install backend.ai packages from /dist (these are not in requirements.txt or PyPI)
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-manager==${PKGVER} --find-links=/dist --no-deps
-
-FROM python:${PYTHON_VERSION}
-COPY --from=builder /wheels /wheels
-COPY ./dist /dist
-# Install all wheels and also look in /dist for backend.ai packages
-RUN pip install --no-cache-dir --find-links=/dist /wheels/*.whl && rm -rf /wheels /dist
+FROM lablup/backend.ai-base:${PKGVER}
 
 # Create necessary directories
 RUN mkdir -p /tmp/backend.ai/ipc /var/log/backend.ai /etc/backend.ai /app/fixtures

--- a/docker/backend.ai-storage-proxy.dockerfile
+++ b/docker/backend.ai-storage-proxy.dockerfile
@@ -1,14 +1,9 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-storage-proxy.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
-ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION} AS builder
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-storage-proxy --set '*.platform=linux/amd64' --load
 ARG PKGVER
-COPY ./dist /dist
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-storage-proxy==${PKGVER} --find-links=/dist
-
-FROM python:${PYTHON_VERSION}
-COPY --from=builder /wheels /wheels
-RUN pip install --no-cache-dir /wheels/*.whl && rm -rf /wheels /dist
+FROM lablup/backend.ai-base:${PKGVER}
 
 # Create necessary directories
 RUN mkdir -p /var/log/backend.ai /etc/backend.ai
@@ -16,4 +11,4 @@ RUN mkdir -p /var/log/backend.ai /etc/backend.ai
 # Set working directory
 WORKDIR /app
 
-CMD ["python", "-m", "ai.backend.storage.server", "-f", "/etc/backend.ai/storage-proxy.toml"]
+CMD ["backend.ai", "storage", "start-server", "-f", "/etc/backend.ai/storage-proxy.toml"]

--- a/docker/backend.ai-webserver.dockerfile
+++ b/docker/backend.ai-webserver.dockerfile
@@ -1,20 +1,9 @@
-# Build context MUST be the repository root (the paths below are context-relative):
-#   docker build -f docker/backend.ai-webserver.dockerfile --build-arg PYTHON_VERSION=<ver> --build-arg PKGVER=<ver> .
-ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION} AS builder
+# Build context MUST be the repository root.  Starts FROM the shared
+# backend.ai-base image (docker/backend.ai-base.dockerfile), which must be
+# buildable at the same PKGVER — bake builds both (see docker-bake.hcl):
+#   docker buildx bake backend_ai-webserver --set '*.platform=linux/amd64' --load
 ARG PKGVER
-COPY ./dist /dist
-COPY ./requirements.txt /requirements.txt
-# Install dependencies from requirements.txt to respect version constraints
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir -r /requirements.txt
-# Install backend.ai packages from /dist (these are not in requirements.txt or PyPI)
-RUN pip wheel --wheel-dir=/wheels --no-cache-dir backend.ai-webserver==${PKGVER} --find-links=/dist --no-deps --find-links=/dist
-
-FROM python:${PYTHON_VERSION}
-COPY --from=builder /wheels /wheels
-COPY ./dist /dist
-# Install all wheels and also look in /dist for backend.ai packages
-RUN pip install --no-cache-dir --find-links=/dist /wheels/*.whl && rm -rf /wheels /dist
+FROM lablup/backend.ai-base:${PKGVER}
 
 # Create necessary directories
 RUN mkdir -p /var/log/backend.ai /etc/backend.ai
@@ -22,4 +11,4 @@ RUN mkdir -p /var/log/backend.ai /etc/backend.ai
 # Set working directory
 WORKDIR /app
 
-CMD ["python", "-m", "ai.backend.web.server", "-f", "/etc/backend.ai/webserver.conf"]
+CMD ["backend.ai", "web", "start-server", "-f", "/etc/backend.ai/webserver.conf"]

--- a/scripts/list-dockerfiles.sh
+++ b/scripts/list-dockerfiles.sh
@@ -21,10 +21,16 @@
 #   {"name": "krunner-extractor", "dockerfile": "docker/krunner-extractor.dockerfile",
 #    "context": "docker"}
 #
+# Base images (BASE_IMAGES below) are backend.ai-* dockerfiles that service
+# images build FROM: built inside the docker-images.yml bake run, never
+# published, and emitted only with --all (no `image` field):
+#   {"name": "backend.ai-base", "dockerfile": "docker/backend.ai-base.dockerfile",
+#    "context": "."}
+#
 # Publishing is allowlist-driven: every backend.ai-* dockerfile must be
-# registered in PUBLISHABLE_SERVICES below. An unregistered backend.ai-*
-# dockerfile makes the script fail loudly, so a new dockerfile cannot start
-# publishing an image without a deliberate registration edit here.
+# registered in PUBLISHABLE_SERVICES (or BASE_IMAGES) below. An unregistered
+# backend.ai-* dockerfile makes the script fail loudly, so a new dockerfile
+# cannot start publishing an image without a deliberate registration edit here.
 set -euo pipefail
 
 # Registry of publishable service images (lowercase names):
@@ -39,11 +45,18 @@ PUBLISHABLE_SERVICES=(
   backend.ai-appproxy-worker
 )
 
+# Registry of unpublished base images the service images build FROM
+# (lowercase names). Built as bake dependencies of the service targets in
+# docker-bake.hcl — not pushed anywhere, and not part of --service/--infra.
+BASE_IMAGES=(
+  backend.ai-base
+)
+
 print_usage() {
   echo "usage: $0 [--all|--service|--infra]"
   echo ""
   echo "Prints the docker/ dockerfile build matrix as compact JSON."
-  echo "  --all       service and infra images (default)"
+  echo "  --all       every dockerfile: service, infra, and base (default)"
   echo "  --service   publishable backend.ai-* images only"
   echo "  --infra     unpublished infra images only"
   echo "  --help, -h  show this help"
@@ -78,7 +91,7 @@ cd -- "$(dirname "$0")/.." >/dev/null
 files=$(find docker -type f \( -name '*.dockerfile' -o -name '*.Dockerfile' \) | LC_ALL=C sort)
 
 # Fail loudly on any backend.ai-* dockerfile that is not a registered
-# publishable service, before emitting any JSON.
+# publishable service or base image, before emitting any JSON.
 while IFS= read -r file; do
   [ -n "$file" ] || continue
   name="${file##*/}"
@@ -88,14 +101,14 @@ while IFS= read -r file; do
   case "$lower" in
     backend.ai-*)
       registered=false
-      for svc in "${PUBLISHABLE_SERVICES[@]}"; do
+      for svc in "${PUBLISHABLE_SERVICES[@]}" "${BASE_IMAGES[@]}"; do
         if [ "$lower" = "$svc" ]; then
           registered=true
           break
         fi
       done
       if [ "$registered" != true ]; then
-        echo "$0: '$file' looks like a publishable service image, but '$name' is not registered in PUBLISHABLE_SERVICES." >&2
+        echo "$0: '$file' looks like a publishable service image, but '$name' is not registered in PUBLISHABLE_SERVICES (or BASE_IMAGES)." >&2
         echo "$0: register the name in scripts/list-dockerfiles.sh (or rename the dockerfile) to proceed." >&2
         exit 1
       fi
@@ -104,12 +117,15 @@ while IFS= read -r file; do
 done <<<"$files"
 
 printf '%s\n' "$files" \
-  | jq -R -s -c --arg mode "$mode" '
-      split("\n")
+  | jq -R -s -c --arg mode "$mode" --arg base "${BASE_IMAGES[*]}" '
+      ($base | split(" ")) as $base_names
+      | split("\n")
       | map(select(length > 0))
       | map(
           (split("/")[-1] | sub("\\.[dD]ockerfile$"; "")) as $name
-          | if ($name | ascii_downcase | startswith("backend.ai-")) then
+          | if ($base_names | index($name | ascii_downcase)) then
+              {category: "base", name: $name, dockerfile: ., context: "."}
+            elif ($name | ascii_downcase | startswith("backend.ai-")) then
               {category: "service", name: $name, dockerfile: .,
                context: ".", image: ("lablup/" + $name)}
             else


### PR DESCRIPTION
## Summary
- Add `docker/backend.ai-base.dockerfile`: a shared, **unpublished** base image that installs every backend.ai package once — a joint `pip wheel` resolve of `-r requirements.txt` plus the seven service packages (`--find-links=dist/`, PyPI fallback), so dependency versions cannot drift from the tested set, with a BuildKit `RUN --mount` install so no wheel or dist bytes ship in any image layer.
- Rewrite the seven service dockerfiles as thin layers `FROM backend.ai-base:${PKGVER}`: every image now carries all packages and the full `backend.ai` CLI, differing only in default command, prepared directories, and extras (agent keeps its digest-pinned Docker CLI, entrypoint, and the krunner fail-fast probe). Multi-service hosts download the shared base layers once, and the same-version rule becomes structural.
- Default commands switch from `python -m …` to the `backend.ai <alias> start-server` lazy-import CLI entry points (`mgr`/`ag`/`web`/`storage`/`app-proxy-*`).
- Add `docker-bake.hcl`: the base is wired into the service targets as a named build context (`target:base`), so it is built in-run per platform and never needs to exist in a registry; tags, OCI labels, provenance+SBOM attestations, and per-image gha cache scopes live here.
- Register `backend.ai-base` as a build-only entry in `scripts/list-dockerfiles.sh` (excluded from `--service` publishing and `--infra`), and update `docker/README.md` for the base-image build contract.

**Merge order note:** stacked on #13703 (BA-7321) of the BA-7264 chain; retarget to `main` after the base PR merges. The CI switch to bake follows in the next PR of the stack.

Part of the BA-7264 epic (#13582).