### PR TITLE
chore(BA-7349): rename the main-keypair wording the first sweep missed

### DIFF
--- a/changes/13744.misc.md
+++ b/changes/13744.misc.md
@@ -1,0 +1,1 @@
+Rename the remaining internal "main keypair" wording (including the hyphenated `main-keypair` spelling and the `UserResourceQuotaExceeded` message) to "default keypair".

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -77,7 +77,7 @@ class SlotTypeInfo:
 class UserEnqueuePolicy:
     """Per-user gates applied at session enqueue.
 
-    Sourced from the user's main-keypair resource policy row until
+    Sourced from the user's default-keypair resource policy row until
     user-level policy columns exist; carries only the fields the
     enqueue path actually consumes.
     """

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
@@ -120,7 +120,7 @@ class UserResourceQuotaExceeded(SchedulingValidationError):
 
     @override
     def summary(self) -> str:
-        return f"Your main-keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+        return f"Your default-keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
 
     @override
     def error_code(self) -> ErrorCode:

--- a/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
+++ b/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
@@ -142,15 +142,15 @@ class TestResolveUserAndActiveAccessKey:
             result = await db_source._resolve_user_and_active_access_key(sess, user_uuid)
         return result.access_key
 
-    async def test_picks_the_main_keypair_when_active(
+    async def test_picks_the_default_keypair_when_active(
         self,
         db: ExtendedAsyncSAEngine,
         db_source: DeploymentDBSource,
     ) -> None:
-        # The main keypair wins over a newer active key.
+        # The default keypair wins over a newer active key.
         user_uuid = uuid.uuid4()
         now = datetime.now(tz=UTC)
-        main_key = "AK" + "M" * 18
+        default_key = "AK" + "M" * 18
         other_active = "AK" + "O" * 18
         await self._seed(
             db,
@@ -159,7 +159,7 @@ class TestResolveUserAndActiveAccessKey:
                 domain_name=f"d-{uuid.uuid4().hex[:8]}",
                 keypairs=[
                     KeypairSpec(
-                        main_key,
+                        default_key,
                         is_active=True,
                         created_at=now - timedelta(days=10),
                         is_default=True,
@@ -171,7 +171,7 @@ class TestResolveUserAndActiveAccessKey:
 
         chosen = await self._resolve(db_source, user_uuid)
 
-        assert chosen == AccessKey(main_key)
+        assert chosen == AccessKey(default_key)
 
     async def test_raises_no_active_keypair_when_all_inactive(
         self,

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -162,7 +162,7 @@ def setup_successful_auth(
         active_sessions=[],
     )
 
-    # Step 2: get_user_row_by_uuid returns a user row with a main keypair
+    # Step 2: get_user_row_by_uuid returns a user row with a default keypair
     mock_user_row = MagicMock()
     mock_user_row.get_default_keypair_row.return_value = _make_mock_keypair_row()
     mock_auth_repository.get_user_row_by_uuid.return_value = mock_user_row

--- a/tests/unit/manager/test_idle_check_host.py
+++ b/tests/unit/manager/test_idle_check_host.py
@@ -1,7 +1,7 @@
 """
 Tests for ``IdleCheckerHost.do_idle_check()`` against a real database.
 
-The idle policy is resolved through the user's main keypair — the one marked
+The idle policy is resolved through the user's default keypair — the one marked
 ``keypairs.is_default`` — instead of the kernel's own ``access_key``, which a
 keypair deletion can leave orphaned. A kernel whose policy cannot be resolved,
 or whose checker raises, must not stop the remaining kernels of the same cycle


### PR DESCRIPTION
Resolves #13742 (BA-7349)

## Summary
- Follow-up to #13740, covering the non-wire leftovers its Copilot review found: the module docstring of `test_idle_check_host.py`, the `test_picks_the_main_keypair_when_active` naming and `main_key` variable in `test_active_access_key_resolution.py`, a comment in `test_authorize.py`, the `UserEnqueuePolicy` docstring, and the user-visible `UserResourceQuotaExceeded` message ("Your main-keypair resource quota is exceeded").
- The first sweep missed these because it only grepped prose in `src/` and did not match the hyphenated `main-keypair` spelling; a hyphen-aware re-scan of `src/` and `tests/` finds no further non-wire leftovers.
- Independent of #13740 (no overlapping lines) — the two PRs can merge in either order.

## Test plan
- [ ] CI green (wording/naming-only change; the renamed deployment test is covered by the unit-test job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)