### PR TITLE
fix(BA-6288): scan every ldd output line when resolving image distro

### DIFF
--- a/changes/13719.fix.md
+++ b/changes/13719.fix.md
@@ -1,0 +1,1 @@
+Fix session creation failing with `Could not determine the C library variant.` when an image's `ldd --version` output does not start with the libc banner

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -166,7 +166,7 @@ if TYPE_CHECKING:
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 eof_sentinel = Sentinel.TOKEN
 
-LDD_GLIBC_REGEX = re.compile(r"^ldd \([^\)]+\) ([\d\.]+)$")
+LDD_GLIBC_REGEX = re.compile(r"^ldd \([^\)]+\) (\d+\.\d+)[\d\.]*$")
 LDD_MUSL_REGEX = re.compile(r"^musl libc .+$")
 
 known_glibc_distros: Final[dict[float, str]] = {
@@ -178,6 +178,23 @@ known_glibc_distros: Final[dict[float, str]] = {
     2.35: "ubuntu22.04",
     2.39: "ubuntu24.04",
 }
+
+
+def parse_distro_from_ldd_output(output: str) -> str | None:
+    for line in output.splitlines():
+        stripped_line = line.strip()
+        if m := LDD_GLIBC_REGEX.search(stripped_line):
+            version = float(m.group(1))
+            if version in known_glibc_distros:
+                return known_glibc_distros[version]
+            for idx, known_version in enumerate(known_glibc_distros.keys()):
+                if version < known_version:
+                    return list(known_glibc_distros.values())[max(idx - 1, 0)]
+            return list(known_glibc_distros.values())[-1]
+        if LDD_MUSL_REGEX.search(stripped_line):
+            return "alpine3.8"
+    return None
+
 
 deeplearning_image_keys = {
     "tensorflow",
@@ -1753,21 +1770,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             await container.stop()
             await container.delete()
             log.debug("response: {}", container_log)
-            version_lines = container_log[0].splitlines()
-            if m := LDD_GLIBC_REGEX.search(version_lines[0]):
-                version = float(m.group(1))
-                if version in known_glibc_distros:
-                    distro = known_glibc_distros[version]
-                else:
-                    for idx, known_version in enumerate(known_glibc_distros.keys()):
-                        if version < known_version:
-                            distro = list(known_glibc_distros.values())[idx - 1]
-                            break
-                    else:
-                        distro = list(known_glibc_distros.values())[-1]
-            elif m := LDD_MUSL_REGEX.search(version_lines[0]):
-                distro = "alpine3.8"
-            else:
+            distro = parse_distro_from_ldd_output("\n".join(container_log))
+            if distro is None:
                 raise RuntimeError("Could not determine the C library variant.")
             await self.valkey_stat_client.set_image_distro(image_id, distro)
             return distro

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -166,7 +166,7 @@ if TYPE_CHECKING:
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 eof_sentinel = Sentinel.TOKEN
 
-LDD_GLIBC_REGEX = re.compile(r"^ldd \([^\)]+\) (\d+\.\d+)[\d\.]*$")
+LDD_GLIBC_REGEX = re.compile(r"^ldd \([^\)]+\) (\d+(?:\.\d+)?)[\d\.]*$")
 LDD_MUSL_REGEX = re.compile(r"^musl libc .+$")
 
 known_glibc_distros: Final[dict[float, str]] = {
@@ -180,7 +180,7 @@ known_glibc_distros: Final[dict[float, str]] = {
 }
 
 
-def parse_distro_from_ldd_output(output: str) -> str | None:
+def _parse_distro_from_ldd_output(output: str) -> str | None:
     for line in output.splitlines():
         stripped_line = line.strip()
         if m := LDD_GLIBC_REGEX.search(stripped_line):
@@ -1770,7 +1770,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             await container.stop()
             await container.delete()
             log.debug("response: {}", container_log)
-            distro = parse_distro_from_ldd_output("\n".join(container_log))
+            distro = _parse_distro_from_ldd_output("\n".join(container_log))
             if distro is None:
                 raise RuntimeError("Could not determine the C library variant.")
             await self.valkey_stat_client.set_image_distro(image_id, distro)

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -180,8 +180,8 @@ known_glibc_distros: Final[dict[float, str]] = {
 }
 
 
-def _parse_distro_from_ldd_output(output: str) -> str | None:
-    for line in output.splitlines():
+def _parse_distro_from_ldd_output(log_chunks: Sequence[str]) -> str | None:
+    for line in "".join(log_chunks).splitlines():
         stripped_line = line.strip()
         if m := LDD_GLIBC_REGEX.search(stripped_line):
             version = float(m.group(1))
@@ -1770,7 +1770,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             await container.stop()
             await container.delete()
             log.debug("response: {}", container_log)
-            distro = _parse_distro_from_ldd_output("\n".join(container_log))
+            distro = _parse_distro_from_ldd_output(container_log)
             if distro is None:
                 raise RuntimeError("Could not determine the C library variant.")
             await self.valkey_stat_client.set_image_distro(image_id, distro)

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -51,67 +51,81 @@ def _make_docker_mock(network_get: AsyncMock | None = None) -> MagicMock:
 
 
 class TestParseDistroFromLddOutput:
-    def test_glibc_version_on_first_line(self) -> None:
-        output = f"ldd (GNU libc) 2.35\n{LDD_GLIBC_TRAILER}"
+    @pytest.mark.parametrize(
+        ("output", "expected"),
+        [
+            pytest.param(
+                f"ldd (GNU libc) 2.35\n{LDD_GLIBC_TRAILER}",
+                "ubuntu22.04",
+                id="glibc-banner-on-first-line",
+            ),
+            pytest.param(
+                "\n".join([
+                    LDD_PRELOAD_ERROR_LINES,
+                    "ldd (Ubuntu GLIBC 2.39-0ubuntu8.7) 2.39",
+                    LDD_GLIBC_TRAILER,
+                ]),
+                "ubuntu24.04",
+                id="glibc-banner-after-ld-preload-errors",
+            ),
+            pytest.param(
+                "ERROR: ld.so: ignored.\r\nldd (Ubuntu GLIBC 2.31-0ubuntu9) 2.31\r\n",
+                "ubuntu20.04",
+                id="glibc-banner-with-carriage-returns",
+            ),
+            pytest.param(
+                "ldd (GNU libc) 2.39.1",
+                "ubuntu24.04",
+                id="glibc-version-with-patch-component",
+            ),
+            pytest.param(
+                "ldd (GNU libc) 2",
+                "centos7.6",
+                id="glibc-version-without-minor-component",
+            ),
+            pytest.param(
+                "ldd (GNU libc) 2.33",
+                "ubuntu20.04",
+                id="glibc-version-between-known-versions",
+            ),
+            pytest.param(
+                "ldd (GNU libc) 2.12",
+                "centos7.6",
+                id="glibc-version-older-than-known-versions",
+            ),
+            pytest.param(
+                "ldd (GNU libc) 2.41",
+                "ubuntu24.04",
+                id="glibc-version-newer-than-known-versions",
+            ),
+            pytest.param(
+                "musl libc (x86_64)\nVersion 1.2.4\nDynamic Program Loader",
+                "alpine3.8",
+                id="musl-banner-on-first-line",
+            ),
+            pytest.param(
+                f"{LDD_PRELOAD_ERROR_LINES}\nmusl libc (x86_64)\nVersion 1.2.4",
+                "alpine3.8",
+                id="musl-banner-after-ld-preload-errors",
+            ),
+        ],
+    )
+    def test_detects_distro_from_libc_banner(self, output: str, expected: str) -> None:
+        assert _parse_distro_from_ldd_output(output) == expected
 
-        assert _parse_distro_from_ldd_output(output) == "ubuntu22.04"
-
-    def test_glibc_version_after_ld_preload_errors(self) -> None:
-        output = "\n".join([
-            LDD_PRELOAD_ERROR_LINES,
-            "ldd (Ubuntu GLIBC 2.39-0ubuntu8.7) 2.39",
-            LDD_GLIBC_TRAILER,
-        ])
-
-        assert _parse_distro_from_ldd_output(output) == "ubuntu24.04"
-
-    def test_glibc_version_with_carriage_returns(self) -> None:
-        output = "ERROR: ld.so: ignored.\r\nldd (Ubuntu GLIBC 2.31-0ubuntu9) 2.31\r\n"
-
-        assert _parse_distro_from_ldd_output(output) == "ubuntu20.04"
-
-    def test_glibc_version_with_patch_component(self) -> None:
-        output = "ldd (GNU libc) 2.39.1"
-
-        assert _parse_distro_from_ldd_output(output) == "ubuntu24.04"
-
-    def test_unknown_glibc_version_falls_back_to_lower_known_version(self) -> None:
-        output = "ldd (GNU libc) 2.33"
-
-        assert _parse_distro_from_ldd_output(output) == "ubuntu20.04"
-
-    def test_glibc_version_without_minor_component(self) -> None:
-        output = "ldd (GNU libc) 2"
-
-        assert _parse_distro_from_ldd_output(output) == "centos7.6"
-
-    def test_glibc_version_older_than_known_versions(self) -> None:
-        output = "ldd (GNU libc) 2.12"
-
-        assert _parse_distro_from_ldd_output(output) == "centos7.6"
-
-    def test_glibc_version_newer_than_known_versions(self) -> None:
-        output = "ldd (GNU libc) 2.41"
-
-        assert _parse_distro_from_ldd_output(output) == "ubuntu24.04"
-
-    def test_musl_banner_on_first_line(self) -> None:
-        output = "musl libc (x86_64)\nVersion 1.2.4\nDynamic Program Loader"
-
-        assert _parse_distro_from_ldd_output(output) == "alpine3.8"
-
-    def test_musl_banner_after_ld_preload_errors(self) -> None:
-        output = f"{LDD_PRELOAD_ERROR_LINES}\nmusl libc (x86_64)\nVersion 1.2.4"
-
-        assert _parse_distro_from_ldd_output(output) == "alpine3.8"
-
-    def test_returns_none_when_no_libc_banner_found(self) -> None:
-        output = f"{LDD_PRELOAD_ERROR_LINES}\nldd: command not found"
-
+    @pytest.mark.parametrize(
+        "output",
+        [
+            pytest.param("", id="empty-output"),
+            pytest.param(
+                f"{LDD_PRELOAD_ERROR_LINES}\nldd: command not found",
+                id="no-libc-banner",
+            ),
+            pytest.param("ldd (GNU libc)", id="banner-without-version"),
+        ],
+    )
+    def test_returns_none_without_libc_banner(self, output: str) -> None:
         assert _parse_distro_from_ldd_output(output) is None
-
-    def test_returns_none_for_empty_output(self) -> None:
-        assert _parse_distro_from_ldd_output("") is None
 
 
 @pytest.fixture

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -111,7 +111,20 @@ class TestParseDistroFromLddOutput:
         ],
     )
     def test_detects_distro_from_libc_banner(self, output: str, expected: str) -> None:
-        assert _parse_distro_from_ldd_output(output) == expected
+        assert _parse_distro_from_ldd_output([output]) == expected
+
+    @pytest.mark.parametrize(
+        "chunk_size",
+        [pytest.param(1, id="one-byte-chunks"), pytest.param(16, id="sixteen-byte-chunks")],
+    )
+    def test_detects_distro_from_chunked_log(self, chunk_size: int) -> None:
+        output = "\r\n".join([
+            LDD_PRELOAD_ERROR_LINES,
+            "ldd (Ubuntu GLIBC 2.39-0ubuntu8.7) 2.39",
+            LDD_GLIBC_TRAILER,
+        ])
+        chunks = [output[i : i + chunk_size] for i in range(0, len(output), chunk_size)]
+        assert _parse_distro_from_ldd_output(chunks) == "ubuntu24.04"
 
     @pytest.mark.parametrize(
         "output",
@@ -125,7 +138,7 @@ class TestParseDistroFromLddOutput:
         ],
     )
     def test_returns_none_without_libc_banner(self, output: str) -> None:
-        assert _parse_distro_from_ldd_output(output) is None
+        assert _parse_distro_from_ldd_output([output]) is None
 
 
 @pytest.fixture

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -13,7 +13,7 @@ from aiodocker.exceptions import DockerError
 
 from ai.backend.agent.docker.agent import (
     DockerKernelCreationContext,
-    parse_distro_from_ldd_output,
+    _parse_distro_from_ldd_output,
 )
 
 LDD_PRELOAD_ERROR_LINES = "\n".join([
@@ -54,7 +54,7 @@ class TestParseDistroFromLddOutput:
     def test_glibc_version_on_first_line(self) -> None:
         output = f"ldd (GNU libc) 2.35\n{LDD_GLIBC_TRAILER}"
 
-        assert parse_distro_from_ldd_output(output) == "ubuntu22.04"
+        assert _parse_distro_from_ldd_output(output) == "ubuntu22.04"
 
     def test_glibc_version_after_ld_preload_errors(self) -> None:
         output = "\n".join([
@@ -63,50 +63,55 @@ class TestParseDistroFromLddOutput:
             LDD_GLIBC_TRAILER,
         ])
 
-        assert parse_distro_from_ldd_output(output) == "ubuntu24.04"
+        assert _parse_distro_from_ldd_output(output) == "ubuntu24.04"
 
     def test_glibc_version_with_carriage_returns(self) -> None:
         output = "ERROR: ld.so: ignored.\r\nldd (Ubuntu GLIBC 2.31-0ubuntu9) 2.31\r\n"
 
-        assert parse_distro_from_ldd_output(output) == "ubuntu20.04"
+        assert _parse_distro_from_ldd_output(output) == "ubuntu20.04"
 
     def test_glibc_version_with_patch_component(self) -> None:
         output = "ldd (GNU libc) 2.39.1"
 
-        assert parse_distro_from_ldd_output(output) == "ubuntu24.04"
+        assert _parse_distro_from_ldd_output(output) == "ubuntu24.04"
 
     def test_unknown_glibc_version_falls_back_to_lower_known_version(self) -> None:
         output = "ldd (GNU libc) 2.33"
 
-        assert parse_distro_from_ldd_output(output) == "ubuntu20.04"
+        assert _parse_distro_from_ldd_output(output) == "ubuntu20.04"
+
+    def test_glibc_version_without_minor_component(self) -> None:
+        output = "ldd (GNU libc) 2"
+
+        assert _parse_distro_from_ldd_output(output) == "centos7.6"
 
     def test_glibc_version_older_than_known_versions(self) -> None:
         output = "ldd (GNU libc) 2.12"
 
-        assert parse_distro_from_ldd_output(output) == "centos7.6"
+        assert _parse_distro_from_ldd_output(output) == "centos7.6"
 
     def test_glibc_version_newer_than_known_versions(self) -> None:
         output = "ldd (GNU libc) 2.41"
 
-        assert parse_distro_from_ldd_output(output) == "ubuntu24.04"
+        assert _parse_distro_from_ldd_output(output) == "ubuntu24.04"
 
     def test_musl_banner_on_first_line(self) -> None:
         output = "musl libc (x86_64)\nVersion 1.2.4\nDynamic Program Loader"
 
-        assert parse_distro_from_ldd_output(output) == "alpine3.8"
+        assert _parse_distro_from_ldd_output(output) == "alpine3.8"
 
     def test_musl_banner_after_ld_preload_errors(self) -> None:
         output = f"{LDD_PRELOAD_ERROR_LINES}\nmusl libc (x86_64)\nVersion 1.2.4"
 
-        assert parse_distro_from_ldd_output(output) == "alpine3.8"
+        assert _parse_distro_from_ldd_output(output) == "alpine3.8"
 
     def test_returns_none_when_no_libc_banner_found(self) -> None:
         output = f"{LDD_PRELOAD_ERROR_LINES}\nldd: command not found"
 
-        assert parse_distro_from_ldd_output(output) is None
+        assert _parse_distro_from_ldd_output(output) is None
 
     def test_returns_none_for_empty_output(self) -> None:
-        assert parse_distro_from_ldd_output("") is None
+        assert _parse_distro_from_ldd_output("") is None
 
 
 @pytest.fixture

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -1,5 +1,5 @@
 """
-Unit tests for `DockerKernelCreationContext` helpers.
+Unit tests for `ai.backend.agent.docker.agent` helpers.
 """
 
 from __future__ import annotations
@@ -11,7 +11,25 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiodocker.exceptions import DockerError
 
-from ai.backend.agent.docker.agent import DockerKernelCreationContext
+from ai.backend.agent.docker.agent import (
+    DockerKernelCreationContext,
+    parse_distro_from_ldd_output,
+)
+
+LDD_PRELOAD_ERROR_LINES = "\n".join([
+    "ERROR: ld.so: object '/opt/kernel/libbaihook.so' from LD_PRELOAD cannot be preloaded"
+    " (file too short): ignored.",
+    "ERROR: ld.so: object '/opt/kernel/libnvmlhook.ubuntu18.04.x86_64.so' from LD_PRELOAD cannot"
+    " be preloaded (file too short): ignored.",
+    "ERROR: ld.so: object '/opt/kernel/libcudahook.ubuntu18.04.x86_64.so' from /etc/ld.so.preload"
+    " cannot be preloaded (file too short): ignored.",
+])
+LDD_GLIBC_TRAILER = "\n".join([
+    "Copyright (C) 2024 Free Software Foundation, Inc.",
+    "This is free software; see the source for copying conditions.  There is NO",
+    "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+    "Written by Roland McGrath and Ulrich Drepper.",
+])
 
 
 def _make_container_show_response(networks: dict[str, dict[str, Any] | None]) -> dict[str, Any]:
@@ -30,6 +48,65 @@ def _make_docker_mock(network_get: AsyncMock | None = None) -> MagicMock:
     docker.networks = MagicMock()
     docker.networks.get = network_get if network_get is not None else AsyncMock()
     return docker
+
+
+class TestParseDistroFromLddOutput:
+    def test_glibc_version_on_first_line(self) -> None:
+        output = f"ldd (GNU libc) 2.35\n{LDD_GLIBC_TRAILER}"
+
+        assert parse_distro_from_ldd_output(output) == "ubuntu22.04"
+
+    def test_glibc_version_after_ld_preload_errors(self) -> None:
+        output = "\n".join([
+            LDD_PRELOAD_ERROR_LINES,
+            "ldd (Ubuntu GLIBC 2.39-0ubuntu8.7) 2.39",
+            LDD_GLIBC_TRAILER,
+        ])
+
+        assert parse_distro_from_ldd_output(output) == "ubuntu24.04"
+
+    def test_glibc_version_with_carriage_returns(self) -> None:
+        output = "ERROR: ld.so: ignored.\r\nldd (Ubuntu GLIBC 2.31-0ubuntu9) 2.31\r\n"
+
+        assert parse_distro_from_ldd_output(output) == "ubuntu20.04"
+
+    def test_glibc_version_with_patch_component(self) -> None:
+        output = "ldd (GNU libc) 2.39.1"
+
+        assert parse_distro_from_ldd_output(output) == "ubuntu24.04"
+
+    def test_unknown_glibc_version_falls_back_to_lower_known_version(self) -> None:
+        output = "ldd (GNU libc) 2.33"
+
+        assert parse_distro_from_ldd_output(output) == "ubuntu20.04"
+
+    def test_glibc_version_older_than_known_versions(self) -> None:
+        output = "ldd (GNU libc) 2.12"
+
+        assert parse_distro_from_ldd_output(output) == "centos7.6"
+
+    def test_glibc_version_newer_than_known_versions(self) -> None:
+        output = "ldd (GNU libc) 2.41"
+
+        assert parse_distro_from_ldd_output(output) == "ubuntu24.04"
+
+    def test_musl_banner_on_first_line(self) -> None:
+        output = "musl libc (x86_64)\nVersion 1.2.4\nDynamic Program Loader"
+
+        assert parse_distro_from_ldd_output(output) == "alpine3.8"
+
+    def test_musl_banner_after_ld_preload_errors(self) -> None:
+        output = f"{LDD_PRELOAD_ERROR_LINES}\nmusl libc (x86_64)\nVersion 1.2.4"
+
+        assert parse_distro_from_ldd_output(output) == "alpine3.8"
+
+    def test_returns_none_when_no_libc_banner_found(self) -> None:
+        output = f"{LDD_PRELOAD_ERROR_LINES}\nldd: command not found"
+
+        assert parse_distro_from_ldd_output(output) is None
+
+    def test_returns_none_for_empty_output(self) -> None:
+        assert parse_distro_from_ldd_output("") is None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- `resolve_image_distro()` matched the glibc/musl banner against only the first line of the first `ldd --version` log chunk. When an image emitted noise first — e.g. `ld.so` LD_PRELOAD failures for the Backend.AI hook libraries — detection raised `RuntimeError: Could not determine the C library variant.` and the session stayed stuck in `CREATING`.
- Extracted `parse_distro_from_ldd_output()`, which scans every line (and strips each one, so TTY carriage returns do not break the regex anchors), joins all log chunks instead of reading `container_log[0]` only, and accepts three-component glibc versions such as `2.39.1` — the latter also removes a latent `float()` `ValueError`.
- Fixed the version-mapping fallback: a glibc older than the lowest known version (2.17) hit `values[idx - 1]` with `idx == 0`, wrapping to the newest distro (`ubuntu24.04`) instead of the oldest (`centos7.6`). Since `distro` selects the krunner volume, libc style and krunner Python version, that mounted a glibc 2.39 krunner into a glibc 2.12 image.

## Test plan

- [x] `TestParseDistroFromLddOutput` in `tests/unit/agent/test_docker_agent.py` — 11 cases: banner on the first line, banner after LD_PRELOAD errors, CRLF output, three-component version, unknown version falling back to the lower/older/newer known version, musl on the first and a later line, no banner, empty output
- [x] `pants fmt` / `pants fix` / `pants lint` / `pants check` clean
- [x] `pants test tests/unit/agent/test_docker_agent.py` — 19 passed

Resolves BA-6288