### PR TITLE
fix(BA-7321): mount only per-service configs into the non-elevated DOCKER-mode containers

### DIFF
--- a/changes/docker-minimal-service-mounts.fix.md
+++ b/changes/docker-minimal-service-mounts.fix.md
@@ -1,0 +1,1 @@
+Mount only each service's own config file (read-only) into the DOCKER install-mode webserver and app-proxy containers instead of the whole install directory, so they cannot read the credentials in the other services' configs

--- a/docker/README.md
+++ b/docker/README.md
@@ -181,9 +181,14 @@ the **DOCKER install mode** of `backend.ai-installer` generates at
 
 - Every service runs on the host network, so the generated configs use the
   same `127.0.0.1` addressing as a package-based install.
-- The install directory is bind-mounted into every container at the identical
-  absolute path, and each service's `command:` reads its config from there —
-  no `/etc/backend.ai` mounts.
+- Each service's `command:` reads its config from the install directory — no
+  `/etc/backend.ai` mounts. The install directory is bind-mounted at the
+  identical absolute path (path parity) only into the services whose files
+  must resolve on the host or that share bootstrap state: agent and
+  storage-proxy (paths handed to the host Docker daemon) plus
+  manager/manager-cli (RPC keypair fixtures). The webserver and app-proxy
+  services mount **only their own config file, read-only**, so a compromised
+  one never sees the credentials in the other configs.
 - `/etc/machine-id` is passed through read-only to the manager and agent so
   anything deriving a stable host identity sees the host's, not the
   container's.

--- a/src/ai/backend/install/configs/docker-compose.services.yml
+++ b/src/ai/backend/install/configs/docker-compose.services.yml
@@ -11,9 +11,16 @@
 # - Every service runs on the host network, so the generated configs use the
 #   same 127.0.0.1 addressing as the package-based install layout.
 # - The install directory is bind-mounted at the SAME absolute path (path
-#   parity): every path under it that a service hands to the host Docker
-#   daemon (scratch roots, IPC sockets, vfolder trees, plugin var state)
-#   resolves identically on the host and inside the containers.
+#   parity) into the services whose paths must resolve on the host — the
+#   agent and storage-proxy hand paths under it to the host Docker daemon
+#   (scratch roots, IPC sockets, vfolder trees, plugin var state), and the
+#   manager/manager-cli share bootstrap state (RPC keypair fixtures, fixture
+#   files) through it.
+# - The remaining services (webserver, app-proxy trio) mount ONLY their own
+#   config file, read-only: they never see the credentials in the other
+#   configs (e.g. the manager's DB password). Their working-dir-relative
+#   state (ipc/, var/, logs) stays container-local and ephemeral, which is
+#   fine — nothing outside the container consumes it.
 # - The agent additionally needs pid/cgroup host namespaces and the
 #   /var/lib/backend.ai/krunner share for kernel-runner bind-mounts.
 # - No agent-watcher container ships in this mode; the watcher endpoint in
@@ -76,7 +83,7 @@ services:
     working_dir: {{BASE_PATH}}
     command: ["python", "-m", "ai.backend.web.server", "-f", "{{BASE_PATH}}/webserver.conf"]
     volumes:
-      - {{BASE_PATH}}:{{BASE_PATH}}
+      - {{BASE_PATH}}/webserver.conf:{{BASE_PATH}}/webserver.conf:ro
     restart: unless-stopped
 
   storage-proxy:
@@ -94,7 +101,7 @@ services:
     working_dir: {{BASE_PATH}}
     command: ["python", "-m", "ai.backend.appproxy.coordinator.server", "-f", "{{BASE_PATH}}/app-proxy-coordinator.toml"]
     volumes:
-      - {{BASE_PATH}}:{{BASE_PATH}}
+      - {{BASE_PATH}}/app-proxy-coordinator.toml:{{BASE_PATH}}/app-proxy-coordinator.toml:ro
     restart: unless-stopped
 
   appproxy-worker:
@@ -103,7 +110,7 @@ services:
     working_dir: {{BASE_PATH}}
     command: ["python", "-m", "ai.backend.appproxy.worker.server", "-f", "{{BASE_PATH}}/app-proxy-worker.toml"]
     volumes:
-      - {{BASE_PATH}}:{{BASE_PATH}}
+      - {{BASE_PATH}}/app-proxy-worker.toml:{{BASE_PATH}}/app-proxy-worker.toml:ro
     restart: unless-stopped
 
   appproxy-worker-tcp:
@@ -112,5 +119,5 @@ services:
     working_dir: {{BASE_PATH}}
     command: ["python", "-m", "ai.backend.appproxy.worker.server", "-f", "{{BASE_PATH}}/app-proxy-worker-tcp.toml"]
     volumes:
-      - {{BASE_PATH}}:{{BASE_PATH}}
+      - {{BASE_PATH}}/app-proxy-worker-tcp.toml:{{BASE_PATH}}/app-proxy-worker-tcp.toml:ro
     restart: unless-stopped

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -2301,15 +2301,20 @@ class DockerContext(Context):
 
     - Every service container runs on the host network, so the configs
       generated for the package layout (127.0.0.1 addressing) work unchanged.
-    - The install target directory is bind-mounted into every service
-      container at the identical absolute path (path parity), so every path
-      under it that a service hands to the host Docker daemon — scratch
-      roots, IPC sockets, vfolder trees, plugin var state — resolves on the
-      host.
+    - The install target directory is bind-mounted at the identical absolute
+      path (path parity) into the services whose files must resolve on the
+      host or that share bootstrap state: the agent and storage-proxy hand
+      paths under it to the host Docker daemon (scratch roots, IPC sockets,
+      vfolder trees, plugin var state), and the manager/manager-cli exchange
+      the RPC keypair fixtures through it.
+    - The remaining services (webserver, app-proxy trio) mount only their own
+      config file read-only, so a compromised one cannot read the credentials
+      in the other configs; their working-dir-relative state stays
+      container-local.
     - One-off management commands (schema init, fixture loading, image
       rescan) run through ``docker compose run`` using the same images, with
-      host paths outside the install directory bind-mounted read-only on
-      demand.
+      host paths passed as arguments bind-mounted read-only on demand — only
+      paths already covered by the service's parity mount are skipped.
     """
 
     SERVICES_COMPOSE_FILENAME = "docker-compose.services.yml"
@@ -2373,20 +2378,35 @@ class DockerContext(Context):
             str(self.install_info.base_path / self.SERVICES_COMPOSE_FILENAME),
         ]
 
-    async def _run_service_cli(self, service: str, container_cmd: Sequence[str]) -> int:
+    async def _run_service_cli(
+        self,
+        service: str,
+        container_cmd: Sequence[str],
+        *,
+        parity_mounted: bool = True,
+    ) -> int:
         """
         Run a one-off management command inside a fresh container of the given
-        compose service (same image, same host network, same base_path parity
-        mount). Host paths passed as arguments that live outside the install
-        directory (e.g. fixture files extracted from the installer package)
-        are bind-mounted read-only at the identical path so the in-container
-        command can read them unchanged.
+        compose service (same image, same host network, same volumes). Host
+        paths passed as arguments (e.g. fixture files extracted from the
+        installer package) are bind-mounted read-only at the identical path so
+        the in-container command can read them unchanged.
+
+        ``parity_mounted`` states whether the compose service carries the
+        base_path parity mount: when it does, arguments under base_path are
+        already visible and are not mounted again (a duplicate mount target
+        would fail); when it does not (the config-only services), base_path
+        arguments get the same per-file read-only treatment as outside paths.
         """
         base_path = self.install_info.base_path
         volume_args: list[str] = []
         for arg in container_cmd:
             p = Path(arg)
-            if p.is_absolute() and p.exists() and not p.is_relative_to(base_path):
+            if (
+                p.is_absolute()
+                and p.exists()
+                and (not parity_mounted or not p.is_relative_to(base_path))
+            ):
                 volume_args += ["-v", f"{p}:{p}:ro"]
         return await self.run_exec([
             *self.docker_sudo,
@@ -2414,9 +2434,13 @@ class DockerContext(Context):
 
     @override
     async def run_appproxy_coordinator_cli(self, cmdargs: Sequence[str]) -> None:
+        # The coordinator service mounts only its own config file, so
+        # base_path arguments (e.g. the copied alembic-appproxy.ini) need the
+        # per-file read-only mounts too.
         exit_code = await self._run_service_cli(
             "appproxy-coordinator",
             ["backend.ai", "app-proxy-coordinator", *cmdargs],
+            parity_mounted=False,
         )
         if exit_code != 0:
             raise RuntimeError(

--- a/tests/unit/install/test_docker_services_compose.py
+++ b/tests/unit/install/test_docker_services_compose.py
@@ -21,6 +21,20 @@ EXPECTED_SERVICES = {
 # One-off helper service: started only via `docker compose run`, never `up -d`.
 CLI_ONLY_SERVICES = {"manager-cli"}
 
+# Services carrying the base_path parity mount: the agent and storage-proxy
+# hand paths under it to the host Docker daemon, and the manager/manager-cli
+# share bootstrap state (RPC keypair fixtures) through it.
+PARITY_SERVICES = {"manager", "manager-cli", "agent", "storage-proxy"}
+
+# The rest mount ONLY their own config file, read-only — they must never see
+# the credentials in the other configs (e.g. the manager's DB password).
+CONFIG_ONLY_SERVICES = {
+    "webserver": "webserver.conf",
+    "appproxy-coordinator": "app-proxy-coordinator.toml",
+    "appproxy-worker": "app-proxy-worker.toml",
+    "appproxy-worker-tcp": "app-proxy-worker-tcp.toml",
+}
+
 BASE_PATH = Path("/home/bai/backendai")
 VERSION = "26.9.0"
 
@@ -56,21 +70,41 @@ def test_rendered_compose_has_dedicated_project_name(template: str) -> None:
     assert doc["name"] == "backendai-services"
 
 
-def test_rendered_compose_has_all_services_with_parity_mounts(template: str) -> None:
+def test_rendered_compose_has_all_services_with_expected_mounts(template: str) -> None:
     doc = render(template, enable_gpu=False)
     services = doc["services"]
     assert set(services.keys()) == EXPECTED_SERVICES
+    assert PARITY_SERVICES | set(CONFIG_ONLY_SERVICES) == EXPECTED_SERVICES
     parity_mount = f"{BASE_PATH}:{BASE_PATH}"
     for name, service in services.items():
         assert service["image"] == service["image"].split(":")[0] + f":{VERSION}"
         assert service["image"].startswith("lablup/backend.ai-")
         assert service["network_mode"] == "host"
         assert service["working_dir"] == str(BASE_PATH)
-        assert parity_mount in service["volumes"], f"{name} lacks the base_path parity mount"
+        if name in PARITY_SERVICES:
+            assert parity_mount in service["volumes"], f"{name} lacks the base_path parity mount"
+        else:
+            assert parity_mount not in service["volumes"], (
+                f"{name} must not see the whole install directory"
+            )
         if name in CLI_ONLY_SERVICES:
             assert "restart" not in service, f"{name} must not auto-restart"
         else:
             assert service["restart"] == "unless-stopped"
+
+
+def test_rendered_compose_config_only_services_mount_just_their_config(template: str) -> None:
+    doc = render(template, enable_gpu=False)
+    services = doc["services"]
+    for name, config_filename in CONFIG_ONLY_SERVICES.items():
+        service = services[name]
+        config_path = BASE_PATH / config_filename
+        # Exactly one volume: the service's own config, read-only — nothing
+        # else from the install directory (the other configs carry
+        # credentials this service has no business reading).
+        assert service["volumes"] == [f"{config_path}:{config_path}:ro"], name
+        # The command reads the exact file that is mounted.
+        assert str(config_path) in service["command"], name
 
 
 def test_rendered_compose_elevated_services(template: str) -> None:


### PR DESCRIPTION
## Summary
- The DOCKER install mode mounted the whole install directory into **every** service container, so a compromised webserver or app-proxy container could read `manager.toml` (DB credentials) and every other secret in the tree. The parity mount is only genuinely needed where paths must resolve on the host or bootstrap state is shared.
- `docker-compose.services.yml`: the webserver, appproxy-coordinator, appproxy-worker, and appproxy-worker-tcp services now mount **only their own config file, read-only**; the base_path parity mount remains on manager, manager-cli, agent, and storage-proxy (agent/storage-proxy hand paths under it to the host Docker daemon; manager/manager-cli exchange the RPC keypair fixtures through it). Host networking and the `command:` override are unchanged, so the generated configs still work verbatim — their working-dir-relative state (`ipc/`, `var/`, logs) simply becomes container-local, which nothing external consumes (the file log driver is inactive; logs go to the console).
- `DockerContext._run_service_cli` gains `parity_mounted`: for the config-only coordinator service, one-off `docker compose run` arguments under the install directory (e.g. the copied `alembic-appproxy.ini` for `schema oneshot`) now get the same per-file read-only bind mounts as outside paths.
- Tests: the compose-rendering suite now asserts the parity/config-only split exactly — config-only services carry precisely one volume (their own config, `:ro`) matching the file their command reads.
- `docker/README.md` DOCKER-mode contract updated accordingly.

Deliberately NOT adopted from the hand-maintained `dockerized/` layout: bridge networking with published ports — that would require the config generators to emit container-DNS addressing and keep compose port maps in lockstep with the tomls, forking the PACKAGE-mode code path this mode exists to reuse.

**Needs a live re-verification** of the DOCKER install flow on a real Docker host before undrafting (webserver/app-proxy startup and the appproxy `schema oneshot` one-off are the affected paths) — part of the BA-7270 E2E scope.

**Merge order note:** stacked on the bake CI PR — last PR of the BA-7264 chain; retarget to `main` after the base PR merges.

Part of the BA-7264 epic (#13582).