### PR TITLE
chore(BA-7349): rename leftover internal main-keypair wording to default

### DIFF
--- a/changes/13740.misc.md
+++ b/changes/13740.misc.md
@@ -1,0 +1,1 @@
+Rename leftover internal "main keypair" wording to "default keypair" following the replacement of `users.main_access_key` with the `is_default` marker on keypairs; wire-facing names such as DTO fields and `switchMyMainAccessKey` are unchanged.

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -240,7 +240,7 @@ class SessionAdapter(BaseAdapter):
         """Enqueue a new session for scheduling.
 
         When ``input.owner_id`` is set, the session is created on behalf of the
-        target user: their main access key, role, and domain are used in place
+        target user: their default access key, role, and domain are used in place
         of the caller's. Resolution and authorization of the delegated user
         are handled by the downstream session service, not by this adapter.
         """
@@ -347,7 +347,7 @@ class SessionAdapter(BaseAdapter):
 
         A self-service query: the requesting user is resolved from the request
         context and passed as ``user_uuid``. The service resolves that user's
-        main access key from it, so the adapter supplies no access key.
+        default access key from it, so the adapter supplies no access key.
         """
         cluster_mode = (
             ClusterMode.MULTI_NODE

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -77,7 +77,7 @@ class SlotTypeInfo:
 class UserEnqueuePolicy:
     """Per-user gates applied at session enqueue.
 
-    Sourced from the user's main-keypair resource policy row until
+    Sourced from the user's default-keypair resource policy row until
     user-level policy columns exist; carries only the fields the
     enqueue path actually consumes.
     """

--- a/src/ai/backend/manager/repositories/export/reports/user.py
+++ b/src/ai/backend/manager/repositories/export/reports/user.py
@@ -63,8 +63,8 @@ PROJECT_JOIN = JoinDef(
 )
 PROJECT_JOINS = (ASSOC_GROUP_USER_JOIN, PROJECT_JOIN)
 
-# Main Keypair JOIN (N:1, no duplication)
-MAIN_KEYPAIR_JOIN = JoinDef(
+# Default Keypair JOIN (N:1, no duplication)
+DEFAULT_KEYPAIR_JOIN = JoinDef(
     table=KeyPairRow.__table__,
     condition=(KeyPairRow.user == UserRow.uuid) & KeyPairRow.is_default,
 )
@@ -243,7 +243,7 @@ USER_FIELDS: list[ExportFieldDef] = [
         joins=PROJECT_JOINS,
     ),
     # =========================================================================
-    # Main Keypair Fields (N:1, no duplication)
+    # Default Keypair Fields (N:1, no duplication)
     # =========================================================================
     ExportFieldDef(
         key="main_access_key",
@@ -254,7 +254,7 @@ USER_FIELDS: list[ExportFieldDef] = [
         ),
         field_type=ExportFieldType.STRING,
         column=KeyPairRow.access_key,
-        joins=frozenset({MAIN_KEYPAIR_JOIN}),
+        joins=frozenset({DEFAULT_KEYPAIR_JOIN}),
     ),
     ExportFieldDef(
         key="main_keypair_is_active",
@@ -262,7 +262,7 @@ USER_FIELDS: list[ExportFieldDef] = [
         description="Main keypair active status",
         field_type=ExportFieldType.BOOLEAN,
         column=KeyPairRow.is_active,
-        joins=frozenset({MAIN_KEYPAIR_JOIN}),
+        joins=frozenset({DEFAULT_KEYPAIR_JOIN}),
     ),
     ExportFieldDef(
         key="main_keypair_created_at",
@@ -271,7 +271,7 @@ USER_FIELDS: list[ExportFieldDef] = [
         field_type=ExportFieldType.DATETIME,
         column=KeyPairRow.created_at,
         formatter=lambda v: v.isoformat() if v else "",
-        joins=frozenset({MAIN_KEYPAIR_JOIN}),
+        joins=frozenset({DEFAULT_KEYPAIR_JOIN}),
     ),
     ExportFieldDef(
         key="main_keypair_last_used",
@@ -280,7 +280,7 @@ USER_FIELDS: list[ExportFieldDef] = [
         field_type=ExportFieldType.DATETIME,
         column=KeyPairRow.last_used,
         formatter=lambda v: v.isoformat() if v else "",
-        joins=frozenset({MAIN_KEYPAIR_JOIN}),
+        joins=frozenset({DEFAULT_KEYPAIR_JOIN}),
     ),
 ]
 

--- a/src/ai/backend/manager/repositories/keypair_resource_policy/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/keypair_resource_policy/db_source/db_source.py
@@ -47,7 +47,7 @@ class KeypairResourcePolicyDBSource:
 
     @keypair_resource_policy_db_source_resilience.apply()
     async def get_by_user_id(self, user_id: UUID) -> KeyPairResourcePolicyData:
-        """Retrieves the keypair resource policy assigned to a user's main keypair."""
+        """Retrieves the keypair resource policy assigned to a user's default keypair."""
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             query = (
                 sa.select(KeyPairResourcePolicyRow)

--- a/src/ai/backend/manager/repositories/model_serving/repository.py
+++ b/src/ai/backend/manager/repositories/model_serving/repository.py
@@ -563,7 +563,7 @@ class ModelServingRepository:
     @model_serving_repository_resilience.apply()
     async def get_user_with_keypair(self, user_id: uuid.UUID) -> Any | None:
         """
-        Get user with their main access key.
+        Get the user row joined with one of their keypairs.
         """
         async with self._db.begin_readonly_session_read_committed() as session:
             query = (

--- a/src/ai/backend/manager/repositories/resource_allocation/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_allocation/db_source/db_source.py
@@ -90,7 +90,7 @@ class ResourceAllocationDBSource:
             result = await session.execute(query)
             row = result.first()
             if row is None:
-                raise PermissionError(f"No main keypair found for user (id: {user_id})")
+                raise PermissionError(f"No default keypair found for user (id: {user_id})")
             return KeypairContextData(
                 access_key=AccessKey(row.access_key),
                 resource_policy={

--- a/src/ai/backend/manager/repositories/resource_allocation/repository.py
+++ b/src/ai/backend/manager/repositories/resource_allocation/repository.py
@@ -42,7 +42,7 @@ class ResourceAllocationRepository:
         self._config_provider = config_provider
 
     async def get_keypair_context(self, user_id: UUID) -> KeypairContextData:
-        """Resolve a user's main keypair context (access_key + resource_policy)."""
+        """Resolve a user's default keypair context (access_key + resource_policy)."""
         return await self._db_source.get_keypair_context(user_id)
 
     async def _get_known_slot_types(self) -> Mapping[SlotName, SlotTypes]:

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -333,7 +333,7 @@ class VfolderRepository:
         A user can hold multiple keypairs, each pointing to its own keypair
         resource policy. This method unions ``allowed_vfolder_hosts`` across
         every active keypair so that the host-permission check reflects the
-        full set of hosts available to the user (rather than only the main
+        full set of hosts available to the user (rather than only the default
         keypair).
 
         Implementation note: a single LEFT OUTER JOIN is used (instead of an
@@ -2093,7 +2093,7 @@ class VfolderRepository:
         """
         Resolve all storage hosts and per-host permissions accessible to a user.
 
-        Internally fetches the user's main keypair resource policy and unions
+        Internally fetches the user's default keypair resource policy and unions
         domain/group/keypair allowed vfolder hosts. Returns the host permission
         map without filtering against currently mountable volumes — callers that
         depend on volume availability must intersect with ``StorageSessionManager``.

--- a/src/ai/backend/manager/services/resource_allocation/service.py
+++ b/src/ai/backend/manager/services/resource_allocation/service.py
@@ -63,7 +63,7 @@ class ResourceAllocationService:
     async def resolve_keypair_context(
         self, action: ResolveKeypairContextAction
     ) -> ResolveKeypairContextActionResult:
-        """Resolve a user's main keypair context (access_key + resource_policy)."""
+        """Resolve a user's default keypair context (access_key + resource_policy)."""
         ctx = await self._resource_allocation_repository.get_keypair_context(
             user_id=action.user_id,
         )

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -1596,7 +1596,7 @@ class SessionService:
             owner = await self._user_repository.get_user_by_uuid(action.owner_id)
             if owner.default_access_key is None:
                 raise InternalServerError(
-                    f"Delegated owner {action.owner_id} has no main access key configured"
+                    f"Delegated owner {action.owner_id} has no default access key configured"
                 )
             if owner.role is None:
                 raise InternalServerError(

--- a/src/ai/backend/manager/services/user/README.md
+++ b/src/ai/backend/manager/services/user/README.md
@@ -136,15 +136,14 @@ result = await user_processor.delete_user.wait_for_complete(action)
 
 #### Complete User Removal
 ```python
+from ai.backend.manager.data.user.types import UserInfoContext
 from ai.backend.manager.services.user.actions.purge_user import PurgeUserAction
-from ai.backend.manager.services.user.type import UserInfoContext
 
 action = PurgeUserAction(
     email="user@example.com",
     user_info_ctx=UserInfoContext(
         uuid=user_uuid,
         email="user@example.com",
-        main_access_key=user_access_key,
     ),
 )
 ```

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
@@ -120,7 +120,9 @@ class UserResourceQuotaExceeded(SchedulingValidationError):
 
     @override
     def summary(self) -> str:
-        return f"Your main-keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+        return (
+            f"Your default-keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+        )
 
     @override
     def error_code(self) -> ErrorCode:

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/pending_session_count_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/pending_session_count_limit_rule.py
@@ -5,7 +5,7 @@ session limits are deliberately NOT enforced here: an over-limit session
 simply waits in the queue and is admitted by the scheduler-side
 ``ResourcePolicyValidator`` once an existing session finishes. What must
 be bounded at enqueue is the queue itself, via the
-``max_pending_session_count`` ceiling of the user's main keypair policy.
+``max_pending_session_count`` ceiling of the user's default keypair policy.
 """
 
 from __future__ import annotations

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/pending_session_resource_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/pending_session_resource_limit_rule.py
@@ -3,7 +3,7 @@
 The resource-side counterpart of ``PendingSessionCountLimitRule``: the
 total resource slots parked in a user's pending queue are bounded at
 enqueue time by the ``max_pending_session_resource_slots`` ceiling of
-the user's main keypair policy. Only the slot names the policy lists
+the user's default keypair policy. Only the slot names the policy lists
 are capped; slots absent from the policy stay unbounded.
 """
 

--- a/src/ai/backend/manager/sokovan/scheduling_controller/validators/priority_limit_rule.py
+++ b/src/ai/backend/manager/sokovan/scheduling_controller/validators/priority_limit_rule.py
@@ -1,7 +1,7 @@
 """Per-user scheduling-priority cap rule.
 
 Bounds the *global* scheduler ``priority`` a user may declare at enqueue
-time via the ``max_priority`` ceiling of the user's main keypair policy.
+time via the ``max_priority`` ceiling of the user's default keypair policy.
 The scope-local ``job_priority`` only ranks the owner's own sessions and
 is therefore deliberately left uncapped.
 """

--- a/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
+++ b/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
@@ -142,15 +142,15 @@ class TestResolveUserAndActiveAccessKey:
             result = await db_source._resolve_user_and_active_access_key(sess, user_uuid)
         return result.access_key
 
-    async def test_picks_the_main_keypair_when_active(
+    async def test_picks_the_default_keypair_when_active(
         self,
         db: ExtendedAsyncSAEngine,
         db_source: DeploymentDBSource,
     ) -> None:
-        # The main keypair wins over a newer active key.
+        # The default keypair wins over a newer active key.
         user_uuid = uuid.uuid4()
         now = datetime.now(tz=UTC)
-        main_key = "AK" + "M" * 18
+        default_key = "AK" + "M" * 18
         other_active = "AK" + "O" * 18
         await self._seed(
             db,
@@ -159,7 +159,7 @@ class TestResolveUserAndActiveAccessKey:
                 domain_name=f"d-{uuid.uuid4().hex[:8]}",
                 keypairs=[
                     KeypairSpec(
-                        main_key,
+                        default_key,
                         is_active=True,
                         created_at=now - timedelta(days=10),
                         is_default=True,
@@ -171,7 +171,7 @@ class TestResolveUserAndActiveAccessKey:
 
         chosen = await self._resolve(db_source, user_uuid)
 
-        assert chosen == AccessKey(main_key)
+        assert chosen == AccessKey(default_key)
 
     async def test_raises_no_active_keypair_when_all_inactive(
         self,

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -1448,7 +1448,7 @@ class TestDeploymentRevisionOperations:
                 RoleRow,
                 UserRoleRow,  # UserRow relationship dependency
                 UserRow,
-                KeyPairRow,  # UserRow.main_access_key FK target
+                KeyPairRow,  # UserRow.default_keypair relationship target
                 GroupRow,
                 VFolderRow,
                 ContainerRegistryRow,

--- a/tests/unit/manager/repositories/export/reports/test_user.py
+++ b/tests/unit/manager/repositories/export/reports/test_user.py
@@ -12,7 +12,7 @@ from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base.export import ExportFieldDef
 from ai.backend.manager.repositories.export.reports.user import (
     ASSOC_GROUP_USER_JOIN,
-    MAIN_KEYPAIR_JOIN,
+    DEFAULT_KEYPAIR_JOIN,
     PROJECT_JOIN,
     PROJECT_JOINS,
     USER_FIELDS,
@@ -120,9 +120,9 @@ class TestJoinDefinitions:
         """Project JOIN should use GroupRow table."""
         assert PROJECT_JOIN.table is GroupRow.__table__
 
-    def test_main_keypair_join_table(self) -> None:
-        """Main keypair JOIN should use KeyPairRow table."""
-        assert MAIN_KEYPAIR_JOIN.table is KeyPairRow.__table__
+    def test_default_keypair_join_table(self) -> None:
+        """Default keypair JOIN should use KeyPairRow table."""
+        assert DEFAULT_KEYPAIR_JOIN.table is KeyPairRow.__table__
 
 
 class TestFieldJoinAssignments:
@@ -151,7 +151,7 @@ class TestFieldJoinAssignments:
         """main_access_key comes from the marked keypair, so it needs the keypair join."""
         field = fields_by_key["main_access_key"]
         assert field.joins is not None
-        assert MAIN_KEYPAIR_JOIN in field.joins
+        assert DEFAULT_KEYPAIR_JOIN in field.joins
         assert len(field.joins) == 1
 
     def test_resource_policy_detail_fields_have_join(
@@ -190,7 +190,7 @@ class TestFieldJoinAssignments:
     def test_main_keypair_detail_fields_have_join(
         self, fields_by_key: dict[str, ExportFieldDef]
     ) -> None:
-        """Main keypair detail fields should have MAIN_KEYPAIR_JOIN."""
+        """Main keypair detail fields should have DEFAULT_KEYPAIR_JOIN."""
         keypair_detail_keys = [
             "main_keypair_is_active",
             "main_keypair_created_at",
@@ -199,7 +199,7 @@ class TestFieldJoinAssignments:
         for key in keypair_detail_keys:
             field = fields_by_key[key]
             assert field.joins is not None
-            assert MAIN_KEYPAIR_JOIN in field.joins
+            assert DEFAULT_KEYPAIR_JOIN in field.joins
             assert len(field.joins) == 1
 
 

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -162,7 +162,7 @@ def setup_successful_auth(
         active_sessions=[],
     )
 
-    # Step 2: get_user_row_by_uuid returns a user row with a main keypair
+    # Step 2: get_user_row_by_uuid returns a user row with a default keypair
     mock_user_row = MagicMock()
     mock_user_row.get_default_keypair_row.return_value = _make_mock_keypair_row()
     mock_auth_repository.get_user_row_by_uuid.return_value = mock_user_row

--- a/tests/unit/manager/test_idle_check_host.py
+++ b/tests/unit/manager/test_idle_check_host.py
@@ -300,9 +300,9 @@ class TestDoIdleCheck:
         *,
         domain_name: str,
         user_resource_policy_name: str,
-        main_keypair_idle_timeout: int | None,
+        default_keypair_idle_timeout: int | None,
     ) -> tuple[uuid.UUID, AccessKey | None]:
-        """Create a user; ``None`` idle timeout leaves the user without a main keypair."""
+        """Create a user; ``None`` idle timeout leaves the user without a default keypair."""
         user_uuid = uuid.uuid4()
         async with db.begin_session() as db_sess:
             db_sess.add(
@@ -317,10 +317,10 @@ class TestDoIdleCheck:
                 )
             )
             await db_sess.flush()
-        if main_keypair_idle_timeout is None:
+        if default_keypair_idle_timeout is None:
             return user_uuid, None
         access_key = await self._create_keypair(
-            db, user_uuid=user_uuid, idle_timeout=main_keypair_idle_timeout, is_default=True
+            db, user_uuid=user_uuid, idle_timeout=default_keypair_idle_timeout, is_default=True
         )
         return user_uuid, access_key
 
@@ -440,7 +440,7 @@ class TestDoIdleCheck:
         host.add_checker(checker)
         return host
 
-    async def test_policy_resolved_via_main_keypair(
+    async def test_policy_resolved_via_default_keypair(
         self,
         db: ExtendedAsyncSAEngine,
         domain: tuple[DomainID, str],
@@ -448,14 +448,14 @@ class TestDoIdleCheck:
         group_id: uuid.UUID,
         user_resource_policy_name: str,
     ) -> None:
-        """A kernel created with a secondary keypair uses the main keypair's policy."""
-        user_uuid, main_access_key = await self._create_user(
+        """A kernel created with a secondary keypair uses the default keypair's policy."""
+        user_uuid, default_access_key = await self._create_user(
             db,
             domain_name=domain[1],
             user_resource_policy_name=user_resource_policy_name,
-            main_keypair_idle_timeout=600,
+            default_keypair_idle_timeout=600,
         )
-        assert main_access_key is not None
+        assert default_access_key is not None
         secondary_access_key = await self._create_keypair(db, user_uuid=user_uuid, idle_timeout=30)
         kernel_id = await self._create_running_kernel(
             db,
@@ -485,7 +485,7 @@ class TestDoIdleCheck:
             db,
             domain_name=domain[1],
             user_resource_policy_name=user_resource_policy_name,
-            main_keypair_idle_timeout=600,
+            default_keypair_idle_timeout=600,
         )
         kernel_id = await self._create_running_kernel(
             db,
@@ -511,19 +511,19 @@ class TestDoIdleCheck:
         user_resource_policy_name: str,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """A user without a main access key never blocks the rest of the cycle,
+        """A user without a default access key never blocks the rest of the cycle,
         and its missing policy is warned about only once."""
         policyless_uuid, _ = await self._create_user(
             db,
             domain_name=domain[1],
             user_resource_policy_name=user_resource_policy_name,
-            main_keypair_idle_timeout=None,
+            default_keypair_idle_timeout=None,
         )
         normal_uuid, normal_access_key = await self._create_user(
             db,
             domain_name=domain[1],
             user_resource_policy_name=user_resource_policy_name,
-            main_keypair_idle_timeout=600,
+            default_keypair_idle_timeout=600,
         )
         assert normal_access_key is not None
         orphan_access_key = AccessKey(f"AKDELETED{uuid.uuid4().hex[:11]}")
@@ -573,7 +573,7 @@ class TestDoIdleCheck:
             db,
             domain_name=domain[1],
             user_resource_policy_name=user_resource_policy_name,
-            main_keypair_idle_timeout=600,
+            default_keypair_idle_timeout=600,
         )
         assert access_key is not None
         kernel_ids = [

--- a/tests/unit/manager/test_idle_check_host.py
+++ b/tests/unit/manager/test_idle_check_host.py
@@ -1,7 +1,7 @@
 """
 Tests for ``IdleCheckerHost.do_idle_check()`` against a real database.
 
-The idle policy is resolved through the user's main keypair — the one marked
+The idle policy is resolved through the user's default keypair — the one marked
 ``keypairs.is_default`` — instead of the kernel's own ``access_key``, which a
 keypair deletion can leave orphaned. A kernel whose policy cannot be resolved,
 or whose checker raises, must not stop the remaining kernels of the same cycle


### PR DESCRIPTION
Resolves #13742 (BA-7349)

## Summary
- Sweep the wording left over from the `users.main_access_key` → keypair `is_default` migration: internal docstrings, comments, and error messages now say "default keypair", matching the code that already reads `KeyPairRow.is_default` / `UserRow.default_keypair`.
- Fix the stale `PurgeUserAction` example in `services/user/README.md` (`UserInfoContext` no longer takes `main_access_key`) and correct the docstring of `ModelServingRepository.get_user_with_keypair`, which joins any of the user's keypairs rather than the default one.
- Rename the internal `MAIN_KEYPAIR_JOIN` constant in the user export report and the `main_*` naming in `test_idle_check_host.py` to `default_*`.
- Also cover the non-wire leftovers found in review (including the hyphenated `main-keypair` spelling): the idle-check test module docstring, the `test_picks_the_main_keypair_when_active` naming in the deployment tests, an auth test comment, the `UserEnqueuePolicy` docstring, and the user-visible `UserResourceQuotaExceeded` message.
- Wire-facing names are intentionally untouched: v1/v2 DTO fields, the `switchMyMainAccessKey` mutation, and the export report field keys (`main_access_key`, `main_keypair_*`) keep the `main` terminology for compatibility.

## Test plan
- [ ] CI green (wording/naming-only change; the renamed tests are covered by the unit-test job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)