### PR TITLE
feat(BA-7343): backfill missing idle_checkers.target_session_types (26.8)

### DIFF
--- a/changes/13727.fix.md
+++ b/changes/13727.fix.md
@@ -1,0 +1,1 @@
+Fix `UndefinedColumnError` on `idle_checkers.target_session_types` for databases migrated on 26.7.x by re-adding the column idempotently with an empty-array backfill

--- a/src/ai/backend/manager/models/alembic/versions/f2d658cac56b_ensure_idle_checkers_target_session_types.py
+++ b/src/ai/backend/manager/models/alembic/versions/f2d658cac56b_ensure_idle_checkers_target_session_types.py
@@ -1,0 +1,36 @@
+"""ensure idle_checkers.target_session_types exists
+
+26.7.0 released ``d3f8a1c45e9b`` without ``target_session_types``; the column
+was later added by editing that migration in place (#12398), so databases
+migrated on 26.7.x never received it and 26.8.x queries fail with
+UndefinedColumnError. Re-adds the column idempotently; pre-existing rows are
+backfilled with an empty array so checkers created before the column existed
+stay inert until an admin assigns target types.
+
+Revision ID: f2d658cac56b
+Revises: b93d1c47af52
+Create Date: 2026-08-12 17:30:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2d658cac56b"
+down_revision = "b93d1c47af52"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE idle_checkers "
+        "ADD COLUMN IF NOT EXISTS target_session_types varchar(64)[] NOT NULL DEFAULT '{}'"
+    )
+    op.execute("ALTER TABLE idle_checkers ALTER COLUMN target_session_types DROP DEFAULT")
+
+
+def downgrade() -> None:
+    # The column is dropped together with the table in d3f8a1c45e9b.
+    pass


### PR DESCRIPTION
## Summary

Manual backport of #13726 to 26.8.

- 26.7.0 released migration `d3f8a1c45e9b` without `target_session_types`; #12398 later added the column by editing that migration in place, so databases migrated on 26.7.x never received it and fail the `idle_check_judgment` lifecycle on 26.8.x with `UndefinedColumnError`.
- Adds the idempotent repair migration `f2d658cac56b` on top of the 26.8 head (`b93d1c47af52`) — the same revision id as the copy inserted into the main chain by #13726, so 26.8 databases can later upgrade to main-based releases without a missing-revision error.
- Pre-existing rows are backfilled with an empty array so checkers created before the column existed stay inert until an admin assigns target types.

## Test plan

- [x] Repair path verified on a cloned schema without the column: column restored, legacy row backfilled with `{}`, NOT NULL without default (matches the model)
- [x] `downgrade -1` → `upgrade head` round trip
- [x] 26.8 chain resolves to the single head `f2d658cac56b`

Resolves BA-7343

🤖 Generated with [Claude Code](https://claude.com/claude-code)