### PR TITLE
feat(BA-7348): apply session idle-check exclusion and inclusion as manual pair upserts

### DIFF
--- a/changes/13743.feature.md
+++ b/changes/13743.feature.md
@@ -1,0 +1,1 @@
+Apply manual session idle-check exclusion and inclusion as per-pair upserts that record the requesting user, report unknown sessions or checkers as per-pair failures, and let re-inclusion restart checks from the grace period

--- a/changes/13743.feature.md
+++ b/changes/13743.feature.md
@@ -1,1 +1,1 @@
-Apply manual session idle-check exclusion and inclusion as per-pair upserts that record the requesting user, report unknown sessions or checkers as per-pair failures, and let re-inclusion restart checks from the grace period
+Apply manual session idle-check exclusion and inclusion as per-pair upserts that record the requesting user, report unknown sessions or checkers as per-pair failures, and reset included pairs so checks start from the grace period

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -18,7 +18,6 @@ from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
-from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.idle_checker.types import (
@@ -33,7 +32,6 @@ from ai.backend.manager.errors.idle_checker import (
     IdleCheckerAssignmentScopeNotFound,
     IdleCheckerNotFound,
 )
-from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.models.domain.conditions import DomainConditions
 from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.group.row import GroupRow
@@ -83,12 +81,12 @@ from ai.backend.manager.repositories.idle_checker.types import (
     SessionIdleCheckPair,
 )
 from ai.backend.manager.repositories.idle_checker.updaters import (
-    SessionIdleCheckIncludeBatchUpdaterSpec,
     SessionIdleCheckJudgmentBatchUpdaterSpec,
     SessionIdleCheckPhaseBatchUpdaterSpec,
 )
 from ai.backend.manager.repositories.idle_checker.upserters import (
     SessionIdleCheckExcludeUpserterSpec,
+    SessionIdleCheckIncludeUpserterSpec,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 
@@ -458,86 +456,69 @@ class IdleCheckerDBSource:
 
     async def batch_exclude_session_idle_checks(
         self,
-        checker_id: IdleCheckerID,
-        session_ids: Sequence[SessionID],
+        upserter: BulkUpserter[SessionIdleCheckRow],
     ) -> SessionIdleCheckBatchResult:
-        """Exclude the sessions' pairs, one savepoint-isolated upsert per row.
+        """Apply the pre-assembled exclusion upserts, one savepoint-isolated upsert per row.
 
-        Session existence is enforced per row by the session_id foreign key (the
-        spec maps the violation to SessionNotFound), so a failing row lands in
-        ``failed`` with its reason instead of failing the batch.
+        Session and checker existence are enforced per row by the foreign keys (the
+        spec maps the violations to SessionNotFound / IdleCheckerNotFound), so a
+        failing row lands in ``failed`` with its reason instead of failing the batch.
         """
         async with self._ops.write_ops() as w:
-            checker = await w.query(Querier(row_class=IdleCheckerRow, pk_value=checker_id))
-            if checker is None:
-                raise IdleCheckerNotFound(str(checker_id))
             result = await w.bulk_upsert_partial(
-                BulkUpserter(
-                    specs=[
-                        SessionIdleCheckExcludeUpserterSpec(
-                            session_id=session_id,
-                            checker_id=checker_id,
-                        )
-                        for session_id in dict.fromkeys(session_ids)
-                    ]
-                ),
+                upserter,
                 index_elements=["session_id", "idle_checker_id"],
             )
-            return SessionIdleCheckBatchResult(
-                success=[SessionID(row.session_id) for row in result.successes],
-                errors={
-                    cast(SessionIdleCheckExcludeUpserterSpec, error.spec).session_id: (
-                        error.exception
+            success: list[SessionIdleCheckPair] = []
+            for row in result.successes:
+                success.append(
+                    SessionIdleCheckPair(
+                        session_id=row.session_id,
+                        checker_id=row.idle_checker_id,
                     )
-                    for error in result.errors
-                },
-            )
+                )
+            errors: dict[SessionIdleCheckPair, Exception] = {}
+            for error in result.errors:
+                spec = cast(SessionIdleCheckExcludeUpserterSpec, error.spec)
+                pair = SessionIdleCheckPair(
+                    session_id=SessionId(spec.session_id),
+                    checker_id=spec.checker_id,
+                )
+                errors[pair] = error.exception
+            return SessionIdleCheckBatchResult(success=success, errors=errors)
 
     async def batch_include_session_idle_checks(
         self,
-        checker_id: IdleCheckerID,
-        session_ids: Sequence[SessionID],
+        upserter: BulkUpserter[SessionIdleCheckRow],
     ) -> SessionIdleCheckBatchResult:
-        """Re-include the existing sessions' pairs.
+        """Apply the pre-assembled re-inclusion upserts, one savepoint-isolated upsert per row.
 
-        Unknown session ids are reported as failed rather than failing the batch;
-        both partitions come back in request order, deduplicated.
+        Session and checker existence are enforced per row by the foreign keys (the
+        spec maps the violations to SessionNotFound / IdleCheckerNotFound), so a
+        failing row lands in ``failed`` with its reason instead of failing the batch.
         """
         async with self._ops.write_ops() as w:
-            checker = await w.query(Querier(row_class=IdleCheckerRow, pk_value=checker_id))
-            if checker is None:
-                raise IdleCheckerNotFound(str(checker_id))
-            querier = BatchQuerier(
-                pagination=NoPagination(),
-                conditions=[
-                    SessionConditions.by_ids([SessionId(session_id) for session_id in session_ids])
-                ],
+            result = await w.bulk_upsert_partial(
+                upserter,
+                index_elements=["session_id", "idle_checker_id"],
             )
-            rows = (await w.batch_query_in_global(sa.select(SessionRow.id), querier)).rows
-            existing = {SessionID(row.id) for row in rows}
-            unique_session_ids = list(dict.fromkeys(session_ids))
-            targets = [session_id for session_id in unique_session_ids if session_id in existing]
-            # Only rows exclusion wrote are reset, so re-including twice is a
-            # no-op, pairs without a row stay absent, and other phases are untouched.
-            for id_batch in batched(targets, _IDLE_CHECK_UPDATE_BATCH_SIZE):
-                pair_values = [(SessionId(session_id), checker_id) for session_id in id_batch]
-                await w.batch_update(
-                    BatchUpdater(
-                        spec=SessionIdleCheckIncludeBatchUpdaterSpec(),
-                        conditions=[
-                            SessionIdleCheckConditions.by_pairs(pair_values),
-                            SessionIdleCheckConditions.by_status_equals(IdleCheckPhase.EXCLUDED),
-                        ],
+            success: list[SessionIdleCheckPair] = []
+            for row in result.successes:
+                success.append(
+                    SessionIdleCheckPair(
+                        session_id=row.session_id,
+                        checker_id=row.idle_checker_id,
                     )
                 )
-            return SessionIdleCheckBatchResult(
-                success=targets,
-                errors={
-                    session_id: SessionNotFound(str(session_id))
-                    for session_id in unique_session_ids
-                    if session_id not in existing
-                },
-            )
+            errors: dict[SessionIdleCheckPair, Exception] = {}
+            for error in result.errors:
+                spec = cast(SessionIdleCheckIncludeUpserterSpec, error.spec)
+                pair = SessionIdleCheckPair(
+                    session_id=SessionId(spec.session_id),
+                    checker_id=spec.checker_id,
+                )
+                errors[pair] = error.exception
+            return SessionIdleCheckBatchResult(success=success, errors=errors)
 
     async def batch_apply_session_idle_check_judgments(
         self,

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -491,7 +491,7 @@ class IdleCheckerDBSource:
         self,
         upserter: BulkUpserter[SessionIdleCheckRow],
     ) -> SessionIdleCheckBatchResult:
-        """Apply the pre-assembled re-inclusion upserts, one savepoint-isolated upsert per row.
+        """Apply the pre-assembled inclusion upserts, one savepoint-isolated upsert per row.
 
         Session and checker existence are enforced per row by the foreign keys (the
         spec maps the violations to SessionNotFound / IdleCheckerNotFound), so a

--- a/src/ai/backend/manager/repositories/idle_checker/repository.py
+++ b/src/ai/backend/manager/repositories/idle_checker/repository.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
-from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.identifier.session import SessionID
 from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.idle_checker.types import IdleCheckerAssignmentData, IdleCheckerData
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.models.idle_checker.row import IdleCheckerBindingRow, IdleCheckerRow
+from ai.backend.manager.models.idle_checker.row import (
+    IdleCheckerBindingRow,
+    IdleCheckerRow,
+    SessionIdleCheckRow,
+)
 from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
+    BulkUpserter,
     Creator,
     Purger,
     Updater,
@@ -128,17 +131,15 @@ class IdleCheckerRepository:
 
     async def batch_exclude_session_idle_checks(
         self,
-        checker_id: IdleCheckerID,
-        session_ids: Sequence[SessionID],
+        upserter: BulkUpserter[SessionIdleCheckRow],
     ) -> SessionIdleCheckBatchResult:
-        return await self._db_source.batch_exclude_session_idle_checks(checker_id, session_ids)
+        return await self._db_source.batch_exclude_session_idle_checks(upserter)
 
     async def batch_include_session_idle_checks(
         self,
-        checker_id: IdleCheckerID,
-        session_ids: Sequence[SessionID],
+        upserter: BulkUpserter[SessionIdleCheckRow],
     ) -> SessionIdleCheckBatchResult:
-        return await self._db_source.batch_include_session_idle_checks(checker_id, session_ids)
+        return await self._db_source.batch_include_session_idle_checks(upserter)
 
     async def batch_apply_session_idle_check_judgments(
         self,

--- a/src/ai/backend/manager/repositories/idle_checker/types.py
+++ b/src/ai/backend/manager/repositories/idle_checker/types.py
@@ -13,7 +13,6 @@ import sqlalchemy as sa
 from ai.backend.common.data.idle_checker.types import CheckerType, IdleCheckerSpec, IdleCheckPhase
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.identifier.session import SessionID
 from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckSession
 from ai.backend.manager.models.clauses import QueryCondition
@@ -82,11 +81,11 @@ class IdleCheckBatchData:
 
 @dataclass(frozen=True)
 class SessionIdleCheckBatchResult:
-    """Per-session outcome of a batch exclusion/inclusion: the sessions the write
+    """Per-pair outcome of a batch exclusion/inclusion: the pairs the write
     was applied to and, for each failed one, the exception saying why."""
 
-    success: Sequence[SessionID]
-    errors: Mapping[SessionID, Exception]
+    success: Sequence[SessionIdleCheckPair]
+    errors: Mapping[SessionIdleCheckPair, Exception]
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/repositories/idle_checker/updaters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/updaters.py
@@ -75,23 +75,6 @@ class SessionIdleCheckPhaseBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow
 
 
 @dataclass
-class SessionIdleCheckIncludeBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
-    @property
-    @override
-    def row_class(self) -> type[SessionIdleCheckRow]:
-        return SessionIdleCheckRow
-
-    @override
-    def build_values(self) -> dict[str, Any]:
-        # Same values a fresh row gets, so a re-included pair restarts the grace period.
-        return {
-            "last_status": IdleCheckPhase.NOT_CHECKED,
-            "expire_at": None,
-            "last_message": "Not checked yet.",
-        }
-
-
-@dataclass
 class SessionIdleCheckJudgmentBatchUpdaterSpec(BatchUpdaterSpec[SessionIdleCheckRow]):
     judgments: Sequence[IdleJudgmentData]
 

--- a/src/ai/backend/manager/repositories/idle_checker/upserters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/upserters.py
@@ -70,7 +70,6 @@ class SessionIdleCheckExcludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
             "last_message": "Excluded from idle checks.",
             "is_manual": True,
             "manually_triggered_by": self.user_id,
-            "updated_at": datetime.now(UTC),
         }
 
 

--- a/src/ai/backend/manager/repositories/idle_checker/upserters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/upserters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any, override
 
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
@@ -69,6 +70,7 @@ class SessionIdleCheckExcludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
             "last_message": "Excluded from idle checks.",
             "is_manual": True,
             "manually_triggered_by": self.user_id,
+            "updated_at": datetime.now(UTC),
         }
 
 
@@ -125,4 +127,5 @@ class SessionIdleCheckIncludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
             "last_message": "Not checked yet.",
             "is_manual": True,
             "manually_triggered_by": self.user_id,
+            "updated_at": datetime.now(UTC),
         }

--- a/src/ai/backend/manager/repositories/idle_checker/upserters.py
+++ b/src/ai/backend/manager/repositories/idle_checker/upserters.py
@@ -7,6 +7,7 @@ from typing import Any, override
 from ai.backend.common.data.idle_checker.types import IdleCheckPhase
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.errors.idle_checker import IdleCheckerNotFound
 from ai.backend.manager.errors.kernel import SessionNotFound
 from ai.backend.manager.errors.repository import ForeignKeyViolationError
@@ -17,10 +18,15 @@ from ai.backend.manager.repositories.base import UpserterSpec
 
 @dataclass
 class SessionIdleCheckExcludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
-    """Mark a pair EXCLUDED, creating the row when assignment-sync has not yet."""
+    """Mark a pair EXCLUDED, creating the row when assignment-sync has not yet.
+
+    Records the managing writer: the row is marked manual and stamped with the
+    requesting user, so assignment-sync leaves it alone.
+    """
 
     session_id: SessionID
     checker_id: IdleCheckerID
+    user_id: UserID
 
     @property
     @override
@@ -51,6 +57,8 @@ class SessionIdleCheckExcludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
             "last_status": IdleCheckPhase.EXCLUDED,
             "expire_at": None,
             "last_message": "Excluded from idle checks.",
+            "is_manual": True,
+            "manually_triggered_by": self.user_id,
         }
 
     @override
@@ -59,4 +67,62 @@ class SessionIdleCheckExcludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
             "last_status": IdleCheckPhase.EXCLUDED,
             "expire_at": None,
             "last_message": "Excluded from idle checks.",
+            "is_manual": True,
+            "manually_triggered_by": self.user_id,
+        }
+
+
+@dataclass
+class SessionIdleCheckIncludeUpserterSpec(UpserterSpec[SessionIdleCheckRow]):
+    """Reset a pair to NOT_CHECKED so its checks restart from the grace period.
+
+    Records the managing writer: the row is marked manual and stamped with the
+    requesting user, so assignment-sync leaves it alone.
+    """
+
+    session_id: SessionID
+    checker_id: IdleCheckerID
+    user_id: UserID
+
+    @property
+    @override
+    def row_class(self) -> type[SessionIdleCheckRow]:
+        return SessionIdleCheckRow
+
+    @property
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return (
+            IntegrityErrorCheck(
+                violation_type=ForeignKeyViolationError,
+                error=SessionNotFound(str(self.session_id)),
+                constraint_name="fk_session_idle_checks_session_id",
+            ),
+            IntegrityErrorCheck(
+                violation_type=ForeignKeyViolationError,
+                error=IdleCheckerNotFound(str(self.checker_id)),
+                constraint_name="fk_session_idle_checks_idle_checker_id",
+            ),
+        )
+
+    @override
+    def build_insert_values(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "idle_checker_id": self.checker_id,
+            "last_status": IdleCheckPhase.NOT_CHECKED,
+            "expire_at": None,
+            "last_message": "Not checked yet.",
+            "is_manual": True,
+            "manually_triggered_by": self.user_id,
+        }
+
+    @override
+    def build_update_values(self) -> dict[str, Any]:
+        return {
+            "last_status": IdleCheckPhase.NOT_CHECKED,
+            "expire_at": None,
+            "last_message": "Not checked yet.",
+            "is_manual": True,
+            "manually_triggered_by": self.user_id,
         }

--- a/src/ai/backend/manager/services/idle_checker/actions/exclude_sessions.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/exclude_sessions.py
@@ -61,7 +61,7 @@ class ExcludeSessionIdleChecksActionResult(BaseBulkActionResult):
                 BulkEntityResult(
                     entity_id=pair.session_id,
                     status=failure.status,
-                    description=failure.description,
+                    description=f"{failure.description} (checker {pair.checker_id})",
                     error_code=failure.error_code,
                 )
             )

--- a/src/ai/backend/manager/services/idle_checker/actions/exclude_sessions.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/exclude_sessions.py
@@ -4,18 +4,18 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.identifier.entity import EntityID
-from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.run_status import ActionRunStatus
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
 from ai.backend.manager.actions.v2.bulk.result import BaseBulkActionResult, BulkEntityResult
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
 
 
 @dataclass(frozen=True)
 class ExcludeSessionIdleChecksAction(BaseBulkAction):
-    checker_id: IdleCheckerID
-    session_ids: list[SessionID]
+    targets: list[SessionIdleCheckPair]
+    user_id: UserID
 
     @classmethod
     @override
@@ -34,14 +34,13 @@ class ExcludeSessionIdleChecksAction(BaseBulkAction):
 
     @override
     def entity_ids(self) -> Sequence[EntityID]:
-        return self.session_ids
+        return [target.session_id for target in self.targets]
 
 
 @dataclass(frozen=True)
 class ExcludeSessionIdleChecksActionResult(BaseBulkActionResult):
-    checker_id: IdleCheckerID
-    success: Sequence[SessionID]
-    errors: Mapping[SessionID, Exception]
+    success: Sequence[SessionIdleCheckPair]
+    errors: Mapping[SessionIdleCheckPair, Exception]
 
     @override
     def entity_results(self) -> Sequence[BulkEntityResult]:
@@ -49,18 +48,18 @@ class ExcludeSessionIdleChecksActionResult(BaseBulkActionResult):
         bulk entity's error reads exactly like a single run's."""
         results = [
             BulkEntityResult(
-                entity_id=session_id,
+                entity_id=pair.session_id,
                 status=OperationStatus.SUCCESS,
-                description=f"Excluded from idle checks by checker {self.checker_id}.",
+                description=f"Excluded from idle checks by checker {pair.checker_id}.",
                 error_code=None,
             )
-            for session_id in self.success
+            for pair in self.success
         ]
-        for session_id, exception in self.errors.items():
+        for pair, exception in self.errors.items():
             failure = ActionRunStatus.of_failure(exception, during_validation=False)
             results.append(
                 BulkEntityResult(
-                    entity_id=session_id,
+                    entity_id=pair.session_id,
                     status=failure.status,
                     description=failure.description,
                     error_code=failure.error_code,

--- a/src/ai/backend/manager/services/idle_checker/actions/include_sessions.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/include_sessions.py
@@ -50,7 +50,7 @@ class IncludeSessionIdleChecksActionResult(BaseBulkActionResult):
             BulkEntityResult(
                 entity_id=pair.session_id,
                 status=OperationStatus.SUCCESS,
-                description=f"Re-included into idle checks by checker {pair.checker_id}.",
+                description=f"Included into idle checks by checker {pair.checker_id}.",
                 error_code=None,
             )
             for pair in self.success

--- a/src/ai/backend/manager/services/idle_checker/actions/include_sessions.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/include_sessions.py
@@ -4,18 +4,18 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.identifier.entity import EntityID
-from ai.backend.common.identifier.idle_checker import IdleCheckerID
-from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.run_status import ActionRunStatus
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
 from ai.backend.manager.actions.v2.bulk.result import BaseBulkActionResult, BulkEntityResult
+from ai.backend.manager.repositories.idle_checker.types import SessionIdleCheckPair
 
 
 @dataclass(frozen=True)
 class IncludeSessionIdleChecksAction(BaseBulkAction):
-    checker_id: IdleCheckerID
-    session_ids: list[SessionID]
+    targets: list[SessionIdleCheckPair]
+    user_id: UserID
 
     @classmethod
     @override
@@ -34,14 +34,13 @@ class IncludeSessionIdleChecksAction(BaseBulkAction):
 
     @override
     def entity_ids(self) -> Sequence[EntityID]:
-        return self.session_ids
+        return [target.session_id for target in self.targets]
 
 
 @dataclass(frozen=True)
 class IncludeSessionIdleChecksActionResult(BaseBulkActionResult):
-    checker_id: IdleCheckerID
-    success: Sequence[SessionID]
-    errors: Mapping[SessionID, Exception]
+    success: Sequence[SessionIdleCheckPair]
+    errors: Mapping[SessionIdleCheckPair, Exception]
 
     @override
     def entity_results(self) -> Sequence[BulkEntityResult]:
@@ -49,18 +48,18 @@ class IncludeSessionIdleChecksActionResult(BaseBulkActionResult):
         bulk entity's error reads exactly like a single run's."""
         results = [
             BulkEntityResult(
-                entity_id=session_id,
+                entity_id=pair.session_id,
                 status=OperationStatus.SUCCESS,
-                description=f"Re-included into idle checks by checker {self.checker_id}.",
+                description=f"Re-included into idle checks by checker {pair.checker_id}.",
                 error_code=None,
             )
-            for session_id in self.success
+            for pair in self.success
         ]
-        for session_id, exception in self.errors.items():
+        for pair, exception in self.errors.items():
             failure = ActionRunStatus.of_failure(exception, during_validation=False)
             results.append(
                 BulkEntityResult(
-                    entity_id=session_id,
+                    entity_id=pair.session_id,
                     status=failure.status,
                     description=failure.description,
                     error_code=failure.error_code,

--- a/src/ai/backend/manager/services/idle_checker/actions/include_sessions.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/include_sessions.py
@@ -61,7 +61,7 @@ class IncludeSessionIdleChecksActionResult(BaseBulkActionResult):
                 BulkEntityResult(
                     entity_id=pair.session_id,
                     status=failure.status,
-                    description=failure.description,
+                    description=f"{failure.description} (checker {pair.checker_id})",
                     error_code=failure.error_code,
                 )
             )

--- a/src/ai/backend/manager/services/idle_checker/service.py
+++ b/src/ai/backend/manager/services/idle_checker/service.py
@@ -2,9 +2,15 @@ from typing import cast
 
 from ai.backend.common.data.idle_checker.types import IdleCheckerSpec
 from ai.backend.common.exception import PrometheusQueryPresetInvalidLabel
+from ai.backend.common.identifier.session import SessionID
+from ai.backend.manager.repositories.base import BulkUpserter
 from ai.backend.manager.repositories.idle_checker.creators import IdleCheckerCreatorSpec
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.repositories.idle_checker.updaters import IdleCheckerUpdaterSpec
+from ai.backend.manager.repositories.idle_checker.upserters import (
+    SessionIdleCheckExcludeUpserterSpec,
+    SessionIdleCheckIncludeUpserterSpec,
+)
 from ai.backend.manager.repositories.prometheus_query_preset.repository import (
     PrometheusQueryPresetRepository,
 )
@@ -100,11 +106,19 @@ class IdleCheckerService:
     async def exclude_sessions(
         self, action: ExcludeSessionIdleChecksAction
     ) -> ExcludeSessionIdleChecksActionResult:
+        specs: list[SessionIdleCheckExcludeUpserterSpec] = []
+        for target in dict.fromkeys(action.targets):
+            specs.append(
+                SessionIdleCheckExcludeUpserterSpec(
+                    session_id=SessionID(target.session_id),
+                    checker_id=target.checker_id,
+                    user_id=action.user_id,
+                )
+            )
         batch_result = await self._repository.batch_exclude_session_idle_checks(
-            action.checker_id, action.session_ids
+            BulkUpserter(specs=specs)
         )
         return ExcludeSessionIdleChecksActionResult(
-            checker_id=action.checker_id,
             success=batch_result.success,
             errors=batch_result.errors,
         )
@@ -112,11 +126,19 @@ class IdleCheckerService:
     async def include_sessions(
         self, action: IncludeSessionIdleChecksAction
     ) -> IncludeSessionIdleChecksActionResult:
+        specs: list[SessionIdleCheckIncludeUpserterSpec] = []
+        for target in dict.fromkeys(action.targets):
+            specs.append(
+                SessionIdleCheckIncludeUpserterSpec(
+                    session_id=SessionID(target.session_id),
+                    checker_id=target.checker_id,
+                    user_id=action.user_id,
+                )
+            )
         batch_result = await self._repository.batch_include_session_idle_checks(
-            action.checker_id, action.session_ids
+            BulkUpserter(specs=specs)
         )
         return IncludeSessionIdleChecksActionResult(
-            checker_id=action.checker_id,
             success=batch_result.success,
             errors=batch_result.errors,
         )

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -1031,59 +1031,6 @@ class ExclusionRows:
     checker_id: IdleCheckerID
     user_id: UserID
 
-    def pair(self, session_id: SessionId) -> SessionIdleCheckPair:
-        return SessionIdleCheckPair(session_id=session_id, checker_id=self.checker_id)
-
-    def exclude_upserter(self, session_ids: list[SessionId]) -> BulkUpserter[SessionIdleCheckRow]:
-        specs: list[SessionIdleCheckExcludeUpserterSpec] = []
-        for session_id in session_ids:
-            specs.append(
-                SessionIdleCheckExcludeUpserterSpec(
-                    session_id=SessionID(session_id),
-                    checker_id=self.checker_id,
-                    user_id=self.user_id,
-                )
-            )
-        return BulkUpserter(specs=specs)
-
-    def include_upserter(self, session_ids: list[SessionId]) -> BulkUpserter[SessionIdleCheckRow]:
-        specs: list[SessionIdleCheckIncludeUpserterSpec] = []
-        for session_id in session_ids:
-            specs.append(
-                SessionIdleCheckIncludeUpserterSpec(
-                    session_id=SessionID(session_id),
-                    checker_id=self.checker_id,
-                    user_id=self.user_id,
-                )
-            )
-        return BulkUpserter(specs=specs)
-
-
-async def _get_check_row(
-    database: ExtendedAsyncSAEngine,
-    pair: SessionIdleCheckPair,
-) -> SessionIdleCheckRow | None:
-    async with database.begin_readonly_session() as db_sess:
-        return await db_sess.get(SessionIdleCheckRow, (pair.session_id, pair.checker_id))
-
-
-def _assert_manually_excluded(row: SessionIdleCheckRow | None, user_id: UserID) -> None:
-    assert row is not None
-    assert row.last_status is IdleCheckPhase.EXCLUDED
-    assert row.expire_at is None
-    assert row.last_message == "Excluded from idle checks."
-    assert row.is_manual is True
-    assert row.manually_triggered_by == user_id
-
-
-def _assert_manually_included(row: SessionIdleCheckRow | None, user_id: UserID) -> None:
-    assert row is not None
-    assert row.last_status is IdleCheckPhase.NOT_CHECKED
-    assert row.expire_at is None
-    assert row.last_message == "Not checked yet."
-    assert row.is_manual is True
-    assert row.manually_triggered_by == user_id
-
 
 class TestSessionIdleCheckExclusion:
     @pytest.fixture
@@ -1127,17 +1074,16 @@ class TestSessionIdleCheckExclusion:
             checker_id=IdleCheckerID(uuid.uuid4()),
             user_id=UserID(uuid.uuid4()),
         )
-        initial_phases = {
-            rows.active_session_id: IdleCheckPhase.ACTIVE,
-            rows.idle_expired_session_id: IdleCheckPhase.IDLE_EXPIRED,
-            rows.excluded_session_id: IdleCheckPhase.EXCLUDED,
-            rows.untouched_session_id: IdleCheckPhase.ACTIVE,
-        }
-        all_session_ids = [
-            *initial_phases,
-            rows.unassigned_session_id,
-            rows.user_excluded_session_id,
-        ]
+        check_specs = (
+            (rows.active_session_id, IdleCheckPhase.ACTIVE, datetime(2026, 2, 1, tzinfo=UTC)),
+            (
+                rows.idle_expired_session_id,
+                IdleCheckPhase.IDLE_EXPIRED,
+                datetime(2026, 2, 1, tzinfo=UTC),
+            ),
+            (rows.excluded_session_id, IdleCheckPhase.EXCLUDED, None),
+            (rows.untouched_session_id, IdleCheckPhase.ACTIVE, datetime(2026, 2, 1, tzinfo=UTC)),
+        )
         async with database.begin_session() as db_sess:
             for scope_row in _expired_check_scope_rows(scope):
                 db_sess.add(scope_row)
@@ -1165,21 +1111,25 @@ class TestSessionIdleCheckExclusion:
                     resource_policy=f"{scope.domain_name}-user-policy",
                 )
             )
-            for session_id in all_session_ids:
+            for session_id, _phase, _expire_at in check_specs:
                 db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
+            # The unassigned session exists but has no idle-check row yet.
+            db_sess.add(
+                _expired_check_session_row(scope, rows.unassigned_session_id, SessionStatus.RUNNING)
+            )
+            db_sess.add(
+                _expired_check_session_row(
+                    scope, rows.user_excluded_session_id, SessionStatus.RUNNING
+                )
+            )
             db_sess.add(_expired_check_checker_row(rows.checker_id))
             await db_sess.flush()
-            # System-written check rows; EXCLUDED pairs carry no expiry.
-            for session_id, phase in initial_phases.items():
+            for session_id, phase, expire_at in check_specs:
                 db_sess.add(
                     SessionIdleCheckRow(
                         session_id=session_id,
                         idle_checker_id=rows.checker_id,
-                        expire_at=(
-                            None
-                            if phase is IdleCheckPhase.EXCLUDED
-                            else datetime(2026, 2, 1, tzinfo=UTC)
-                        ),
+                        expire_at=expire_at,
                         last_status=phase,
                         last_message=f"{phase.value} judgment",
                     )
@@ -1197,32 +1147,6 @@ class TestSessionIdleCheckExclusion:
             )
         return rows
 
-    async def test_exclude_overwrites_any_phase(
-        self,
-        database: ExtendedAsyncSAEngine,
-        repository: IdleCheckerRepository,
-        exclusion_rows: ExclusionRows,
-    ) -> None:
-        await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.exclude_upserter([
-                exclusion_rows.active_session_id,
-                exclusion_rows.idle_expired_session_id,
-            ]),
-        )
-
-        for session_id in (
-            exclusion_rows.active_session_id,
-            exclusion_rows.idle_expired_session_id,
-        ):
-            row = await _get_check_row(database, exclusion_rows.pair(session_id))
-            _assert_manually_excluded(row, exclusion_rows.user_id)
-        untouched_row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.untouched_session_id)
-        )
-        assert untouched_row is not None
-        assert untouched_row.last_status is IdleCheckPhase.ACTIVE
-        assert untouched_row.expire_at == datetime(2026, 2, 1, tzinfo=UTC)
-
     async def test_exclude_upserts_missing_pair_row(
         self,
         database: ExtendedAsyncSAEngine,
@@ -1230,88 +1154,72 @@ class TestSessionIdleCheckExclusion:
         exclusion_rows: ExclusionRows,
     ) -> None:
         await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.exclude_upserter([exclusion_rows.unassigned_session_id]),
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckExcludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.unassigned_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
         )
 
-        row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.unassigned_session_id)
-        )
-        _assert_manually_excluded(row, exclusion_rows.user_id)
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.unassigned_session_id, exclusion_rows.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.EXCLUDED
+        assert row.expire_at is None
+        assert row.last_message == "Excluded from idle checks."
+        assert row.is_manual is True
+        assert row.manually_triggered_by == exclusion_rows.user_id
 
-    async def test_repeated_specs_for_one_pair_are_harmless(
+    async def test_exclude_overwrites_any_phase(
         self,
         database: ExtendedAsyncSAEngine,
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
-        """The service deduplicates; a duplicate spec just re-applies the same upsert."""
         await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.exclude_upserter([
-                exclusion_rows.unassigned_session_id,
-                exclusion_rows.unassigned_session_id,
-            ]),
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckExcludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.active_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                    SessionIdleCheckExcludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.idle_expired_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
         )
 
-        row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.unassigned_session_id)
-        )
-        _assert_manually_excluded(row, exclusion_rows.user_id)
-
-    async def test_include_overwrites_any_phase(
-        self,
-        database: ExtendedAsyncSAEngine,
-        repository: IdleCheckerRepository,
-        exclusion_rows: ExclusionRows,
-    ) -> None:
-        await repository.batch_include_session_idle_checks(
-            exclusion_rows.include_upserter([
-                exclusion_rows.excluded_session_id,
-                exclusion_rows.active_session_id,
-            ]),
-        )
-
-        for session_id in (
-            exclusion_rows.excluded_session_id,
-            exclusion_rows.active_session_id,
-        ):
-            row = await _get_check_row(database, exclusion_rows.pair(session_id))
-            _assert_manually_included(row, exclusion_rows.user_id)
-        untouched_row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.untouched_session_id)
-        )
+        async with database.begin_readonly_session() as db_sess:
+            active_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
+            )
+            idle_expired_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.idle_expired_session_id, exclusion_rows.checker_id),
+            )
+            untouched_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.untouched_session_id, exclusion_rows.checker_id),
+            )
+        assert active_row is not None
+        assert active_row.last_status is IdleCheckPhase.EXCLUDED
+        assert idle_expired_row is not None
+        assert idle_expired_row.last_status is IdleCheckPhase.EXCLUDED
         assert untouched_row is not None
         assert untouched_row.last_status is IdleCheckPhase.ACTIVE
-
-    async def test_include_is_idempotent(
-        self,
-        database: ExtendedAsyncSAEngine,
-        repository: IdleCheckerRepository,
-        exclusion_rows: ExclusionRows,
-    ) -> None:
-        target = [exclusion_rows.excluded_session_id]
-
-        await repository.batch_include_session_idle_checks(exclusion_rows.include_upserter(target))
-        await repository.batch_include_session_idle_checks(exclusion_rows.include_upserter(target))
-
-        row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.excluded_session_id)
-        )
-        _assert_manually_included(row, exclusion_rows.user_id)
-
-    async def test_include_upserts_missing_pair_row(
-        self,
-        database: ExtendedAsyncSAEngine,
-        repository: IdleCheckerRepository,
-        exclusion_rows: ExclusionRows,
-    ) -> None:
-        await repository.batch_include_session_idle_checks(
-            exclusion_rows.include_upserter([exclusion_rows.unassigned_session_id]),
-        )
-
-        row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.unassigned_session_id)
-        )
-        _assert_manually_included(row, exclusion_rows.user_id)
+        assert untouched_row.expire_at == datetime(2026, 2, 1, tzinfo=UTC)
 
     async def test_exclude_skips_unknown_sessions(
         self,
@@ -1322,48 +1230,42 @@ class TestSessionIdleCheckExclusion:
         unknown_session_id = SessionId(uuid.uuid4())
 
         result = await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.exclude_upserter([
-                exclusion_rows.active_session_id,
-                unknown_session_id,
-            ]),
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckExcludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.active_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                    SessionIdleCheckExcludeUpserterSpec(
+                        session_id=SessionID(unknown_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
         )
 
-        assert result.success == [exclusion_rows.pair(exclusion_rows.active_session_id)]
+        assert result.success == [
+            SessionIdleCheckPair(
+                session_id=exclusion_rows.active_session_id,
+                checker_id=exclusion_rows.checker_id,
+            )
+        ]
         # The FK violation is mapped to SessionNotFound naming the session.
-        unknown_pair = exclusion_rows.pair(unknown_session_id)
+        unknown_pair = SessionIdleCheckPair(
+            session_id=unknown_session_id,
+            checker_id=exclusion_rows.checker_id,
+        )
         assert set(result.errors) == {unknown_pair}
         assert isinstance(result.errors[unknown_pair], SessionNotFound)
 
-        excluded_row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.active_session_id)
-        )
-        _assert_manually_excluded(excluded_row, exclusion_rows.user_id)
-        assert await _get_check_row(database, unknown_pair) is None
-
-    async def test_include_skips_unknown_sessions(
-        self,
-        database: ExtendedAsyncSAEngine,
-        repository: IdleCheckerRepository,
-        exclusion_rows: ExclusionRows,
-    ) -> None:
-        unknown_session_id = SessionId(uuid.uuid4())
-
-        result = await repository.batch_include_session_idle_checks(
-            exclusion_rows.include_upserter([
-                exclusion_rows.excluded_session_id,
-                unknown_session_id,
-            ]),
-        )
-
-        assert result.success == [exclusion_rows.pair(exclusion_rows.excluded_session_id)]
-        unknown_pair = exclusion_rows.pair(unknown_session_id)
-        assert set(result.errors) == {unknown_pair}
-        assert isinstance(result.errors[unknown_pair], SessionNotFound)
-
-        reset_row = await _get_check_row(
-            database, exclusion_rows.pair(exclusion_rows.excluded_session_id)
-        )
-        _assert_manually_included(reset_row, exclusion_rows.user_id)
+        async with database.begin_readonly_session() as db_sess:
+            unknown_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (unknown_session_id, exclusion_rows.checker_id),
+            )
+        assert unknown_row is None
 
     async def test_unknown_checker_reported_per_pair(
         self,
@@ -1372,17 +1274,18 @@ class TestSessionIdleCheckExclusion:
     ) -> None:
         """The FK violation is mapped to IdleCheckerNotFound for the failing pair only."""
         unknown_checker_id = IdleCheckerID(uuid.uuid4())
-        upserter = BulkUpserter(
-            specs=[
-                SessionIdleCheckExcludeUpserterSpec(
-                    session_id=SessionID(exclusion_rows.active_session_id),
-                    checker_id=unknown_checker_id,
-                    user_id=exclusion_rows.user_id,
-                )
-            ]
-        )
 
-        result = await repository.batch_exclude_session_idle_checks(upserter)
+        result = await repository.batch_exclude_session_idle_checks(
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckExcludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.active_session_id),
+                        checker_id=unknown_checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
+        )
 
         assert result.success == []
         unknown_pair = SessionIdleCheckPair(
@@ -1392,6 +1295,116 @@ class TestSessionIdleCheckExclusion:
         assert set(result.errors) == {unknown_pair}
         assert isinstance(result.errors[unknown_pair], IdleCheckerNotFound)
 
+    async def test_include_upserts_missing_pair_row(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        exclusion_rows: ExclusionRows,
+    ) -> None:
+        await repository.batch_include_session_idle_checks(
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.unassigned_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.unassigned_session_id, exclusion_rows.checker_id),
+            )
+        assert row is not None
+        assert row.last_status is IdleCheckPhase.NOT_CHECKED
+        assert row.expire_at is None
+        assert row.last_message == "Not checked yet."
+        assert row.is_manual is True
+        assert row.manually_triggered_by == exclusion_rows.user_id
+
+    async def test_include_overwrites_any_phase(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: IdleCheckerRepository,
+        exclusion_rows: ExclusionRows,
+    ) -> None:
+        await repository.batch_include_session_idle_checks(
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.excluded_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.active_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
+        )
+
+        async with database.begin_readonly_session() as db_sess:
+            excluded_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.excluded_session_id, exclusion_rows.checker_id),
+            )
+            active_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
+            )
+            untouched_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.untouched_session_id, exclusion_rows.checker_id),
+            )
+        assert excluded_row is not None
+        assert excluded_row.last_status is IdleCheckPhase.NOT_CHECKED
+        assert active_row is not None
+        assert active_row.last_status is IdleCheckPhase.NOT_CHECKED
+        assert untouched_row is not None
+        assert untouched_row.last_status is IdleCheckPhase.ACTIVE
+
+    async def test_include_skips_unknown_sessions(
+        self,
+        repository: IdleCheckerRepository,
+        exclusion_rows: ExclusionRows,
+    ) -> None:
+        unknown_session_id = SessionId(uuid.uuid4())
+
+        result = await repository.batch_include_session_idle_checks(
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.excluded_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(unknown_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
+        )
+
+        assert result.success == [
+            SessionIdleCheckPair(
+                session_id=exclusion_rows.excluded_session_id,
+                checker_id=exclusion_rows.checker_id,
+            )
+        ]
+        unknown_pair = SessionIdleCheckPair(
+            session_id=unknown_session_id,
+            checker_id=exclusion_rows.checker_id,
+        )
+        assert set(result.errors) == {unknown_pair}
+        assert isinstance(result.errors[unknown_pair], SessionNotFound)
+
     async def test_sync_delete_spares_user_managed_rows(
         self,
         database: ExtendedAsyncSAEngine,
@@ -1399,12 +1412,25 @@ class TestSessionIdleCheckExclusion:
         exclusion_rows: ExclusionRows,
     ) -> None:
         """Assignment sync only cleans its own rows; user-written rows survive."""
-        user_pair = exclusion_rows.pair(exclusion_rows.user_excluded_session_id)
-        system_pair = exclusion_rows.pair(exclusion_rows.active_session_id)
+        await repository.sync_session_idle_check_assignments(
+            [],
+            [
+                SessionIdleCheckPair(
+                    exclusion_rows.user_excluded_session_id, exclusion_rows.checker_id
+                ),
+                SessionIdleCheckPair(exclusion_rows.active_session_id, exclusion_rows.checker_id),
+            ],
+        )
 
-        await repository.sync_session_idle_check_assignments([], [user_pair, system_pair])
-
-        user_row = await _get_check_row(database, user_pair)
+        async with database.begin_readonly_session() as db_sess:
+            user_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.user_excluded_session_id, exclusion_rows.checker_id),
+            )
+            system_row = await db_sess.get(
+                SessionIdleCheckRow,
+                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
+            )
         assert user_row is not None
         assert user_row.is_manual is True
-        assert await _get_check_row(database, system_pair) is None
+        assert system_row is None

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -1132,6 +1132,7 @@ class TestSessionIdleCheckExclusion:
                         expire_at=expire_at,
                         last_status=phase,
                         last_message=f"{phase.value} judgment",
+                        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
                     )
                 )
             # A pair the user excluded by hand.
@@ -1363,6 +1364,8 @@ class TestSessionIdleCheckExclusion:
             )
         assert excluded_row is not None
         assert excluded_row.last_status is IdleCheckPhase.NOT_CHECKED
+        # The grace period restarts from this write, not from the seeded row's age.
+        assert excluded_row.updated_at > datetime(2026, 1, 1, tzinfo=UTC)
         assert active_row is not None
         assert active_row.last_status is IdleCheckPhase.NOT_CHECKED
         assert untouched_row is not None

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -19,6 +19,7 @@ from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     ClusterMode,
     ResourceSlot,
@@ -42,12 +43,17 @@ from ai.backend.manager.models.resource_policy import (
 )
 from ai.backend.manager.models.scaling_group import ScalingGroupRow
 from ai.backend.manager.models.session import SessionRow
-from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.base import BulkUpserter
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
 from ai.backend.manager.repositories.idle_checker.types import (
     IdleJudgmentData,
     SessionIdleCheckPair,
+)
+from ai.backend.manager.repositories.idle_checker.upserters import (
+    SessionIdleCheckExcludeUpserterSpec,
+    SessionIdleCheckIncludeUpserterSpec,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.testutils.db import with_tables
@@ -1009,6 +1015,13 @@ class TestFetchExpiredIdleChecks:
 
 @dataclass(frozen=True)
 class ExclusionRows:
+    """Rows seeded for one checker; each session field names its pair's starting state.
+
+    ``unassigned_session_id`` has no idle-check row yet, ``user_excluded_session_id``'s
+    row is already manual, and the rest start with a system-written row in the phase
+    their name says.
+    """
+
     active_session_id: SessionId
     idle_expired_session_id: SessionId
     excluded_session_id: SessionId
@@ -1016,6 +1029,60 @@ class ExclusionRows:
     unassigned_session_id: SessionId
     user_excluded_session_id: SessionId
     checker_id: IdleCheckerID
+    user_id: UserID
+
+    def pair(self, session_id: SessionId) -> SessionIdleCheckPair:
+        return SessionIdleCheckPair(session_id=session_id, checker_id=self.checker_id)
+
+    def exclude_upserter(self, session_ids: list[SessionId]) -> BulkUpserter[SessionIdleCheckRow]:
+        specs: list[SessionIdleCheckExcludeUpserterSpec] = []
+        for session_id in session_ids:
+            specs.append(
+                SessionIdleCheckExcludeUpserterSpec(
+                    session_id=SessionID(session_id),
+                    checker_id=self.checker_id,
+                    user_id=self.user_id,
+                )
+            )
+        return BulkUpserter(specs=specs)
+
+    def include_upserter(self, session_ids: list[SessionId]) -> BulkUpserter[SessionIdleCheckRow]:
+        specs: list[SessionIdleCheckIncludeUpserterSpec] = []
+        for session_id in session_ids:
+            specs.append(
+                SessionIdleCheckIncludeUpserterSpec(
+                    session_id=SessionID(session_id),
+                    checker_id=self.checker_id,
+                    user_id=self.user_id,
+                )
+            )
+        return BulkUpserter(specs=specs)
+
+
+async def _get_check_row(
+    database: ExtendedAsyncSAEngine,
+    pair: SessionIdleCheckPair,
+) -> SessionIdleCheckRow | None:
+    async with database.begin_readonly_session() as db_sess:
+        return await db_sess.get(SessionIdleCheckRow, (pair.session_id, pair.checker_id))
+
+
+def _assert_manually_excluded(row: SessionIdleCheckRow | None, user_id: UserID) -> None:
+    assert row is not None
+    assert row.last_status is IdleCheckPhase.EXCLUDED
+    assert row.expire_at is None
+    assert row.last_message == "Excluded from idle checks."
+    assert row.is_manual is True
+    assert row.manually_triggered_by == user_id
+
+
+def _assert_manually_included(row: SessionIdleCheckRow | None, user_id: UserID) -> None:
+    assert row is not None
+    assert row.last_status is IdleCheckPhase.NOT_CHECKED
+    assert row.expire_at is None
+    assert row.last_message == "Not checked yet."
+    assert row.is_manual is True
+    assert row.manually_triggered_by == user_id
 
 
 class TestSessionIdleCheckExclusion:
@@ -1058,39 +1125,61 @@ class TestSessionIdleCheckExclusion:
             unassigned_session_id=SessionId(uuid.uuid4()),
             user_excluded_session_id=SessionId(uuid.uuid4()),
             checker_id=IdleCheckerID(uuid.uuid4()),
+            user_id=UserID(uuid.uuid4()),
         )
-        check_specs = (
-            (rows.active_session_id, IdleCheckPhase.ACTIVE, datetime(2026, 2, 1, tzinfo=UTC)),
-            (
-                rows.idle_expired_session_id,
-                IdleCheckPhase.IDLE_EXPIRED,
-                datetime(2026, 2, 1, tzinfo=UTC),
-            ),
-            (rows.excluded_session_id, IdleCheckPhase.EXCLUDED, None),
-            (rows.untouched_session_id, IdleCheckPhase.ACTIVE, datetime(2026, 2, 1, tzinfo=UTC)),
-        )
+        initial_phases = {
+            rows.active_session_id: IdleCheckPhase.ACTIVE,
+            rows.idle_expired_session_id: IdleCheckPhase.IDLE_EXPIRED,
+            rows.excluded_session_id: IdleCheckPhase.EXCLUDED,
+            rows.untouched_session_id: IdleCheckPhase.ACTIVE,
+        }
+        all_session_ids = [
+            *initial_phases,
+            rows.unassigned_session_id,
+            rows.user_excluded_session_id,
+        ]
         async with database.begin_session() as db_sess:
             for scope_row in _expired_check_scope_rows(scope):
                 db_sess.add(scope_row)
-            for session_id, _phase, _expire_at in check_specs:
-                db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
-            # The unassigned session exists but has no idle-check row yet.
+            # The requesting user recorded as the managing writer.
             db_sess.add(
-                _expired_check_session_row(scope, rows.unassigned_session_id, SessionStatus.RUNNING)
-            )
-            db_sess.add(
-                _expired_check_session_row(
-                    scope, rows.user_excluded_session_id, SessionStatus.RUNNING
+                UserResourcePolicyRow(
+                    name=f"{scope.domain_name}-user-policy",
+                    max_vfolder_count=10,
+                    max_quota_scope_size=1024,
+                    max_session_count_per_model_session=5,
+                    max_customized_image_count=3,
                 )
             )
+            db_sess.add(
+                UserRow(
+                    uuid=rows.user_id,
+                    username="exclusion-requester",
+                    email="exclusion-requester@example.com",
+                    password=None,
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=scope.domain_name,
+                    role=UserRole.USER,
+                    resource_policy=f"{scope.domain_name}-user-policy",
+                )
+            )
+            for session_id in all_session_ids:
+                db_sess.add(_expired_check_session_row(scope, session_id, SessionStatus.RUNNING))
             db_sess.add(_expired_check_checker_row(rows.checker_id))
             await db_sess.flush()
-            for session_id, phase, expire_at in check_specs:
+            # System-written check rows; EXCLUDED pairs carry no expiry.
+            for session_id, phase in initial_phases.items():
                 db_sess.add(
                     SessionIdleCheckRow(
                         session_id=session_id,
                         idle_checker_id=rows.checker_id,
-                        expire_at=expire_at,
+                        expire_at=(
+                            None
+                            if phase is IdleCheckPhase.EXCLUDED
+                            else datetime(2026, 2, 1, tzinfo=UTC)
+                        ),
                         last_status=phase,
                         last_message=f"{phase.value} judgment",
                     )
@@ -1115,30 +1204,21 @@ class TestSessionIdleCheckExclusion:
         exclusion_rows: ExclusionRows,
     ) -> None:
         await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.checker_id,
-            [
-                SessionID(exclusion_rows.active_session_id),
-                SessionID(exclusion_rows.idle_expired_session_id),
-            ],
-        )
-
-        async with database.begin_readonly_session() as db_sess:
-            for session_id in (
+            exclusion_rows.exclude_upserter([
                 exclusion_rows.active_session_id,
                 exclusion_rows.idle_expired_session_id,
-            ):
-                row = await db_sess.get(
-                    SessionIdleCheckRow,
-                    (session_id, exclusion_rows.checker_id),
-                )
-                assert row is not None
-                assert row.last_status is IdleCheckPhase.EXCLUDED
-                assert row.expire_at is None
-                assert row.last_message == "Excluded from idle checks."
-            untouched_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.untouched_session_id, exclusion_rows.checker_id),
-            )
+            ]),
+        )
+
+        for session_id in (
+            exclusion_rows.active_session_id,
+            exclusion_rows.idle_expired_session_id,
+        ):
+            row = await _get_check_row(database, exclusion_rows.pair(session_id))
+            _assert_manually_excluded(row, exclusion_rows.user_id)
+        untouched_row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.untouched_session_id)
+        )
         assert untouched_row is not None
         assert untouched_row.last_status is IdleCheckPhase.ACTIVE
         assert untouched_row.expire_at == datetime(2026, 2, 1, tzinfo=UTC)
@@ -1150,73 +1230,57 @@ class TestSessionIdleCheckExclusion:
         exclusion_rows: ExclusionRows,
     ) -> None:
         await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.checker_id,
-            [SessionID(exclusion_rows.unassigned_session_id)],
+            exclusion_rows.exclude_upserter([exclusion_rows.unassigned_session_id]),
         )
 
-        async with database.begin_readonly_session() as db_sess:
-            row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.unassigned_session_id, exclusion_rows.checker_id),
-            )
-        assert row is not None
-        assert row.last_status is IdleCheckPhase.EXCLUDED
-        assert row.expire_at is None
-        assert row.last_message == "Excluded from idle checks."
+        row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.unassigned_session_id)
+        )
+        _assert_manually_excluded(row, exclusion_rows.user_id)
 
-    async def test_exclude_deduplicates_repeated_session_ids(
+    async def test_repeated_specs_for_one_pair_are_harmless(
         self,
         database: ExtendedAsyncSAEngine,
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
-        """A repeated session id must not break the single INSERT..ON CONFLICT statement."""
+        """The service deduplicates; a duplicate spec just re-applies the same upsert."""
         await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.checker_id,
-            [
-                SessionID(exclusion_rows.unassigned_session_id),
-                SessionID(exclusion_rows.unassigned_session_id),
-            ],
+            exclusion_rows.exclude_upserter([
+                exclusion_rows.unassigned_session_id,
+                exclusion_rows.unassigned_session_id,
+            ]),
         )
 
-        async with database.begin_readonly_session() as db_sess:
-            row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.unassigned_session_id, exclusion_rows.checker_id),
-            )
-        assert row is not None
-        assert row.last_status is IdleCheckPhase.EXCLUDED
+        row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.unassigned_session_id)
+        )
+        _assert_manually_excluded(row, exclusion_rows.user_id)
 
-    async def test_include_resets_only_excluded_rows(
+    async def test_include_overwrites_any_phase(
         self,
         database: ExtendedAsyncSAEngine,
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
         await repository.batch_include_session_idle_checks(
-            exclusion_rows.checker_id,
-            [
-                SessionID(exclusion_rows.excluded_session_id),
-                SessionID(exclusion_rows.active_session_id),
-            ],
+            exclusion_rows.include_upserter([
+                exclusion_rows.excluded_session_id,
+                exclusion_rows.active_session_id,
+            ]),
         )
 
-        async with database.begin_readonly_session() as db_sess:
-            reset_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.excluded_session_id, exclusion_rows.checker_id),
-            )
-            active_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
-            )
-        assert reset_row is not None
-        assert reset_row.last_status is IdleCheckPhase.NOT_CHECKED
-        assert reset_row.expire_at is None
-        assert reset_row.last_message == "Not checked yet."
-        assert active_row is not None
-        assert active_row.last_status is IdleCheckPhase.ACTIVE
-        assert active_row.last_message == f"{IdleCheckPhase.ACTIVE.value} judgment"
+        for session_id in (
+            exclusion_rows.excluded_session_id,
+            exclusion_rows.active_session_id,
+        ):
+            row = await _get_check_row(database, exclusion_rows.pair(session_id))
+            _assert_manually_included(row, exclusion_rows.user_id)
+        untouched_row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.untouched_session_id)
+        )
+        assert untouched_row is not None
+        assert untouched_row.last_status is IdleCheckPhase.ACTIVE
 
     async def test_include_is_idempotent(
         self,
@@ -1224,37 +1288,30 @@ class TestSessionIdleCheckExclusion:
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
-        target = [SessionID(exclusion_rows.excluded_session_id)]
+        target = [exclusion_rows.excluded_session_id]
 
-        await repository.batch_include_session_idle_checks(exclusion_rows.checker_id, target)
-        await repository.batch_include_session_idle_checks(exclusion_rows.checker_id, target)
+        await repository.batch_include_session_idle_checks(exclusion_rows.include_upserter(target))
+        await repository.batch_include_session_idle_checks(exclusion_rows.include_upserter(target))
 
-        async with database.begin_readonly_session() as db_sess:
-            row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.excluded_session_id, exclusion_rows.checker_id),
-            )
-        assert row is not None
-        assert row.last_status is IdleCheckPhase.NOT_CHECKED
-        assert row.last_message == "Not checked yet."
+        row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.excluded_session_id)
+        )
+        _assert_manually_included(row, exclusion_rows.user_id)
 
-    async def test_include_ignores_pair_without_row(
+    async def test_include_upserts_missing_pair_row(
         self,
         database: ExtendedAsyncSAEngine,
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
         await repository.batch_include_session_idle_checks(
-            exclusion_rows.checker_id,
-            [SessionID(exclusion_rows.unassigned_session_id)],
+            exclusion_rows.include_upserter([exclusion_rows.unassigned_session_id]),
         )
 
-        async with database.begin_readonly_session() as db_sess:
-            row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.unassigned_session_id, exclusion_rows.checker_id),
-            )
-        assert row is None
+        row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.unassigned_session_id)
+        )
+        _assert_manually_included(row, exclusion_rows.user_id)
 
     async def test_exclude_skips_unknown_sessions(
         self,
@@ -1262,33 +1319,26 @@ class TestSessionIdleCheckExclusion:
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
-        unknown_session_id = SessionID(uuid.uuid4())
+        unknown_session_id = SessionId(uuid.uuid4())
 
         result = await repository.batch_exclude_session_idle_checks(
-            exclusion_rows.checker_id,
-            [
-                SessionID(exclusion_rows.active_session_id),
+            exclusion_rows.exclude_upserter([
+                exclusion_rows.active_session_id,
                 unknown_session_id,
-            ],
+            ]),
         )
 
-        assert result.success == [SessionID(exclusion_rows.active_session_id)]
+        assert result.success == [exclusion_rows.pair(exclusion_rows.active_session_id)]
         # The FK violation is mapped to SessionNotFound naming the session.
-        assert set(result.errors) == {unknown_session_id}
-        assert isinstance(result.errors[unknown_session_id], SessionNotFound)
+        unknown_pair = exclusion_rows.pair(unknown_session_id)
+        assert set(result.errors) == {unknown_pair}
+        assert isinstance(result.errors[unknown_pair], SessionNotFound)
 
-        async with database.begin_readonly_session() as db_sess:
-            valid_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
-            )
-            unknown_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (unknown_session_id, exclusion_rows.checker_id),
-            )
-        assert valid_row is not None
-        assert valid_row.last_status is IdleCheckPhase.EXCLUDED
-        assert unknown_row is None
+        excluded_row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.active_session_id)
+        )
+        _assert_manually_excluded(excluded_row, exclusion_rows.user_id)
+        assert await _get_check_row(database, unknown_pair) is None
 
     async def test_include_skips_unknown_sessions(
         self,
@@ -1296,38 +1346,51 @@ class TestSessionIdleCheckExclusion:
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
-        unknown_session_id = SessionID(uuid.uuid4())
+        unknown_session_id = SessionId(uuid.uuid4())
 
         result = await repository.batch_include_session_idle_checks(
-            exclusion_rows.checker_id,
-            [
-                SessionID(exclusion_rows.excluded_session_id),
+            exclusion_rows.include_upserter([
+                exclusion_rows.excluded_session_id,
                 unknown_session_id,
-            ],
+            ]),
         )
 
-        assert result.success == [SessionID(exclusion_rows.excluded_session_id)]
-        assert set(result.errors) == {unknown_session_id}
-        assert isinstance(result.errors[unknown_session_id], SessionNotFound)
+        assert result.success == [exclusion_rows.pair(exclusion_rows.excluded_session_id)]
+        unknown_pair = exclusion_rows.pair(unknown_session_id)
+        assert set(result.errors) == {unknown_pair}
+        assert isinstance(result.errors[unknown_pair], SessionNotFound)
 
-        async with database.begin_readonly_session() as db_sess:
-            reset_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.excluded_session_id, exclusion_rows.checker_id),
-            )
-        assert reset_row is not None
-        assert reset_row.last_status is IdleCheckPhase.NOT_CHECKED
+        reset_row = await _get_check_row(
+            database, exclusion_rows.pair(exclusion_rows.excluded_session_id)
+        )
+        _assert_manually_included(reset_row, exclusion_rows.user_id)
 
-    async def test_unknown_checker_rejects_whole_batch(
+    async def test_unknown_checker_reported_per_pair(
         self,
         repository: IdleCheckerRepository,
         exclusion_rows: ExclusionRows,
     ) -> None:
-        with pytest.raises(IdleCheckerNotFound):
-            await repository.batch_exclude_session_idle_checks(
-                IdleCheckerID(uuid.uuid4()),
-                [SessionID(exclusion_rows.active_session_id)],
-            )
+        """The FK violation is mapped to IdleCheckerNotFound for the failing pair only."""
+        unknown_checker_id = IdleCheckerID(uuid.uuid4())
+        upserter = BulkUpserter(
+            specs=[
+                SessionIdleCheckExcludeUpserterSpec(
+                    session_id=SessionID(exclusion_rows.active_session_id),
+                    checker_id=unknown_checker_id,
+                    user_id=exclusion_rows.user_id,
+                )
+            ]
+        )
+
+        result = await repository.batch_exclude_session_idle_checks(upserter)
+
+        assert result.success == []
+        unknown_pair = SessionIdleCheckPair(
+            session_id=exclusion_rows.active_session_id,
+            checker_id=unknown_checker_id,
+        )
+        assert set(result.errors) == {unknown_pair}
+        assert isinstance(result.errors[unknown_pair], IdleCheckerNotFound)
 
     async def test_sync_delete_spares_user_managed_rows(
         self,
@@ -1336,25 +1399,12 @@ class TestSessionIdleCheckExclusion:
         exclusion_rows: ExclusionRows,
     ) -> None:
         """Assignment sync only cleans its own rows; user-written rows survive."""
-        await repository.sync_session_idle_check_assignments(
-            [],
-            [
-                SessionIdleCheckPair(
-                    exclusion_rows.user_excluded_session_id, exclusion_rows.checker_id
-                ),
-                SessionIdleCheckPair(exclusion_rows.active_session_id, exclusion_rows.checker_id),
-            ],
-        )
+        user_pair = exclusion_rows.pair(exclusion_rows.user_excluded_session_id)
+        system_pair = exclusion_rows.pair(exclusion_rows.active_session_id)
 
-        async with database.begin_readonly_session() as db_sess:
-            user_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.user_excluded_session_id, exclusion_rows.checker_id),
-            )
-            system_row = await db_sess.get(
-                SessionIdleCheckRow,
-                (exclusion_rows.active_session_id, exclusion_rows.checker_id),
-            )
+        await repository.sync_session_idle_check_assignments([], [user_pair, system_pair])
+
+        user_row = await _get_check_row(database, user_pair)
         assert user_row is not None
         assert user_row.is_manual is True
-        assert system_row is None
+        assert await _get_check_row(database, system_pair) is None

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -1217,6 +1217,9 @@ class TestSessionIdleCheckExclusion:
             )
         assert active_row is not None
         assert active_row.last_status is IdleCheckPhase.EXCLUDED
+        # The overwrite restamps the managing writer on a checker-managed row.
+        assert active_row.is_manual is True
+        assert active_row.manually_triggered_by == exclusion_rows.user_id
         assert idle_expired_row is not None
         assert idle_expired_row.last_status is IdleCheckPhase.EXCLUDED
         assert untouched_row is not None
@@ -1367,6 +1370,9 @@ class TestSessionIdleCheckExclusion:
         assert excluded_row.last_status is IdleCheckPhase.NOT_CHECKED
         # The grace period restarts from this write, not from the seeded row's age.
         assert excluded_row.updated_at > datetime(2026, 1, 1, tzinfo=UTC)
+        # The overwrite restamps the managing writer on a checker-managed row.
+        assert excluded_row.is_manual is True
+        assert excluded_row.manually_triggered_by == exclusion_rows.user_id
         assert active_row is not None
         assert active_row.last_status is IdleCheckPhase.NOT_CHECKED
         assert untouched_row is not None
@@ -1408,6 +1414,73 @@ class TestSessionIdleCheckExclusion:
         )
         assert set(result.errors) == {unknown_pair}
         assert isinstance(result.errors[unknown_pair], SessionNotFound)
+
+    async def test_include_unknown_checker_reported_per_pair(
+        self,
+        repository: IdleCheckerRepository,
+        exclusion_rows: ExclusionRows,
+    ) -> None:
+        """The FK violation fails only the pair naming the unknown checker."""
+        unknown_checker_id = IdleCheckerID(uuid.uuid4())
+
+        result = await repository.batch_include_session_idle_checks(
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.excluded_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.active_session_id),
+                        checker_id=unknown_checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
+        )
+
+        assert result.success == [
+            SessionIdleCheckPair(
+                session_id=exclusion_rows.excluded_session_id,
+                checker_id=exclusion_rows.checker_id,
+            )
+        ]
+        unknown_pair = SessionIdleCheckPair(
+            session_id=exclusion_rows.active_session_id,
+            checker_id=unknown_checker_id,
+        )
+        assert set(result.errors) == {unknown_pair}
+        assert isinstance(result.errors[unknown_pair], IdleCheckerNotFound)
+
+    async def test_include_restarts_grace_period_from_new_write(
+        self,
+        repository: IdleCheckerRepository,
+        exclusion_rows: ExclusionRows,
+    ) -> None:
+        """The included pair reenters the grace fetch with this write as its start."""
+        await repository.batch_include_session_idle_checks(
+            BulkUpserter(
+                specs=[
+                    SessionIdleCheckIncludeUpserterSpec(
+                        session_id=SessionID(exclusion_rows.excluded_session_id),
+                        checker_id=exclusion_rows.checker_id,
+                        user_id=exclusion_rows.user_id,
+                    ),
+                ]
+            )
+        )
+
+        batch = await repository.fetch_initial_grace_period_checks([SessionStatus.RUNNING])
+
+        assert [check.pair for check in batch.checks] == [
+            SessionIdleCheckPair(
+                session_id=exclusion_rows.excluded_session_id,
+                checker_id=exclusion_rows.checker_id,
+            )
+        ]
+        # The grace start is this write's timestamp, not the seeded row's age.
+        assert batch.checks[0].grace_started_at > datetime(2026, 1, 1, tzinfo=UTC)
 
     async def test_sync_delete_spares_user_managed_rows(
         self,

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -1107,6 +1107,7 @@ class TestSessionIdleCheckExclusion:
                     status=UserStatus.ACTIVE,
                     status_info="active",
                     domain_name=scope.domain_name,
+                    domain_id=scope.domain_id,
                     role=UserRole.USER,
                     resource_policy=f"{scope.domain_name}-user-policy",
                 )

--- a/tests/unit/manager/services/idle_checker/test_service.py
+++ b/tests/unit/manager/services/idle_checker/test_service.py
@@ -16,17 +16,33 @@ from ai.backend.common.data.idle_checker.types import (
     UtilizationThresholdEntry,
 )
 from ai.backend.common.exception import PrometheusQueryPresetInvalidLabel
+from ai.backend.common.identifier.idle_checker import IdleCheckerID
 from ai.backend.common.identifier.prometheus_query_preset import PrometheusQueryPresetID
-from ai.backend.common.types import SessionTypes
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import SessionId, SessionTypes
 from ai.backend.manager.data.prometheus_query_preset.types import PrometheusQueryPresetData
 from ai.backend.manager.repositories.base import Creator, Updater
 from ai.backend.manager.repositories.idle_checker.creators import IdleCheckerCreatorSpec
 from ai.backend.manager.repositories.idle_checker.repository import IdleCheckerRepository
+from ai.backend.manager.repositories.idle_checker.types import (
+    SessionIdleCheckBatchResult,
+    SessionIdleCheckPair,
+)
 from ai.backend.manager.repositories.idle_checker.updaters import IdleCheckerUpdaterSpec
+from ai.backend.manager.repositories.idle_checker.upserters import (
+    SessionIdleCheckExcludeUpserterSpec,
+    SessionIdleCheckIncludeUpserterSpec,
+)
 from ai.backend.manager.repositories.prometheus_query_preset.repository import (
     PrometheusQueryPresetRepository,
 )
 from ai.backend.manager.services.idle_checker.actions.create import CreateIdleCheckerAction
+from ai.backend.manager.services.idle_checker.actions.exclude_sessions import (
+    ExcludeSessionIdleChecksAction,
+)
+from ai.backend.manager.services.idle_checker.actions.include_sessions import (
+    IncludeSessionIdleChecksAction,
+)
 from ai.backend.manager.services.idle_checker.actions.update import UpdateIdleCheckerAction
 from ai.backend.manager.services.idle_checker.service import IdleCheckerService
 from ai.backend.manager.types import OptionalState
@@ -191,3 +207,69 @@ class TestIdleCheckerSpecLabelValidation:
 
         preset_repository.get_by_id.assert_not_awaited()
         repository.update.assert_awaited_once()
+
+
+class TestSessionIdleCheckUpserterAssembly:
+    @pytest.fixture()
+    def repository(self) -> MagicMock:
+        repository = MagicMock(spec=IdleCheckerRepository)
+        empty_result = SessionIdleCheckBatchResult(success=[], errors={})
+        repository.batch_exclude_session_idle_checks = AsyncMock(return_value=empty_result)
+        repository.batch_include_session_idle_checks = AsyncMock(return_value=empty_result)
+        return repository
+
+    @pytest.fixture()
+    def service(self, repository: MagicMock) -> IdleCheckerService:
+        return IdleCheckerService(repository, MagicMock(spec=PrometheusQueryPresetRepository))
+
+    async def test_exclude_assembles_deduplicated_manual_specs(
+        self,
+        service: IdleCheckerService,
+        repository: MagicMock,
+    ) -> None:
+        checker_id = IdleCheckerID(uuid4())
+        user_id = UserID(uuid4())
+        first_pair = SessionIdleCheckPair(session_id=SessionId(uuid4()), checker_id=checker_id)
+        second_pair = SessionIdleCheckPair(session_id=SessionId(uuid4()), checker_id=checker_id)
+
+        await service.exclude_sessions(
+            ExcludeSessionIdleChecksAction(
+                targets=[first_pair, second_pair, first_pair],
+                user_id=user_id,
+            )
+        )
+
+        repository.batch_exclude_session_idle_checks.assert_awaited_once()
+        (upserter,) = repository.batch_exclude_session_idle_checks.await_args.args
+        assert [spec.session_id for spec in upserter.specs] == [
+            first_pair.session_id,
+            second_pair.session_id,
+        ]
+        for spec in upserter.specs:
+            assert isinstance(spec, SessionIdleCheckExcludeUpserterSpec)
+            assert spec.checker_id == checker_id
+            assert spec.user_id == user_id
+
+    async def test_include_assembles_include_specs(
+        self,
+        service: IdleCheckerService,
+        repository: MagicMock,
+    ) -> None:
+        checker_id = IdleCheckerID(uuid4())
+        user_id = UserID(uuid4())
+        pair = SessionIdleCheckPair(session_id=SessionId(uuid4()), checker_id=checker_id)
+
+        await service.include_sessions(
+            IncludeSessionIdleChecksAction(
+                targets=[pair],
+                user_id=user_id,
+            )
+        )
+
+        repository.batch_include_session_idle_checks.assert_awaited_once()
+        (upserter,) = repository.batch_include_session_idle_checks.await_args.args
+        spec = upserter.specs[0]
+        assert isinstance(spec, SessionIdleCheckIncludeUpserterSpec)
+        assert spec.session_id == pair.session_id
+        assert spec.checker_id == checker_id
+        assert spec.user_id == user_id


### PR DESCRIPTION
## Summary
- Rework the session idle-check exclusion/inclusion chain below the adapter (landed by BA-7120) to operate on (checker, session) pair targets applied as manual upserts.
- The service owns upserter assembly: it deduplicates the pair targets and builds the `SessionIdleCheckExclude/IncludeUpserterSpec`s (`is_manual=True`, `manually_triggered_by=<requesting user>`, BA-7339); the repository receives only the assembled `BulkUpserter` and executes it with savepoint-isolated partial success.
- Inclusion becomes an upsert mirroring exclusion: any phase resets to `NOT_CHECKED` (grace period restarts) and missing pair rows are created.
- The checker pre-check is dropped — the foreign keys map an unknown session/checker to `SessionNotFound` / `IdleCheckerNotFound` for that pair only, instead of failing the whole batch.
- **The PR boundary is the adapter**: no API-layer changes here. The BA-7243 adapter stubs (#13682) keep raising `NotImplementedError` and are wired to these processors once both PRs land.

## Behavior changes
| Before | After |
|--------|-------|
| Unknown checker fails the whole batch | Fails only the pairs referencing it |
| Include updates only `EXCLUDED` rows | Include resets any phase and creates missing rows |
| Rows written without provenance | Both verbs set `is_manual` + `manually_triggered_by`, so assignment sync spares them |

## Test plan
- [x] Repository tests (real DB): per-pair upsert semantics, partial failure mapping (`SessionNotFound` / `IdleCheckerNotFound`), writer stamping, assignment sync sparing manual rows
- [x] Service tests (mocked repository): pair dedup and upserter spec assembly
- [ ] Live E2E on the dev stack once wired through #13682: mixed valid/unknown pairs over REST/GQL/CLI return partial `success`/`failed` payloads and per-pair audit records

## Dependencies
- Independent of #13682 (BA-7243) at the code level; the two meet when the adapter stubs are wired after both land.

Resolves BA-7348

🤖 Generated with [Claude Code](https://claude.com/claude-code)