### PR TITLE
refactor(BA-7354): adopt the timestamp mixin on the account manager keypairs

### DIFF
--- a/changes/13753.enhance.md
+++ b/changes/13753.enhance.md
@@ -1,0 +1,1 @@
+Rename the account manager's `keypairs.modified_at` and `user_profiles.modified_at` columns to `updated_at` and make both lifecycle timestamps non-nullable, matching the manager's schema.

--- a/changes/13753.enhance.md
+++ b/changes/13753.enhance.md
@@ -1,1 +1,1 @@
-Rename the account manager's `keypairs.modified_at` and `user_profiles.modified_at` columns to `updated_at` and make both lifecycle timestamps non-nullable, matching the manager's schema.
+Rename the account manager's `keypairs.modified_at` column to `updated_at` and make both lifecycle timestamps non-nullable, matching the manager's schema.

--- a/src/ai/backend/account_manager/models/alembic/versions/ebe5354693b3_adopt_lifecycle_timestamps_mixin.py
+++ b/src/ai/backend/account_manager/models/alembic/versions/ebe5354693b3_adopt_lifecycle_timestamps_mixin.py
@@ -1,0 +1,49 @@
+"""adopt lifecycle timestamps mixin on keypairs and user_profiles
+
+Renames the legacy ``modified_at`` columns of keypairs / user_profiles to
+``updated_at``, backfills NULLs and sets both timestamps NOT NULL so the
+mixin's declaration holds.
+
+Revision ID: ebe5354693b3
+Revises: 1449797cc931
+Create Date: 2026-08-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "ebe5354693b3"
+down_revision: str | None = "1449797cc931"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_RENAMED_TABLES = ("keypairs", "user_profiles")
+
+# (table, column, backfill expression) — created_at is backfilled from the
+# sibling timestamp first, so the sibling's own backfill sees a non-NULL value.
+_TARGETS = (
+    ("keypairs", "created_at", "COALESCE(updated_at, now())"),
+    ("keypairs", "updated_at", "COALESCE(created_at, now())"),
+    ("user_profiles", "created_at", "COALESCE(updated_at, now())"),
+    ("user_profiles", "updated_at", "COALESCE(created_at, now())"),
+)
+
+
+def upgrade() -> None:
+    for table in _RENAMED_TABLES:
+        op.alter_column(table, "modified_at", new_column_name="updated_at")
+    for table, column, backfill in _TARGETS:
+        op.execute(sa.text(f"UPDATE {table} SET {column} = {backfill} WHERE {column} IS NULL"))
+        op.alter_column(table, column, nullable=False)
+
+
+def downgrade() -> None:
+    for table, column, _ in reversed(_TARGETS):
+        op.alter_column(table, column, nullable=True)
+    for table in reversed(_RENAMED_TABLES):
+        op.alter_column(table, "updated_at", new_column_name="modified_at")

--- a/src/ai/backend/account_manager/models/alembic/versions/ebe5354693b3_adopt_lifecycle_timestamps_mixin.py
+++ b/src/ai/backend/account_manager/models/alembic/versions/ebe5354693b3_adopt_lifecycle_timestamps_mixin.py
@@ -1,8 +1,8 @@
-"""adopt lifecycle timestamps mixin on keypairs and user_profiles
+"""adopt lifecycle timestamps mixin on keypairs
 
-Renames the legacy ``modified_at`` columns of keypairs / user_profiles to
-``updated_at``, backfills NULLs and sets both timestamps NOT NULL so the
-mixin's declaration holds.
+Renames the legacy ``modified_at`` column of keypairs to ``updated_at``,
+backfills NULLs and sets both timestamps NOT NULL so the mixin's declaration
+holds.
 
 Revision ID: ebe5354693b3
 Revises: 1449797cc931
@@ -22,28 +22,22 @@ down_revision: str | None = "1449797cc931"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
-_RENAMED_TABLES = ("keypairs", "user_profiles")
-
-# (table, column, backfill expression) — created_at is backfilled from the
-# sibling timestamp first, so the sibling's own backfill sees a non-NULL value.
+# (column, backfill expression) — created_at is backfilled from the sibling
+# timestamp first, so the sibling's own backfill sees a non-NULL value.
 _TARGETS = (
-    ("keypairs", "created_at", "COALESCE(updated_at, now())"),
-    ("keypairs", "updated_at", "COALESCE(created_at, now())"),
-    ("user_profiles", "created_at", "COALESCE(updated_at, now())"),
-    ("user_profiles", "updated_at", "COALESCE(created_at, now())"),
+    ("created_at", "COALESCE(updated_at, now())"),
+    ("updated_at", "COALESCE(created_at, now())"),
 )
 
 
 def upgrade() -> None:
-    for table in _RENAMED_TABLES:
-        op.alter_column(table, "modified_at", new_column_name="updated_at")
-    for table, column, backfill in _TARGETS:
-        op.execute(sa.text(f"UPDATE {table} SET {column} = {backfill} WHERE {column} IS NULL"))
-        op.alter_column(table, column, nullable=False)
+    op.alter_column("keypairs", "modified_at", new_column_name="updated_at")
+    for column, backfill in _TARGETS:
+        op.execute(sa.text(f"UPDATE keypairs SET {column} = {backfill} WHERE {column} IS NULL"))
+        op.alter_column("keypairs", column, nullable=False)
 
 
 def downgrade() -> None:
-    for table, column, _ in reversed(_TARGETS):
-        op.alter_column(table, column, nullable=True)
-    for table in reversed(_RENAMED_TABLES):
-        op.alter_column(table, "updated_at", new_column_name="modified_at")
+    for column, _ in reversed(_TARGETS):
+        op.alter_column("keypairs", column, nullable=True)
+    op.alter_column("keypairs", "updated_at", new_column_name="modified_at")

--- a/src/ai/backend/account_manager/models/keypair.py
+++ b/src/ai/backend/account_manager/models/keypair.py
@@ -2,11 +2,12 @@ import sqlalchemy as sa
 from sqlalchemy.orm import relationship
 
 from .base import GUID, Base, IDColumn
+from .mixins.timestamp import LifecycleTimestampsMixin
 
 __all__: tuple[str, ...] = ("KeypairRow",)
 
 
-class KeypairRow(Base):
+class KeypairRow(LifecycleTimestampsMixin, Base):
     __tablename__ = "keypairs"
     id = IDColumn()
     # user_id is nullable to allow creating spare keypairs.
@@ -14,13 +15,6 @@ class KeypairRow(Base):
     access_key = sa.Column("access_key", sa.String(length=20), unique=True)
     secret_key = sa.Column("secret_key", sa.String(length=40))
     is_active = sa.Column("is_active", sa.Boolean, index=True, server_default=sa.true())
-    created_at = sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now())
-    modified_at = sa.Column(
-        "modified_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.current_timestamp(),
-    )
     expired_at = sa.Column("expired_at", sa.DateTime(timezone=True), nullable=True)
     last_used = sa.Column("last_used", sa.DateTime(timezone=True), nullable=True)
 

--- a/src/ai/backend/account_manager/models/mixins/timestamp.py
+++ b/src/ai/backend/account_manager/models/mixins/timestamp.py
@@ -1,0 +1,37 @@
+"""Shared mixins for record audit timestamps.
+
+Mirrors ``manager/models/mixins/timestamp.py``. The two components cannot share
+one module because ``ai.backend.common`` carries no SQLAlchemy dependency.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+
+class CreatedAtMixin:
+    created_at: Mapped[datetime] = mapped_column(
+        "created_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        sort_order=9998,
+    )
+
+
+class UpdatedAtMixin:
+    updated_at: Mapped[datetime] = mapped_column(
+        "updated_at",
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+        sort_order=9999,
+    )
+
+
+class LifecycleTimestampsMixin(CreatedAtMixin, UpdatedAtMixin):
+    pass

--- a/src/ai/backend/account_manager/models/userprofile.py
+++ b/src/ai/backend/account_manager/models/userprofile.py
@@ -8,11 +8,12 @@ from ai.backend.account_manager.types import UserRole, UserStatus
 from ai.backend.account_manager.utils import verify_password
 
 from .base import GUID, Base, PasswordColumn, StrEnumType
+from .mixins.timestamp import LifecycleTimestampsMixin
 
 __all__: tuple[str, ...] = ("UserProfileRow",)
 
 
-class UserProfileRow(Base):
+class UserProfileRow(LifecycleTimestampsMixin, Base):
     __tablename__ = "user_profiles"
     id: Mapped[UUID] = mapped_column(
         GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
@@ -45,14 +46,6 @@ class UserProfileRow(Base):
         "status", StrEnumType(UserStatus), server_default=UserStatus.ACTIVE.value, nullable=False
     )
     status_info: Mapped[str | None] = mapped_column("status_info", sa.Unicode(), nullable=True)
-
-    created_at = sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now())
-    modified_at = sa.Column(
-        "modified_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.current_timestamp(),
-    )
 
     user_row = relationship(
         "UserRow",

--- a/src/ai/backend/account_manager/models/userprofile.py
+++ b/src/ai/backend/account_manager/models/userprofile.py
@@ -8,12 +8,11 @@ from ai.backend.account_manager.types import UserRole, UserStatus
 from ai.backend.account_manager.utils import verify_password
 
 from .base import GUID, Base, PasswordColumn, StrEnumType
-from .mixins.timestamp import LifecycleTimestampsMixin
 
 __all__: tuple[str, ...] = ("UserProfileRow",)
 
 
-class UserProfileRow(LifecycleTimestampsMixin, Base):
+class UserProfileRow(Base):
     __tablename__ = "user_profiles"
     id: Mapped[UUID] = mapped_column(
         GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")
@@ -46,6 +45,14 @@ class UserProfileRow(LifecycleTimestampsMixin, Base):
         "status", StrEnumType(UserStatus), server_default=UserStatus.ACTIVE.value, nullable=False
     )
     status_info: Mapped[str | None] = mapped_column("status_info", sa.Unicode(), nullable=True)
+
+    created_at = sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now())
+    modified_at = sa.Column(
+        "modified_at",
+        sa.DateTime(timezone=True),
+        server_default=sa.func.now(),
+        onupdate=sa.func.current_timestamp(),
+    )
 
     user_row = relationship(
         "UserRow",


### PR DESCRIPTION
Resolves BA-7354

## Summary

- `KeypairRow` inherits `LifecycleTimestampsMixin` instead of hand-rolling nullable `created_at` plus `modified_at`, matching every manager table since BA-7207
- `account_manager/models/mixins/timestamp.py` mirrors the manager's module — `ai.backend.common` carries no SQLAlchemy dependency, so the two components cannot share one
- A migration renames `keypairs.modified_at` to `updated_at`, backfills NULLs from the sibling timestamp, and sets both columns NOT NULL
- Nothing outside the row declaration read `modified_at` in this component, so no service, handler or response shape changes
- `user_profiles` carries the same hand-rolled pair and moves separately

## Test plan

- [x] `pants lint check` on the changed files
- [x] `KeypairRow` maps to `created_at` / `updated_at`, NOT NULL, with `onupdate` on `updated_at`
- [ ] `alembic -c alembic-accountmgr.ini upgrade head` then `downgrade` round-trips on a populated account manager database

🤖 Generated with [Claude Code](https://claude.com/claude-code)