### PR TITLE
feat(BA-7358): resolve session ownership by user instead of access key

### DIFF
--- a/changes/13761.breaking.md
+++ b/changes/13761.breaking.md
@@ -1,0 +1,1 @@
+Session lookups now match sessions owned by the user rather than only those created with the requesting keypair.

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -73,6 +73,7 @@ from ai.backend.common.dto.manager.v2.session.response import (
 from ai.backend.common.dto.manager.v2.session.types import ClusterModeEnum, SessionStatusFilter
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import (
     AccessKey,
@@ -1011,12 +1012,12 @@ class SessionAdapter(BaseAdapter):
         self,
         session_id: UUID,
         input: ShutdownSessionServiceInput,
-        access_key: str,
+        user_id: UserID,
     ) -> None:
         """Shut down a service in a session."""
         action = ShutdownServiceAction(
             session_name=str(session_id),
-            owner_access_key=AccessKey(access_key),
+            owner_user_id=user_id,
             service_name=input.service,
         )
         await self._processors.session.shutdown_service.wait_for_complete(action)
@@ -1028,13 +1029,13 @@ class SessionAdapter(BaseAdapter):
     async def get_logs(
         self,
         session_id: UUID,
-        access_key: str,
+        user_id: UserID,
         kernel_id: UUID | None = None,
     ) -> SessionLogsPayload:
         """Get container logs for a session."""
         action = GetContainerLogsAction(
             session_name=str(session_id),
-            owner_access_key=AccessKey(access_key),
+            owner_user_id=user_id,
             kernel_id=KernelId(kernel_id) if kernel_id else None,
         )
         result = await self._processors.session.get_container_logs.wait_for_complete(action)
@@ -1049,14 +1050,14 @@ class SessionAdapter(BaseAdapter):
         self,
         session_id: UUID,
         input: UpdateSessionInput,
-        access_key: str,
+        user_id: UserID,
     ) -> UpdateSessionPayload:
         """Update session fields (currently supports rename only)."""
         if input.name is not None:
             action = RenameSessionAction(
                 session_name=str(session_id),
                 new_name=input.name,
-                owner_access_key=AccessKey(access_key),
+                owner_user_id=user_id,
             )
             result = await self._processors.session.rename_session.wait_for_complete(action)
             return UpdateSessionPayload(session=self._session_data_to_node(result.session_data))

--- a/src/ai/backend/manager/api/rest/service/handler.py
+++ b/src/ai/backend/manager/api/rest/service/handler.py
@@ -649,6 +649,7 @@ class ServiceHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -540,6 +540,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,
@@ -656,6 +657,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,
@@ -727,6 +729,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,
@@ -775,6 +778,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -793,7 +797,7 @@ class SessionHandler:
         result = await self._session.match_sessions.wait_for_complete(
             MatchSessionsAction(
                 id_or_name_prefix=params.id,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 user_id=user.user_id,
             )
         )
@@ -813,6 +817,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -861,6 +866,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -877,7 +883,7 @@ class SessionHandler:
             result = await self._session.get_session_info.wait_for_complete(
                 GetSessionInfoAction(
                     session_name=session_name,
-                    owner_access_key=owner_access_key,
+                    owner_user_id=scope.owner_user_id,
                 )
             )
         except BackendAIError:
@@ -925,6 +931,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,
@@ -949,7 +956,7 @@ class SessionHandler:
         result = await self._session.destroy_session.wait_for_complete(
             DestroySessionAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 user_role=user_role,
                 forced=params.forced,
                 recursive=params.recursive,
@@ -972,6 +979,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -988,7 +996,7 @@ class SessionHandler:
         result = await self._session.execute_session.wait_for_complete(
             ExecuteSessionAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 api_version=request["api_version"],
                 params=ExecuteSessionActionParams(
                     mode=params.mode,
@@ -1010,6 +1018,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1026,7 +1035,7 @@ class SessionHandler:
             await self._session.interrupt.wait_for_complete(
                 InterruptSessionAction(
                     session_name=session_name,
-                    owner_access_key=owner_access_key,
+                    owner_user_id=scope.owner_user_id,
                 )
             )
         except BackendAIError:
@@ -1049,6 +1058,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1065,7 +1075,7 @@ class SessionHandler:
         action_result = await self._session.complete.wait_for_complete(
             CompleteAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 code=params.code or "",
                 options=params.options or {},
             )
@@ -1124,6 +1134,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1140,7 +1151,7 @@ class SessionHandler:
             await self._session.shutdown_service.wait_for_complete(
                 ShutdownServiceAction(
                     session_name=session_name,
-                    owner_access_key=owner_access_key,
+                    owner_user_id=scope.owner_user_id,
                     service_name=params.service_name,
                 )
             )
@@ -1160,6 +1171,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1176,7 +1188,7 @@ class SessionHandler:
             await self._session.upload_files.wait_for_complete(
                 UploadFilesAction(
                     session_name=session_name,
-                    owner_access_key=owner_access_key,
+                    owner_user_id=scope.owner_user_id,
                     reader=reader,
                 )
             )
@@ -1200,6 +1212,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1216,7 +1229,7 @@ class SessionHandler:
         result = await self._session.download_files.wait_for_complete(
             DownloadFilesAction(
                 user_id=request["user"]["uuid"],
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 session_name=session_name,
                 files=params.files,
             )
@@ -1238,6 +1251,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1255,7 +1269,7 @@ class SessionHandler:
             DownloadFileAction(
                 user_id=request["user"]["uuid"],
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 file=params.file,
             )
         )
@@ -1276,6 +1290,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1294,7 +1309,7 @@ class SessionHandler:
                 user_id=request["user"]["uuid"],
                 path=params.path,
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
             )
         )
         return APIResponse.build(HTTPStatus.OK, ListFilesResponse(dict(result.result)))
@@ -1315,6 +1330,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1332,7 +1348,7 @@ class SessionHandler:
             RenameSessionAction(
                 session_name=session_name,
                 new_name=new_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
             )
         )
         return web.Response(status=HTTPStatus.NO_CONTENT)
@@ -1352,6 +1368,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1367,7 +1384,7 @@ class SessionHandler:
         action_result = await self._session.commit_session.wait_for_complete(
             CommitSessionAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 filename=params.filename,
             )
         )
@@ -1391,6 +1408,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1406,7 +1424,7 @@ class SessionHandler:
         result = await self._session.convert_session_to_image.wait_for_complete(
             ConvertSessionToImageAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
                 image_name=params.image_name,
                 image_visibility=params.image_visibility,
                 image_owner_id=request["user"]["uuid"],
@@ -1435,6 +1453,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1453,7 +1472,7 @@ class SessionHandler:
         result = await self._session.get_commit_status.wait_for_complete(
             GetCommitStatusAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
             )
         )
         return APIResponse.build(
@@ -1475,6 +1494,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1490,7 +1510,7 @@ class SessionHandler:
         result = await self._session.get_abusing_report.wait_for_complete(
             GetAbusingReportAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
             )
         )
         return APIResponse.build(
@@ -1515,6 +1535,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,
@@ -1530,7 +1551,7 @@ class SessionHandler:
         result = await self._session.get_status_history.wait_for_complete(
             GetStatusHistoryAction(
                 session_name=session_name,
-                owner_access_key=request["keypair"]["access_key"],
+                owner_user_id=scope.owner_user_id,
             )
         )
         return APIResponse.build(
@@ -1548,16 +1569,16 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
             )
         )
-        owner_access_key = scope.owner_access_key
         result = await self._session.get_direct_access_info.wait_for_complete(
             GetDirectAccessInfoAction(
                 session_name=session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
             )
         )
         return APIResponse.build(
@@ -1580,6 +1601,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=params.owner_access_key,
@@ -1598,7 +1620,7 @@ class SessionHandler:
             result = await self._session.get_container_logs.wait_for_complete(
                 GetContainerLogsAction(
                     session_name=session_name,
-                    owner_access_key=owner_access_key,
+                    owner_user_id=scope.owner_user_id,
                     kernel_id=kernel_id,
                 )
             )
@@ -1642,7 +1664,6 @@ class SessionHandler:
                 domain_name=domain_name,
                 user_role=user_role,
                 kernel_id=KernelId(params.kernel_id),
-                owner_access_key=request["keypair"]["access_key"],
                 request=request,
             )
         )
@@ -1658,6 +1679,7 @@ class SessionHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
+                requester_user_id=request["user"]["uuid"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
                 owner_access_key=None,
@@ -1673,7 +1695,7 @@ class SessionHandler:
         result = await self._session.get_dependency_graph.wait_for_complete(
             GetDependencyGraphAction(
                 root_session_name=root_session_name,
-                owner_access_key=owner_access_key,
+                owner_user_id=scope.owner_user_id,
             )
         )
         return APIResponse.build(

--- a/src/ai/backend/manager/api/rest/userconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/userconfig/handler.py
@@ -30,6 +30,7 @@ from ai.backend.common.dto.manager.config.response import (
     UpdateBootstrapScriptResponse,
     UpdateDotfileResponse,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.dotfile.types import DotfileScope
 from ai.backend.manager.dto.context import UserContext
@@ -66,6 +67,7 @@ class UserConfigHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=ctx.access_key,
+                requester_user_id=UserID(ctx.user_uuid),
                 requester_role=ctx.user_role,
                 requester_domain=ctx.user_domain,
                 owner_access_key=params.owner_access_key,
@@ -100,6 +102,7 @@ class UserConfigHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=ctx.access_key,
+                requester_user_id=UserID(ctx.user_uuid),
                 requester_role=ctx.user_role,
                 requester_domain=ctx.user_domain,
                 owner_access_key=params.owner_access_key,
@@ -140,6 +143,7 @@ class UserConfigHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=ctx.access_key,
+                requester_user_id=UserID(ctx.user_uuid),
                 requester_role=ctx.user_role,
                 requester_domain=ctx.user_domain,
                 owner_access_key=params.owner_access_key,
@@ -173,6 +177,7 @@ class UserConfigHandler:
         scope = await self._auth.resolve_access_key_scope.wait_for_complete(
             ResolveAccessKeyScopeAction(
                 requester_access_key=ctx.access_key,
+                requester_user_id=UserID(ctx.user_uuid),
                 requester_role=ctx.user_role,
                 requester_domain=ctx.user_domain,
                 owner_access_key=params.owner_access_key,

--- a/src/ai/backend/manager/api/rest/v2/session/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/session/handler.py
@@ -22,6 +22,7 @@ from ai.backend.common.dto.manager.v2.session.request import (
     SessionIdPathParam as SessionIdPathParamDTO,
 )
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AgentId, SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import (
@@ -166,7 +167,7 @@ class V2SessionHandler:
     ) -> APIResponse:
         """Shut down a service in a session."""
         await self._adapter.shutdown_service(
-            path.parsed.session_id, body.parsed, access_key=user_ctx.access_key
+            path.parsed.session_id, body.parsed, user_id=UserID(user_ctx.user_uuid)
         )
         return APIResponse.no_content(status_code=HTTPStatus.NO_CONTENT)
 
@@ -179,7 +180,7 @@ class V2SessionHandler:
         """Get container logs for a session."""
         result = await self._adapter.get_logs(
             path.parsed.session_id,
-            access_key=user_ctx.access_key,
+            user_id=UserID(user_ctx.user_uuid),
             kernel_id=query.parsed.kernel_id,
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
@@ -192,6 +193,6 @@ class V2SessionHandler:
     ) -> APIResponse:
         """Update a session."""
         result = await self._adapter.update(
-            path.parsed.session_id, body.parsed, access_key=user_ctx.access_key
+            path.parsed.session_id, body.parsed, user_id=UserID(user_ctx.user_uuid)
         )
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -38,6 +38,7 @@ from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.identifier.session_group import SessionGroupID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AccessKey,
     ClusterMode,
@@ -243,7 +244,7 @@ async def handle_session_exception(
 
 def _build_session_fetch_query(
     base_cond: Any,
-    access_key: AccessKey | None = None,
+    owner_user_id: UserID | None = None,
     *,
     allow_stale: bool = True,
     for_update: bool = False,
@@ -252,8 +253,8 @@ def _build_session_fetch_query(
     eager_loading_op: Sequence[_AbstractLoad] | None = None,
 ) -> sa.sql.Select[Any]:
     cond = base_cond
-    if access_key:
-        cond = cond & (SessionRow.access_key == access_key)
+    if owner_user_id is not None:
+        cond = cond & (SessionRow.user_uuid == owner_user_id)
     if not allow_stale:
         cond = cond & (~SessionRow.status.in_(DEAD_SESSION_STATUSES))
     query = (
@@ -277,7 +278,7 @@ def _build_session_fetch_query(
 async def _match_sessions_by_id(
     db_session: SASession,
     session_id_or_list: SessionId | list[SessionId],
-    access_key: AccessKey | None = None,
+    owner_user_id: UserID | None = None,
     *,
     allow_prefix: bool = False,
     allow_stale: bool = True,
@@ -295,7 +296,7 @@ async def _match_sessions_by_id(
             cond = SessionRow.id == session_id_or_list
     query = _build_session_fetch_query(
         cond,
-        access_key,
+        owner_user_id,
         max_matches=max_matches,
         allow_stale=allow_stale,
         for_update=for_update,
@@ -309,7 +310,7 @@ async def _match_sessions_by_id(
 async def _match_sessions_by_name(
     db_session: SASession,
     session_name: str,
-    access_key: AccessKey,
+    owner_user_id: UserID | None = None,
     *,
     allow_prefix: bool = False,
     allow_stale: bool = True,
@@ -324,7 +325,7 @@ async def _match_sessions_by_name(
         cond = SessionRow.name == session_name
     query = _build_session_fetch_query(
         cond,
-        access_key,
+        owner_user_id,
         max_matches=max_matches,
         allow_stale=allow_stale,
         for_update=for_update,
@@ -942,7 +943,7 @@ class SessionRow(CreatedAtMixin, Base):
         cls,
         db_session: SASession,
         session_reference: str | UUID | list[UUID],
-        access_key: AccessKey | None,
+        owner_user_id: UserID | None,
         *,
         allow_prefix: bool = False,
         allow_stale: bool = True,
@@ -952,7 +953,7 @@ class SessionRow(CreatedAtMixin, Base):
     ) -> list[SessionRow]:
         """
         Match the prefix of session ID or session name among the sessions
-        that belongs to the given access key, and return the list of SessionRow.
+        owned by the given user, and return the list of SessionRow.
         """
 
         if isinstance(session_reference, list):
@@ -997,7 +998,7 @@ class SessionRow(CreatedAtMixin, Base):
         for fetch_func in query_list:
             rows = await fetch_func(
                 db_session,
-                access_key=access_key,
+                owner_user_id=owner_user_id,
                 allow_stale=allow_stale,
                 for_update=for_update,
                 max_matches=max_matches,
@@ -1013,7 +1014,7 @@ class SessionRow(CreatedAtMixin, Base):
         cls,
         db_session: SASession,
         session_name_or_id: str | UUID,
-        access_key: AccessKey | None = None,
+        owner_user_id: UserID | None = None,
         *,
         allow_stale: bool = False,
         for_update: bool = False,
@@ -1022,12 +1023,12 @@ class SessionRow(CreatedAtMixin, Base):
     ) -> SessionRow:
         """
         Retrieve the session information by session's UUID,
-        or session's name paired with access_key.
+        or session's name paired with the owner's user ID.
         This will return the information of the session and the sibling kernel(s).
 
         :param db_session: Database connection to use when fetching row.
         :param session_name_or_id: Name or ID (UUID) of session to look up.
-        :param access_key: Access key used to create session.
+        :param owner_user_id: UUID of the user who owns the session.
         :param allow_stale: If set to True, filter "inactive" sessions as well as "active" ones.
                             Otherwise filter "active" sessions only.
         :param for_update: Apply for_update during executing select query.
@@ -1059,7 +1060,7 @@ class SessionRow(CreatedAtMixin, Base):
         session_list = await cls.match_sessions(
             db_session,
             session_name_or_id,
-            access_key,
+            owner_user_id,
             allow_stale=allow_stale,
             for_update=for_update,
             eager_loading_op=_eager_loading_op,
@@ -1084,7 +1085,7 @@ class SessionRow(CreatedAtMixin, Base):
         cls,
         db_session: SASession,
         session_ids: list[UUID],
-        access_key: AccessKey | None = None,
+        owner_user_id: UserID | None = None,
         *,
         allow_stale: bool = False,
         for_update: bool = False,
@@ -1116,7 +1117,7 @@ class SessionRow(CreatedAtMixin, Base):
         session_list = await cls.match_sessions(
             db_session,
             session_ids,
-            access_key,
+            owner_user_id,
             allow_stale=allow_stale,
             for_update=for_update,
             eager_loading_op=_eager_loading_op,
@@ -1132,7 +1133,7 @@ class SessionRow(CreatedAtMixin, Base):
         cls,
         db_session: SASession,
         session_id: SessionId,
-        access_key: AccessKey | None = None,
+        owner_user_id: UserID | None = None,
         *,
         max_matches: int | None = None,
         allow_stale: bool = True,
@@ -1142,7 +1143,7 @@ class SessionRow(CreatedAtMixin, Base):
         sessions = await _match_sessions_by_id(
             db_session,
             session_id,
-            access_key,
+            owner_user_id,
             max_matches=max_matches,
             allow_stale=allow_stale,
             for_update=for_update,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -74,6 +74,7 @@ from ai.backend.common.identifier.project import ProjectID
 from ai.backend.common.identifier.resource_group import ResourceGroupName
 from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.common.types import (
@@ -533,7 +534,7 @@ class AgentRegistry:
                 sess = await SessionRow.get_session(
                     db_session,
                     session_name,
-                    owner_access_key,
+                    UserID(user_scope.user_uuid),
                     kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
                 )
                 if sess.main_kernel.image is None:
@@ -763,7 +764,7 @@ class AgentRegistry:
                 await SessionRow.get_session(
                     db_sess,
                     session_name,
-                    owner_access_key,
+                    UserID(user_scope.user_uuid),
                 )
         except SessionNotFound:
             pass
@@ -1632,7 +1633,6 @@ class AgentRegistry:
     async def download_single(
         self,
         session: SessionRow,
-        _access_key: AccessKey,
         filepath: str,
     ) -> bytes:
         kernel = session.main_kernel

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -270,14 +270,14 @@ class AuthDBSource:
         )
 
     @auth_db_source_resilience.apply()
-    async def fetch_user_info_by_access_key(self, access_key: str) -> tuple[str, UserRole]:
-        """Join keypairs→users to get (domain_name, role) for the owner of *access_key*.
+    async def fetch_user_info_by_access_key(self, access_key: str) -> tuple[str, UserRole, UserID]:
+        """Join keypairs→users to get (domain_name, role, user_id) for the owner of *access_key*.
 
         Raises ``ValueError`` if the access key is unknown.
         """
         async with self._db.begin_readonly() as conn:
             query = (
-                sa.select(users.c.domain_name, users.c.role)
+                sa.select(users.c.domain_name, users.c.role, users.c.uuid)
                 .select_from(sa.join(keypairs, users, keypairs.c.user == users.c.uuid))
                 .where(keypairs.c.access_key == access_key)
             )
@@ -285,7 +285,7 @@ class AuthDBSource:
             row = result.first()
             if row is None:
                 raise ValueError("Unknown owner access key")
-            return row.domain_name, row.role
+            return row.domain_name, row.role, UserID(row.uuid)
 
     @auth_db_source_resilience.apply()
     async def fetch_user_id_by_access_key(self, access_key: AccessKey) -> UserID:

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -97,7 +97,9 @@ class AuthRepository:
         await self._db_source.modify_ssh_keypair(access_key, public_key, private_key)
 
     @auth_repository_resilience.apply()
-    async def get_delegation_target_by_access_key(self, access_key: str) -> tuple[str, UserRole]:
+    async def get_delegation_target_by_access_key(
+        self, access_key: str
+    ) -> tuple[str, UserRole, UserID]:
         return await self._db_source.fetch_user_info_by_access_key(access_key)
 
     @auth_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/events/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/events/db_source/db_source.py
@@ -20,10 +20,17 @@ class EventsDBSource:
         session_name: str,
         access_key: AccessKey,
     ) -> list[SessionRow]:
+        # The SSE stream is scoped by the owner_access_key wire parameter and
+        # its event filter matches on access_key, so this lookup stays
+        # keypair-scoped unlike the user-scoped SessionRow.match_sessions.
         async with self._db.begin_readonly_session(isolation_level="READ COMMITTED") as db_sess:
-            return await SessionRow.match_sessions(
-                db_sess, session_name, access_key, allow_prefix=False
+            query = (
+                sa.select(SessionRow)
+                .where((SessionRow.name == session_name) & (SessionRow.access_key == access_key))
+                .order_by(sa.desc(SessionRow.created_at))
+                .limit(10)
             )
+            return list((await db_sess.scalars(query)).all())
 
     async def resolve_group_id(self, group_name: str) -> uuid.UUID:
         async with self._db.begin_readonly(isolation_level="READ COMMITTED") as conn:

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm.strategy_options import _AbstractLoad
 
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
@@ -151,7 +152,7 @@ class SessionDBSource:
     async def get_session_validated(
         self,
         session_name_or_id: str | SessionId,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
         kernel_loading_strategy: KernelLoadingStrategy = KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         allow_stale: bool = False,
         eager_loading_op: Sequence[_AbstractLoad] | None = None,
@@ -161,7 +162,7 @@ class SessionDBSource:
             return await SessionRow.get_session(
                 db_sess,
                 session_name_or_id,
-                owner_access_key,
+                owner_user_id,
                 kernel_loading_strategy=kernel_loading_strategy,
                 allow_stale=allow_stale,
                 eager_loading_op=list(eager_loading_op) if eager_loading_op else None,
@@ -170,13 +171,13 @@ class SessionDBSource:
     async def match_sessions(
         self,
         id_or_name_prefix: str,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
     ) -> list[SessionRow]:
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             return await SessionRow.match_sessions(
                 db_sess,
                 id_or_name_prefix,
-                owner_access_key,
+                owner_user_id,
             )
 
     async def get_template_by_id(
@@ -213,7 +214,7 @@ class SessionDBSource:
         self,
         session_name_or_id: str | SessionId,
         new_name: str,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
     ) -> SessionRow:
         async def _update(db_session: AsyncSession) -> SessionRow:
             # Check if new name already exists for this owner
@@ -221,7 +222,7 @@ class SessionDBSource:
                 await SessionRow.get_session(
                     db_session,
                     new_name,
-                    owner_access_key,
+                    owner_user_id,
                     kernel_loading_strategy=KernelLoadingStrategy.NONE,
                 )
                 raise SessionAlreadyExists(f"Session with name '{new_name}' already exists")
@@ -232,7 +233,7 @@ class SessionDBSource:
             session_row = await SessionRow.get_session(
                 db_session,
                 session_name_or_id,
-                owner_access_key,
+                owner_user_id,
                 kernel_loading_strategy=KernelLoadingStrategy.ALL_KERNELS,
             )
 
@@ -386,13 +387,13 @@ class SessionDBSource:
             if session_row is None:
                 raise SessionNotFound(f"Session not found (id:{session_id})")
 
-            if session_name and session_row.access_key is not None:
+            if session_name:
                 # Check the owner of the target session has any session with the same name
                 try:
                     sess = await SessionRow.get_session(
                         db_session,
                         session_name,
-                        AccessKey(session_row.access_key),
+                        UserID(session_row.user_uuid),
                     )
                 except SessionNotFound:
                     pass
@@ -452,7 +453,7 @@ class SessionDBSource:
         self,
         db_sess: AsyncSession,
         root_session_name_or_id: str | uuid.UUID,
-        access_key: AccessKey,
+        owner_user_id: UserID,
         allow_stale: bool = False,
     ) -> tuple[uuid.UUID, set[uuid.UUID]]:
         """
@@ -460,7 +461,7 @@ class SessionDBSource:
 
         :param db_sess: Database session
         :param root_session_name_or_id: Root session name or ID
-        :param access_key: Access key of the session owner
+        :param owner_user_id: UUID of the session owner
         :param allow_stale: Whether to allow stale sessions
         :return: Tuple of (root_session_id, set of dependent session IDs)
         """
@@ -482,7 +483,7 @@ class SessionDBSource:
         root_session = await SessionRow.get_session(
             db_sess,
             root_session_name_or_id,
-            access_key=access_key,
+            owner_user_id=owner_user_id,
             allow_stale=allow_stale,
         )
         root_session_id = cast(uuid.UUID, root_session.id)
@@ -493,14 +494,14 @@ class SessionDBSource:
     async def get_target_session_ids(
         self,
         session_name_or_id: str | uuid.UUID,
-        access_key: AccessKey,
+        owner_user_id: UserID,
         recursive: bool = False,
     ) -> list[SessionId]:
         """
         Get list of session IDs including dependent sessions if recursive.
 
         :param session_name_or_id: Name or ID of the primary session
-        :param access_key: Access key of the session owner
+        :param owner_user_id: UUID of the session owner
         :param recursive: If True, include dependent sessions
         :return: List of session IDs
         """
@@ -511,7 +512,7 @@ class SessionDBSource:
                     root_id, dependent_ids = await self._find_dependent_sessions(
                         db_sess,
                         session_name_or_id,
-                        access_key,
+                        owner_user_id,
                         allow_stale=True,
                     )
                     # Return dependent sessions first, then root session
@@ -522,7 +523,7 @@ class SessionDBSource:
                     session = await SessionRow.get_session(
                         db_sess,
                         session_name_or_id,
-                        access_key,
+                        owner_user_id,
                         kernel_loading_strategy=KernelLoadingStrategy.NONE,
                         allow_stale=True,
                     )
@@ -535,19 +536,19 @@ class SessionDBSource:
     async def find_dependency_sessions(
         self,
         session_name_or_id: uuid.UUID | str,
-        access_key: AccessKey,
+        owner_user_id: UserID,
     ) -> dict[str, list[Any] | str]:
         async with self._db.begin_readonly_session_read_committed() as db_sess:
             return await find_dependency_sessions(
                 session_name_or_id,
                 db_sess,
-                access_key,
+                owner_user_id,
             )
 
     async def get_session_with_group(
         self,
         session_name_or_id: str | SessionId,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
         kernel_loading_strategy: KernelLoadingStrategy = KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         allow_stale: bool = False,
     ) -> SessionRow:
@@ -556,7 +557,7 @@ class SessionDBSource:
             return await SessionRow.get_session(
                 db_sess,
                 session_name_or_id,
-                owner_access_key,
+                owner_user_id,
                 kernel_loading_strategy=kernel_loading_strategy,
                 allow_stale=allow_stale,
                 eager_loading_op=[selectinload(SessionRow.group)],

--- a/src/ai/backend/manager/repositories/session/dependency_graph.py
+++ b/src/ai/backend/manager/repositories/session/dependency_graph.py
@@ -13,7 +13,7 @@ import aiotools
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.errors.kernel import InvalidSessionData, SessionNotFound
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.session import SessionDependencyRow, SessionRow
@@ -23,12 +23,12 @@ from ai.backend.manager.models.session import SessionDependencyRow, SessionRow
 async def _find_dependency_sessions(
     session_name_or_id: UUID | str,
     db_session: SASession,
-    access_key: AccessKey,
+    owner_user_id: UserID,
 ) -> dict[str, list[Any] | str]:
     sessions = await SessionRow.match_sessions(
         db_session,
         session_name_or_id,
-        access_key=access_key,
+        owner_user_id=owner_user_id,
     )
 
     if len(sessions) < 1:
@@ -66,7 +66,7 @@ async def _find_dependency_sessions(
         "status": str(kernel_query_result[0]),
         "status_changed": str(kernel_query_result[1]),
         "depends_on": [
-            await _find_dependency_sessions(dependency_session_id, db_session, access_key)
+            await _find_dependency_sessions(dependency_session_id, db_session, owner_user_id)
             for dependency_session_id in dependency_session_ids
         ],
     }
@@ -77,15 +77,15 @@ async def _find_dependency_sessions(
 async def find_dependency_sessions(
     session_name_or_id: UUID | str,
     db_session: SASession,
-    access_key: AccessKey,
+    owner_user_id: UserID,
 ) -> dict[str, list[Any] | str]:
-    return await _find_dependency_sessions(session_name_or_id, db_session, access_key)
+    return await _find_dependency_sessions(session_name_or_id, db_session, owner_user_id)
 
 
 async def find_dependent_sessions(
     root_session_name_or_id: str | UUID,
     db_session: SASession,
-    access_key: AccessKey,
+    owner_user_id: UserID,
     *,
     allow_stale: bool = False,
 ) -> set[UUID]:
@@ -108,7 +108,7 @@ async def find_dependent_sessions(
     root_session = await SessionRow.get_session(
         db_session,
         root_session_name_or_id,
-        access_key=access_key,
+        owner_user_id=owner_user_id,
         allow_stale=allow_stale,
     )
     return await _find_dependent_sessions(cast(UUID, root_session.id))

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.strategy_options import _AbstractLoad
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
@@ -86,14 +87,14 @@ class SessionRepository:
     async def get_session_validated(
         self,
         session_name_or_id: str | SessionId,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
         kernel_loading_strategy: KernelLoadingStrategy = KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         allow_stale: bool = False,
         eager_loading_op: Sequence[_AbstractLoad] | None = None,
     ) -> SessionRow:
         return await self._db_source.get_session_validated(
             session_name_or_id,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy,
             allow_stale,
             eager_loading_op,
@@ -103,9 +104,9 @@ class SessionRepository:
     async def match_sessions(
         self,
         id_or_name_prefix: str,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
     ) -> list[SessionRow]:
-        return await self._db_source.match_sessions(id_or_name_prefix, owner_access_key)
+        return await self._db_source.match_sessions(id_or_name_prefix, owner_user_id)
 
     @session_repository_resilience.apply()
     async def get_template_by_id(
@@ -126,10 +127,10 @@ class SessionRepository:
         self,
         session_name_or_id: str | SessionId,
         new_name: str,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
     ) -> SessionRow:
         return await self._db_source.update_session_name(
-            session_name_or_id, new_name, owner_access_key
+            session_name_or_id, new_name, owner_user_id
         )
 
     @session_repository_resilience.apply()
@@ -232,40 +233,40 @@ class SessionRepository:
     async def get_target_session_ids(
         self,
         session_name_or_id: str | uuid.UUID,
-        access_key: AccessKey,
+        owner_user_id: UserID,
         recursive: bool = False,
     ) -> list[SessionId]:
         """
         Get list of session IDs including dependent sessions if recursive.
 
         :param session_name_or_id: Name or ID of the primary session
-        :param access_key: Access key of the session owner
+        :param owner_user_id: UUID of the session owner
         :param recursive: If True, include dependent sessions
         :return: List of session IDs
         """
         return await self._db_source.get_target_session_ids(
-            session_name_or_id, access_key, recursive
+            session_name_or_id, owner_user_id, recursive
         )
 
     @session_repository_resilience.apply()
     async def find_dependency_sessions(
         self,
         session_name_or_id: uuid.UUID | str,
-        access_key: AccessKey,
+        owner_user_id: UserID,
     ) -> dict[str, list[Any] | str]:
-        return await self._db_source.find_dependency_sessions(session_name_or_id, access_key)
+        return await self._db_source.find_dependency_sessions(session_name_or_id, owner_user_id)
 
     @session_repository_resilience.apply()
     async def get_session_with_group(
         self,
         session_name_or_id: str | SessionId,
-        owner_access_key: AccessKey,
+        owner_user_id: UserID,
         kernel_loading_strategy: KernelLoadingStrategy = KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         allow_stale: bool = False,
     ) -> SessionRow:
         """Get session with group information eagerly loaded"""
         return await self._db_source.get_session_with_group(
-            session_name_or_id, owner_access_key, kernel_loading_strategy, allow_stale
+            session_name_or_id, owner_user_id, kernel_loading_strategy, allow_stale
         )
 
     @session_repository_resilience.apply()

--- a/src/ai/backend/manager/services/auth/actions/resolve_access_key_scope.py
+++ b/src/ai/backend/manager/services/auth/actions/resolve_access_key_scope.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
@@ -11,6 +12,7 @@ from ai.backend.manager.services.auth.actions.base import AuthAction
 @dataclass
 class ResolveAccessKeyScopeAction(AuthAction):
     requester_access_key: str
+    requester_user_id: UserID
     requester_role: UserRole
     requester_domain: str
     owner_access_key: str | None  # None = self
@@ -29,6 +31,7 @@ class ResolveAccessKeyScopeAction(AuthAction):
 class ResolveAccessKeyScopeResult(BaseActionResult):
     requester_access_key: AccessKey
     owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -727,12 +727,14 @@ class AuthService:
             return ResolveAccessKeyScopeResult(
                 requester_access_key=requester_ak,
                 owner_access_key=requester_ak,
+                owner_user_id=action.requester_user_id,
             )
         owner_ak = AccessKey(action.owner_access_key)
         try:
             (
                 owner_domain,
                 owner_role,
+                owner_user_id,
             ) = await self._auth_repository.get_delegation_target_by_access_key(
                 action.owner_access_key,
             )
@@ -750,6 +752,7 @@ class AuthService:
         return ResolveAccessKeyScopeResult(
             requester_access_key=requester_ak,
             owner_access_key=owner_ak,
+            owner_user_id=owner_user_id,
         )
 
     async def resolve_user_id_by_access_key(

--- a/src/ai/backend/manager/services/session/actions/commit_session.py
+++ b/src/ai/backend/manager/services/session/actions/commit_session.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.actions.commit_base import SessionCommi
 @dataclass
 class CommitSessionAction(SessionCommitAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     filename: str | None
 
     @override

--- a/src/ai/backend/manager/services/session/actions/complete.py
+++ b/src/ai/backend/manager/services/session/actions/complete.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.dto.agent.response import CodeCompletionResp
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -14,7 +14,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class CompleteAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     code: str
     # TODO: Add type
     options: Mapping[str, Any] | None

--- a/src/ai/backend/manager/services/session/actions/convert_session_to_image.py
+++ b/src/ai/backend/manager/services/session/actions/convert_session_to_image.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.session.types import CustomizedImageVisibilityScope
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -13,7 +13,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class ConvertSessionToImageAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     image_name: str
     image_visibility: CustomizedImageVisibilityScope
     image_owner_id: uuid.UUID

--- a/src/ai/backend/manager/services/session/actions/destroy_session.py
+++ b/src/ai/backend/manager/services/session/actions/destroy_session.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey, SessionId
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import SessionId
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.user import UserRole
@@ -15,7 +16,7 @@ class DestroySessionAction(SessionAction):
     session_name: str
     forced: bool
     recursive: bool
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/download_file.py
+++ b/src/ai/backend/manager/services/session/actions/download_file.py
@@ -2,7 +2,7 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -14,7 +14,7 @@ class DownloadFileAction(SessionFileAction):
     user_id: uuid.UUID
     session_name: str
     file: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/download_files.py
+++ b/src/ai/backend/manager/services/session/actions/download_files.py
@@ -2,7 +2,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -14,7 +14,7 @@ class DownloadFilesAction(SessionFileAction):
     user_id: uuid.UUID
     session_name: str
     files: list[str]
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/execute_session.py
+++ b/src/ai/backend/manager/services/session/actions/execute_session.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -21,7 +21,7 @@ class ExecuteSessionActionParams:
 class ExecuteSessionAction(SessionAction):
     session_name: str
     api_version: tuple[Any, ...]
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     params: ExecuteSessionActionParams
 
     @override

--- a/src/ai/backend/manager/services/session/actions/get_abusing_report.py
+++ b/src/ai/backend/manager/services/session/actions/get_abusing_report.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import EntityType
-from ai.backend.common.types import AbuseReport, AccessKey
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import AbuseReport
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +13,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class GetAbusingReportAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/get_commit_status.py
+++ b/src/ai/backend/manager/services/session/actions/get_commit_status.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.types import CommitStatusInfo
 @dataclass
 class GetCommitStatusAction(SessionCommitAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/get_container_logs.py
+++ b/src/ai/backend/manager/services/session/actions/get_container_logs.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.permission.types import EntityType
-from ai.backend.common.types import AccessKey, KernelId
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import KernelId
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +13,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class GetContainerLogsAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     kernel_id: KernelId | None
 
     @override

--- a/src/ai/backend/manager/services/session/actions/get_dependency_graph.py
+++ b/src/ai/backend/manager/services/session/actions/get_dependency_graph.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.permission.types import EntityType
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class GetDependencyGraphAction(SessionAction):
     root_session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/get_direct_access_info.py
+++ b/src/ai/backend/manager/services/session/actions/get_direct_access_info.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.permission.types import EntityType
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class GetDirectAccessInfoAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/get_session_info.py
+++ b/src/ai/backend/manager/services/session/actions/get_session_info.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.types import LegacySessionInfo
 @dataclass
 class GetSessionInfoAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/get_status_history.py
+++ b/src/ai/backend/manager/services/session/actions/get_status_history.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.permission.types import EntityType
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.session.base import SessionAction
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class GetStatusHistoryAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/interrupt_session.py
+++ b/src/ai/backend/manager/services/session/actions/interrupt_session.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -11,7 +11,7 @@ from ai.backend.manager.services.session.base import SessionAction
 @dataclass
 class InterruptSessionAction(SessionAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/list_files.py
+++ b/src/ai/backend/manager/services/session/actions/list_files.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -15,7 +15,7 @@ class ListFilesAction(SessionFileAction):
     user_id: uuid.UUID
     path: str
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/match_sessions.py
+++ b/src/ai/backend/manager/services/session/actions/match_sessions.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.types import RBACElementRef
@@ -20,7 +20,7 @@ class MatchSessionsAction(SessionScopeAction):
     """
 
     id_or_name_prefix: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     user_id: uuid.UUID
 
     @override

--- a/src/ai/backend/manager/services/session/actions/rename_session.py
+++ b/src/ai/backend/manager/services/session/actions/rename_session.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -12,7 +12,7 @@ from ai.backend.manager.services.session.base import SessionAction
 class RenameSessionAction(SessionAction):
     session_name: str
     new_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
 
     @override
     def entity_id(self) -> str | None:

--- a/src/ai/backend/manager/services/session/actions/shutdown_service.py
+++ b/src/ai/backend/manager/services/session/actions/shutdown_service.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -11,7 +11,7 @@ from ai.backend.manager.services.session.actions.app_service_base import Session
 @dataclass
 class ShutdownServiceAction(SessionAppServiceAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     service_name: str
 
     @override

--- a/src/ai/backend/manager/services/session/actions/upload_files.py
+++ b/src/ai/backend/manager/services/session/actions/upload_files.py
@@ -3,7 +3,7 @@ from typing import Any, override
 
 from aiohttp import MultipartReader
 
-from ai.backend.common.types import AccessKey
+from ai.backend.common.identifier.user import UserID
 from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
@@ -13,7 +13,7 @@ from ai.backend.manager.services.session.actions.file_base import SessionFileAct
 @dataclass
 class UploadFilesAction(SessionFileAction):
     session_name: str
-    owner_access_key: AccessKey
+    owner_user_id: UserID
     # TODO: Refactor this.
     reader: MultipartReader
 

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -365,7 +365,7 @@ class SessionService:
 
     async def commit_session(self, action: CommitSessionAction) -> CommitSessionActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         filename = action.filename
 
         myself = asyncio.current_task()
@@ -374,7 +374,7 @@ class SessionService:
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 
@@ -391,13 +391,13 @@ class SessionService:
 
     async def complete(self, action: CompleteAction) -> CompleteActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         code = action.code
         options = action.options or {}
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         try:
@@ -413,7 +413,7 @@ class SessionService:
         self, action: ConvertSessionToImageAction
     ) -> ConvertSessionToImageActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         image_name = action.image_name
         image_visibility = action.image_visibility
         image_owner_id = action.image_owner_id
@@ -444,7 +444,7 @@ class SessionService:
 
         session = await self._session_repository.get_session_with_group(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 
@@ -860,14 +860,14 @@ class SessionService:
 
     async def destroy_session(self, action: DestroySessionAction) -> DestroySessionActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         forced = action.forced
         recursive = action.recursive
 
         # Get session IDs to terminate (based on recursive flag)
         session_ids = await self._session_repository.get_target_session_ids(
             session_name,
-            owner_access_key,
+            owner_user_id,
             recursive=recursive,
         )
 
@@ -917,16 +917,16 @@ class SessionService:
 
     async def download_file(self, action: DownloadFileAction) -> DownloadFileActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         user_id = action.user_id
         file = action.file
         try:
             session = await self._session_repository.get_session_validated(
                 session_name,
-                owner_access_key,
+                owner_user_id,
                 kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
             )
-            result = await self._agent_registry.download_single(session, owner_access_key, file)
+            result = await self._agent_registry.download_single(session, file)
         except (ValueError, FileNotFoundError) as e:
             raise InvalidAPIParameters("The file is not found.") from e
         except asyncio.CancelledError:
@@ -942,12 +942,12 @@ class SessionService:
 
     async def download_files(self, action: DownloadFilesAction) -> DownloadFilesActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         user_id = action.user_id
         files = action.files
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         try:
@@ -984,13 +984,13 @@ class SessionService:
 
     async def execute_session(self, action: ExecuteSessionAction) -> ExecuteSessionActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         api_version = action.api_version
 
         resp = {}
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         try:
@@ -1065,10 +1065,10 @@ class SessionService:
         self, action: GetAbusingReportAction
     ) -> GetAbusingReportActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         kernel = session.main_kernel
@@ -1079,11 +1079,11 @@ class SessionService:
 
     async def get_commit_status(self, action: GetCommitStatusAction) -> GetCommitStatusActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         statuses = await self._agent_registry.get_commit_status([session.main_kernel.id])
@@ -1100,12 +1100,12 @@ class SessionService:
     ) -> GetContainerLogsActionResult:
         resp = {"result": {"logs": ""}}
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         kernel_id = action.kernel_id
 
         compute_session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             allow_stale=True,
             kernel_loading_strategy=(
                 KernelLoadingStrategy.MAIN_KERNEL_ONLY
@@ -1145,10 +1145,10 @@ class SessionService:
         self, action: GetDependencyGraphAction
     ) -> GetDependencyGraphActionResult:
         root_session_name = action.root_session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         dependency_graph = await self._session_repository.find_dependency_sessions(
-            root_session_name, owner_access_key
+            root_session_name, owner_user_id
         )
 
         session_id = (
@@ -1171,11 +1171,11 @@ class SessionService:
         self, action: GetDirectAccessInfoAction
     ) -> GetDirectAccessInfoActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         sess = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         resp = {}
@@ -1208,11 +1208,11 @@ class SessionService:
 
     async def get_session_info(self, action: GetSessionInfoAction) -> GetSessionInfoActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         sess = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 
@@ -1256,11 +1256,11 @@ class SessionService:
         self, action: GetStatusHistoryAction
     ) -> GetStatusHistoryActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         session_row = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.NONE,
         )
         result = session_row.status_history or {}
@@ -1269,11 +1269,11 @@ class SessionService:
 
     async def interrupt(self, action: InterruptSessionAction) -> InterruptSessionActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         await self._agent_registry.interrupt_session(session)
@@ -1282,13 +1282,13 @@ class SessionService:
 
     async def list_files(self, action: ListFilesAction) -> ListFilesActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         user_id = action.user_id
         path = action.path
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 
@@ -1310,12 +1310,12 @@ class SessionService:
 
     async def match_sessions(self, action: MatchSessionsAction) -> MatchSessionsActionResult:
         id_or_name_prefix = action.id_or_name_prefix
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
 
         matches: list[dict[str, Any]] = []
         sessions = await self._session_repository.match_sessions(
             id_or_name_prefix,
-            owner_access_key,
+            owner_user_id,
         )
         if sessions:
             matches.extend(
@@ -1330,12 +1330,12 @@ class SessionService:
 
     async def rename_session(self, action: RenameSessionAction) -> RenameSessionActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         new_name = action.new_name
 
         try:
             compute_session = await self._session_repository.update_session_name(
-                session_name, new_name, owner_access_key
+                session_name, new_name, owner_user_id
             )
             if compute_session.status != SessionStatus.RUNNING:
                 raise InvalidAPIParameters("Can't change name of not running session")
@@ -1348,12 +1348,12 @@ class SessionService:
 
     async def shutdown_service(self, action: ShutdownServiceAction) -> ShutdownServiceActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         service_name = action.service_name
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
         await self._agent_registry.shutdown_service(session, service_name)
@@ -1469,12 +1469,12 @@ class SessionService:
 
     async def upload_files(self, action: UploadFilesAction) -> UploadFilesActionResult:
         session_name = action.session_name
-        owner_access_key = action.owner_access_key
+        owner_user_id = action.owner_user_id
         reader = action.reader
 
         session = await self._session_repository.get_session_validated(
             session_name,
-            owner_access_key,
+            owner_user_id,
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 

--- a/src/ai/backend/manager/services/vfolder/actions/base.py
+++ b/src/ai/backend/manager/services/vfolder/actions/base.py
@@ -5,7 +5,6 @@ from typing import Any, override
 
 from ai.backend.common.data.permission.types import EntityType, RBACElementType, ScopeType
 from ai.backend.common.types import (
-    AccessKey,
     KernelId,
     QuotaScopeID,
     VFolderUsageMode,
@@ -566,7 +565,6 @@ class GetTaskLogsAction(VFolderSingleEntityAction):
     domain_name: str
     user_role: UserRole
     kernel_id: KernelId
-    owner_access_key: AccessKey
 
     # TODO: Remove this.
     request: Any

--- a/tests/unit/manager/api/service/test_handler.py
+++ b/tests/unit/manager/api/service/test_handler.py
@@ -16,6 +16,7 @@ import pytest
 from ai.backend.common.dto.manager.model_serving.request import (
     NewServiceRequestModel,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.identifier.vfolder import VFolderUUID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.api.rest.service.handler import ServiceHandler
@@ -84,6 +85,7 @@ class TestRunValidationUsesKeypairResourcePolicy:
         scope_result = ResolveAccessKeyScopeResult(
             requester_access_key=AccessKey("TESTACCESSKEY01"),
             owner_access_key=AccessKey("TESTACCESSKEY01"),
+            owner_user_id=UserID(uuid.UUID("00000000-0000-0000-0000-000000000001")),
         )
         mock = MagicMock()
         mock.resolve_access_key_scope = MagicMock()

--- a/tests/unit/manager/services/auth/test_resolve_scope.py
+++ b/tests/unit/manager/services/auth/test_resolve_scope.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.errors.common import GenericForbidden
 from ai.backend.manager.models.user import UserRole
@@ -58,6 +59,7 @@ class TestResolveAccessKeyScope:
     ) -> None:
         action = ResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
+            requester_user_id=UserID(REQUESTER_UUID),
             requester_role=UserRole.USER,
             requester_domain="default",
             owner_access_key=None,
@@ -65,6 +67,7 @@ class TestResolveAccessKeyScope:
         result = await auth_service.resolve_access_key_scope(action)
         assert result.requester_access_key == AccessKey(REQUESTER_AK)
         assert result.owner_access_key == AccessKey(REQUESTER_AK)
+        assert result.owner_user_id == UserID(REQUESTER_UUID)
 
     async def test_owner_equals_requester_returns_same_key(
         self,
@@ -72,6 +75,7 @@ class TestResolveAccessKeyScope:
     ) -> None:
         action = ResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
+            requester_user_id=UserID(REQUESTER_UUID),
             requester_role=UserRole.ADMIN,
             requester_domain="default",
             owner_access_key=REQUESTER_AK,
@@ -87,9 +91,11 @@ class TestResolveAccessKeyScope:
         mock_auth_repository.get_delegation_target_by_access_key.return_value = (
             "default",
             UserRole.ADMIN,
+            UserID(OWNER_UUID),
         )
         action = ResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
+            requester_user_id=UserID(REQUESTER_UUID),
             requester_role=UserRole.USER,
             requester_domain="default",
             owner_access_key=OWNER_AK,
@@ -107,6 +113,7 @@ class TestResolveAccessKeyScope:
         )
         action = ResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
+            requester_user_id=UserID(REQUESTER_UUID),
             requester_role=UserRole.SUPERADMIN,
             requester_domain="default",
             owner_access_key="NONEXISTENT_KEY",
@@ -122,9 +129,11 @@ class TestResolveAccessKeyScope:
         mock_auth_repository.get_delegation_target_by_access_key.return_value = (
             "other-domain",
             UserRole.USER,
+            UserID(OWNER_UUID),
         )
         action = ResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
+            requester_user_id=UserID(REQUESTER_UUID),
             requester_role=UserRole.ADMIN,
             requester_domain="default",
             owner_access_key=OWNER_AK,

--- a/tests/unit/manager/services/session/test_session_lifecycle_service.py
+++ b/tests/unit/manager/services/session/test_session_lifecycle_service.py
@@ -18,6 +18,7 @@ from dateutil.tz import tzutc
 
 from ai.backend.common.exception import InvalidAPIParameters, UnknownImageReference
 from ai.backend.common.identifier.session import SessionID
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AbuseReport,
     AccessKey,
@@ -341,7 +342,7 @@ class TestCommitSession:
 
         action = CommitSessionAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             filename=None,
         )
 
@@ -353,6 +354,7 @@ class TestCommitSession:
 
     async def test_commit_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -363,7 +365,7 @@ class TestCommitSession:
 
         action = CommitSessionAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             filename=None,
         )
 
@@ -392,7 +394,7 @@ class TestCommitSession:
 
         action = CommitSessionAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             filename="my-snapshot.tar.gz",
         )
 
@@ -427,7 +429,7 @@ class TestGetCommitStatus:
 
         action = GetCommitStatusAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_commit_status(action)
 
@@ -436,6 +438,7 @@ class TestGetCommitStatus:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -446,7 +449,7 @@ class TestGetCommitStatus:
 
         action = GetCommitStatusAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -489,7 +492,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(1,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode=None,
                 options=None,
@@ -534,7 +537,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(2,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode="batch",
                 options=None,
@@ -573,7 +576,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(2,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode="complete",
                 options={},
@@ -604,7 +607,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(2,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode="continue",
                 options=None,
@@ -635,7 +638,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(2,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode="invalid_mode",
                 options=None,
@@ -666,7 +669,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(2,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode=None,
                 options=None,
@@ -707,7 +710,7 @@ class TestExecuteSession:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(2,),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=ExecuteSessionActionParams(
                 mode="query",
                 options=None,
@@ -1665,7 +1668,7 @@ class TestMatchSessions:
 
         action = MatchSessionsAction(
             id_or_name_prefix="test",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             user_id=sample_user_id,
         )
         result = await session_service.match_sessions(action)
@@ -1685,14 +1688,14 @@ class TestMatchSessions:
 
         action = MatchSessionsAction(
             id_or_name_prefix="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             user_id=sample_user_id,
         )
         result = await session_service.match_sessions(action)
 
         assert result.result == []
 
-    async def test_owner_access_key_filtering(
+    async def test_owner_user_filtering(
         self,
         session_service: SessionService,
         mock_session_repository: MagicMock,
@@ -1703,12 +1706,14 @@ class TestMatchSessions:
 
         action = MatchSessionsAction(
             id_or_name_prefix="test",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             user_id=sample_user_id,
         )
         await session_service.match_sessions(action)
 
-        mock_session_repository.match_sessions.assert_called_once_with("test", sample_access_key)
+        mock_session_repository.match_sessions.assert_called_once_with(
+            "test", UserID(sample_user_id)
+        )
 
 
 # ==================== GetAbusingReport Tests ====================
@@ -1735,7 +1740,7 @@ class TestGetAbusingReport:
 
         action = GetAbusingReportAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_abusing_report(action)
 
@@ -1743,6 +1748,7 @@ class TestGetAbusingReport:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1753,7 +1759,7 @@ class TestGetAbusingReport:
 
         action = GetAbusingReportAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -1787,7 +1793,7 @@ class TestGetDirectAccessInfo:
 
         action = GetDirectAccessInfoAction(
             session_name="system-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_direct_access_info(action)
 
@@ -1817,7 +1823,7 @@ class TestGetDirectAccessInfo:
 
         action = GetDirectAccessInfoAction(
             session_name="interactive-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_direct_access_info(action)
 
@@ -1846,7 +1852,7 @@ class TestGetDirectAccessInfo:
 
         action = GetDirectAccessInfoAction(
             session_name="system-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(KernelNotReady):
@@ -1881,7 +1887,7 @@ class TestGetDependencyGraph:
 
         action = GetDependencyGraphAction(
             root_session_name="root-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_dependency_graph(action)
 
@@ -1910,7 +1916,7 @@ class TestGetDependencyGraph:
 
         action = GetDependencyGraphAction(
             root_session_name="root-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_dependency_graph(action)
 
@@ -1918,6 +1924,7 @@ class TestGetDependencyGraph:
 
     async def test_empty_session_id_raises_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1928,7 +1935,7 @@ class TestGetDependencyGraph:
 
         action = GetDependencyGraphAction(
             root_session_name="root-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -2156,7 +2163,7 @@ class TestShutdownService:
 
         action = ShutdownServiceAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             service_name="jupyter",
         )
         result = await session_service.shutdown_service(action)
@@ -2166,6 +2173,7 @@ class TestShutdownService:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -2176,7 +2184,7 @@ class TestShutdownService:
 
         action = ShutdownServiceAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             service_name="jupyter",
         )
 

--- a/tests/unit/manager/services/session/test_session_service.py
+++ b/tests/unit/manager/services/session/test_session_service.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.agent.response import CodeCompletionResp, CodeComplet
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import (
     AccessKey,
     BinarySize,
@@ -311,7 +312,7 @@ class TestMatchSessions:
 
         action = MatchSessionsAction(
             id_or_name_prefix="test",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             user_id=sample_user_id,
         )
         result = await session_service.match_sessions(action)
@@ -320,7 +321,9 @@ class TestMatchSessions:
         assert result.result[0]["id"] == str(sample_session_data.id)
         assert result.result[0]["name"] == sample_session_data.name
         assert result.result[0]["status"] == sample_session_data.status.name
-        mock_session_repository.match_sessions.assert_called_once_with("test", sample_access_key)
+        mock_session_repository.match_sessions.assert_called_once_with(
+            "test", UserID(sample_user_id)
+        )
 
     async def test_no_matches(
         self,
@@ -334,7 +337,7 @@ class TestMatchSessions:
 
         action = MatchSessionsAction(
             id_or_name_prefix="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             user_id=sample_user_id,
         )
         result = await session_service.match_sessions(action)
@@ -402,7 +405,7 @@ class TestMatchSessions:
 
         action = MatchSessionsAction(
             id_or_name_prefix="test",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             user_id=sample_user_id,
         )
         result = await session_service.match_sessions(action)
@@ -420,6 +423,7 @@ class TestGetStatusHistory:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_session_id: SessionId,
@@ -439,7 +443,7 @@ class TestGetStatusHistory:
 
         action = GetStatusHistoryAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_status_history(action)
 
@@ -449,6 +453,7 @@ class TestGetStatusHistory:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -460,7 +465,7 @@ class TestGetStatusHistory:
 
         action = GetStatusHistoryAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -468,6 +473,7 @@ class TestGetStatusHistory:
 
     async def test_empty_status_history(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_session_id: SessionId,
@@ -481,7 +487,7 @@ class TestGetStatusHistory:
 
         action = GetStatusHistoryAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_status_history(action)
 
@@ -497,6 +503,7 @@ class TestDestroySession:
 
     async def test_success_cancelled(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_scheduling_controller: MagicMock,
@@ -519,7 +526,7 @@ class TestDestroySession:
             session_name="test-session",
             forced=False,
             recursive=False,
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.destroy_session(action)
 
@@ -533,6 +540,7 @@ class TestDestroySession:
 
     async def test_success_terminated(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_scheduling_controller: MagicMock,
@@ -555,7 +563,7 @@ class TestDestroySession:
             session_name="test-session",
             forced=False,
             recursive=False,
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.destroy_session(action)
 
@@ -568,6 +576,7 @@ class TestDestroySession:
 
     async def test_force_terminate_directly_terminated(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_scheduling_controller: MagicMock,
@@ -590,7 +599,7 @@ class TestDestroySession:
             session_name="test-session",
             forced=True,
             recursive=False,
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.destroy_session(action)
 
@@ -603,6 +612,7 @@ class TestDestroySession:
 
     async def test_recursive_destroy(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_scheduling_controller: MagicMock,
@@ -625,7 +635,7 @@ class TestDestroySession:
             session_name="test-session",
             forced=False,
             recursive=True,
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.destroy_session(action)
 
@@ -638,6 +648,7 @@ class TestDestroySession:
 
     async def test_no_sessions_to_destroy(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_scheduling_controller: MagicMock,
@@ -659,7 +670,7 @@ class TestDestroySession:
             session_name="nonexistent",
             forced=False,
             recursive=False,
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.destroy_session(action)
 
@@ -676,6 +687,7 @@ class TestComplete:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -698,7 +710,7 @@ class TestComplete:
 
         action = CompleteAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             code="print('Hello')",
             options=None,
         )
@@ -712,6 +724,7 @@ class TestComplete:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -723,7 +736,7 @@ class TestComplete:
 
         action = CompleteAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             code="print('Hello')",
             options=None,
         )
@@ -777,6 +790,7 @@ class TestGetSessionInfo:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -789,7 +803,7 @@ class TestGetSessionInfo:
 
         action = GetSessionInfoAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_session_info(action)
 
@@ -804,6 +818,7 @@ class TestGetSessionInfo:
 
     async def test_success_with_no_container_id(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_running_session: MagicMock,
@@ -816,7 +831,7 @@ class TestGetSessionInfo:
 
         action = GetSessionInfoAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_session_info(action)
 
@@ -825,6 +840,7 @@ class TestGetSessionInfo:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -836,7 +852,7 @@ class TestGetSessionInfo:
 
         action = GetSessionInfoAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -867,7 +883,7 @@ class TestDownloadFiles:
         action = DownloadFilesAction(
             user_id=sample_user_id,
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             files=["test_file.txt"],
         )
         result = await session_service.download_files(action)
@@ -893,7 +909,7 @@ class TestDownloadFiles:
         action = DownloadFilesAction(
             user_id=sample_user_id,
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             files=["test_file.txt"],
         )
 
@@ -916,7 +932,7 @@ class TestDownloadFiles:
         action = DownloadFilesAction(
             user_id=sample_user_id,
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             files=["file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt", "file6.txt"],
         )
 
@@ -932,6 +948,7 @@ class TestGetDirectAccessInfo:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -946,7 +963,7 @@ class TestGetDirectAccessInfo:
 
         action = GetDirectAccessInfoAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.get_direct_access_info(action)
 
@@ -958,6 +975,7 @@ class TestGetDirectAccessInfo:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -969,7 +987,7 @@ class TestGetDirectAccessInfo:
 
         action = GetDirectAccessInfoAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -984,6 +1002,7 @@ class TestRenameSession:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_session_data: SessionData,
@@ -997,7 +1016,7 @@ class TestRenameSession:
 
         action = RenameSessionAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             new_name="new-session-name",
         )
         result = await session_service.rename_session(action)
@@ -1010,6 +1029,7 @@ class TestRenameSession:
 
     async def test_not_running_session(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_session_data: SessionData,
@@ -1022,7 +1042,7 @@ class TestRenameSession:
 
         action = RenameSessionAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             new_name="new-session-name",
         )
 
@@ -1072,6 +1092,7 @@ class TestShutdownService:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -1086,7 +1107,7 @@ class TestShutdownService:
 
         action = ShutdownServiceAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             service_name="test-service",
         )
         result = await session_service.shutdown_service(action)
@@ -1099,6 +1120,7 @@ class TestShutdownService:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1110,7 +1132,7 @@ class TestShutdownService:
 
         action = ShutdownServiceAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             service_name="test-service",
         )
 
@@ -1126,6 +1148,7 @@ class TestUploadFiles:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -1157,7 +1180,7 @@ class TestUploadFiles:
 
         action = UploadFilesAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             reader=mock_reader,
         )
         result = await session_service.upload_files(action)
@@ -1168,6 +1191,7 @@ class TestUploadFiles:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1181,7 +1205,7 @@ class TestUploadFiles:
 
         action = UploadFilesAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             reader=mock_reader,
         )
 
@@ -1197,6 +1221,7 @@ class TestExecute:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -1227,7 +1252,7 @@ class TestExecute:
         action = ExecuteSessionAction(
             session_name="test-session",
             api_version=(4, 0),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=params,
         )
         result = await session_service.execute_session(action)
@@ -1241,6 +1266,7 @@ class TestExecute:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1259,7 +1285,7 @@ class TestExecute:
         action = ExecuteSessionAction(
             session_name="nonexistent",
             api_version=(4, 0),
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             params=params,
         )
 
@@ -1275,6 +1301,7 @@ class TestInterrupt:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -1289,7 +1316,7 @@ class TestInterrupt:
 
         action = InterruptSessionAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.interrupt(action)
 
@@ -1300,6 +1327,7 @@ class TestInterrupt:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1311,7 +1339,7 @@ class TestInterrupt:
 
         action = InterruptSessionAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -1345,7 +1373,7 @@ class TestListFiles:
             user_id=sample_user_id,
             path="/home/work",
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
         result = await session_service.list_files(action)
 
@@ -1371,7 +1399,7 @@ class TestListFiles:
             user_id=sample_user_id,
             path="/home/work",
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
         )
 
         with pytest.raises(SessionNotFound):
@@ -1386,6 +1414,7 @@ class TestGetContainerLogs:
 
     async def test_success(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         mock_agent_registry: MagicMock,
@@ -1404,7 +1433,7 @@ class TestGetContainerLogs:
 
         action = GetContainerLogsAction(
             session_name="test-session",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             kernel_id=None,  # Optional - get logs from main kernel
         )
         result = await session_service.get_container_logs(action)
@@ -1418,6 +1447,7 @@ class TestGetContainerLogs:
 
     async def test_session_not_found(
         self,
+        sample_user_id: UUID,
         session_service: SessionService,
         mock_session_repository: MagicMock,
         sample_access_key: AccessKey,
@@ -1429,7 +1459,7 @@ class TestGetContainerLogs:
 
         action = GetContainerLogsAction(
             session_name="nonexistent",
-            owner_access_key=sample_access_key,
+            owner_user_id=UserID(sample_user_id),
             kernel_id=None,
         )
 


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the auth identity migration stack (epic BA-7356). **Merge in order (bottom-up):**

1. #13759 — `feat(BA-7357)`: make request authentication user-primary
2. 👉 **#13761 — `feat(BA-7358)`: resolve session ownership by user instead of access key** ← you are here

Resolves #13760 (BA-7358)

## Summary
- `SessionRow.get_session`/`match_sessions`/`list_sessions` and the session repository lookup/control paths (match, rename, destroy, logs, files, dependency graph, direct-access info, status history) filter by the owner's user UUID instead of `sessions.access_key`.
- `ResolveAccessKeyScopeAction` gains `requester_user_id` and its result carries the resolved `owner_user_id` (the delegation lookup returns the target's user UUID), so the ~20 lookup/control session actions now carry `owner_user_id`. The v2 session adapter (shutdown_service/get_logs/rename) takes the caller's user id.
- **Behavior change:** name-based lookups now match all sessions owned by the user, not only those created with the requesting keypair. A multi-keypair user may now hit `TooManySessionsMatched` where names collide across their keypairs.

Kept access-key-based on purpose (later issues in the epic): the session creation path (`query_userinfo`, `sessions.access_key` stamping, model-service validation), dotfiles (keypair-owned entities), the SSE event stream (wire `owner_access_key` param + event filter — its name match is now a local query in the events repository), rate limiting, and occupancy accounting.

## Test plan
- [x] `tests/unit/manager/services/auth/test_resolve_scope.py`: resolver returns the owner user id for self and delegation cases
- [x] `tests/unit/manager/services/session/`: lookup/control service tests updated to user-scoped repository calls; creation tests still exercise the access-key path
- [ ] CI full suite
- [ ] Live check: session create/list/destroy by name with a multi-keypair user

🤖 Generated with [Claude Code](https://claude.com/claude-code)
