### PR TITLE
ci(BA-7264): build and push the service images via a single bake run

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,6 +1,12 @@
-# Builds the lablup/backend.ai-* service images from the docker/backend.ai-*
-# dockerfiles (discovered via scripts/list-dockerfiles.sh --service) and pushes
-# them to Docker Hub, multi-arch (linux/amd64 + linux/arm64).
+# Builds the lablup/backend.ai-* service images and pushes them to Docker Hub,
+# multi-arch (linux/amd64 + linux/arm64), in a single `docker buildx bake` run
+# (docker-bake.hcl): every service dockerfile starts FROM the shared
+# unpublished backend.ai-base image, which bake builds once per platform and
+# feeds to the service targets via named contexts — the heavy dependency layer
+# is built once instead of per image, and the base never has to exist in a
+# registry.  scripts/list-dockerfiles.sh remains the publishing registry: the
+# prepare job fails (scripts/check-bake-targets.sh) when its --service list
+# and the bake default group drift apart.
 #
 # Authentication is OIDC-only — no registry secret is stored in this repository:
 # - The Docker Hub org `lablup` has an OIDC connection whose ruleset accepts
@@ -52,12 +58,11 @@ concurrency:
 
 jobs:
   prepare:
-    name: Prepare build matrix
+    name: Validate the image registry and resolve versions
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
       python-version: ${{ steps.pyver.outputs.version }}
       pkgver: ${{ steps.pkgver.outputs.version }}
       is-prerelease: ${{ steps.release-type.outputs.is-prerelease }}
@@ -67,17 +72,8 @@ jobs:
       with:
         lfs: false
 
-    - name: Build the service image matrix
-      id: set-matrix
-      run: |
-        MATRIX_JSON=$(scripts/list-dockerfiles.sh --service)
-        echo "Found service image matrix:"
-        echo "$MATRIX_JSON" | jq .
-        if [ "$(echo "$MATRIX_JSON" | jq '.include | length')" -eq 0 ]; then
-          echo "::error::scripts/list-dockerfiles.sh --service returned an empty matrix — no service images would be built. This is always a bug on a release."
-          exit 1
-        fi
-        echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+    - name: Check the bake definition against the dockerfile registry
+      run: scripts/check-bake-targets.sh docker-bake.hcl
 
     - name: Resolve project Python version
       id: pyver
@@ -118,9 +114,8 @@ jobs:
         echo "is-prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
   build-push:
-    name: Build and push ${{ matrix.name }}
+    name: Build and push all service images
     needs: prepare
-    if: needs.prepare.outputs.matrix != '{"include":[]}'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     environment: deploy-to-dockerhub
@@ -128,9 +123,6 @@ jobs:
       contents: read
       actions: read  # let download-artifact's REST path read the wheels artifact
       id-token: write  # mint the OIDC token exchanged for the Docker Hub login
-    strategy:
-      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-      fail-fast: false
     steps:
     - name: Check the OIDC connection variable
       env:
@@ -167,30 +159,19 @@ jobs:
       with:
         username: lablup
 
-    - name: Generate image metadata
-      id: meta
-      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+    # Tags, platforms, attestations (provenance mode=max + SBOM), and the gha
+    # cache configuration all live in docker-bake.hcl; the env vars below fill
+    # its variables.  `source: .` makes bake build from the checked-out
+    # workspace (where the wheels were just downloaded into dist/) instead of
+    # the action's default remote Git context.
+    - name: Build and push all service images
+      uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b  # v7.3.0
+      env:
+        PYTHON_VERSION: ${{ needs.prepare.outputs.python-version }}
+        PKGVER: ${{ needs.prepare.outputs.pkgver }}
+        TAG_LATEST: ${{ needs.prepare.outputs.is-prerelease == 'false' }}
+        REVISION: ${{ github.sha }}
       with:
-        images: ${{ matrix.image }}
-        flavor: |
-          latest=false
-        tags: |
-          type=raw,value=${{ needs.prepare.outputs.pkgver }}
-          type=raw,value=latest,enable=${{ needs.prepare.outputs.is-prerelease == 'false' }}
-
-    - name: Build and push
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
-      with:
-        context: ${{ matrix.context }}
-        file: ${{ matrix.dockerfile }}
-        platforms: linux/amd64,linux/arm64
+        source: .
+        files: docker-bake.hcl
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        provenance: mode=max
-        sbom: true
-        cache-from: type=gha,scope=${{ matrix.name }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.name }}
-        build-args: |
-          PYTHON_VERSION=${{ needs.prepare.outputs.python-version }}
-          PKGVER=${{ needs.prepare.outputs.pkgver }}

--- a/changes/docker-images-bake.misc.md
+++ b/changes/docker-images-bake.misc.md
@@ -1,0 +1,1 @@
+Build and push the seven service images in a single `docker buildx bake` run wiring the shared base image in as a bake target, with a drift check between `docker-bake.hcl` and the `list-dockerfiles.sh` publishing registry

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,7 +74,8 @@ current, see `AGENTS.md` in this directory.
 | `.github/scripts/create-version-branch.sh` | Tags the `X.Y.0rc1` a release commit made and cuts the `X.Y` branch at that same commit | auto — `create-version-branch.yml` |
 | `.github/scripts/sync-changelog-to-main.sh` | Opens the pull request carrying a final release's `CHANGELOG/X.Y.md` back to `main` | auto — `changelog-sync.yml` |
 | `extract-release-changelog.py` | Extracts the tagged version's block for the GitHub release body | auto — `ci.yml` (release job) |
-| `list-dockerfiles.sh` | Prints the `docker/` dockerfile build matrix (`--service` / `--infra`) as JSON; a new `backend.ai-*` dockerfile must be registered in its allowlist | auto — `sbom.yml`; `docker-images.yml`; `osv-scanner.yml` (also scheduled: weekly cron + push to `main`) |
+| `list-dockerfiles.sh` | Prints the `docker/` dockerfile build matrix (`--service` / `--infra`) as JSON; a new `backend.ai-*` dockerfile must be registered in its allowlist | auto — `sbom.yml`; `docker-images.yml` (via `check-bake-targets.sh`); `osv-scanner.yml` (also scheduled: weekly cron + push to `main`) |
+| `check-bake-targets.sh` | Fails when `docker-bake.hcl`'s default group and the `list-dockerfiles.sh --service` registry drift apart | auto — `docker-images.yml` |
 | `determine-release-type.py` | Sets `IS_PRERELEASE` from the `VERSION` file | auto — `ci.yml` (release job) |
 | `normalize-version.py` | Prints the PEP 440-normalized version used for docker image tags, rejecting local segments (`+` is not a legal docker tag character) | auto — `docker-images.yml` |
 | `build-wheels.sh` | Builds the platform-specific and generic wheels | auto — `ci.yml` (release job) |

--- a/scripts/check-bake-targets.sh
+++ b/scripts/check-bake-targets.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Check that a bake definition's default group covers exactly the publishable
+# service images registered in scripts/list-dockerfiles.sh.
+#
+# Usage:
+#   scripts/check-bake-targets.sh <bake-file>
+#
+# Bake target names cannot contain dots, so docker-bake.hcl names its targets
+# backend_ai-<name>; this script maps them back to backend.ai-<name> before
+# comparing.  Prints the verified image-name list on success; exits non-zero
+# with the drift when the two registries disagree, so a new dockerfile cannot
+# be registered for publishing without also being wired into the bake build
+# (and vice versa).
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <bake-file>" >&2
+  exit 2
+fi
+bake_file=$1
+
+unset CDPATH
+cd -- "$(dirname "$0")/.." >/dev/null
+
+expected=$(scripts/list-dockerfiles.sh --service | jq -r '.include[].name' | LC_ALL=C sort)
+actual=$(docker buildx bake --file "$bake_file" --print default 2>/dev/null \
+  | jq -r '.group.default.targets[]' \
+  | sed 's/^backend_ai-/backend.ai-/' \
+  | LC_ALL=C sort)
+
+if [ "$expected" != "$actual" ]; then
+  echo "$0: the default group of '$bake_file' and PUBLISHABLE_SERVICES in scripts/list-dockerfiles.sh have drifted:" >&2
+  diff --label registered --label baked \
+    <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") >&2 || true
+  echo "$0: register the image in both places (or remove it from both) to proceed." >&2
+  exit 1
+fi
+
+printf '%s\n' "$expected"


### PR DESCRIPTION
## Summary
- Rework `.github/workflows/docker-images.yml`: the per-image matrix becomes one `docker/bake-action` step (SHA-pinned v7.3.0, `source: .` so bake sees the downloaded wheels) running the `docker-bake.hcl` default group — the shared base builds once per platform instead of the dependency set building seven times under QEMU, and tags/attestations/cache config move into the bake file. The `workflow_call` interface is unchanged, so the ci.yml wiring (#13701) needs no edits.
- Add `scripts/check-bake-targets.sh`: the prepare job fails when the bake default group and the `list-dockerfiles.sh --service` publishing registry drift apart, preserving the fail-loud allowlist property across both files.
- `sbom.yml` / `osv-scanner.yml` are unaffected (they consume `--infra` only, which never includes the base).

**Merge order note:** stacked on the backend.ai-base image PR — last PR of the BA-7264 chain; retarget to `main` after the base PR merges.

Part of the BA-7264 epic (#13582).