### PR TITLE
feat(BA-7339): record the managing writer on session idle-check rows

### DIFF
--- a/changes/13718.feature.md
+++ b/changes/13718.feature.md
@@ -1,0 +1,1 @@
+Track manual writes on session idle-check rows with their triggering user and exempt them from assignment-sync cleanup

--- a/src/ai/backend/manager/models/alembic/versions/dfab9fd24208_add_manual_provenance_to_session_idle_checks.py
+++ b/src/ai/backend/manager/models/alembic/versions/dfab9fd24208_add_manual_provenance_to_session_idle_checks.py
@@ -1,0 +1,68 @@
+"""add manual provenance to session_idle_checks
+
+Mark rows written by the exclusion/inclusion user APIs (is_manual, plus
+who triggered them) so assignment sync only deletes its own rows
+(BA-7339).
+
+Revision ID: dfab9fd24208
+Revises: c8d51e7a3b62
+Create Date: 2026-08-12 14:42:45.963593
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "dfab9fd24208"
+down_revision = "c8d51e7a3b62"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "session_idle_checks",
+        sa.Column(
+            "is_manual",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "session_idle_checks",
+        sa.Column("manually_triggered_by", GUID, nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_session_idle_checks_manually_triggered_by",
+        "session_idle_checks",
+        "users",
+        ["manually_triggered_by"],
+        ["uuid"],
+        ondelete="SET NULL",
+    )
+    op.create_check_constraint(
+        "manual_trigger",
+        "session_idle_checks",
+        "manually_triggered_by IS NULL OR is_manual",
+    )
+
+
+def downgrade() -> None:
+    # The ck naming convention templates explicit names, so pass the short name.
+    op.drop_constraint(
+        "manual_trigger",
+        "session_idle_checks",
+        type_="check",
+    )
+    op.drop_constraint(
+        "fk_session_idle_checks_manually_triggered_by",
+        "session_idle_checks",
+        type_="foreignkey",
+    )
+    op.drop_column("session_idle_checks", "manually_triggered_by")
+    op.drop_column("session_idle_checks", "is_manual")

--- a/src/ai/backend/manager/models/idle_checker/row.py
+++ b/src/ai/backend/manager/models/idle_checker/row.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec, IdleCheckPhase
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.idle_checker import IdleCheckerAssignmentID, IdleCheckerID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckerAssignmentData, IdleCheckerData
 from ai.backend.manager.models.base import GUID, Base, PydanticColumn, StrEnumType
@@ -126,10 +127,20 @@ class SessionIdleCheckRow(UpdatedAtMixin, Base):
             "idle_checker_id",
             name="pk_session_idle_checks",
         ),
+        sa.ForeignKeyConstraint(
+            ["manually_triggered_by"],
+            ["users.uuid"],
+            name="fk_session_idle_checks_manually_triggered_by",
+            ondelete="SET NULL",
+        ),
         sa.Index(
             "ix_session_idle_checks_expire_at_not_null",
             "expire_at",
             postgresql_where=sa.text("expire_at IS NOT NULL"),
+        ),
+        sa.CheckConstraint(
+            "manually_triggered_by IS NULL OR is_manual",
+            name="manual_trigger",
         ),
     )
 
@@ -144,3 +155,13 @@ class SessionIdleCheckRow(UpdatedAtMixin, Base):
         "last_status", StrEnumType(IdleCheckPhase), nullable=False
     )
     last_message: Mapped[str] = mapped_column("last_message", sa.Text, nullable=False)
+    is_manual: Mapped[bool] = mapped_column(
+        "is_manual",
+        sa.Boolean,
+        nullable=False,
+        default=False,
+        server_default=sa.false(),
+    )
+    manually_triggered_by: Mapped[UserID | None] = mapped_column(
+        "manually_triggered_by", GUID(UserID), nullable=True, default=None
+    )

--- a/src/ai/backend/manager/repositories/idle_checker/creators.py
+++ b/src/ai/backend/manager/repositories/idle_checker/creators.py
@@ -94,4 +94,6 @@ class SessionIdleCheckCreatorSpec(CreatorSpec[SessionIdleCheckRow]):
             expire_at=None,
             last_status=IdleCheckPhase.NOT_CHECKED,
             last_message="Not checked yet.",
+            is_manual=False,
+            manually_triggered_by=None,
         )

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -67,7 +67,7 @@ from ai.backend.manager.repositories.idle_checker.creators import (
     SessionIdleCheckCreatorSpec,
 )
 from ai.backend.manager.repositories.idle_checker.purgers import (
-    SessionIdleCheckBatchPurgerSpec,
+    SessionIdleCheckSyncPurgerSpec,
 )
 from ai.backend.manager.repositories.idle_checker.types import (
     ExpiredIdleCheckBatchData,
@@ -431,7 +431,7 @@ class IdleCheckerDBSource:
                 for pair_batch in batched(pairs_to_delete, _ASSIGNMENT_DELETE_BATCH_SIZE):
                     await w.batch_purge(
                         BatchPurger(
-                            spec=SessionIdleCheckBatchPurgerSpec(pair_batch),
+                            spec=SessionIdleCheckSyncPurgerSpec(pair_batch),
                             batch_size=_ASSIGNMENT_DELETE_BATCH_SIZE,
                         )
                     )

--- a/src/ai/backend/manager/repositories/idle_checker/purgers.py
+++ b/src/ai/backend/manager/repositories/idle_checker/purgers.py
@@ -68,7 +68,7 @@ class IdleCheckerPurgerSpec(PurgerSpec[IdleCheckerRow]):
 
 
 @dataclass
-class SessionIdleCheckBatchPurgerSpec(BatchPurgerSpec[SessionIdleCheckRow]):
+class SessionIdleCheckSyncPurgerSpec(BatchPurgerSpec[SessionIdleCheckRow]):
     pairs: Sequence[SessionIdleCheckPair]
 
     @override

--- a/src/ai/backend/manager/repositories/idle_checker/purgers.py
+++ b/src/ai/backend/manager/repositories/idle_checker/purgers.py
@@ -80,6 +80,7 @@ class SessionIdleCheckBatchPurgerSpec(BatchPurgerSpec[SessionIdleCheckRow]):
                 SessionIdleCheckRow.idle_checker_id,
             ).in_(pair_values),
             SessionIdleCheckRow.last_status != IdleCheckPhase.IDLE_EXPIRED,
+            sa.not_(SessionIdleCheckRow.is_manual),
         )
 
     @override

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -36,9 +36,13 @@ from ai.backend.manager.models.idle_checker.row import (
     IdleCheckerRow,
     SessionIdleCheckRow,
 )
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.repositories.idle_checker.types import (
@@ -193,6 +197,8 @@ class TestFetchJudgmentBatch:
             [
                 ProjectResourcePolicyRow,
                 DomainRow,
+                UserResourcePolicyRow,
+                UserRow,
                 GroupRow,
                 ScalingGroupRow,
                 SessionRow,
@@ -672,6 +678,7 @@ class TestFetchJudgmentBatch:
         assert row.expire_at is None
         assert row.last_status is IdleCheckPhase.NOT_CHECKED
         assert row.last_message == "Not checked yet."
+        assert row.is_manual is False
 
     async def test_disabled_binding_deletes_non_expired_rows(
         self,
@@ -843,6 +850,8 @@ class TestFetchExpiredIdleChecks:
             [
                 ProjectResourcePolicyRow,
                 DomainRow,
+                UserResourcePolicyRow,
+                UserRow,
                 GroupRow,
                 ScalingGroupRow,
                 SessionRow,
@@ -1005,6 +1014,7 @@ class ExclusionRows:
     excluded_session_id: SessionId
     untouched_session_id: SessionId
     unassigned_session_id: SessionId
+    user_excluded_session_id: SessionId
     checker_id: IdleCheckerID
 
 
@@ -1019,6 +1029,8 @@ class TestSessionIdleCheckExclusion:
             [
                 ProjectResourcePolicyRow,
                 DomainRow,
+                UserResourcePolicyRow,
+                UserRow,
                 GroupRow,
                 ScalingGroupRow,
                 SessionRow,
@@ -1044,6 +1056,7 @@ class TestSessionIdleCheckExclusion:
             excluded_session_id=SessionId(uuid.uuid4()),
             untouched_session_id=SessionId(uuid.uuid4()),
             unassigned_session_id=SessionId(uuid.uuid4()),
+            user_excluded_session_id=SessionId(uuid.uuid4()),
             checker_id=IdleCheckerID(uuid.uuid4()),
         )
         check_specs = (
@@ -1065,6 +1078,11 @@ class TestSessionIdleCheckExclusion:
             db_sess.add(
                 _expired_check_session_row(scope, rows.unassigned_session_id, SessionStatus.RUNNING)
             )
+            db_sess.add(
+                _expired_check_session_row(
+                    scope, rows.user_excluded_session_id, SessionStatus.RUNNING
+                )
+            )
             db_sess.add(_expired_check_checker_row(rows.checker_id))
             await db_sess.flush()
             for session_id, phase, expire_at in check_specs:
@@ -1077,6 +1095,17 @@ class TestSessionIdleCheckExclusion:
                         last_message=f"{phase.value} judgment",
                     )
                 )
+            # A pair the user excluded by hand.
+            db_sess.add(
+                SessionIdleCheckRow(
+                    session_id=rows.user_excluded_session_id,
+                    idle_checker_id=rows.checker_id,
+                    expire_at=None,
+                    last_status=IdleCheckPhase.EXCLUDED,
+                    last_message="Excluded from idle checks.",
+                    is_manual=True,
+                )
+            )
         return rows
 
     async def test_exclude_overwrites_any_phase(
@@ -1299,3 +1328,33 @@ class TestSessionIdleCheckExclusion:
                 IdleCheckerID(uuid.uuid4()),
                 [SessionID(exclusion_rows.active_session_id)],
             )
+
+    async def test_sync_delete_spares_user_managed_rows(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        exclusion_rows: ExclusionRows,
+    ) -> None:
+        """Assignment sync only cleans its own rows; user-written rows survive."""
+        await repository.sync_session_idle_check_assignments(
+            [],
+            [
+                SessionIdleCheckPair(
+                    exclusion_rows.user_excluded_session_id, exclusion_rows.checker_id
+                ),
+                SessionIdleCheckPair(exclusion_rows.active_session_id, exclusion_rows.checker_id),
+            ],
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            user_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.user_excluded_session_id, exclusion_rows.checker_id),
+            )
+            system_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
+            )
+        assert user_row is not None
+        assert user_row.is_manual is True
+        assert system_row is None

--- a/tests/unit/manager/repositories/idle_checker/test_row.py
+++ b/tests/unit/manager/repositories/idle_checker/test_row.py
@@ -28,9 +28,13 @@ from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.idle_checker.row import IdleCheckerRow, SessionIdleCheckRow
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.testutils.db import with_tables
 
@@ -52,6 +56,8 @@ class TestSessionIdleCheckRow:
             [
                 ProjectResourcePolicyRow,
                 DomainRow,
+                UserResourcePolicyRow,
+                UserRow,
                 GroupRow,
                 ScalingGroupRow,
                 SessionRow,


### PR DESCRIPTION
## Summary
- Add manual-write provenance to `session_idle_checks`: `is_manual` (bool) and `manually_triggered_by` (FK to `users.uuid`, `ON DELETE SET NULL` — the flag outlives user deletion). Existing rows and assignment-sync writes stay non-manual.
- Assignment sync's cleanup now skips manual rows, so manually written exclusions/inclusions are not silently removed when scope assignments change.
- Nothing writes manual rows yet — the exclusion/inclusion APIs that stamp these columns land in BA-7243 (#13682); this PR carries only the schema and the sync guard.
- A check constraint keeps the pair consistent: `manually_triggered_by IS NULL OR is_manual`.

## Test plan
- [x] Repository unit test: sync deletion spares a manual row while removing the non-manual one; assignment-sync-created rows assert `is_manual == False`
- [x] `alembic upgrade head` and a downgrade→upgrade round-trip verified on the local dev stack

Resolves BA-7339

🤖 Generated with [Claude Code](https://claude.com/claude-code)