### PR TITLE
feat(BA-7364): deliver the user ID to the webserver session at login

### DIFF
--- a/changes/13770.feature.md
+++ b/changes/13770.feature.md
@@ -1,0 +1,1 @@
+Include the user ID in the login authorize response and keep it in the webserver session so that webserver-side features can identify the user without extra manager queries.

--- a/src/ai/backend/common/dto/manager/auth/types.py
+++ b/src/ai/backend/common/dto/manager/auth/types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, Self
 
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import BackendAISchema
 
 __all__ = (
@@ -55,6 +56,8 @@ class AuthSuccessResponse(AuthResponse):
     role: str
     status: str
     session_token: str
+    # Optional for wire compatibility with managers that do not send it yet.
+    user_id: UserID | None = None
     type: AuthTokenType = AuthTokenType.KEYPAIR
 
     def to_dict(self) -> dict[str, str]:

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -46,6 +46,7 @@ from ai.backend.common.dto.manager.auth.types import (
     AuthSuccessResponse,
     AuthTokenType,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.middleware.auth import extract_client_ip
 from ai.backend.manager.dto.context import RequestCtx, UserContext
@@ -168,6 +169,7 @@ class AuthHandler:
             role=auth_result.role,
             status=auth_result.status,
             session_token=auth_result.session_token,
+            user_id=UserID(auth_result.user_id),
         )
         resp = AuthorizeResponse(data=data)
         return APIResponse.build(HTTPStatus.OK, resp)

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -506,6 +506,7 @@ async def login_handler(request: web.Request) -> web.Response:
                     "secret_key": token.secret_key,
                     "role": token.role,
                     "status": token.status,
+                    "user_id": str(token.user_id) if token.user_id is not None else None,
                 }
                 public_return = {
                     "access_key": token.access_key,
@@ -767,6 +768,7 @@ async def token_login_handler(request: web.Request) -> web.Response:
             "secret_key": token.secret_key,
             "role": token.role,
             "status": token.status,
+            "user_id": str(token.user_id) if token.user_id is not None else None,
         }
         public_return = {
             "access_key": token.access_key,

--- a/tests/unit/common/dto/manager/auth/test_auth_types.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import UUID, uuid4
+
 from ai.backend.common.dto.manager.auth.types import (
     AuthResponseType,
     AuthSuccessResponse,
@@ -9,6 +11,7 @@ from ai.backend.common.dto.manager.auth.types import (
     TwoFactorType,
     parse_auth_response,
 )
+from ai.backend.common.identifier.user import UserID
 
 
 def test_auth_token_type_values() -> None:
@@ -119,6 +122,37 @@ def test_parse_auth_response_success() -> None:
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)
     assert result.access_key == "AK"
+    assert result.user_id is None
+
+
+def test_parse_auth_response_success_with_user_id() -> None:
+    data = {
+        "response_type": "success",
+        "access_key": "AK",
+        "secret_key": "SK",
+        "role": "user",
+        "status": "active",
+        "session_token": "test_token",
+        "user_id": "12345678-1234-5678-1234-567812345678",
+    }
+    result = parse_auth_response(data)
+    assert isinstance(result, AuthSuccessResponse)
+    assert result.user_id == UUID("12345678-1234-5678-1234-567812345678")
+
+
+def test_auth_success_response_to_dict_serializes_user_id() -> None:
+    user_id = UserID(uuid4())
+    resp = AuthSuccessResponse(
+        response_type=AuthResponseType.SUCCESS,
+        access_key="AK",
+        secret_key="SK",
+        role="user",
+        status="active",
+        session_token="test_token",
+        user_id=user_id,
+    )
+    d = resp.to_dict()
+    assert d["user_id"] == str(user_id)
 
 
 def test_parse_auth_response_two_factor_registration() -> None:

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -279,6 +279,7 @@ class TestAuthorize:
         assert isinstance(data, dict)
         assert data["data"]["access_key"] == authorize_result.authorization_result.access_key
         assert data["data"]["secret_key"] == authorize_result.authorization_result.secret_key
+        assert data["data"]["user_id"] == str(authorize_result.authorization_result.user_id)
 
     async def test_passes_params_to_action(
         self,


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 2-PR stack. **Merge in order:**

1. 👉 **#13770** — `feat(BA-7364): deliver the user ID to the webserver session at login` ← you are here
2. ⬇️ #13771 — `feat(BA-7365): add a per-user rate limit middleware to the webserver`

Only the final tip (#13771) is guaranteed to build / pass CI; intermediate PRs are logical slices for reviewability.

## Summary
- Add an optional `user_id` field (`UserID` identifier type) to `AuthSuccessResponse`; optional keeps the wire format compatible with managers that do not send it yet.
- Fill it in the manager REST `authorize` handler from `AuthorizationResult.user_id`, which the auth service already returns.
- Store `user_id` in the webserver session token in both login paths (credential login and token login), so the webserver-side rate limiter (#13771) can key per-user counters on it.

Resolves BA-7364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)