### PR TITLE
refactor(BA-7340): make event message conversion final

### DIFF
--- a/changes/13724.misc.md
+++ b/changes/13724.misc.md
@@ -1,0 +1,1 @@
+Make the conversion between an event and its queue message final so no event can redefine how its body is rendered

--- a/src/ai/backend/common/events/AGENTS.md
+++ b/src/ai/backend/common/events/AGENTS.md
@@ -5,10 +5,10 @@ Event classes live in `event_types/{domain}/{anycast|broadcast}.py`; base types 
 ## Define an event
 
 - Subclass `AbstractAnycastEvent` (one consumer) or `AbstractBroadcastEvent` (all subscribers) from `types.py`. The base class — not a flag — decides the delivery pattern.
-- An event is a Pydantic model: declare its body as annotated fields, and construct it by keyword. Do NOT use `@dataclass`.
+- An event is a Pydantic model: declare its body as annotated fields, and construct it by keyword.
 - Implement `event_name()` (unique snake_case), `event_domain()` (an `EventDomain` value), and `serialize()` / `deserialize()`.
 - **`serialize()` and `deserialize()` must use the same tuple order** — a mismatch silently swaps fields.
-- Do NOT write `to_message()` / `from_message()`. `AbstractEvent` derives both from the model's fields, so the body an event carries is its field set and nothing else. Override them only to refuse — an event that must never cross the queue raises there, as `BgtaskAlreadyDoneEvent` does.
+- `to_message()` / `from_message()` are `@final` on `AbstractEvent` and derive from the model's fields, so the body an event carries is its field set and nothing else.
 - If the domain is new, add it to `EventDomain` in `types.py` first.
 - Broadcast events auto-register by `event_name()` via `__init_subclass__`; a duplicate name raises at import. Anycast events are not registered — they are referenced directly at `consume()`.
 

--- a/src/ai/backend/common/events/event_types/bgtask/broadcast.py
+++ b/src/ai/backend/common/events/event_types/bgtask/broadcast.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import logging
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Never, Self, override
+from typing import Any, Self, override
 
 from pydantic import Field
 
 from ai.backend.common.bgtask.types import BgtaskStatus
-from ai.backend.common.events.message import EventMessage
 from ai.backend.common.events.types import AbstractBroadcastEvent, EventDomain
 from ai.backend.common.events.user_event.user_bgtask_event import (
     UserBgtaskCancelledEvent,
@@ -17,10 +15,6 @@ from ai.backend.common.events.user_event.user_bgtask_event import (
     UserBgtaskUpdatedEvent,
 )
 from ai.backend.common.events.user_event.user_event import UserEvent
-from ai.backend.common.exception import UnreachableError
-from ai.backend.logging import BraceStyleAdapter
-
-log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 class BaseBgtaskEvent(AbstractBroadcastEvent, ABC):
@@ -126,72 +120,6 @@ class BgtaskDoneEvent(BaseBgtaskDoneEvent):
             task_id=str(self.task_id),
             message=str(self.message),
         )
-
-
-class BgtaskAlreadyDoneEvent(BaseBgtaskEvent):
-    """
-    Event triggered when the Bgtask is already completed.
-    An event recreated based on the last status of the Bgtask.
-    """
-
-    task_status: BgtaskStatus
-    message: str | None = None
-    current: str = "0"
-    total: str = "0"
-
-    @override
-    def to_message(self) -> Never:
-        raise UnreachableError("BgtaskAlreadyDoneEvent should not be serialized.")
-
-    @classmethod
-    @override
-    def from_message(cls, message: EventMessage) -> Never:
-        raise UnreachableError("BgtaskAlreadyDoneEvent should not be deserialized.")
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        raise UnreachableError("BgtaskAlreadyDoneEvent should not be serialized.")
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Never:
-        raise UnreachableError("BgtaskAlreadyDoneEvent should not be deserialized.")
-
-    @classmethod
-    @override
-    def event_name(cls) -> str:
-        return "bgtask_already_done"
-
-    @override
-    def status(self) -> BgtaskStatus:
-        return self.task_status
-
-    @override
-    def user_event(self) -> UserEvent | None:
-        match self.task_status:
-            case BgtaskStatus.DONE:
-                return UserBgtaskDoneEvent(
-                    task_id=str(self.task_id),
-                    message=str(self.message),
-                )
-            case BgtaskStatus.CANCELLED:
-                return UserBgtaskCancelledEvent(
-                    task_id=str(self.task_id),
-                    message=str(self.message),
-                )
-            case BgtaskStatus.FAILED:
-                return UserBgtaskFailedEvent(
-                    task_id=str(self.task_id),
-                    message=str(self.message),
-                )
-            case BgtaskStatus.PARTIAL_SUCCESS:
-                return UserBgtaskDoneEvent(
-                    task_id=str(self.task_id),
-                    message=str(self.message),
-                )
-            case _:
-                log.exception("unknown task status {}", self.task_status)
-                raise UnreachableError(f"Unknown task status {self.task_status}")
 
 
 class BgtaskCancelledEvent(BaseBgtaskDoneEvent):

--- a/src/ai/backend/common/events/types.py
+++ b/src/ai/backend/common/events/types.py
@@ -66,9 +66,9 @@ class AbstractEvent(BaseModel, ABC):
     The base of every event.
 
     An event is a Pydantic model, so its own fields are the message body: the
-    conversion to and from `EventMessage` below is the same for every event and is
-    written once here. An event that must never cross the message queue overrides
-    them to refuse.
+    conversion to and from `EventMessage` below is the same for every event, is
+    written once here, and is final — no event may redefine how its body is
+    rendered.
 
     Unknown fields are ignored rather than rejected, which is what lets a producer
     add a field without breaking a consumer running an older version — the whole
@@ -77,6 +77,7 @@ class AbstractEvent(BaseModel, ABC):
 
     model_config = ConfigDict(extra="ignore")
 
+    @final
     def to_message(self) -> EventMessage:
         """
         Render this event as the message it is handed to the queue as.
@@ -86,6 +87,7 @@ class AbstractEvent(BaseModel, ABC):
             payload=self.model_dump_json(),
         )
 
+    @final
     @classmethod
     def from_message(cls, message: EventMessage) -> Self:
         """

--- a/src/ai/backend/manager/api/gql/background_task.py
+++ b/src/ai/backend/manager/api/gql/background_task.py
@@ -8,13 +8,11 @@ from enum import StrEnum
 import strawberry
 from strawberry import Info
 
-from ai.backend.common.bgtask.types import BgtaskStatus
 from ai.backend.common.dto.manager.v2.background_task import (
     BackgroundTaskEventPayloadNode,
     BgtaskEventTypeDTO,
 )
 from ai.backend.common.events.event_types.bgtask.broadcast import (
-    BgtaskAlreadyDoneEvent,
     BgtaskCancelledEvent,
     BgtaskDoneEvent,
     BgtaskFailedEvent,
@@ -107,29 +105,6 @@ class BackgroundTaskEventPayloadGQL:
         )
         return cls.from_pydantic(dto)  # type: ignore[attr-defined, no-any-return]
 
-    @classmethod
-    def from_already_done_event(
-        cls, event: BgtaskAlreadyDoneEvent
-    ) -> BackgroundTaskEventPayloadGQL:
-        """Create payload from BgtaskAlreadyDoneEvent based on its status."""
-        match event.task_status:
-            case BgtaskStatus.DONE | BgtaskStatus.PARTIAL_SUCCESS:
-                event_type_dto = BgtaskEventTypeDTO.DONE
-            case BgtaskStatus.CANCELLED:
-                event_type_dto = BgtaskEventTypeDTO.CANCELLED
-            case BgtaskStatus.FAILED:
-                event_type_dto = BgtaskEventTypeDTO.FAILED
-            case _:
-                log.warning("Unknown task status in BgtaskAlreadyDoneEvent: {}", event.task_status)
-                event_type_dto = BgtaskEventTypeDTO.FAILED
-
-        dto = BackgroundTaskEventPayloadNode(
-            task_id=str(event.task_id),
-            event_type=event_type_dto,
-            message=event.message or "",
-        )
-        return cls.from_pydantic(dto)  # type: ignore[attr-defined, no-any-return]
-
 
 @gql_subscription(
     BackendAIGQLMeta(
@@ -195,9 +170,6 @@ async def background_task_events(
                 is_close_event = True
             elif isinstance(event, BgtaskFailedEvent):
                 payload = BackgroundTaskEventPayloadGQL.from_failed_event(event)
-                is_close_event = True
-            elif isinstance(event, BgtaskAlreadyDoneEvent):
-                payload = BackgroundTaskEventPayloadGQL.from_already_done_event(event)
                 is_close_event = True
             else:
                 log.warning(


### PR DESCRIPTION
## Summary
- Mark `AbstractEvent.to_message()` / `from_message()` as `@final` — an event's body is its field set, and no event may redefine how it is rendered. `serialize()` / `deserialize()` stay overridable.
- Drop `BgtaskAlreadyDoneEvent`, whose only reason to exist was overriding that pair to refuse the conversion. Nothing has constructed it since the bgtask propagator switched to fetching cached broadcast messages (#4792), so the manager GraphQL `isinstance` branch and `from_already_done_event()` were unreachable too.
- Restate the rule in `common/events/AGENTS.md` positively ("an event is a Pydantic model") and drop the sentence permitting an override to refuse, which `@final` makes moot.

## Test plan
- [x] `pants check ::` — mypy accepts `@final` on both methods and finds no remaining reference to the removed event
- [x] `pants test tests/unit/common/events:: tests/unit/manager/api::`

Resolves BA-7340