### PR TITLE
refactor(BA-7315): carry event payloads as JSON instead of msgpack

### DIFF
--- a/changes/13746.breaking.md
+++ b/changes/13746.breaking.md
@@ -1,0 +1,1 @@
+Carry event payloads as JSON instead of msgpack; all cluster components must run the same version across this upgrade

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -146,7 +146,12 @@ from ai.backend.common.events.event_types.kernel.broadcast import (
     KernelStartedBroadcastEvent,
     KernelTerminatedBroadcastEvent,
 )
-from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
+from ai.backend.common.events.event_types.kernel.types import (
+    KernelCreationInfo,
+    KernelLifecycleEventReason,
+    ServicePortInfo,
+    UsedDevices,
+)
 from ai.backend.common.events.event_types.session.anycast import (
     ExecutionFinishedAnycastEvent,
     ExecutionStartedAnycastEvent,
@@ -3301,24 +3306,29 @@ class AbstractAgent[
                             )
 
                     # Finally we are done.
+                    creation_info = KernelCreationInfo(
+                        container_id=ContainerId(str(kernel_obj["container_id"])),
+                        kernel_host=str(kernel_obj["kernel_host"]),
+                        repl_in_port=kernel_obj["repl_in_port"],
+                        repl_out_port=kernel_obj["repl_out_port"],
+                        service_ports=[
+                            ServicePortInfo.model_validate(service_port)
+                            for service_port in public_service_ports
+                        ],
+                        used_devices=UsedDevices.from_allocations(
+                            resource_spec.allocations, attached_devices
+                        ),
+                    )
                     await self.anycast_and_broadcast_event(
                         KernelStartedAnycastEvent(
                             kernel_id=kernel_id,
                             session_id=session_id,
-                            creation_info={
-                                **kernel_creation_info,
-                                "id": str(KernelId(kernel_id)),
-                                "container_id": str(kernel_obj["container_id"]),
-                            },
+                            creation_info=creation_info,
                         ),
                         KernelStartedBroadcastEvent(
                             kernel_id=kernel_id,
                             session_id=session_id,
-                            creation_info={
-                                **kernel_creation_info,
-                                "id": str(KernelId(kernel_id)),
-                                "container_id": str(kernel_obj["container_id"]),
-                            },
+                            creation_info=creation_info,
                         ),
                     )
                     async with self.registry_lock:

--- a/src/ai/backend/appproxy/common/events.py
+++ b/src/ai/backend/appproxy/common/events.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import json
-from typing import Any, Self, override
-
-from pydantic import TypeAdapter
+from typing import override
 
 from ai.backend.common.events.types import AbstractAnycastEvent, AbstractBroadcastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
@@ -15,21 +12,6 @@ from .types import SerializableCircuit as Circuit
 class AppProxyCircuitEvent(AbstractBroadcastEvent):
     target_worker_authority: str
     circuits: list[Circuit]
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.target_worker_authority,
-            TypeAdapter(list[Circuit]).dump_json(self.circuits).decode("utf-8"),
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            target_worker_authority=value[0],
-            circuits=[Circuit(**r) for r in json.loads(value[1])],
-        )
 
     @classmethod
     @override
@@ -49,23 +31,6 @@ class AppProxyCircuitRouteUpdatedEvent(AbstractBroadcastEvent):
     target_worker_authority: str
     circuit: Circuit
     routes: list[RouteInfo]
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.target_worker_authority,
-            self.circuit.model_dump_json(),
-            TypeAdapter(list[RouteInfo]).dump_json(self.routes).decode("utf-8"),
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            target_worker_authority=value[0],
-            circuit=Circuit(**json.loads(value[1])),
-            routes=[RouteInfo(**r) for r in json.loads(value[2])],
-        )
 
     @classmethod
     @override
@@ -89,18 +54,6 @@ class AppProxyCircuitRouteUpdatedEvent(AbstractBroadcastEvent):
 class GenericWorkerEvent(AbstractAnycastEvent):
     worker_id: str
     reason: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.worker_id,
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(worker_id=value[0], reason=value[1])
 
     @classmethod
     @override
@@ -152,15 +105,6 @@ class WorkerTerminatedEvent(GenericWorkerEvent):
 
 
 class DoCheckWorkerLostEvent(AbstractAnycastEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return tuple()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -181,15 +125,6 @@ class DoCheckWorkerLostEvent(AbstractAnycastEvent):
 
 
 class DoCheckUnusedPortEvent(AbstractAnycastEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return tuple()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -216,15 +151,6 @@ class DoReconcileTraefikRoutesEvent(AbstractAnycastEvent):
     the etcd-based Traefik provider eventually converges on the DB-backed
     source of truth.
     """
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return tuple()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/AGENTS.md
+++ b/src/ai/backend/common/events/AGENTS.md
@@ -6,9 +6,9 @@ Event classes live in `event_types/{domain}/{anycast|broadcast}.py`; base types 
 
 - Subclass `AbstractAnycastEvent` (one consumer) or `AbstractBroadcastEvent` (all subscribers) from `types.py`. The base class — not a flag — decides the delivery pattern.
 - An event is a Pydantic model: declare its body as annotated fields, and construct it by keyword.
-- Implement `event_name()` (unique snake_case), `event_domain()` (an `EventDomain` value), and `serialize()` / `deserialize()`.
-- **`serialize()` and `deserialize()` must use the same tuple order** — a mismatch silently swaps fields.
-- `to_message()` / `from_message()` are `@final` on `AbstractEvent` and derive from the model's fields, so the body an event carries is its field set and nothing else.
+- Implement `event_name()` (unique snake_case) and `event_domain()` (an `EventDomain` value).
+- The wire body is JSON. `to_message()` / `from_message()` are `@final` on `AbstractEvent` and derive from the model's fields, so the body an event carries is its field set and nothing else — there is no per-event serialization to write.
+- **Every field must be JSON-representable and round-trip unchanged.** Do NOT type a field `Any`, or as a type that only survives pickling (`ResourceSlot`, `SlotName`, `BinarySize`, `Decimal`, `Path`) — declare an explicit model or a string/int form instead. A field that breaks this raises `EventPayloadEncodingError` at publish time (`exceptions.py`).
 - If the domain is new, add it to `EventDomain` in `types.py` first.
 - Broadcast events auto-register by `event_name()` via `__init_subclass__`; a duplicate name raises at import. Anycast events are not registered — they are referenced directly at `consume()`.
 

--- a/src/ai/backend/common/events/dispatcher.py
+++ b/src/ai/backend/common/events/dispatcher.py
@@ -31,12 +31,14 @@ from ai.backend.common.message_queue.payload import (
     CachedBroadcastMessagePayload,
 )
 from ai.backend.common.message_queue.queue import AbstractMessageQueue
-from ai.backend.common.message_queue.types import MessageMetadata, MessageName
+from ai.backend.common.message_queue.types import MessageMetadata
 from ai.backend.common.types import (
     AgentId,
 )
 from ai.backend.logging import BraceStyleAdapter
 
+from .exceptions import EventPayloadDecodingError
+from .message import EventMessage
 from .reporter import AbstractEventReporter, CompleteEventReportArgs, PrepareEventReportArgs
 from .types import AbstractAnycastEvent, AbstractBroadcastEvent, AbstractEvent
 
@@ -81,7 +83,6 @@ class EventHandler[TContext, TEvent: "AbstractEvent"]:
     handler_type: _EventHandlerType
     coalescing_opts: CoalescingOptions | None
     coalescing_state: CoalescingState
-    args_matcher: Callable[[tuple[Any, ...]], bool] | None
     event_start_reporters: tuple[AbstractEventReporter, ...] = attrs.field(factory=tuple)
     event_complete_reporters: tuple[AbstractEventReporter, ...] = attrs.field(factory=tuple)
 
@@ -214,7 +215,6 @@ class EventDispatcherGroup(ABC):
         coalescing_opts: CoalescingOptions | None = None,
         *,
         name: str | None = None,
-        args_matcher: Callable[[tuple[Any, ...]], bool] | None = None,
     ) -> EventHandler[TContext, TConsumedEvent]:
         raise NotImplementedError
 
@@ -228,7 +228,6 @@ class EventDispatcherGroup(ABC):
         *,
         name: str | None = None,
         override_event_name: str | None = None,
-        args_matcher: Callable[[tuple[Any, ...]], bool] | None = None,
     ) -> EventHandler[TContext, TSubscirbedEvent]:
         raise NotImplementedError
 
@@ -270,7 +269,6 @@ class _EventDispatcherWrapper(EventDispatcherGroup):
         coalescing_opts: CoalescingOptions | None = None,
         *,
         name: str | None = None,
-        args_matcher: Callable[[tuple[Any, ...]], bool] | None = None,
     ) -> EventHandler[TContext, TConsumedEvent]:
         return self._event_dispatcher.consume(
             event_cls,
@@ -278,7 +276,6 @@ class _EventDispatcherWrapper(EventDispatcherGroup):
             callback,
             coalescing_opts=coalescing_opts,
             name=name,
-            args_matcher=args_matcher,
             start_reporters=tuple(self._start_reporters),
             complete_reporters=tuple(self._complete_reporters),
         )
@@ -293,7 +290,6 @@ class _EventDispatcherWrapper(EventDispatcherGroup):
         *,
         name: str | None = None,
         override_event_name: str | None = None,
-        args_matcher: Callable[[tuple[Any, ...]], bool] | None = None,
     ) -> EventHandler[TContext, TSubscirbedEvent]:
         return self._event_dispatcher.subscribe(
             event_cls,
@@ -302,7 +298,6 @@ class _EventDispatcherWrapper(EventDispatcherGroup):
             coalescing_opts=coalescing_opts,
             name=name,
             override_event_name=override_event_name,
-            args_matcher=args_matcher,
             start_reporters=tuple(self._start_reporters),
             complete_reporters=tuple(self._complete_reporters),
         )
@@ -408,17 +403,12 @@ class EventDispatcher(EventDispatcherGroup):
         coalescing_opts: CoalescingOptions | None = None,
         *,
         name: str | None = None,
-        args_matcher: Callable[[tuple[Any, ...]], bool] | None = None,
         start_reporters: Sequence[AbstractEventReporter] = tuple(),
         complete_reporters: Sequence[AbstractEventReporter] = tuple(),
     ) -> EventHandler[TContext, TConsumedEvent]:
         """
         Register a callback as a consumer. When multiple callback registers as a consumer
         on a single event, only one callable among those will be called.
-
-        args_matcher:
-          Optional. A callable which accepts event argument and supplies a bool as a return value.
-          When specified, EventDispatcher will only execute callback when this lambda returns True.
         """
 
         if name is None:
@@ -431,7 +421,6 @@ class EventDispatcher(EventDispatcherGroup):
             _EventHandlerType.CONSUMER,
             coalescing_opts,
             CoalescingState(),
-            args_matcher,
             event_start_reporters=tuple(start_reporters),
             event_complete_reporters=tuple(complete_reporters),
         )
@@ -456,16 +445,11 @@ class EventDispatcher(EventDispatcherGroup):
         *,
         name: str | None = None,
         override_event_name: str | None = None,
-        args_matcher: Callable[[tuple[Any, ...]], bool] | None = None,
         start_reporters: Sequence[AbstractEventReporter] = tuple(),
         complete_reporters: Sequence[AbstractEventReporter] = tuple(),
     ) -> EventHandler[TContext, TSubscirbedEvent]:
         """
         Subscribes to given event. All handlers will be called when certain event pops up.
-
-        args_matcher:
-          Optional. A callable which accepts event argument and supplies a bool as a return value.
-          When specified, EventDispatcher will only execute callback when this lambda returns True.
         """
 
         if name is None:
@@ -478,7 +462,6 @@ class EventDispatcher(EventDispatcherGroup):
             _EventHandlerType.SUBSCRIBER,
             coalescing_opts,
             CoalescingState(),
-            args_matcher,
             event_start_reporters=tuple(start_reporters),
             event_complete_reporters=tuple(complete_reporters),
         )
@@ -501,12 +484,10 @@ class EventDispatcher(EventDispatcherGroup):
         self,
         evh: EventHandler,  # type: ignore[type-arg]
         source: AgentId,
-        args: tuple[Any, ...],
+        message: EventMessage,
         post_callbacks: Sequence[PostCallback] = tuple(),
         metadata: MessageMetadata | None = None,
     ) -> None:
-        if evh.args_matcher and not evh.args_matcher(args):
-            return
         coalescing_opts = evh.coalescing_opts
         coalescing_state = evh.coalescing_state
         cb = evh.callback
@@ -515,8 +496,26 @@ class EventDispatcher(EventDispatcherGroup):
         if self._closed:
             return
         event_type = event_cls.event_name()
-        event = event_cls.deserialize(args)
         start = time.perf_counter()
+        try:
+            event = event_cls.from_message(message)
+        except EventPayloadDecodingError as e:
+            # A body this consumer cannot read will never become readable, so ack it via
+            # the post callbacks instead of leaving it to be redelivered until discarded.
+            log.exception(
+                "EventDispatcher.{}(ev:{}, evh:{}): undecodable-payload",
+                evh_type.name,
+                event_type,
+                evh.name,
+            )
+            self._metric_observer.observe_event_failure(
+                event_type=event_type,
+                duration=time.perf_counter() - start,
+                exception=e,
+            )
+            for post_callback in post_callbacks:
+                await post_callback.done()
+            return
         for start_reporter in evh.event_start_reporters:
             await start_reporter.prepare_event_report(event, PrepareEventReportArgs())
         try:
@@ -588,13 +587,13 @@ class EventDispatcher(EventDispatcherGroup):
         if self._log_events:
             log.debug("DISPATCH_CONSUMERS(ev:{})", event_name)
         payload = mq_msg.payload
-        args = payload.decode_args()
+        message = EventMessage(name=payload.name, payload=payload.payload)
         for consumer in consumer_handlers.copy():
             self._consumer_taskgroup.create_task(
                 self._handle(
                     consumer,
                     AgentId(payload.legacy_source),
-                    args,
+                    message,
                     [post_callback],
                     payload.metadata,
                 ),
@@ -611,13 +610,13 @@ class EventDispatcher(EventDispatcherGroup):
             return
         if self._log_events:
             log.debug("DISPATCH_SUBSCRIBERS(ev:{})", event_name)
-        args = payload.decode_args()
+        message = EventMessage(name=payload.name, payload=payload.payload)
         for subscriber in subscriber_handlers.copy():
             self._subscriber_taskgroup.create_task(
                 self._handle(
                     subscriber,
                     AgentId(payload.legacy_source),
-                    args,
+                    message,
                     tuple(),
                     payload.metadata,
                 ),
@@ -697,10 +696,11 @@ class EventProducer:
             user=user,
             triggered_user=triggered,
         )
-        payload = AnycastMessagePayload.from_event_args(
-            name=MessageName(event.event_name()),
+        message = event.to_message()
+        payload = AnycastMessagePayload.from_event_body(
+            name=message.name,
             source=source,
-            args=event.serialize(),
+            payload=message.payload,
             metadata=metadata,
         )
         await self._msg_queue.send(payload)
@@ -724,10 +724,11 @@ class EventProducer:
             user=user,
             triggered_user=triggered,
         )
-        payload = BroadcastMessagePayload.from_event_args(
-            name=MessageName(event.event_name()),
+        message = event.to_message()
+        payload = BroadcastMessagePayload.from_event_body(
+            name=message.name,
             source=source,
-            args=event.serialize(),
+            payload=message.payload,
             metadata=metadata,
         )
         await self._msg_queue.broadcast(payload)
@@ -750,10 +751,11 @@ class EventProducer:
             user=user,
             triggered_user=triggered,
         )
-        payload = BroadcastMessagePayload.from_event_args(
-            name=MessageName(event.event_name()),
+        message = event.to_message()
+        payload = BroadcastMessagePayload.from_event_body(
+            name=message.name,
             source=str(self._source),
-            args=event.serialize(),
+            payload=message.payload,
             metadata=metadata,
         )
         await self._msg_queue.broadcast_with_cache(
@@ -786,10 +788,11 @@ class EventProducer:
 
         broadcast_payloads: list[CachedBroadcastMessagePayload] = []
         for event in events:
-            payload = BroadcastMessagePayload.from_event_args(
-                name=MessageName(event.event_name()),
+            message = event.to_message()
+            payload = BroadcastMessagePayload.from_event_body(
+                name=message.name,
                 source=str(self._source),
-                args=event.serialize(),
+                payload=message.payload,
                 metadata=metadata,
             )
             broadcast_payloads.append(

--- a/src/ai/backend/common/events/event_types/agent/anycast.py
+++ b/src/ai/backend/common/events/event_types/agent/anycast.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, Self, override
+from typing import override
 
 from pydantic import Field
 
@@ -10,6 +10,7 @@ from ai.backend.common.events.types import (
     EventDomain,
 )
 from ai.backend.common.events.user_event.user_event import UserEvent
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AgentId,
     ImageCanonical,
@@ -26,15 +27,6 @@ class BaseAgentEvent(AbstractAnycastEvent):
 
 class BaseAgentLifecycleEvent(BaseAgentEvent):
     reason: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.reason,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(reason=value[0])
 
     @override
     def domain_id(self) -> str | None:
@@ -72,30 +64,9 @@ class AgentOperationEvent(BaseAgentEvent):
 class AgentErrorEvent(AgentOperationEvent):
     message: str
     traceback: str | None = None
-    user: Any | None = None
-    context_env: Mapping[str, Any] = Field(default_factory=dict)
+    user: UserID | None = None
+    context_env: Mapping[str, str] = Field(default_factory=dict)
     severity: LogLevel = LogLevel.ERROR
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.message,
-            self.traceback,
-            self.user,
-            self.context_env,
-            self.severity.value,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            message=value[0],
-            traceback=value[1],
-            user=value[2],
-            context_env=value[3],
-            severity=LogLevel(value[4]),
-        )
 
     @classmethod
     @override
@@ -105,15 +76,6 @@ class AgentErrorEvent(AgentOperationEvent):
 
 class AgentHeartbeatEvent(AgentOperationEvent):
     agent_info: AgentInfo
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.agent_info.model_dump(),)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(agent_info=AgentInfo.model_validate(value[0]))
 
     @classmethod
     @override
@@ -126,15 +88,6 @@ class AgentHeartbeatEvent(AgentOperationEvent):
 class AgentImagesRemoveEvent(AgentOperationEvent):
     image_canonicals: list[ImageCanonical]
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.image_canonicals,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(image_canonicals=value[0])
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -144,21 +97,6 @@ class AgentImagesRemoveEvent(AgentOperationEvent):
 class AgentInstalledImagesRemoveEvent(AgentOperationEvent):
     scanned_images: Mapping[ImageCanonical, ScannedImage]
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        result = {}
-        for canonical, image in self.scanned_images.items():
-            result[str(canonical)] = image.to_dict()
-        return (result,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        result = {}
-        for canonical, image_data in value[0].items():
-            result[ImageCanonical(canonical)] = ScannedImage.from_dict(image_data)
-        return cls(scanned_images=result)
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -167,15 +105,6 @@ class AgentInstalledImagesRemoveEvent(AgentOperationEvent):
 
 class DoAgentResourceCheckEvent(AgentOperationEvent):
     agent_id: AgentId
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.agent_id,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(agent_id=AgentId(value[0]))
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/artifact/anycast.py
+++ b/src/ai/backend/common/events/event_types/artifact/anycast.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.data.artifact.types import (
     ArtifactRegistryType,
@@ -49,20 +49,6 @@ class ModelVerifyingEvent(BaseArtifactEvent):
         return "model_verifying"
 
     @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.model_id, self.revision, self.registry_type, self.registry_name)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            model_id=value[0],
-            revision=value[1],
-            registry_type=value[2],
-            registry_name=value[3],
-        )
-
-    @override
     def domain_id(self) -> str | None:
         return None
 
@@ -86,39 +72,6 @@ class ModelImportDoneEvent(BaseArtifactEvent):
         return "model_import_done"
 
     @override
-    def serialize(self) -> tuple[Any, ...]:
-        verification_result = None
-        if self.verification_result is not None:
-            verification_result = self.verification_result.model_dump()
-
-        return (
-            self.model_id,
-            self.revision,
-            self.registry_type,
-            self.registry_name,
-            self.success,
-            self.digest,
-            verification_result,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        verification_result = None
-        if value[6] is not None:
-            verification_result = VerificationStepResult.model_validate(value[6])
-
-        return cls(
-            model_id=value[0],
-            revision=value[1],
-            registry_type=value[2],
-            registry_name=value[3],
-            success=value[4],
-            digest=value[5],
-            verification_result=verification_result,
-        )
-
-    @override
     def domain_id(self) -> str | None:
         return None
 
@@ -134,31 +87,6 @@ class ModelMetadataFetchDoneEvent(BaseArtifactEvent):
     @override
     def event_name(cls) -> str:
         return "models_metadata_fetch_done"
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.model.model_id,
-            self.model.revision,
-            self.model.readme_content,
-            self.model.registry_name,
-            self.model.registry_type,
-            self.model.size,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            model=ModelMetadataInfo(
-                model_id=value[0],
-                revision=value[1],
-                readme_content=value[2],
-                registry_name=value[3],
-                registry_type=value[4],
-                size=value[5],
-            )
-        )
 
     @override
     def domain_id(self) -> str | None:

--- a/src/ai/backend/common/events/event_types/artifact_registry/anycast.py
+++ b/src/ai/backend/common/events/event_types/artifact_registry/anycast.py
@@ -1,4 +1,4 @@
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
@@ -6,15 +6,6 @@ from ai.backend.common.events.user_event.user_event import UserEvent
 
 class DoScanReservoirRegistryEvent(AbstractAnycastEvent):
     """Event to trigger reservoir registry scanning."""
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return ()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/bgtask/broadcast.py
+++ b/src/ai/backend/common/events/event_types/bgtask/broadcast.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Self, override
+from typing import override
 
 from pydantic import Field
 
@@ -39,25 +39,6 @@ class BgtaskUpdatedEvent(BaseBgtaskEvent):
     total_progress: float
     message: str | None = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.task_id),
-            self.current_progress,
-            self.total_progress,
-            self.message,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            task_id=uuid.UUID(value[0]),
-            current_progress=value[1],
-            total_progress=value[2],
-            message=value[3],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -83,21 +64,6 @@ class BaseBgtaskDoneEvent(BaseBgtaskEvent):
     """
 
     message: str | None = None
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.task_id),
-            self.message,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            task_id=uuid.UUID(value[0]),
-            message=value[1],
-        )
 
 
 class BgtaskDoneEvent(BaseBgtaskDoneEvent):
@@ -160,23 +126,6 @@ class BgtaskFailedEvent(BaseBgtaskDoneEvent):
 
 class BgtaskPartialSuccessEvent(BaseBgtaskDoneEvent):
     errors: list[str] = Field(default_factory=list)
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.task_id),
-            self.message,
-            self.errors,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            task_id=uuid.UUID(value[0]),
-            message=value[1],
-            errors=value[2],
-        )
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/idle/anycast.py
+++ b/src/ai/backend/common/events/event_types/idle/anycast.py
@@ -1,19 +1,10 @@
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 
 
 class BaseIdleCheckEvent(AbstractAnycastEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return tuple()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
-
     @classmethod
     @override
     def event_domain(cls) -> EventDomain:

--- a/src/ai/backend/common/events/event_types/image/anycast.py
+++ b/src/ai/backend/common/events/event_types/image/anycast.py
@@ -1,4 +1,4 @@
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
@@ -28,36 +28,6 @@ class ImagePullStartedEvent(BaseImageEvent):
     timestamp: float
     image_ref: ImageRef | None = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        if self.image_ref is None:
-            return (self.image, str(self.agent_id), self.timestamp)
-
-        return (
-            self.image,
-            str(self.agent_id),
-            self.timestamp,
-            self.image_ref,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        # Backward compatibility
-        if len(value) <= 3:
-            return cls(
-                image=value[0],
-                agent_id=AgentId(value[1]),
-                timestamp=value[2],
-            )
-
-        return cls(
-            image=value[0],
-            agent_id=AgentId(value[1]),
-            timestamp=value[2],
-            image_ref=value[3],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -69,36 +39,6 @@ class ImagePullFinishedEvent(BaseImageEvent):
     msg: str | None = None
     image_ref: ImageRef | None = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.image,
-            str(self.agent_id),
-            self.timestamp,
-            self.msg,
-            self.image_ref,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        # Backward compatibility
-        if len(value) <= 4:
-            return cls(
-                image=value[0],
-                agent_id=AgentId(value[1]),
-                timestamp=value[2],
-                msg=value[3],
-            )
-
-        return cls(
-            image=value[0],
-            agent_id=AgentId(value[1]),
-            timestamp=value[2],
-            msg=value[3],
-            image_ref=value[4],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -108,30 +48,6 @@ class ImagePullFinishedEvent(BaseImageEvent):
 class ImagePullFailedEvent(BaseImageEvent):
     msg: str
     image_ref: ImageRef | None = None
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        if self.image_ref is None:
-            return (self.image, str(self.agent_id), self.msg)
-        return (self.image, str(self.agent_id), self.msg, self.image_ref)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        # Backward compatibility
-        if len(value) <= 3:
-            return cls(
-                image=value[0],
-                agent_id=AgentId(value[1]),
-                msg=value[2],
-            )
-
-        return cls(
-            image=value[0],
-            agent_id=AgentId(value[1]),
-            msg=value[2],
-            image_ref=value[3],
-        )
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/kernel/anycast.py
+++ b/src/ai/backend/common/events/event_types/kernel/anycast.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import uuid
-from collections.abc import Mapping
-from typing import Any, Self, override
+from typing import override
 
-from pydantic import Field
-
+from ai.backend.common.events.event_types.kernel.types import KernelCreationInfo
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 from ai.backend.common.types import KernelId, SessionId
@@ -36,27 +33,6 @@ class KernelLifecycleEvent(BaseKernelEvent):
 
 
 class KernelCreationEvent(KernelLifecycleEvent):
-    creation_info: Mapping[str, Any] = Field(default_factory=dict)
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.reason,
-            self.creation_info,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            reason=value[2],
-            creation_info=value[3],
-        )
-
     @override
     def user_event(self) -> UserEvent | None:
         return None
@@ -84,6 +60,10 @@ class KernelCreatingAnycastEvent(KernelCreationEvent):
 
 
 class KernelStartedAnycastEvent(KernelCreationEvent):
+    """The only creation event that reports how the container came up."""
+
+    creation_info: KernelCreationInfo
+
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -91,23 +71,6 @@ class KernelStartedAnycastEvent(KernelCreationEvent):
 
 
 class KernelCancelledAnycastEvent(KernelLifecycleEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            reason=value[2],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -118,25 +81,6 @@ class KernelTerminationEvent(BaseKernelEvent):
     session_id: SessionId
     reason: KernelLifecycleEventReason = KernelLifecycleEventReason.UNKNOWN
     exit_code: int = -1
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.reason,
-            self.exit_code,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            reason=value[2],
-            exit_code=value[3],
-        )
 
     @override
     def domain_id(self) -> str | None:
@@ -163,21 +107,6 @@ class KernelTerminatedAnycastEvent(KernelTerminationEvent):
 
 class DoSyncKernelLogsEvent(BaseKernelEvent):
     container_id: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            self.container_id,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            container_id=value[1],
-        )
 
     @override
     def user_event(self) -> UserEvent | None:

--- a/src/ai/backend/common/events/event_types/kernel/broadcast.py
+++ b/src/ai/backend/common/events/event_types/kernel/broadcast.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import uuid
-from collections.abc import Mapping
-from typing import Any, Self, override
+from typing import override
 
-from pydantic import Field
-
+from ai.backend.common.events.event_types.kernel.types import KernelCreationInfo
 from ai.backend.common.events.types import AbstractBroadcastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 from ai.backend.common.types import KernelId, SessionId
@@ -36,27 +33,6 @@ class KernelLifecycleEvent(BaseKernelEvent):
 
 
 class KernelCreationEvent(KernelLifecycleEvent):
-    creation_info: Mapping[str, Any] = Field(default_factory=dict)
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.reason,
-            self.creation_info,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            reason=value[2],
-            creation_info=value[3],
-        )
-
     @override
     def user_event(self) -> UserEvent | None:
         return None
@@ -84,6 +60,10 @@ class KernelCreatingBroadcastEvent(KernelCreationEvent):
 
 
 class KernelStartedBroadcastEvent(KernelCreationEvent):
+    """The only creation event that reports how the container came up."""
+
+    creation_info: KernelCreationInfo
+
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -91,23 +71,6 @@ class KernelStartedBroadcastEvent(KernelCreationEvent):
 
 
 class KernelCancelledBroadcastEvent(KernelLifecycleEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            reason=value[2],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -118,25 +81,6 @@ class KernelTerminationEvent(BaseKernelEvent):
     session_id: SessionId
     reason: KernelLifecycleEventReason = KernelLifecycleEventReason.UNKNOWN
     exit_code: int = -1
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.kernel_id),
-            str(self.session_id),
-            self.reason,
-            self.exit_code,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            kernel_id=KernelId(uuid.UUID(value[0])),
-            session_id=SessionId(uuid.UUID(value[1])),
-            reason=value[2],
-            exit_code=value[3],
-        )
 
     @override
     def user_event(self) -> UserEvent | None:

--- a/src/ai/backend/common/events/event_types/kernel/types.py
+++ b/src/ai/backend/common/events/event_types/kernel/types.py
@@ -1,5 +1,6 @@
 import enum
-from collections.abc import Mapping
+from collections import defaultdict
+from collections.abc import Mapping, MutableMapping, Sequence
 from decimal import Decimal
 from typing import Self
 
@@ -8,9 +9,11 @@ from ai.backend.common.types import (
     BackendAISchema,
     ContainerId,
     DeviceId,
+    DeviceModelInfo,
     DeviceName,
     ResourceSlotEntry,
     ServicePortProtocols,
+    SlotName,
 )
 
 
@@ -73,6 +76,24 @@ class UsedDevice(BackendAISchema):
     processing_units: int | None
     memory_size: int | None
 
+    @classmethod
+    def from_model_info(
+        cls,
+        used: Mapping[ResourceSlotName, Decimal],
+        model: DeviceModelInfo | None,
+    ) -> Self:
+        """Describe one unit from its amounts and what the device plugin reports of it."""
+        if model is None:
+            return cls(model_name=None, used=used, processing_units=None, memory_size=None)
+        capacity = model["data"]
+        memory_size = capacity.get("mem")
+        return cls(
+            model_name=model["model_name"],
+            used=used,
+            processing_units=capacity.get("proc"),
+            memory_size=int(memory_size) if memory_size is not None else None,
+        )
+
 
 class UsedDevices(BackendAISchema):
     """
@@ -83,6 +104,38 @@ class UsedDevices(BackendAISchema):
     """
 
     units: Mapping[DeviceName, Mapping[DeviceId, UsedDevice]]
+
+    @classmethod
+    def from_allocations(
+        cls,
+        allocations: Mapping[DeviceName, Mapping[SlotName, Mapping[DeviceId, Decimal]]],
+        attached_devices: Mapping[DeviceName, Sequence[DeviceModelInfo]],
+    ) -> Self:
+        """
+        Build the payload from the two forms the agent holds it in.
+
+        The amounts and the device facts arrive apart — the agent's resource spec keys
+        the amounts by slot and then by unit, while `get_attached_devices()` describes
+        the units themselves — so they are transposed and joined here by device id. An
+        intrinsic slot has no plugin describing it, and its units carry the amounts alone.
+        """
+        units: dict[DeviceName, dict[DeviceId, UsedDevice]] = {}
+        for device_name, per_slot_alloc in allocations.items():
+            models = {
+                DeviceId(str(info["device_id"])): info
+                for info in attached_devices.get(device_name, [])
+            }
+            used_by_unit: MutableMapping[DeviceId, dict[ResourceSlotName, Decimal]] = defaultdict(
+                dict
+            )
+            for slot_name, per_unit_alloc in per_slot_alloc.items():
+                for device_id, amount in per_unit_alloc.items():
+                    used_by_unit[device_id][ResourceSlotName(str(slot_name))] = amount
+            units[device_name] = {
+                device_id: UsedDevice.from_model_info(used, models.get(device_id))
+                for device_id, used in used_by_unit.items()
+            }
+        return cls(units=units)
 
     @property
     def slot_totals(self) -> list[ResourceSlotEntry]:

--- a/src/ai/backend/common/events/event_types/notification/anycast.py
+++ b/src/ai/backend/common/events/event_types/notification/anycast.py
@@ -8,7 +8,6 @@ from pydantic import Field
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
-from ai.backend.common.json import dump_json_str, load_json
 from ai.backend.common.types import BackendAISchema
 
 __all__ = ("NotificationTriggeredEvent",)
@@ -54,20 +53,3 @@ class NotificationTriggeredEvent(BackendAISchema, AbstractAnycastEvent):
     @override
     def user_event(self) -> UserEvent | None:
         return None
-
-    @override
-    def serialize(self) -> tuple[bytes, ...]:
-        return (
-            self.rule_type.encode(),
-            self.timestamp.isoformat().encode(),
-            dump_json_str(self.notification_data).encode(),
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[bytes, ...]) -> NotificationTriggeredEvent:
-        return cls(
-            rule_type=value[0].decode(),
-            timestamp=datetime.fromisoformat(value[1].decode()),
-            notification_data=load_json(value[2]),
-        )

--- a/src/ai/backend/common/events/event_types/schedule/anycast.py
+++ b/src/ai/backend/common/events/event_types/schedule/anycast.py
@@ -1,19 +1,10 @@
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
 
 
 class BaseScheduleEvent(AbstractAnycastEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return tuple()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
-
     @classmethod
     @override
     def event_domain(cls) -> EventDomain:
@@ -32,15 +23,6 @@ class DoSokovanProcessIfNeededEvent(AbstractAnycastEvent):
     """Event to trigger Sokovan scheduler to process if marks are present (short cycle)."""
 
     schedule_type: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.schedule_type,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(schedule_type=value[0])
 
     @classmethod
     @override
@@ -65,15 +47,6 @@ class DoSokovanProcessScheduleEvent(AbstractAnycastEvent):
     """Event to trigger Sokovan scheduler to process unconditionally (long cycle)."""
 
     schedule_type: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.schedule_type,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(schedule_type=value[0])
 
     @classmethod
     @override
@@ -100,15 +73,6 @@ class DoDeploymentLifecycleIfNeededEvent(AbstractAnycastEvent):
     lifecycle_type: str
     sub_step: str | None = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.lifecycle_type, self.sub_step)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(lifecycle_type=value[0], sub_step=value[1] if len(value) > 1 else None)
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -134,15 +98,6 @@ class DoDeploymentLifecycleEvent(AbstractAnycastEvent):
     lifecycle_type: str
     sub_step: str | None = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.lifecycle_type, self.sub_step)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(lifecycle_type=value[0], sub_step=value[1] if len(value) > 1 else None)
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -166,15 +121,6 @@ class DoRouteLifecycleIfNeededEvent(AbstractAnycastEvent):
     """Event to trigger route lifecycle processing if needed (short cycle)."""
 
     lifecycle_type: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.lifecycle_type,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(lifecycle_type=value[0])
 
     @classmethod
     @override
@@ -200,15 +146,6 @@ class DoRouteLifecycleEvent(AbstractAnycastEvent):
 
     lifecycle_type: str
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.lifecycle_type,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(lifecycle_type=value[0])
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -233,15 +170,6 @@ class DoReconcileProcessIfNeededEvent(AbstractAnycastEvent):
 
     reconcile_type: str
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.reconcile_type,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(reconcile_type=value[0])
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -265,15 +193,6 @@ class DoReconcileProcessEvent(AbstractAnycastEvent):
     """Event to trigger a generic reconcile stage unconditionally (long cycle)."""
 
     reconcile_type: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.reconcile_type,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(reconcile_type=value[0])
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/service_discovery/anycast.py
+++ b/src/ai/backend/common/events/event_types/service_discovery/anycast.py
@@ -7,7 +7,6 @@ from pydantic import Field
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
-from ai.backend.common.json import dump_json_str, load_json
 from ai.backend.common.types import BackendAISchema
 
 __all__ = (
@@ -82,36 +81,6 @@ class ServiceRegisteredEvent(BackendAISchema, BaseServiceDiscoveryEvent):
     def event_name(cls) -> str:
         return "service_registered"
 
-    @override
-    def serialize(self) -> tuple[bytes, ...]:
-        return (
-            dump_json_str({
-                "instance_id": self.instance_id,
-                "service_group": self.service_group,
-                "display_name": self.display_name,
-                "version": self.version,
-                "labels": self.labels,
-                "endpoints": [ep.model_dump() for ep in self.endpoints],
-                "config_hash": self.config_hash,
-            }).encode(),
-            self.startup_time.isoformat().encode(),
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[bytes, ...]) -> ServiceRegisteredEvent:
-        data = load_json(value[0])
-        return cls(
-            instance_id=data["instance_id"],
-            service_group=data["service_group"],
-            display_name=data["display_name"],
-            version=data["version"],
-            labels=data.get("labels", {}),
-            endpoints=[ServiceEndpointInfo(**ep) for ep in data.get("endpoints", [])],
-            startup_time=datetime.fromisoformat(value[1].decode()),
-            config_hash=data.get("config_hash", ""),
-        )
-
 
 class DoSweepStaleServicesEvent(BaseServiceDiscoveryEvent):
     """Event to trigger sweeping stale services in the catalog."""
@@ -120,15 +89,6 @@ class DoSweepStaleServicesEvent(BaseServiceDiscoveryEvent):
     @override
     def event_name(cls) -> str:
         return "do_sweep_stale_services"
-
-    @override
-    def serialize(self) -> tuple[bytes, ...]:
-        return (b"",)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[bytes, ...]) -> DoSweepStaleServicesEvent:
-        return cls()
 
 
 class ServiceDeregisteredEvent(BackendAISchema, BaseServiceDiscoveryEvent):
@@ -141,18 +101,3 @@ class ServiceDeregisteredEvent(BackendAISchema, BaseServiceDiscoveryEvent):
     @override
     def event_name(cls) -> str:
         return "service_deregistered"
-
-    @override
-    def serialize(self) -> tuple[bytes, ...]:
-        return (
-            self.instance_id.encode(),
-            self.service_group.encode(),
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[bytes, ...]) -> ServiceDeregisteredEvent:
-        return cls(
-            instance_id=value[0].decode(),
-            service_group=value[1].decode(),
-        )

--- a/src/ai/backend/common/events/event_types/session/anycast.py
+++ b/src/ai/backend/common/events/event_types/session/anycast.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import uuid
 from abc import abstractmethod
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.kernel import KernelLifecycleEventReason
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
@@ -11,15 +10,6 @@ from ai.backend.common.types import SessionExecutionStatus, SessionId
 
 
 class SessionLifecycleEvent(AbstractAnycastEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return tuple()
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls()
-
     @classmethod
     @override
     def event_domain(cls) -> EventDomain:
@@ -54,21 +44,6 @@ class BaseSessionEvent(AbstractAnycastEvent):
 class DoTerminateSessionEvent(BaseSessionEvent):
     reason: KernelLifecycleEventReason
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            reason=value[1],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -78,23 +53,6 @@ class DoTerminateSessionEvent(BaseSessionEvent):
 class SessionCreationEvent(BaseSessionEvent):
     creation_id: str
     reason: KernelLifecycleEventReason = KernelLifecycleEventReason.UNKNOWN
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.creation_id,
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            creation_id=value[1],
-            reason=value[2],
-        )
 
     @override
     def user_event(self) -> UserEvent | None:
@@ -133,21 +91,6 @@ class SessionTerminationEvent(BaseSessionEvent):
     reason: str = ""
 
     @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            reason=value[1],
-        )
-
-    @override
     def user_event(self) -> UserEvent | None:
         return None
 
@@ -171,23 +114,6 @@ class SessionResultEvent(BaseSessionEvent):
     exit_code: int = -1
 
     @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.reason,
-            self.exit_code,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            reason=value[1],
-            exit_code=value[2],
-        )
-
-    @override
     def user_event(self) -> UserEvent | None:
         return None
 
@@ -207,17 +133,6 @@ class SessionFailureAnycastEvent(SessionResultEvent):
 
 
 class BaseSessionExecutionEvent(BaseSessionEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (str(self.session_id),)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-        )
-
     @override
     def user_event(self) -> UserEvent | None:
         return None

--- a/src/ai/backend/common/events/event_types/session/broadcast.py
+++ b/src/ai/backend/common/events/event_types/session/broadcast.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import uuid
 from dataclasses import dataclass
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.events.types import (
@@ -34,21 +33,6 @@ class BaseSessionEvent(AbstractBroadcastEvent):
 class DoTerminateSessionEvent(BaseSessionEvent):
     reason: KernelLifecycleEventReason
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            reason=value[1],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -58,23 +42,6 @@ class DoTerminateSessionEvent(BaseSessionEvent):
 class SessionCreationEvent(BaseSessionEvent):
     creation_id: str
     reason: KernelLifecycleEventReason = KernelLifecycleEventReason.UNKNOWN
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.creation_id,
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            creation_id=value[1],
-            reason=value[2],
-        )
 
     @override
     def user_event(self) -> UserEvent | None:
@@ -106,21 +73,6 @@ class SessionTerminationEvent(BaseSessionEvent):
     reason: str = ""
 
     @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            reason=value[1],
-        )
-
-    @override
     def user_event(self) -> UserEvent | None:
         return None
 
@@ -142,23 +94,6 @@ class SessionTerminatedBroadcastEvent(SessionTerminationEvent):
 class SessionResultEvent(BaseSessionEvent):
     reason: KernelLifecycleEventReason = KernelLifecycleEventReason.UNKNOWN
     exit_code: int = -1
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.reason,
-            self.exit_code,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            reason=value[1],
-            exit_code=value[2],
-        )
 
     @override
     def user_event(self) -> UserEvent | None:
@@ -203,25 +138,6 @@ class SchedulingBroadcastEvent(AbstractBroadcastEvent):
     @override
     def domain_id(self) -> str | None:
         return str(self.session_id)
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.session_id),
-            self.creation_id,
-            self.status_transition,
-            self.reason,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            session_id=SessionId(uuid.UUID(value[0])),
-            creation_id=value[1],
-            status_transition=value[2],
-            reason=value[3],
-        )
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/vfolder/anycast.py
+++ b/src/ai/backend/common/events/event_types/vfolder/anycast.py
@@ -1,4 +1,4 @@
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.types import AbstractAnycastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
@@ -23,17 +23,6 @@ class VFolderEvent(AbstractAnycastEvent):
 
 
 class VFolderDeletionSuccessEvent(VFolderEvent):
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (str(self.vfid),)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            vfid=VFolderID.from_str(value[0]),
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -42,21 +31,6 @@ class VFolderDeletionSuccessEvent(VFolderEvent):
 
 class VFolderDeletionFailureEvent(VFolderEvent):
     message: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.vfid),
-            self.message,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            vfid=VFolderID.from_str(value[0]),
-            message=value[1],
-        )
 
     @classmethod
     @override
@@ -67,21 +41,6 @@ class VFolderDeletionFailureEvent(VFolderEvent):
 class VFolderCloneSuccessEvent(VFolderEvent):
     dst_vfid: VFolderID
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.vfid),
-            str(self.dst_vfid),
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            vfid=VFolderID.from_str(value[0]),
-            dst_vfid=VFolderID.from_str(value[1]),
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -91,23 +50,6 @@ class VFolderCloneSuccessEvent(VFolderEvent):
 class VFolderCloneFailureEvent(VFolderEvent):
     dst_vfid: VFolderID
     message: str
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            str(self.vfid),
-            str(self.dst_vfid),
-            self.message,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            vfid=VFolderID.from_str(value[0]),
-            dst_vfid=VFolderID.from_str(value[1]),
-            message=value[2],
-        )
 
     @classmethod
     @override

--- a/src/ai/backend/common/events/event_types/volume/broadcast.py
+++ b/src/ai/backend/common/events/event_types/volume/broadcast.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Self, override
+from typing import override
 
 from ai.backend.common.events.types import AbstractBroadcastEvent, EventDomain
 from ai.backend.common.events.user_event.user_event import UserEvent
@@ -39,35 +39,6 @@ class DoVolumeMountEvent(BaseVolumeEvent):
     edit_fstab: bool = False
     fstab_path: str = "/etc/fstab"
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.dir_name,
-            self.volume_backend_name,
-            str(self.quota_scope_id),
-            self.fs_location,
-            self.fs_type,
-            self.cmd_options,
-            self.scaling_group,
-            self.edit_fstab,
-            self.fstab_path,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            dir_name=value[0],
-            volume_backend_name=value[1],
-            quota_scope_id=QuotaScopeID.parse(value[2]),
-            fs_location=value[3],
-            fs_type=value[4],
-            cmd_options=value[5],
-            scaling_group=value[6],
-            edit_fstab=value[7],
-            fstab_path=value[8],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -87,29 +58,6 @@ class DoVolumeUnmountEvent(BaseVolumeEvent):
     edit_fstab: bool = False
     fstab_path: str | None = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.dir_name,
-            self.volume_backend_name,
-            str(self.quota_scope_id),
-            self.scaling_group,
-            self.edit_fstab,
-            self.fstab_path,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            dir_name=value[0],
-            volume_backend_name=value[1],
-            quota_scope_id=QuotaScopeID.parse(value[2]),
-            scaling_group=value[3],
-            edit_fstab=value[4],
-            fstab_path=value[5],
-        )
-
     @classmethod
     @override
     def event_name(cls) -> str:
@@ -122,27 +70,6 @@ class BaseAgentVolumeMountEvent(BaseVolumeEvent):
     mount_path: str
     quota_scope_id: QuotaScopeID
     err_msg: str | None = None
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (
-            self.node_id,
-            str(self.node_type),
-            self.mount_path,
-            str(self.quota_scope_id),
-            self.err_msg,
-        )
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> Self:
-        return cls(
-            node_id=value[0],
-            node_type=VolumeMountableNodeType(value[1]),
-            mount_path=value[2],
-            quota_scope_id=QuotaScopeID.parse(value[3]),
-            err_msg=value[4],
-        )
 
 
 class VolumeMounted(BaseAgentVolumeMountEvent):

--- a/src/ai/backend/common/events/fetcher.py
+++ b/src/ai/backend/common/events/fetcher.py
@@ -19,4 +19,4 @@ class EventFetcher:
         payload = await self._msg_queue.fetch_cached_broadcast_message(cache_id)
         if payload is None:
             return None
-        return AbstractBroadcastEvent.deserialize_from_wrapper(payload)
+        return AbstractBroadcastEvent.from_broadcast_payload(payload)

--- a/src/ai/backend/common/events/types.py
+++ b/src/ai/backend/common/events/types.py
@@ -119,21 +119,6 @@ class AbstractEvent(BaseModel, ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def serialize(self) -> tuple[bytes, ...]:
-        """
-        Return a msgpack-serializable tuple.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def deserialize(cls, value: tuple[bytes, ...]) -> Self:
-        """
-        Construct the event args from a tuple deserialized from msgpack.
-        """
-        raise NotImplementedError
-
     @classmethod
     @abstractmethod
     def event_domain(cls) -> EventDomain:
@@ -198,14 +183,18 @@ class AbstractBroadcastEvent(AbstractEvent):
             return
 
     @classmethod
-    def deserialize_from_wrapper(cls, payload: BroadcastMessagePayload) -> "AbstractBroadcastEvent":
+    def from_broadcast_payload(cls, payload: BroadcastMessagePayload) -> "AbstractBroadcastEvent":
         """
-        Deserialize the event from its broadcast payload.
+        Reconstruct the event a broadcast payload carries.
+
+        A payload names its event but does not carry its class, so this is where the
+        name is resolved against the registry — the one place a subscriber that holds
+        only a payload can get back to a typed event.
         """
         event_class = cls._register_dict.get(payload.name)
         if not event_class:
             raise ValueError(f"Event class for name {payload.name} not found")
-        return event_class.deserialize(payload.decode_args())
+        return event_class.from_message(EventMessage(name=payload.name, payload=payload.payload))
 
     @classmethod
     @override

--- a/src/ai/backend/common/message_queue/AGENTS.md
+++ b/src/ai/backend/common/message_queue/AGENTS.md
@@ -13,7 +13,8 @@ Abstraction over Redis streams (anycast) and pub/sub (broadcast). `RedisQueue` (
 - Subscribers do not ack (broadcast may be lost by design).
 - Anycast carries `AnycastMessagePayload`, broadcast carries `BroadcastMessagePayload`. Do not mix, and do not hand-build the wire mapping — the payload models own the encoding.
 - An event's own body reaches this layer as `EventMessage` (`common/events/message.py`) — `name` plus the already-serialized `payload`. This layer adds `source`, `metadata`, and `retry_count`; an event never supplies them.
-- `legacy_source` / `legacy_body` are on the way out. Construct them by their wire keys (`source=` / `body=`) and do not add new readers of them — new code goes through `payload`.
+- `legacy_source` is on the way out. Construct it by its wire key (`source=`) and do not add new readers of it.
+- The body on the wire is JSON and nothing else — do NOT reintroduce msgpack here.
 - Decode received messages with `from_stream_fields()` / `from_json()`; they raise `InvalidMessagePayloadError` instead of failing later at field access.
 - Configure only the streams/channels you use (`consume_stream_keys=None` / `subscribe_channels=None`) to avoid idle background loops.
 - Always `await close()` the queue/components to avoid connection and task leaks.

--- a/src/ai/backend/common/message_queue/payload.py
+++ b/src/ai/backend/common/message_queue/payload.py
@@ -1,20 +1,17 @@
-import base64
-import binascii
 from collections.abc import Mapping
-from typing import Any, Final, Self, cast
+from typing import Final, Self
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from ai.backend.common import msgpack
 from ai.backend.common.json import dump_json, load_json
 
 from .exceptions import InvalidMessagePayloadError
 from .types import MessageMetadata, MessageName
 
-# Wire field names. The body is still carried as "args" until the producers cut over to JSON.
+# Wire field names.
 _NAME_FIELD: Final[str] = "name"
 _SOURCE_FIELD: Final[str] = "source"
-_BODY_FIELD: Final[str] = "args"
+_PAYLOAD_FIELD: Final[str] = "payload"
 _METADATA_FIELD: Final[str] = "metadata"
 _RETRY_COUNT_FIELD: Final[str] = "_retry_count"
 
@@ -27,13 +24,8 @@ class AnycastMessagePayload(BaseModel):
     A payload delivered to exactly one consumer, carried as the field mapping of a
     stream entry.
 
-    `payload` holds the serialized event arguments in the form a stream field takes.
-    It is not on the wire yet: producers still fill `legacy_body`, so it stays None
-    until the producer cutover.
-
-    `legacy_body` is opaque to this layer: it holds the msgpack-packed event arguments
-    and is neither inspected nor decoded here. It is superseded by `payload` and goes
-    away once no supported producer writes msgpack.
+    `payload` is the JSON-serialized event body. It is opaque to this layer: what shape
+    the body has is the event's business, not the transport's.
 
     `retry_count` is transport-level redelivery state maintained by the auto-claim
     path. Broadcast has no ack path, so it has no counterpart there.
@@ -42,31 +34,24 @@ class AnycastMessagePayload(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     name: MessageName
-    payload: bytes | None = None
+    payload: str
     legacy_source: str = Field(validation_alias="source")
-    legacy_body: bytes = Field(validation_alias="body")
     metadata: MessageMetadata | None = None
     retry_count: int = 0
 
     @classmethod
-    def from_event_args(
+    def from_event_body(
         cls,
         *,
         name: MessageName,
         source: str,
-        args: tuple[Any, ...],
+        payload: str,
         metadata: MessageMetadata | None = None,
     ) -> Self:
         """
-        Build a payload out of the serializable arguments of an event.
+        Build a payload out of the serialized body of an event.
         """
-        return cls(name=name, source=source, body=msgpack.packb(args), metadata=metadata)
-
-    def decode_args(self) -> tuple[Any, ...]:
-        """
-        Decode the event arguments carried by the body.
-        """
-        return cast(tuple[Any, ...], msgpack.unpackb(self.legacy_body))
+        return cls(name=name, source=source, payload=payload, metadata=metadata)
 
     def to_stream_fields(self) -> dict[bytes, bytes]:
         """
@@ -75,7 +60,7 @@ class AnycastMessagePayload(BaseModel):
         fields = {
             _NAME_FIELD.encode(): self.name.encode("utf-8"),
             _SOURCE_FIELD.encode(): self.legacy_source.encode("utf-8"),
-            _BODY_FIELD.encode(): self.legacy_body,
+            _PAYLOAD_FIELD.encode(): self.payload.encode("utf-8"),
         }
         if self.metadata is not None:
             fields[_METADATA_FIELD.encode()] = self.metadata.serialize()
@@ -97,11 +82,11 @@ class AnycastMessagePayload(BaseModel):
             return cls(
                 name=MessageName(fields[_NAME_FIELD.encode()].decode("utf-8")),
                 source=fields[_SOURCE_FIELD.encode()].decode("utf-8"),
-                body=fields[_BODY_FIELD.encode()],
+                payload=fields[_PAYLOAD_FIELD.encode()].decode("utf-8"),
                 metadata=MessageMetadata.deserialize(raw_metadata) if raw_metadata else None,
                 retry_count=int(raw_retry_count) if raw_retry_count else 0,
             )
-        except _DECODE_ERRORS as e:
+        except (*_DECODE_ERRORS, UnicodeDecodeError) as e:
             raise InvalidMessagePayloadError(f"Malformed anycast message: {e}") from e
 
     def increment_retry(self) -> Self:
@@ -113,42 +98,30 @@ class BroadcastMessagePayload(BaseModel):
     A payload delivered to every subscriber, carried as a JSON message on a channel.
     There is no ack, hence no retry state.
 
-    `payload` holds the serialized event arguments in the form a JSON message takes.
-    It is not on the wire yet: producers still fill `legacy_body`, so it stays None
-    until the producer cutover.
-
-    `legacy_body` is opaque to this layer: it holds the msgpack-packed event arguments
-    and is neither inspected nor decoded here. It is superseded by `payload` and goes
-    away once no supported producer writes msgpack.
+    `payload` is the JSON-serialized event body. It is opaque to this layer: what shape
+    the body has is the event's business, not the transport's.
     """
 
     model_config = ConfigDict(frozen=True)
 
     name: MessageName
-    payload: str | None = None
+    payload: str
     legacy_source: str = Field(validation_alias="source")
-    legacy_body: bytes = Field(validation_alias="body")
     metadata: MessageMetadata | None = None
 
     @classmethod
-    def from_event_args(
+    def from_event_body(
         cls,
         *,
         name: MessageName,
         source: str,
-        args: tuple[Any, ...],
+        payload: str,
         metadata: MessageMetadata | None = None,
     ) -> Self:
         """
-        Build a payload out of the serializable arguments of an event.
+        Build a payload out of the serialized body of an event.
         """
-        return cls(name=name, source=source, body=msgpack.packb(args), metadata=metadata)
-
-    def decode_args(self) -> tuple[Any, ...]:
-        """
-        Decode the event arguments carried by the body.
-        """
-        return cast(tuple[Any, ...], msgpack.unpackb(self.legacy_body))
+        return cls(name=name, source=source, payload=payload, metadata=metadata)
 
     def to_json(self) -> bytes:
         """
@@ -157,7 +130,7 @@ class BroadcastMessagePayload(BaseModel):
         fields = {
             _NAME_FIELD: self.name,
             _SOURCE_FIELD: self.legacy_source,
-            _BODY_FIELD: base64.b64encode(self.legacy_body).decode("ascii"),
+            _PAYLOAD_FIELD: self.payload,
         }
         if self.metadata is not None:
             fields[_METADATA_FIELD] = self.metadata.serialize().decode("utf-8")
@@ -177,10 +150,10 @@ class BroadcastMessagePayload(BaseModel):
             return cls(
                 name=MessageName(fields[_NAME_FIELD]),
                 source=fields[_SOURCE_FIELD],
-                body=base64.b64decode(fields[_BODY_FIELD], validate=True),
+                payload=fields[_PAYLOAD_FIELD],
                 metadata=MessageMetadata.deserialize(raw_metadata) if raw_metadata else None,
             )
-        except (*_DECODE_ERRORS, binascii.Error, AttributeError) as e:
+        except (*_DECODE_ERRORS, AttributeError) as e:
             raise InvalidMessagePayloadError(f"Malformed broadcast message: {e}") from e
 
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -12,7 +12,6 @@ from collections.abc import (
     Sequence,
 )
 from datetime import datetime, timedelta
-from decimal import Decimal
 from typing import (
     Any,
     cast,
@@ -80,11 +79,9 @@ from ai.backend.common.types import (
     AbuseReport,
     AccessKey,
     AgentId,
-    BinarySize,
     ClusterMode,
     ClusterSSHKeyPair,
     CommitStatus,
-    DeviceId,
     HardwareMetadata,
     ImageAlias,
     ImageRegistry,
@@ -97,7 +94,6 @@ from ai.backend.common.types import (
     SessionEnqueueingConfig,
     SessionId,
     SessionTypes,
-    SlotName,
 )
 from ai.backend.common.utils import str_to_timedelta
 from ai.backend.logging import BraceStyleAdapter
@@ -1250,29 +1246,6 @@ class AgentRegistry:
             network=network,
             startup_command=startup_command,
         )
-
-    def convert_resource_spec_to_resource_slot(
-        self,
-        allocations: Mapping[str, Mapping[SlotName, Mapping[DeviceId, str]]],
-    ) -> ResourceSlot:
-        """
-        Convert per-device resource spec allocations (agent-side format)
-        back into a resource slot (manager-side format).
-        """
-        slots = ResourceSlot()
-        for alloc_map in allocations.values():
-            for slot_name, allocation_by_device in alloc_map.items():
-                total_allocs: list[Decimal] = []
-                for allocation in allocation_by_device.values():
-                    if (
-                        isinstance(allocation, (BinarySize, str))
-                        and BinarySize.suffix_map.get(allocation[-1].lower()) is not None
-                    ):
-                        total_allocs.append(Decimal(BinarySize.from_str(allocation)))
-                    else:  # maybe Decimal("Infinity"), etc.
-                        total_allocs.append(Decimal(allocation))
-                slots[slot_name] = str(sum(total_allocs))
-        return slots
 
     async def create_cluster_ssh_keypair(self) -> ClusterSSHKeyPair:
         key = rsa.generate_private_key(

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -25,6 +25,7 @@ from ai.backend.common import msgpack
 from ai.backend.common.data.permission.types import (
     RBACElementType,
 )
+from ai.backend.common.events.event_types.kernel.types import KernelCreationInfo
 from ai.backend.common.identifier.architecture import ArchName
 from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.image import ImageID
@@ -45,6 +46,7 @@ from ai.backend.common.types import (
     PreemptionMode,
     PreemptionVictimScope,
     ResourceSlot,
+    ResourceSlotEntry,
     SessionId,
     SessionTypes,
     SlotTypes,
@@ -145,7 +147,6 @@ from ai.backend.manager.views.sokovan.allocation import (
 from ai.backend.manager.views.sokovan.image import ImageConfigData
 from ai.backend.manager.views.sokovan.lifecycle import (
     KernelBindingData,
-    KernelCreationInfo,
     SessionDataForPull,
     SessionDataForStart,
     SessionsForPullWithImages,
@@ -2635,7 +2636,7 @@ class ScheduleDBSource:
 
         :param kernel_id: Kernel ID to update
         :param reason: The reason for status change
-        :param creation_info: Container creation information as dataclass
+        :param creation_info: What the agent reported about the started container
         :return: True if update was successful, False otherwise
         """
         log.debug(
@@ -2661,7 +2662,25 @@ class ScheduleDBSource:
                 log.debug("[DBSource] Kernel {} not found!", kernel_id)
 
             now = await self._get_db_now_in_session(db_sess)
-            occupied_slots = creation_info.get_resource_allocations()
+            used_devices = creation_info.used_devices
+            occupied_slots = ResourceSlotEntry.inputs_to_resource_slot(used_devices.slot_totals)
+            # The JSONB columns take plain JSON: the engine's serializer does not know
+            # how to render the typed sub-models. `attached_devices` keeps the shape its
+            # readers already expect, and stays limited to the units a plugin describes —
+            # an intrinsic slot reports no model, as it did when the agent sent this column.
+            attached_devices = {
+                str(device_name): [
+                    {
+                        "device_id": str(device_id),
+                        "model_name": device.model_name,
+                        "data": {"mem": device.memory_size, "proc": device.processing_units},
+                    }
+                    for device_id, device in units.items()
+                    if device.model_name is not None
+                ]
+                for device_name, units in used_devices.units.items()
+            }
+            service_ports = [port.model_dump(mode="json") for port in creation_info.service_ports]
             stmt = (
                 sa.update(KernelRow)
                 .where(
@@ -2677,12 +2696,10 @@ class ScheduleDBSource:
                     starts_at=now,
                     occupied_slots=occupied_slots,
                     container_id=creation_info.container_id,
-                    attached_devices=creation_info.attached_devices,
+                    attached_devices=attached_devices,
                     repl_in_port=creation_info.repl_in_port,
                     repl_out_port=creation_info.repl_out_port,
-                    stdin_port=creation_info.stdin_port,
-                    stdout_port=creation_info.stdout_port,
-                    service_ports=creation_info.service_ports,
+                    service_ports=service_ports,
                     kernel_host=creation_info.kernel_host,
                     status_history=sql_json_merge(
                         KernelRow.__table__.c.status_history,

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 from ai.backend.common.clients.valkey_client.valkey_schedule import ValkeyScheduleClient
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
+from ai.backend.common.events.event_types.kernel.types import KernelCreationInfo
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.image import ImageID
@@ -55,7 +56,6 @@ from ai.backend.manager.types import UserScope
 from ai.backend.manager.views.sokovan.agent import AgentLimit, ResourceGroupResource
 from ai.backend.manager.views.sokovan.allocation import SessionAllocation
 from ai.backend.manager.views.sokovan.lifecycle import (
-    KernelCreationInfo,
     SessionsForPullWithImages,
     SessionWithKernels,
 )

--- a/src/ai/backend/manager/sokovan/scheduler/coordinator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/coordinator.py
@@ -58,7 +58,6 @@ from ai.backend.manager.sokovan.scheduler.types import ScheduleType
 from ai.backend.manager.sokovan.scheduling_controller import SchedulingController
 from ai.backend.manager.types import DistributedLockFactory
 from ai.backend.manager.views.sokovan.lifecycle import (
-    KernelCreationInfo,
     LastPhase,
     SessionWithKernels,
 )
@@ -1613,12 +1612,10 @@ class ScheduleCoordinator:
 
     async def handle_kernel_running(self, event: KernelStartedAnycastEvent) -> bool:
         """Handle kernel running event through the kernel state engine."""
-        # Convert event data to dataclass (always present, may be empty)
-        creation_info = KernelCreationInfo.from_dict(dict(event.creation_info))
         result = await self._kernel_state_engine.mark_kernel_running(
             event.kernel_id,
             event.reason,
-            creation_info,
+            event.creation_info,
         )
         if result:
             # Request CHECK_CREATING_PROGRESS to check if session should transition to RUNNING

--- a/src/ai/backend/manager/sokovan/scheduler/kernel/state_engine.py
+++ b/src/ai/backend/manager/sokovan/scheduler/kernel/state_engine.py
@@ -8,10 +8,10 @@ All database operations go through the repository pattern.
 import logging
 from uuid import UUID
 
+from ai.backend.common.events.event_types.kernel.types import KernelCreationInfo
 from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.repositories.scheduler import SchedulerRepository
-from ai.backend.manager.views.sokovan.lifecycle import KernelCreationInfo
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -82,7 +82,7 @@ class KernelStateEngine:
 
         :param kernel_id: The kernel ID
         :param reason: The reason for the state change
-        :param creation_info: Creation information as dataclass
+        :param creation_info: What the agent reported about the started container
         :return: True if the update was successful
         """
         log.debug("Marking kernel {} as RUNNING", kernel_id)

--- a/src/ai/backend/manager/views/sokovan/lifecycle.py
+++ b/src/ai/backend/manager/views/sokovan/lifecycle.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
@@ -12,7 +11,6 @@ from ai.backend.common.identifier.architecture import ArchName
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
-    BinarySize,
     ClusterMode,
     KernelId,
     ResourceSlot,
@@ -177,111 +175,6 @@ class PreparedSessionsWithImages:
 
     sessions: list[PreparedSessionData]
     image_configs: dict[UUID, ImageConfigData]
-
-
-@dataclass
-class KernelCreationInfo:
-    """Information about kernel creation from agent."""
-
-    container_id: str | None = None
-    resource_spec: dict[str, Any] | None = None
-    attached_devices: dict[str, Any] = field(default_factory=dict)
-    repl_in_port: int | None = None
-    repl_out_port: int | None = None
-    stdin_port: int | None = None
-    stdout_port: int | None = None
-    service_ports: list[int] = field(default_factory=list)
-    kernel_host: str | None = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> KernelCreationInfo:
-        """Create from dictionary, handling missing or invalid fields."""
-        return cls(
-            container_id=data.get("container_id"),
-            resource_spec=data.get("resource_spec"),
-            attached_devices=data.get("attached_devices", {}),
-            repl_in_port=data.get("repl_in_port"),
-            repl_out_port=data.get("repl_out_port"),
-            stdin_port=data.get("stdin_port"),
-            stdout_port=data.get("stdout_port"),
-            service_ports=data.get("service_ports", []),
-            kernel_host=data.get("kernel_host"),
-        )
-
-    def get_resource_allocations(self) -> ResourceSlot:
-        """
-        Extract resource allocations from resource_spec.
-        Compatible with AgentRegistry.convert_resource_spec_to_resource_slot() format.
-
-        Handles the agent-side nested format:
-        allocations: {
-            "device_type": {
-                "slot_name": {
-                    "device_id": "value"
-                }
-            }
-        }
-        """
-        if not self.resource_spec or "allocations" not in self.resource_spec:
-            return ResourceSlot()
-
-        allocations = self.resource_spec["allocations"]
-        return self.convert_allocations_to_resource_slot(allocations)
-
-    @staticmethod
-    def convert_allocations_to_resource_slot(allocations: dict[str, Any]) -> ResourceSlot:
-        """
-        Convert per-device resource spec allocations (agent-side format)
-        back into a resource slot (manager-side format).
-
-        This is a static method that mirrors AgentRegistry.convert_resource_spec_to_resource_slot()
-        for compatibility.
-
-        Args:
-            allocations: The allocations dict from resource_spec
-
-        Returns:
-            ResourceSlot with aggregated resource values
-        """
-        if not allocations or not isinstance(allocations, dict):
-            return ResourceSlot()
-
-        slots = ResourceSlot()
-
-        # Handle the nested structure from agent
-        for alloc_map in allocations.values():
-            if not isinstance(alloc_map, dict):
-                continue
-
-            for slot_name, allocation_by_device in alloc_map.items():
-                if not isinstance(allocation_by_device, dict):
-                    # If it's not the expected nested structure,
-                    # try to use it directly as a value
-                    if allocation_by_device is not None:
-                        slots[slot_name] = str(allocation_by_device)
-                    continue
-
-                # Sum allocations across devices
-                total_allocs: list[Decimal] = []
-                for allocation in allocation_by_device.values():
-                    if allocation is None:
-                        continue
-
-                    # Handle BinarySize values (e.g., "1073741824b", "1g")
-                    if (
-                        isinstance(allocation, str)
-                        and len(allocation) > 0
-                        and BinarySize.suffix_map.get(allocation[-1].lower()) is not None
-                    ):
-                        total_allocs.append(Decimal(BinarySize.from_str(allocation)))
-                    else:
-                        # Regular decimal value or special values like "Infinity"
-                        total_allocs.append(Decimal(allocation))
-
-                if total_allocs:
-                    slots[slot_name] = str(sum(total_allocs))
-
-        return slots
 
 
 @dataclass(frozen=True)

--- a/tests/unit/common/clients/valkey_client/test_valkey_stream_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_stream_client.py
@@ -11,11 +11,11 @@ from ai.backend.common.message_queue.types import MessageName
 
 
 def _anycast_payload() -> AnycastMessagePayload:
-    return AnycastMessagePayload(name=MessageName("test-event"), source="i-test", body=b"body")
+    return AnycastMessagePayload(name=MessageName("test-event"), source="i-test", payload="{}")
 
 
 def _broadcast_payload() -> BroadcastMessagePayload:
-    return BroadcastMessagePayload(name=MessageName("test-event"), source="i-test", body=b"body")
+    return BroadcastMessagePayload(name=MessageName("test-event"), source="i-test", payload="{}")
 
 
 async def test_valkey_stream_anycast(test_valkey_stream: ValkeyStreamClient) -> None:

--- a/tests/unit/common/events/test_agent_heartbeat_event.py
+++ b/tests/unit/common/events/test_agent_heartbeat_event.py
@@ -113,7 +113,7 @@ class TestAgentHeartbeatEvent:
         ],
         ids=["string_keys", "slotname_keys", "mixed_keys"],
     )
-    async def test_serialization_deserialization_round_trip_with_different_key_formats(
+    async def test_message_roundtrip_with_different_key_formats(
         self,
         agent_info_dict: dict[str, Any],
         expected_slot_keys: dict[SlotName, SlotTypes],
@@ -121,7 +121,6 @@ class TestAgentHeartbeatEvent:
         """The slot key form used to build the event does not survive into a difference."""
         event = AgentHeartbeatEvent(agent_info=AgentInfo.model_validate(agent_info_dict))
 
-        serialized = event.serialize()
-        deserialized = AgentHeartbeatEvent.deserialize(serialized)
+        deserialized = AgentHeartbeatEvent.from_message(event.to_message())
 
         assert deserialized.agent_info.slot_key_and_units == expected_slot_keys

--- a/tests/unit/common/events/test_dispatcher.py
+++ b/tests/unit/common/events/test_dispatcher.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
-from typing import Any, override
+from typing import override
 
-import msgpack
 import pytest
 
 from ai.backend.common.events.dispatcher import EventDispatcher
@@ -22,15 +21,6 @@ from ai.backend.common.types import AgentId
 
 class DummyAnycastEvent(AbstractAnycastEvent):
     value: int
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.value,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> DummyAnycastEvent:
-        return cls(value=value[0])
 
     @classmethod
     @override
@@ -54,15 +44,6 @@ class DummyAnycastEvent(AbstractAnycastEvent):
 class DummyBroadcastEvent(AbstractBroadcastEvent):
     value: int
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.value,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> DummyBroadcastEvent:
-        return cls(value=value[0])
-
     @classmethod
     @override
     def event_domain(cls) -> EventDomain:
@@ -83,21 +64,23 @@ class DummyBroadcastEvent(AbstractBroadcastEvent):
 
 
 def _make_anycast_mq_message(event: AbstractAnycastEvent) -> MQMessage:
+    message = event.to_message()
     return MQMessage(
         msg_id=b"test-msg-id",
         payload=AnycastMessagePayload(
-            name=MessageName(event.event_name()),
+            name=message.name,
             source="i-test",
-            body=msgpack.packb(event.serialize()),
+            payload=message.payload,
         ),
     )
 
 
 def _make_broadcast_payload(event: AbstractBroadcastEvent) -> BroadcastMessagePayload:
+    message = event.to_message()
     return BroadcastMessagePayload(
-        name=MessageName(event.event_name()),
+        name=message.name,
         source="i-test",
-        body=msgpack.packb(event.serialize()),
+        payload=message.payload,
     )
 
 
@@ -239,3 +222,57 @@ class TestDispatchSubscribers:
         await no_subscriber_dispatcher.start()
         await asyncio.sleep(0.1)
         await no_subscriber_dispatcher.close()
+
+
+class TestUndecodablePayload:
+    """A body the handler's event class cannot validate is dropped, not retried forever.
+
+    Redelivery cannot fix a payload that does not match the schema, so the message has to
+    be acked — otherwise it occupies the stream until the retry limit discards it.
+    """
+
+    @pytest.fixture
+    def received(self) -> list[DummyAnycastEvent]:
+        return []
+
+    @pytest.fixture
+    def mq(self) -> StubMessageQueue:
+        return StubMessageQueue(
+            anycast_messages=[
+                MQMessage(
+                    msg_id=b"test-msg-id",
+                    payload=AnycastMessagePayload(
+                        name=MessageName(DummyAnycastEvent.event_name()),
+                        source="i-test",
+                        payload='{"value":"not-an-int"}',
+                    ),
+                )
+            ],
+        )
+
+    @pytest.fixture
+    async def dispatcher(
+        self,
+        mq: StubMessageQueue,
+        received: list[DummyAnycastEvent],
+    ) -> EventDispatcher:
+        dispatcher = EventDispatcher(mq)  # type: ignore[arg-type]
+
+        async def handler(ctx: object, source: AgentId, ev: DummyAnycastEvent) -> None:
+            received.append(ev)
+
+        dispatcher.consume(DummyAnycastEvent, object(), handler)
+        return dispatcher
+
+    async def test_handler_is_skipped_and_the_message_is_acked(
+        self,
+        dispatcher: EventDispatcher,
+        mq: StubMessageQueue,
+        received: list[DummyAnycastEvent],
+    ) -> None:
+        await dispatcher.start()
+        await asyncio.sleep(0.1)
+        await dispatcher.close()
+
+        assert received == []
+        assert mq.done_calls == [b"test-msg-id"]

--- a/tests/unit/common/events/test_hub.py
+++ b/tests/unit/common/events/test_hub.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import Self, override
+from typing import override
 from unittest.mock import AsyncMock
 
 from ai.backend.common.events.hub import WILDCARD, EventHub, EventPropagator
@@ -20,15 +20,6 @@ class DummyBaseEvent(AbstractEvent):
     @override
     def delivery_pattern(cls) -> DeliveryPattern:
         return DeliveryPattern.BROADCAST
-
-    @override
-    def serialize(self) -> tuple[bytes, ...]:
-        raise NotImplementedError
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[bytes, ...]) -> Self:
-        raise NotImplementedError
 
     @classmethod
     @override

--- a/tests/unit/common/events/test_kernel_creation_event.py
+++ b/tests/unit/common/events/test_kernel_creation_event.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from ai.backend.common.events.event_types.kernel.anycast import (
+    KernelPreparingAnycastEvent,
+    KernelStartedAnycastEvent,
+)
+from ai.backend.common.events.event_types.kernel.types import (
+    KernelCreationInfo,
+    ServicePortInfo,
+    UsedDevice,
+    UsedDevices,
+)
+from ai.backend.common.identifier.resource_slot import ResourceSlotName
+from ai.backend.common.types import (
+    ContainerId,
+    DeviceId,
+    DeviceName,
+    KernelId,
+    ServicePortProtocols,
+    SessionId,
+)
+
+
+@pytest.fixture
+def kernel_id() -> KernelId:
+    return KernelId(uuid.uuid4())
+
+
+@pytest.fixture
+def session_id() -> SessionId:
+    return SessionId(uuid.uuid4())
+
+
+@pytest.fixture
+def creation_info() -> KernelCreationInfo:
+    return KernelCreationInfo(
+        container_id=ContainerId("c0ffee"),
+        kernel_host="127.0.0.1",
+        repl_in_port=2000,
+        repl_out_port=2001,
+        service_ports=[
+            ServicePortInfo(
+                name="jupyter",
+                protocol=ServicePortProtocols.HTTP,
+                container_ports=[8080],
+                host_ports=[30000],
+                is_inference=False,
+            )
+        ],
+        used_devices=UsedDevices(
+            units={
+                DeviceName("mem"): {
+                    DeviceId("0"): UsedDevice(
+                        model_name=None,
+                        used={ResourceSlotName("mem"): Decimal(4 * 1024**3)},
+                        processing_units=None,
+                        memory_size=None,
+                    )
+                },
+                DeviceName("cuda"): {
+                    DeviceId("0"): UsedDevice(
+                        model_name="A100",
+                        used={ResourceSlotName("cuda.shares"): Decimal("0.5")},
+                        processing_units=54,
+                        memory_size=21474836480,
+                    )
+                },
+            }
+        ),
+    )
+
+
+class TestKernelCreationEventPayload:
+    """`creation_info` must survive the JSON wire body unchanged.
+
+    It is the one event field that used to travel as pickled `ResourceSlot` /
+    `Decimal` values, so it is where a lossy conversion would show up first.
+    `TestKernelCreationInfo` covers the type on its own; what is at stake here is
+    that carrying it as an event field does not flatten it on the way.
+    """
+
+    def test_creation_info_roundtrip(
+        self,
+        kernel_id: KernelId,
+        session_id: SessionId,
+        creation_info: KernelCreationInfo,
+    ) -> None:
+        event = KernelStartedAnycastEvent(
+            kernel_id=kernel_id, session_id=session_id, creation_info=creation_info
+        )
+
+        restored = KernelStartedAnycastEvent.from_message(event.to_message())
+
+        assert restored == event
+        assert restored.creation_info.service_ports[0].protocol is ServicePortProtocols.HTTP
+        cuda = restored.creation_info.used_devices.units[DeviceName("cuda")][DeviceId("0")]
+        assert cuda.used[ResourceSlotName("cuda.shares")] == Decimal("0.5")
+        assert cuda.memory_size == 21474836480
+
+    def test_earlier_creation_events_carry_no_creation_info(
+        self, kernel_id: KernelId, session_id: SessionId
+    ) -> None:
+        event = KernelPreparingAnycastEvent(kernel_id=kernel_id, session_id=session_id)
+
+        assert "creation_info" not in event.to_message().payload
+        assert KernelPreparingAnycastEvent.from_message(event.to_message()) == event

--- a/tests/unit/common/events/test_kernel_types.py
+++ b/tests/unit/common/events/test_kernel_types.py
@@ -14,11 +14,14 @@ from ai.backend.common.events.event_types.kernel.types import (
 from ai.backend.common.exception import BackendAISchemaValidationFailed
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.types import (
+    BinarySize,
     ContainerId,
     DeviceId,
+    DeviceModelInfo,
     DeviceName,
     ResourceSlotEntry,
     ServicePortProtocols,
+    SlotName,
 )
 
 
@@ -186,3 +189,62 @@ class TestSlotTotals:
 
     def test_a_kernel_holding_nothing_totals_nothing(self) -> None:
         assert UsedDevices(units={}).slot_totals == []
+
+
+class TestFromAllocations:
+    """`from_allocations()` is where the agent's two views of a kernel's devices meet."""
+
+    ALLOCATIONS = {
+        DeviceName("cpu"): {SlotName("cpu"): {DeviceId("0"): Decimal(2)}},
+        DeviceName("cuda"): {
+            SlotName("cuda.device"): {DeviceId("0"): Decimal(1)},
+            SlotName("cuda.shares"): {DeviceId("0"): Decimal("0.5")},
+        },
+    }
+
+    def test_a_unit_metered_on_two_axes_is_described_once(self) -> None:
+        """The spec keys amounts by slot and then by unit; the payload keys them the
+        other way round, so the unit on two axes has to collapse into one entry."""
+        cuda = UsedDevices.from_allocations(self.ALLOCATIONS, {}).units[DeviceName("cuda")]
+
+        assert list(cuda) == [DeviceId("0")]
+        assert cuda[DeviceId("0")].used == {
+            "cuda.device": Decimal(1),
+            "cuda.shares": Decimal("0.5"),
+        }
+
+    def test_the_reported_device_facts_are_joined_by_device_id(self) -> None:
+        attached: dict[DeviceName, list[DeviceModelInfo]] = {
+            DeviceName("cuda"): [
+                {
+                    "device_id": DeviceId("0"),
+                    "model_name": "A100",
+                    "data": {"mem": BinarySize(21474836480), "proc": 54},
+                }
+            ]
+        }
+
+        cuda = UsedDevices.from_allocations(self.ALLOCATIONS, attached).units[DeviceName("cuda")]
+
+        assert (
+            cuda[DeviceId("0")].model_name,
+            cuda[DeviceId("0")].processing_units,
+            cuda[DeviceId("0")].memory_size,
+        ) == ("A100", 54, 21474836480)
+
+    def test_an_intrinsic_device_reports_no_model(self) -> None:
+        """A cpu or mem plugin attaches nothing, so its units carry the amounts alone."""
+        cpu = UsedDevices.from_allocations(self.ALLOCATIONS, {DeviceName("cpu"): []}).units[
+            DeviceName("cpu")
+        ][DeviceId("0")]
+
+        assert (cpu.model_name, cpu.processing_units, cpu.memory_size) == (None, None, None)
+        assert cpu.used == {"cpu": Decimal(2)}
+
+    def test_the_totals_are_what_the_manager_records_as_occupancy(self) -> None:
+        totals = {
+            entry.resource_type: entry.quantity
+            for entry in UsedDevices.from_allocations(self.ALLOCATIONS, {}).slot_totals
+        }
+
+        assert totals == {"cpu": "2", "cuda.device": "1", "cuda.shares": "0.5"}

--- a/tests/unit/common/events/test_message_conversion.py
+++ b/tests/unit/common/events/test_message_conversion.py
@@ -26,15 +26,6 @@ class DummyEvent(AbstractAnycastEvent):
     value: int = 0
     blob: Any = None
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.value,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> DummyEvent:
-        return cls(value=value[0])
-
     @classmethod
     @override
     def event_domain(cls) -> EventDomain:

--- a/tests/unit/common/events/test_service_discovery_events.py
+++ b/tests/unit/common/events/test_service_discovery_events.py
@@ -19,7 +19,7 @@ class TestServiceRegisteredEvent:
     def test_event_domain(self) -> None:
         assert ServiceRegisteredEvent.event_domain() == EventDomain.SERVICE_DISCOVERY
 
-    def test_serialize_deserialize_roundtrip(self) -> None:
+    def test_message_roundtrip(self) -> None:
         startup = datetime(2026, 1, 15, 10, 30, 0, tzinfo=UTC)
         event = ServiceRegisteredEvent(
             instance_id="manager-001",
@@ -41,11 +41,7 @@ class TestServiceRegisteredEvent:
             config_hash="abc123",
         )
 
-        serialized = event.serialize()
-        assert isinstance(serialized, tuple)
-        assert len(serialized) == 2
-
-        restored = ServiceRegisteredEvent.deserialize(serialized)
+        restored = ServiceRegisteredEvent.from_message(event.to_message())
         assert restored.instance_id == "manager-001"
         assert restored.service_group == "manager"
         assert restored.display_name == "Manager Instance 1"
@@ -58,7 +54,7 @@ class TestServiceRegisteredEvent:
         assert restored.startup_time == startup
         assert restored.config_hash == "abc123"
 
-    def test_serialize_deserialize_minimal(self) -> None:
+    def test_message_roundtrip_minimal(self) -> None:
         startup = datetime(2026, 2, 1, 0, 0, 0, tzinfo=UTC)
         event = ServiceRegisteredEvent(
             instance_id="agent-001",
@@ -68,7 +64,7 @@ class TestServiceRegisteredEvent:
             startup_time=startup,
         )
 
-        restored = ServiceRegisteredEvent.deserialize(event.serialize())
+        restored = ServiceRegisteredEvent.from_message(event.to_message())
         assert restored.instance_id == "agent-001"
         assert restored.labels == {}
         assert restored.endpoints == []
@@ -104,17 +100,13 @@ class TestServiceDeregisteredEvent:
     def test_event_domain(self) -> None:
         assert ServiceDeregisteredEvent.event_domain() == EventDomain.SERVICE_DISCOVERY
 
-    def test_serialize_deserialize_roundtrip(self) -> None:
+    def test_message_roundtrip(self) -> None:
         event = ServiceDeregisteredEvent(
             instance_id="manager-001",
             service_group="manager",
         )
 
-        serialized = event.serialize()
-        assert isinstance(serialized, tuple)
-        assert len(serialized) == 2
-
-        restored = ServiceDeregisteredEvent.deserialize(serialized)
+        restored = ServiceDeregisteredEvent.from_message(event.to_message())
         assert restored.instance_id == "manager-001"
         assert restored.service_group == "manager"
 

--- a/tests/unit/common/message_queue/test_payload.py
+++ b/tests/unit/common/message_queue/test_payload.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.common.message_queue.exceptions import InvalidMessagePayloadError
+from ai.backend.common.message_queue.payload import (
+    AnycastMessagePayload,
+    BroadcastMessagePayload,
+)
+from ai.backend.common.message_queue.types import MessageMetadata, MessageName
+
+_PAYLOAD = '{"value":42}'
+
+
+class TestAnycastMessagePayload:
+    @pytest.fixture
+    def payload(self) -> AnycastMessagePayload:
+        return AnycastMessagePayload.from_event_body(
+            name=MessageName("test_event"),
+            source="i-test",
+            payload=_PAYLOAD,
+            metadata=MessageMetadata(request_id="req-1"),
+        )
+
+    def test_stream_fields_roundtrip(self, payload: AnycastMessagePayload) -> None:
+        assert AnycastMessagePayload.from_stream_fields(payload.to_stream_fields()) == payload
+
+    def test_retry_count_survives_the_roundtrip(self, payload: AnycastMessagePayload) -> None:
+        retried = payload.increment_retry()
+        restored = AnycastMessagePayload.from_stream_fields(retried.to_stream_fields())
+        assert restored.retry_count == 1
+
+    def test_entry_without_a_payload_field_is_rejected(self) -> None:
+        with pytest.raises(InvalidMessagePayloadError):
+            AnycastMessagePayload.from_stream_fields({
+                b"name": b"test_event",
+                b"source": b"i-test",
+            })
+
+
+class TestBroadcastMessagePayload:
+    @pytest.fixture
+    def payload(self) -> BroadcastMessagePayload:
+        return BroadcastMessagePayload.from_event_body(
+            name=MessageName("test_event"),
+            source="i-test",
+            payload=_PAYLOAD,
+            metadata=MessageMetadata(request_id="req-1"),
+        )
+
+    def test_json_roundtrip(self, payload: BroadcastMessagePayload) -> None:
+        assert BroadcastMessagePayload.from_json(payload.to_json()) == payload
+
+    def test_message_without_a_payload_field_is_rejected(self) -> None:
+        with pytest.raises(InvalidMessagePayloadError):
+            BroadcastMessagePayload.from_json(b'{"name":"test_event","source":"i-test"}')
+
+    def test_malformed_json_is_rejected(self) -> None:
+        with pytest.raises(InvalidMessagePayloadError):
+            BroadcastMessagePayload.from_json(b"not json")

--- a/tests/unit/common/message_queue/test_redis_queue.py
+++ b/tests/unit/common/message_queue/test_redis_queue.py
@@ -90,7 +90,7 @@ async def redis_queue(
 async def test_send_and_consume(redis_queue: RedisQueue) -> None:
     # Test message sending and consuming
     test_payload = AnycastMessagePayload(
-        name=MessageName("test-event"), source="i-test", body=b"body"
+        name=MessageName("test-event"), source="i-test", payload="{}"
     )
 
     # Send message
@@ -107,7 +107,7 @@ async def test_send_and_consume(redis_queue: RedisQueue) -> None:
 async def test_subscribe(redis_queue: RedisQueue) -> None:
     # Test message subscription
     test_payload = BroadcastMessagePayload(
-        name=MessageName("test-event"), source="i-test", body=b"body"
+        name=MessageName("test-event"), source="i-test", payload="{}"
     )
 
     # Create task to subscribe
@@ -135,7 +135,7 @@ async def test_subscribe(redis_queue: RedisQueue) -> None:
 async def test_broadcast_with_cache(redis_queue: RedisQueue) -> None:
     # Test broadcasting with cache
     test_payload = BroadcastMessagePayload(
-        name=MessageName("test-event"), source="i-test", body=b"body"
+        name=MessageName("test-event"), source="i-test", payload="{}"
     )
     cache_id = f"test-cache-id-{random.randint(1000, 9999)}"
 
@@ -168,7 +168,7 @@ async def test_broadcast_with_cache(redis_queue: RedisQueue) -> None:
 async def test_done(redis_queue: RedisQueue) -> None:
     # Test message acknowledgment
     test_payload = AnycastMessagePayload(
-        name=MessageName("test-event"), source="i-test", body=b"body"
+        name=MessageName("test-event"), source="i-test", payload="{}"
     )
 
     # Send message

--- a/tests/unit/common/test_distributed.py
+++ b/tests/unit/common/test_distributed.py
@@ -74,15 +74,6 @@ def dslice(start: Decimal, stop: Decimal, num: int) -> Iterable[Decimal]:
 class NoopAnycastEvent(AbstractAnycastEvent):
     test_case_ns: str
 
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.test_case_ns,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> NoopAnycastEvent:
-        return cls(test_case_ns=value[0])
-
     @classmethod
     @override
     def event_domain(cls) -> EventDomain:

--- a/tests/unit/common/test_events.py
+++ b/tests/unit/common/test_events.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from types import TracebackType
-from typing import Any, override
+from typing import override
 
 import aiotools
 
@@ -23,15 +23,6 @@ from ai.backend.common.types import AgentId
 
 class DummyBroadcastEvent(AbstractBroadcastEvent):
     value: int
-
-    @override
-    def serialize(self) -> tuple[Any, ...]:
-        return (self.value + 1,)
-
-    @classmethod
-    @override
-    def deserialize(cls, value: tuple[Any, ...]) -> DummyBroadcastEvent:
-        return cls(value=value[0] + 1)
 
     @classmethod
     @override
@@ -70,7 +61,7 @@ async def test_dispatch(test_valkey_stream_mq: RedisQueue, test_node_id: str) ->
         assert source == AgentId("i-test")
         assert isinstance(event, DummyBroadcastEvent)
         assert event.event_name() == "testing"
-        assert event.value == 1001
+        assert event.value == 999
         await asyncio.sleep(0.01)
         records.add("async")
 
@@ -79,7 +70,7 @@ async def test_dispatch(test_valkey_stream_mq: RedisQueue, test_node_id: str) ->
         assert source == AgentId("i-test")
         assert isinstance(event, DummyBroadcastEvent)
         assert event.event_name() == "testing"
-        assert event.value == 1001
+        assert event.value == 999
         records.add("sync")
 
     dispatcher.subscribe(DummyBroadcastEvent, app, acb)

--- a/tests/unit/manager/repositories/scheduler/conftest.py
+++ b/tests/unit/manager/repositories/scheduler/conftest.py
@@ -19,14 +19,23 @@ import sqlalchemy as sa
 from dateutil.tz import tzutc
 
 from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.events.event_types.kernel.types import (
+    KernelCreationInfo,
+    UsedDevice,
+    UsedDevices,
+)
 from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.identifier.session_group import SessionGroupID
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
     ClusterMode,
+    ContainerId,
     DefaultForUnspecified,
+    DeviceId,
+    DeviceName,
     KernelId,
     ResourceSlot,
     SecretKey,
@@ -68,7 +77,6 @@ from ai.backend.manager.views.sokovan.allocation import (
     KernelAllocation,
     SessionAllocation,
 )
-from ai.backend.manager.views.sokovan.lifecycle import KernelCreationInfo
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -345,19 +353,33 @@ async def resource_slot_types(
 
 
 def make_creation_info(cpu: str = "2", mem: str = "4096") -> KernelCreationInfo:
-    """Build a KernelCreationInfo whose get_resource_allocations() returns the given slots."""
+    """Build a KernelCreationInfo whose used devices aggregate to the given slots."""
     return KernelCreationInfo(
-        container_id=f"container-{uuid.uuid4().hex[:8]}",
-        resource_spec={
-            "allocations": {
-                "cpu": {"cpu": {"0": cpu}},
-                "mem": {"mem": {"0": mem}},
-            },
-        },
+        container_id=ContainerId(f"container-{uuid.uuid4().hex[:8]}"),
+        kernel_host="127.0.0.1",
         repl_in_port=2001,
         repl_out_port=2002,
-        stdin_port=2003,
-        stdout_port=2004,
+        service_ports=[],
+        used_devices=UsedDevices(
+            units={
+                DeviceName("cpu"): {
+                    DeviceId("0"): UsedDevice(
+                        model_name=None,
+                        used={ResourceSlotName("cpu"): Decimal(cpu)},
+                        processing_units=None,
+                        memory_size=None,
+                    )
+                },
+                DeviceName("mem"): {
+                    DeviceId("0"): UsedDevice(
+                        model_name=None,
+                        used={ResourceSlotName("mem"): Decimal(mem)},
+                        processing_units=None,
+                        memory_size=None,
+                    )
+                },
+            }
+        ),
     )
 
 

--- a/tests/unit/manager/repositories/scheduler/test_resource_allocation.py
+++ b/tests/unit/manager/repositories/scheduler/test_resource_allocation.py
@@ -16,12 +16,21 @@ import sqlalchemy as sa
 from dateutil.tz import tzutc
 
 from ai.backend.common.data.user.types import UserRole
+from ai.backend.common.events.event_types.kernel.types import (
+    KernelCreationInfo,
+    UsedDevice,
+    UsedDevices,
+)
 from ai.backend.common.identifier.domain import DomainID, DomainName
 from ai.backend.common.identifier.resource_group import ResourceGroupID
+from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
+    ContainerId,
     DefaultForUnspecified,
+    DeviceId,
+    DeviceName,
     KernelId,
     ResourceSlot,
     SecretKey,
@@ -59,7 +68,6 @@ from ai.backend.manager.models.session import SessionDependencyRow, SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.scheduler.db_source.db_source import ScheduleDBSource
-from ai.backend.manager.views.sokovan.lifecycle import KernelCreationInfo
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -68,19 +76,33 @@ def _make_creation_info(
     cpu: str = "2",
     mem: str = "4096",
 ) -> KernelCreationInfo:
-    """Build a KernelCreationInfo whose get_resource_allocations() returns the given slots."""
+    """Build a KernelCreationInfo whose used devices aggregate to the given slots."""
     return KernelCreationInfo(
-        container_id="test-container",
-        resource_spec={
-            "allocations": {
-                "cpu": {"cpu": {"0": cpu}},
-                "mem": {"mem": {"0": mem}},
-            },
-        },
+        container_id=ContainerId("test-container"),
+        kernel_host="127.0.0.1",
         repl_in_port=2001,
         repl_out_port=2002,
-        stdin_port=2003,
-        stdout_port=2004,
+        service_ports=[],
+        used_devices=UsedDevices(
+            units={
+                DeviceName("cpu"): {
+                    DeviceId("0"): UsedDevice(
+                        model_name=None,
+                        used={ResourceSlotName("cpu"): Decimal(cpu)},
+                        processing_units=None,
+                        memory_size=None,
+                    )
+                },
+                DeviceName("mem"): {
+                    DeviceId("0"): UsedDevice(
+                        model_name=None,
+                        used={ResourceSlotName("mem"): Decimal(mem)},
+                        processing_units=None,
+                        memory_size=None,
+                    )
+                },
+            }
+        ),
     )
 
 

--- a/tests/unit/manager/test_registry.py
+++ b/tests/unit/manager/test_registry.py
@@ -5,7 +5,6 @@ import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,10 +21,7 @@ from ai.backend.common.events.event_types.session.broadcast import SchedulingBro
 from ai.backend.common.events.types import AbstractEvent
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.types import (
-    BinarySize,
-    DeviceId,
     SessionId,
-    SlotName,
 )
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.session.types import SessionStatus
@@ -147,41 +143,6 @@ async def registry_ctx() -> AsyncGenerator[
         )
     finally:
         await registry.shutdown()
-
-
-async def test_convert_resource_spec_to_resource_slot(
-    registry_ctx: tuple[
-        AgentRegistry, MagicMock, MagicMock, MagicMock, ManagerConfigProvider, MagicMock, MagicMock
-    ],
-) -> None:
-    registry, _, _, _, _, _, _ = registry_ctx
-    allocations = {
-        "cuda": {
-            SlotName("cuda.shares"): {
-                DeviceId("a0"): "2.5",
-                DeviceId("a1"): "2.0",
-            },
-        },
-    }
-    converted_allocations = registry.convert_resource_spec_to_resource_slot(allocations)
-    assert converted_allocations["cuda.shares"] == Decimal("4.5")
-    allocations = {
-        "cpu": {
-            SlotName("cpu"): {
-                DeviceId("a0"): "3",
-                DeviceId("a1"): "1",
-            },
-        },
-        "ram": {
-            SlotName("ram"): {
-                DeviceId("b0"): "2.5g",
-                DeviceId("b1"): "512m",
-            },
-        },
-    }
-    converted_allocations = registry.convert_resource_spec_to_resource_slot(allocations)
-    assert converted_allocations["cpu"] == Decimal("4")
-    assert converted_allocations["ram"] == Decimal(BinarySize.from_str("1g")) * 3
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Publish every event body as JSON, derived from the event's own Pydantic fields via the `@final` `to_message()` / `from_message()` pair, and remove the 130 hand-written `serialize()` / `deserialize()` implementations plus the msgpack wire format beneath them. A positional tuple can no longer disagree with the field order it is built from.
- Replace `creation_info: Mapping[str, Any]` with a typed `KernelCreationInfo` whose leaves are JSON-representable. This was the one payload relying on pickled `ResourceSlot` / `Decimal` / `Path` values carried in msgpack ext types, and it is now declared only on the started events — the only ones that ever carried it. The manager's untyped duplicate view of the same data is gone, and its allocation aggregation is now `KernelResourceSpecData.to_resource_slot()`.
- Raise `EventPayloadEncodingError` / `EventPayloadDecodingError` from the conversion pair instead of letting Pydantic errors escape, and ack a message whose body cannot be decoded rather than leaving it to be redelivered until the retry limit discards it. Also drops `args_matcher`, which matched against the positional tuple and had no callers.

Every component reads and writes the same single stream (`events`) and channel (`events_all`), so this requires the cluster to run one version across the upgrade. In-flight msgpack entries are logged and skipped as malformed.

This folds BA-7316 (removing the msgpack fallback) into this change: with the write path on JSON only, there is no fallback left to keep.

## Test plan

- [x] `pants test tests/unit/common/events:: tests/unit/common/message_queue::`
- [x] `pants test tests/unit/common/test_events.py tests/unit/common/test_distributed.py`
- [x] `pants test tests/unit/manager/repositories/scheduler::`
- [x] Verify event flows end to end on a live server: session create/terminate (kernel lifecycle), agent heartbeat, and image scan

Resolves BA-7315
