### PR TITLE
feat(BA-7345): limit the size of an app config fragment

### DIFF
--- a/changes/13739.feature.md
+++ b/changes/13739.feature.md
@@ -1,0 +1,1 @@
+Limit one app config fragment to 64 KiB of JSON; a larger document is now rejected at upsert time instead of being stored unbounded.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -1254,7 +1254,9 @@ input AppConfigFragmentUpsertItem
   """Registered config name."""
   configName: String!
 
-  """The fragment's JSON config document."""
+  """
+  The fragment's JSON config document, at most 65536 bytes once serialized.
+  """
   config: JSON!
 }
 

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -928,7 +928,9 @@ input AppConfigFragmentUpsertItem {
   """Registered config name."""
   configName: String!
 
-  """The fragment's JSON config document."""
+  """
+  The fragment's JSON config document, at most 65536 bytes once serialized.
+  """
   config: JSON!
 }
 

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -1097,7 +1097,7 @@
           },
           "config": {
             "additionalProperties": true,
-            "description": "The fragment's JSON config document.",
+            "description": "The fragment's JSON config document, at most 65536 bytes once serialized.",
             "title": "Config",
             "type": "object"
           }

--- a/src/ai/backend/common/data/app_config/types.py
+++ b/src/ai/backend/common/data/app_config/types.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import enum
+from typing import Final
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 
-__all__ = ("AppConfigScopeType",)
+__all__ = (
+    "MAX_APP_CONFIG_FRAGMENT_BYTES",
+    "AppConfigScopeType",
+)
+
+#: Upper bound on one fragment's config document, measured on its compact JSON encoding.
+MAX_APP_CONFIG_FRAGMENT_BYTES: Final[int] = 64 * 1024
 
 
 class AppConfigScopeType(enum.StrEnum):

--- a/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/app_config_fragment/request.py
@@ -7,7 +7,10 @@ from typing import Any, Self
 from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import (
+    MAX_APP_CONFIG_FRAGMENT_BYTES,
+    AppConfigScopeType,
+)
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.app_config_fragment.types import (
     AppConfigFragmentOrderField,
@@ -84,7 +87,12 @@ class AppConfigFragmentUpsertItem(BaseRequestModel):
     """One (config_name, config) pair to upsert at the request's scope."""
 
     config_name: str = Field(min_length=1, max_length=128, description="Registered config name.")
-    config: dict[str, Any] = Field(description="The fragment's JSON config document.")
+    config: dict[str, Any] = Field(
+        description=(
+            "The fragment's JSON config document, at most "
+            f"{MAX_APP_CONFIG_FRAGMENT_BYTES} bytes once serialized."
+        )
+    )
 
 
 class ScopedUpsertAppConfigFragmentsInput(BaseRequestModel):

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -194,6 +194,7 @@ class ErrorDomain(enum.StrEnum):
     RUNTIME_VARIANT = "runtime-variant"
     ROLE_INVITATION = "role-invitation"
     RETENTION_POLICY = "retention-policy"
+    APP_CONFIG_FRAGMENT = "app-config-fragment"
 
     EXTERNAL_SYSTEM = "external-system"  # Errors from external systems
 

--- a/src/ai/backend/manager/api/gql/app_config_fragment/types.py
+++ b/src/ai/backend/manager/api/gql/app_config_fragment/types.py
@@ -12,7 +12,10 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
-from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import (
+    MAX_APP_CONFIG_FRAGMENT_BYTES,
+    AppConfigScopeType,
+)
 from ai.backend.common.dto.manager.v2.app_config_fragment.request import (
     AppConfigFragmentFilter as AppConfigFragmentFilterDTO,
 )
@@ -85,7 +88,12 @@ __all__ = (
 )
 class AppConfigFragmentUpsertItemGQL(PydanticInputMixin[AppConfigFragmentUpsertItemDTO]):
     config_name: str = gql_field(description="Registered config name.")
-    config: JSON = gql_field(description="The fragment's JSON config document.")
+    config: JSON = gql_field(
+        description=(
+            "The fragment's JSON config document, at most "
+            f"{MAX_APP_CONFIG_FRAGMENT_BYTES} bytes once serialized."
+        )
+    )
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/errors/app_config.py
+++ b/src/ai/backend/manager/errors/app_config.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
-from ai.backend.manager.errors.common import GenericForbidden, ObjectNotFound
+from typing import override
+
+from ai.backend.common.exception import ErrorCode, ErrorDetail, ErrorDomain, ErrorOperation
+from ai.backend.manager.errors.common import (
+    GenericBadRequest,
+    GenericForbidden,
+    ObjectNotFound,
+)
 
 __all__ = (
     "AppConfigAllowListNotFound",
     "AppConfigDefinitionNotFound",
     "AppConfigFragmentNotFound",
+    "AppConfigFragmentTooLarge",
     "AppConfigFragmentWriteNotAllowed",
 )
 
@@ -34,3 +42,22 @@ class AppConfigFragmentWriteNotAllowed(GenericForbidden):
 
     error_type = "https://api.backend.ai/probs/app-config-fragment-write-not-allowed"
     error_title = "App config fragment write is not allowed for this config/scope."
+
+
+class AppConfigFragmentTooLarge(GenericBadRequest):
+    """A fragment write was rejected for exceeding the per-fragment size limit.
+
+    The size is checked before the batch reaches the repository, so one oversize item
+    rejects the whole bulk upsert.
+    """
+
+    error_type = "https://api.backend.ai/probs/app-config-fragment-too-large"
+    error_title = "App config fragment exceeds the maximum size."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.APP_CONFIG_FRAGMENT,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )

--- a/src/ai/backend/manager/services/app_config_fragment/service.py
+++ b/src/ai/backend/manager/services/app_config_fragment/service.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from ai.backend.common.data.app_config.types import MAX_APP_CONFIG_FRAGMENT_BYTES
+from ai.backend.common.json import dump_json
+from ai.backend.manager.errors.app_config import AppConfigFragmentTooLarge
 from ai.backend.manager.repositories.app_config_fragment.repository import (
     AppConfigFragmentRepository,
 )
@@ -53,6 +56,13 @@ class AppConfigFragmentService:
     async def bulk_upsert(
         self, action: BulkUpsertAppConfigFragmentsAction
     ) -> BulkUpsertAppConfigFragmentsActionResult:
+        for spec in action.upserter_specs:
+            config_size = len(dump_json(spec.config))
+            if config_size > MAX_APP_CONFIG_FRAGMENT_BYTES:
+                raise AppConfigFragmentTooLarge(
+                    f"App config {spec.config_name!r} is {config_size} bytes, over the "
+                    f"{MAX_APP_CONFIG_FRAGMENT_BYTES} byte limit."
+                )
         result = await self._repository.bulk_upsert(action.upserter_specs)
         return BulkUpsertAppConfigFragmentsActionResult(
             items=result.items, failed=result.failed, _scope=action.scope

--- a/tests/unit/manager/services/app_config_fragment/test_service.py
+++ b/tests/unit/manager/services/app_config_fragment/test_service.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ai.backend.common.data.app_config.types import AppConfigScopeType
+from ai.backend.common.data.app_config.types import (
+    MAX_APP_CONFIG_FRAGMENT_BYTES,
+    AppConfigScopeType,
+)
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.app_config import AppConfigScopeID
 from ai.backend.common.identifier.app_config_fragment import AppConfigFragmentID
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.user import UserID
+from ai.backend.common.json import dump_json
 from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentBulkResult,
     AppConfigFragmentData,
@@ -22,7 +27,10 @@ from ai.backend.manager.data.app_config_fragment.types import (
     AppConfigFragmentUpsertBulkResult,
     AppConfigFragmentUpsertItemError,
 )
-from ai.backend.manager.errors.app_config import AppConfigFragmentNotFound
+from ai.backend.manager.errors.app_config import (
+    AppConfigFragmentNotFound,
+    AppConfigFragmentTooLarge,
+)
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.app_config_fragment.purgers import (
     AppConfigFragmentPurgerSpec,
@@ -77,6 +85,19 @@ class _ScopedSearchCase:
 def rejected_upsert_item() -> AppConfigFragmentUpsertItemError:
     """One rejected item for the repository mock to return alongside the written fragment."""
     return AppConfigFragmentUpsertItemError(config_name="menu", message="not allow-listed")
+
+
+@pytest.fixture
+def config_at_limit() -> dict[str, Any]:
+    """A config document whose compact JSON encoding is exactly the size limit."""
+    padding = MAX_APP_CONFIG_FRAGMENT_BYTES - len(dump_json({"k": ""}))
+    return {"k": "x" * padding}
+
+
+@pytest.fixture
+def config_over_limit(config_at_limit: dict[str, Any]) -> dict[str, Any]:
+    """The same document grown by one byte, so it sits just over the limit."""
+    return {"k": f"{config_at_limit['k']}x"}
 
 
 @pytest.fixture
@@ -177,6 +198,72 @@ class TestAppConfigFragmentService:
         assert result.scope_type() == case.expected_scope_type
         assert result.scope_id() == case.expected_scope_id
         mock_repository.bulk_upsert.assert_called_once_with(specs)
+
+    async def test_upsert_accepts_a_config_at_the_size_limit(
+        self,
+        service: AppConfigFragmentService,
+        mock_repository: MagicMock,
+        scoped_fragment: AppConfigFragmentData,
+        config_at_limit: dict[str, Any],
+    ) -> None:
+        mock_repository.bulk_upsert = AsyncMock(
+            return_value=AppConfigFragmentUpsertBulkResult(items=[scoped_fragment], failed=[])
+        )
+        specs = [
+            AppConfigFragmentUpserterSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=_USER_SCOPE_ID,
+                config=config_at_limit,
+            )
+        ]
+
+        result = await service.bulk_upsert(
+            BulkUpsertAppConfigFragmentsAction(
+                scope=AppConfigFragmentOperationScope(
+                    scope_type=AppConfigScopeType.USER, scope_id=_USER_SCOPE_ID
+                ),
+                upserter_specs=specs,
+            )
+        )
+
+        assert result.items == [scoped_fragment]
+        mock_repository.bulk_upsert.assert_called_once_with(specs)
+
+    async def test_upsert_rejects_the_batch_when_an_item_is_over_the_size_limit(
+        self,
+        service: AppConfigFragmentService,
+        mock_repository: MagicMock,
+        config_at_limit: dict[str, Any],
+        config_over_limit: dict[str, Any],
+    ) -> None:
+        mock_repository.bulk_upsert = AsyncMock()
+        specs = [
+            AppConfigFragmentUpserterSpec(
+                config_name="theme",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=_USER_SCOPE_ID,
+                config=config_at_limit,
+            ),
+            AppConfigFragmentUpserterSpec(
+                config_name="menu",
+                scope_type=AppConfigScopeType.USER,
+                scope_id=_USER_SCOPE_ID,
+                config=config_over_limit,
+            ),
+        ]
+
+        with pytest.raises(AppConfigFragmentTooLarge):
+            await service.bulk_upsert(
+                BulkUpsertAppConfigFragmentsAction(
+                    scope=AppConfigFragmentOperationScope(
+                        scope_type=AppConfigScopeType.USER, scope_id=_USER_SCOPE_ID
+                    ),
+                    upserter_specs=specs,
+                )
+            )
+
+        mock_repository.bulk_upsert.assert_not_called()
 
     # --- get / search ---
 


### PR DESCRIPTION
Resolves #13730 (BA-7345)

## Summary
- Cap one app config fragment at 64 KiB of compact JSON (`MAX_APP_CONFIG_FRAGMENT_BYTES`), checked in `AppConfigFragmentService.bulk_upsert` before the batch reaches the repository, so the GraphQL and the REST v2 write paths are both covered. Nothing bounded the document until now — the DTO accepted any dict and the JSONB column stopped only at Postgres' field ceiling.
- Reject an oversize document with a new `AppConfigFragmentTooLarge` error under a new `ErrorDomain.APP_CONFIG_FRAGMENT`. One oversize item rejects the whole batch, as the allow-list write gate already does.
- State the limit in the upsert input's field description, on the v2 DTO and on the GraphQL input.

The value is arbitrary for this PR. BA-7345 keeps the open questions: the number itself, whether it belongs in the manager config or per config name on the definition / allow-list entry, whether the merged result of all fragments for one config name needs its own cap, and whether the per-request item count should be bounded too.

## Test plan
- [x] Unit tests for the service: a document exactly at the limit is written, and a batch holding one oversize item is rejected without reaching the repository
- [ ] CI green — the suite was not exercised locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
