### PR TITLE
refactor(BA-7355): move login_client_types onto the timestamp mixin

### DIFF
--- a/changes/13756.enhance.md
+++ b/changes/13756.enhance.md
@@ -1,0 +1,1 @@
+Rename the `login_client_types.modified_at` column to `updated_at`, so every manager table names its lifecycle timestamps the same way.

--- a/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
@@ -89,7 +89,7 @@ class LoginClientTypeAdapter(BaseAdapter):
                 case LoginClientTypeOrderField.CREATED_AT:
                     result.append(LoginClientTypeOrders.created_at(ascending))
                 case LoginClientTypeOrderField.MODIFIED_AT:
-                    result.append(LoginClientTypeOrders.modified_at(ascending))
+                    result.append(LoginClientTypeOrders.updated_at(ascending))
         return result
 
     # --- Non-admin methods ---
@@ -213,9 +213,9 @@ class LoginClientTypeAdapter(BaseAdapter):
 
         if filter.modified_at is not None:
             condition = filter.modified_at.build_query_condition(
-                before_factory=LoginClientTypeConditions.by_modified_at_before,
-                after_factory=LoginClientTypeConditions.by_modified_at_after,
-                equals_factory=LoginClientTypeConditions.by_modified_at_equals,
+                before_factory=LoginClientTypeConditions.by_updated_at_before,
+                after_factory=LoginClientTypeConditions.by_updated_at_after,
+                equals_factory=LoginClientTypeConditions.by_updated_at_equals,
             )
             if condition is not None:
                 conditions.append(condition)

--- a/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
@@ -75,7 +75,7 @@ class LoginClientTypeAdapter(BaseAdapter):
             name=data.name,
             description=data.description,
             created_at=data.created_at,
-            modified_at=data.modified_at,
+            modified_at=data.updated_at,
         )
 
     @staticmethod

--- a/src/ai/backend/manager/data/login_client_type/types.py
+++ b/src/ai/backend/manager/data/login_client_type/types.py
@@ -16,7 +16,7 @@ class LoginClientTypeData:
     name: str
     description: str | None
     created_at: datetime
-    modified_at: datetime
+    updated_at: datetime
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/models/alembic/versions/99365294b8d9_rename_login_client_types_modified_at.py
+++ b/src/ai/backend/manager/models/alembic/versions/99365294b8d9_rename_login_client_types_modified_at.py
@@ -1,0 +1,28 @@
+"""rename login_client_types.modified_at to updated_at
+
+``be1ac9308056`` created the column already matching what
+``LifecycleTimestampsMixin`` declares -- NOT NULL, ``now()`` server default,
+``onupdate`` -- so only the name has to move.
+
+Revision ID: 99365294b8d9
+Revises: b9e3a7c14f28
+Create Date: 2026-08-13 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "99365294b8d9"
+down_revision = "b9e3a7c14f28"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("login_client_types", "modified_at", new_column_name="updated_at")
+
+
+def downgrade() -> None:
+    op.alter_column("login_client_types", "updated_at", new_column_name="modified_at")

--- a/src/ai/backend/manager/models/login_client_type/conditions.py
+++ b/src/ai/backend/manager/models/login_client_type/conditions.py
@@ -155,20 +155,20 @@ class LoginClientTypeConditions:
     @staticmethod
     def by_modified_at_before(dt: datetime) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
-            return LoginClientTypeRow.modified_at < dt
+            return LoginClientTypeRow.updated_at < dt
 
         return inner
 
     @staticmethod
     def by_modified_at_after(dt: datetime) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
-            return LoginClientTypeRow.modified_at > dt
+            return LoginClientTypeRow.updated_at > dt
 
         return inner
 
     @staticmethod
     def by_modified_at_equals(dt: datetime) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
-            return LoginClientTypeRow.modified_at == dt
+            return LoginClientTypeRow.updated_at == dt
 
         return inner

--- a/src/ai/backend/manager/models/login_client_type/conditions.py
+++ b/src/ai/backend/manager/models/login_client_type/conditions.py
@@ -150,24 +150,24 @@ class LoginClientTypeConditions:
 
         return inner
 
-    # --- modified_at datetime filters ---
+    # --- updated_at datetime filters ---
 
     @staticmethod
-    def by_modified_at_before(dt: datetime) -> QueryCondition:
+    def by_updated_at_before(dt: datetime) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
             return LoginClientTypeRow.updated_at < dt
 
         return inner
 
     @staticmethod
-    def by_modified_at_after(dt: datetime) -> QueryCondition:
+    def by_updated_at_after(dt: datetime) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
             return LoginClientTypeRow.updated_at > dt
 
         return inner
 
     @staticmethod
-    def by_modified_at_equals(dt: datetime) -> QueryCondition:
+    def by_updated_at_equals(dt: datetime) -> QueryCondition:
         def inner() -> sa.ColumnElement[bool]:
             return LoginClientTypeRow.updated_at == dt
 

--- a/src/ai/backend/manager/models/login_client_type/orders.py
+++ b/src/ai/backend/manager/models/login_client_type/orders.py
@@ -21,5 +21,5 @@ class LoginClientTypeOrders:
 
     @staticmethod
     def modified_at(ascending: bool = True) -> QueryOrder:
-        col = LoginClientTypeRow.modified_at
+        col = LoginClientTypeRow.updated_at
         return col.asc() if ascending else col.desc()

--- a/src/ai/backend/manager/models/login_client_type/orders.py
+++ b/src/ai/backend/manager/models/login_client_type/orders.py
@@ -20,6 +20,6 @@ class LoginClientTypeOrders:
         return col.asc() if ascending else col.desc()
 
     @staticmethod
-    def modified_at(ascending: bool = True) -> QueryOrder:
+    def updated_at(ascending: bool = True) -> QueryOrder:
         col = LoginClientTypeRow.updated_at
         return col.asc() if ascending else col.desc()

--- a/src/ai/backend/manager/models/login_client_type/row.py
+++ b/src/ai/backend/manager/models/login_client_type/row.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.manager.models.base import GUID, Base
-from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
 
 if TYPE_CHECKING:
     from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
 __all__ = ("LoginClientTypeRow",)
 
 
-class LoginClientTypeRow(CreatedAtMixin, Base):
+class LoginClientTypeRow(LifecycleTimestampsMixin, Base):
     __tablename__ = "login_client_types"
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -24,13 +23,6 @@ class LoginClientTypeRow(CreatedAtMixin, Base):
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=64), nullable=False, unique=True)
     description: Mapped[str | None] = mapped_column("description", sa.Text, nullable=True)
-    modified_at: Mapped[datetime] = mapped_column(
-        "modified_at",
-        sa.DateTime(timezone=True),
-        server_default=sa.func.now(),
-        onupdate=sa.func.now(),
-        nullable=False,
-    )
 
     def to_dataclass(self) -> LoginClientTypeData:
         from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
@@ -40,5 +32,5 @@ class LoginClientTypeRow(CreatedAtMixin, Base):
             name=self.name,
             description=self.description,
             created_at=self.created_at,
-            modified_at=self.modified_at,
+            modified_at=self.updated_at,
         )

--- a/src/ai/backend/manager/models/login_client_type/row.py
+++ b/src/ai/backend/manager/models/login_client_type/row.py
@@ -32,5 +32,5 @@ class LoginClientTypeRow(LifecycleTimestampsMixin, Base):
             name=self.name,
             description=self.description,
             created_at=self.created_at,
-            modified_at=self.updated_at,
+            updated_at=self.updated_at,
         )

--- a/tests/unit/manager/services/login_client_type/test_login_client_type_service.py
+++ b/tests/unit/manager/services/login_client_type/test_login_client_type_service.py
@@ -55,7 +55,7 @@ class TestLoginClientTypeService:
             name="webui",
             description="Backend.AI web console.",
             created_at=datetime.now(UTC),
-            modified_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
     @pytest.fixture
@@ -188,7 +188,7 @@ class TestLoginClientTypeAdminService:
             name="webui",
             description="Backend.AI web console.",
             created_at=datetime.now(UTC),
-            modified_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
         )
 
     @pytest.fixture


### PR DESCRIPTION
Resolves BA-7355

## Summary

- `LoginClientTypeRow` inherits `LifecycleTimestampsMixin` instead of `CreatedAtMixin` plus a hand-rolled `modified_at`, the last manager table still spelling the fact that way after BA-7207 and BA-7352
- A migration renames `login_client_types.modified_at` to `updated_at`. `be1ac9308056` created the column NOT NULL with a `now()` server default and `onupdate`, which is exactly what `UpdatedAtMixin` declares, so no backfill or nullability change is needed
- Internal code follows the column: `LoginClientTypeData.updated_at`, `LoginClientTypeOrders.updated_at`, `LoginClientTypeConditions.by_updated_at_before` / `_after` / `_equals`
- The v2 DTO, the GraphQL type and `LoginClientTypeOrderField.MODIFIED_AT` keep their published `modified_at` names. The adapter is the only place that maps between the two, so no API response or schema changes ship here

## Test plan

- [x] `pants lint check` on the changed files
- [x] The mapped table resolves to `created_at` / `updated_at` only, both NOT NULL with `now()`, `onupdate` on `updated_at`
- [x] `LoginClientTypeData` exposes `updated_at`; `LoginClientTypeNode` still exposes `modified_at`
- [x] `LoginClientTypeOrders.updated_at()` emits `login_client_types.updated_at ASC`; `by_updated_at_after()` emits `login_client_types.updated_at > :param`
- [x] Every remaining `modified_at` for this entity is under `api/` or `common/dto/`
- [ ] `alembic upgrade head` then `downgrade` round-trips on a populated database

🤖 Generated with [Claude Code](https://claude.com/claude-code)