### PR TITLE
feat(BA-7344): unregister idle-check reconciler stages on 26.8

### DIFF
--- a/changes/13734.fix.md
+++ b/changes/13734.fix.md
@@ -1,0 +1,1 @@
+Disable the unreleased idle-check reconciler stages

--- a/src/ai/backend/manager/dependencies/orchestration/sokovan.py
+++ b/src/ai/backend/manager/dependencies/orchestration/sokovan.py
@@ -201,10 +201,6 @@ class SokovanOrchestratorDependency(
         # Reconciler coordinator: sokovan owns its stage assembly (DI just passes deps).
         reconciler_coordinator, reconciler_task_specs = build_reconciler_coordinator(
             replica_group_repository=setup_input.replica_group_repository,
-            idle_checker_repository=setup_input.idle_checker_repository,
-            metric_repository=setup_input.metric_repository,
-            scheduling_controller=setup_input.scheduling_controller,
-            valkey_live=setup_input.valkey_live,
             valkey_schedule=setup_input.valkey_schedule,
             lock_factory=setup_input.distributed_lock_factory,
             config_provider=setup_input.config_provider,

--- a/src/ai/backend/manager/sokovan/stages/factory.py
+++ b/src/ai/backend/manager/sokovan/stages/factory.py
@@ -2,40 +2,22 @@
 
 from __future__ import annotations
 
-from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiveClient
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
-from ai.backend.manager.repositories.metric.repository import MetricRepository
 from ai.backend.manager.repositories.replica_group.repository import ReplicaGroupRepository
 from ai.backend.manager.sokovan.reconciler.base import ReconcilerStageRunner, ReconcilerTaskSpec
 from ai.backend.manager.sokovan.reconciler.coordinator import ReconcilerCoordinator
 from ai.backend.manager.sokovan.reconciler.flag import ValkeyReconcilerFlag
-from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.sokovan.stages.group_autoscale import build_group_autoscale_stage
 from ai.backend.manager.sokovan.stages.group_draining import build_group_draining_stage
 from ai.backend.manager.sokovan.stages.group_rolling import build_group_rolling_stage
 from ai.backend.manager.sokovan.stages.group_scaling import build_group_scaling_stage
-from ai.backend.manager.sokovan.stages.idle_check_assignment_sync import (
-    build_idle_check_assignment_sync_stage,
-)
-from ai.backend.manager.sokovan.stages.idle_check_initial_grace_period import (
-    build_idle_check_initial_grace_period_stage,
-)
-from ai.backend.manager.sokovan.stages.idle_check_judgment import (
-    build_idle_check_judgment_stage,
-)
-from ai.backend.manager.sokovan.stages.idle_check_sweep import build_idle_check_sweep_stage
 from ai.backend.manager.types import DistributedLockFactory
 
 
 def build_reconciler_coordinator(
     *,
     replica_group_repository: ReplicaGroupRepository,
-    idle_checker_repository: IdleCheckerRepository,
-    metric_repository: MetricRepository,
-    scheduling_controller: SchedulingController,
-    valkey_live: ValkeyLiveClient,
     valkey_schedule: ValkeyScheduleClient,
     lock_factory: DistributedLockFactory,
     config_provider: ManagerConfigProvider,
@@ -45,14 +27,9 @@ def build_reconciler_coordinator(
         build_group_rolling_stage(replica_group_repository),
         build_group_draining_stage(replica_group_repository),
         build_group_autoscale_stage(replica_group_repository),
-        build_idle_check_assignment_sync_stage(idle_checker_repository),
-        build_idle_check_initial_grace_period_stage(idle_checker_repository),
-        build_idle_check_judgment_stage(
-            idle_checker_repository,
-            valkey_live,
-            metric_repository,
-        ),
-        build_idle_check_sweep_stage(idle_checker_repository, scheduling_controller),
+        # The idle-check stages stay unregistered on 26.8: the feature is not
+        # enabled in this release and 26.7-migrated databases lack
+        # idle_checkers.target_session_types (BA-7344).
     ]
     stages: dict[str, ReconcilerStageRunner] = {}
     task_specs: list[ReconcilerTaskSpec] = []

--- a/tests/unit/manager/sokovan/idle_check/test_factory.py
+++ b/tests/unit/manager/sokovan/idle_check/test_factory.py
@@ -1,31 +1,23 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from ai.backend.manager.sokovan.stages.factory import build_reconciler_coordinator
 
 
 class TestFactoryRegistration:
-    def test_idle_check_stages_are_registered(self) -> None:
-        metric_repository = MagicMock()
-        with patch(
-            "ai.backend.manager.sokovan.stages.idle_check_judgment.UtilizationChecker"
-        ) as utilization_checker:
-            _, task_specs = build_reconciler_coordinator(
-                replica_group_repository=MagicMock(),
-                idle_checker_repository=MagicMock(),
-                metric_repository=metric_repository,
-                scheduling_controller=MagicMock(),
-                valkey_live=MagicMock(),
-                valkey_schedule=MagicMock(),
-                lock_factory=MagicMock(),
-                config_provider=MagicMock(),
-            )
+    def test_idle_check_stages_are_not_registered(self) -> None:
+        # The idle-check stages stay unregistered on 26.8 (BA-7344).
+        _, task_specs = build_reconciler_coordinator(
+            replica_group_repository=MagicMock(),
+            valkey_schedule=MagicMock(),
+            lock_factory=MagicMock(),
+            config_provider=MagicMock(),
+        )
 
         assert {
             "idle_check_assignment_sync",
             "idle_check_initial_grace_period",
             "idle_check_judgment",
             "idle_check_sweep",
-        }.issubset({task_spec.reconcile_type for task_spec in task_specs})
-        utilization_checker.assert_called_once_with(metric_repository)
+        }.isdisjoint({task_spec.reconcile_type for task_spec in task_specs})


### PR DESCRIPTION
## Summary

- The first-class idle checker is not enabled in 26.8, and databases migrated on 26.7.x lack `idle_checkers.target_session_types` (released migration `d3f8a1c45e9b` was amended in place by #12398), so the `idle_check_judgment` lifecycle fails with `UndefinedColumnError`.
- Drops the four idle-check stage registrations (assignment sync, initial grace period, judgment, sweep) from the reconciler coordinator factory, so neither the stages nor their leader event tasks run on 26.8. Stale queued reconcile events are ignored safely (`stages.get()`).
- The legacy `IdleCheckerHost` (etcd-config) path is unaffected.
- Replaces #13727: no schema repair on 26.8 — main keeps the column via #13726.

## Test plan

- [x] `tests/unit/manager/sokovan/idle_check/` — 52 tests pass against this branch; the factory registration test now guards that the stages stay **unregistered**

Resolves BA-7344

🤖 Generated with [Claude Code](https://claude.com/claude-code)