### PR TITLE
feat(BA-7603): add a per-user rate limit middleware to the web server

### DIFF
--- a/changes/13771.feature.md
+++ b/changes/13771.feature.md
@@ -1,0 +1,1 @@
+Reject over-limit requests at the web server with HTTP 429 before they are proxied to the manager, reading the requesting user's rate limit window from the shared rate limit Redis DB without asking the manager.

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -94,10 +94,10 @@ class ValkeyRateLimitClient:
         self._closed = True
         await self._client.disconnect()
 
-    def _user_window_key(self, user_id: UserID) -> str:
+    def _user_rate_limit_key(self, user_id: UserID) -> str:
         return f"user.{user_id}.rate_limit_window"
 
-    def _ip_window_key(self, client_ip: str) -> str:
+    def _ip_rate_limit_key(self, client_ip: str) -> str:
         return f"ip.{client_ip}.rate_limit_window"
 
     @valkey_rate_limit_resilience.apply()
@@ -112,7 +112,9 @@ class ValkeyRateLimitClient:
         :param limit: The limit to fix for the window, taken only when the request opens one.
         :return: The count, the limit fixed for the window, and the seconds until it ends.
         """
-        return await self._consume_window(self._user_window_key(user_id), window_seconds, limit)
+        return await self._consume_rate_limit(
+            self._user_rate_limit_key(user_id), window_seconds, limit
+        )
 
     @valkey_rate_limit_resilience.apply()
     async def consume_ip_rate_limit(
@@ -126,9 +128,13 @@ class ValkeyRateLimitClient:
         :param limit: The limit to fix for the window, taken only when the request opens one.
         :return: The count, the limit fixed for the window, and the seconds until it ends.
         """
-        return await self._consume_window(self._ip_window_key(client_ip), window_seconds, limit)
+        return await self._consume_rate_limit(
+            self._ip_rate_limit_key(client_ip), window_seconds, limit
+        )
 
-    async def _consume_window(self, key: str, window_seconds: int, limit: int) -> RateLimitState:
+    async def _consume_rate_limit(
+        self, key: str, window_seconds: int, limit: int
+    ) -> RateLimitState:
         """
         ``HSETNX`` and ``EXPIRE NX`` take their argument only from the request that opens
         the window, so a later one leaves the limit and the deadline as they stand.
@@ -158,7 +164,7 @@ class ValkeyRateLimitClient:
         :param user_id: The user the counter is keyed by.
         :return: The window state, or None when no window is open for the user.
         """
-        return await self._read_window_state(self._user_window_key(user_id))
+        return await self._read_rate_limit(self._user_rate_limit_key(user_id))
 
     @valkey_rate_limit_resilience.apply()
     async def get_ip_rate_limit(self, client_ip: str) -> RateLimitState | None:
@@ -168,9 +174,9 @@ class ValkeyRateLimitClient:
         :param client_ip: The address the counter is keyed by.
         :return: The window state, or None when no window is open for the address.
         """
-        return await self._read_window_state(self._ip_window_key(client_ip))
+        return await self._read_rate_limit(self._ip_rate_limit_key(client_ip))
 
-    async def _read_window_state(self, key: str) -> RateLimitState | None:
+    async def _read_rate_limit(self, key: str) -> RateLimitState | None:
         """
         ``consume_*`` fixes the limit in the same atomic batch that opens a window,
         so an open window always carries one.

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -129,6 +129,10 @@ class ValkeyRateLimitClient:
         return await self._consume_window(self._ip_window_key(client_ip), window_seconds, limit)
 
     async def _consume_window(self, key: str, window_seconds: int, limit: int) -> RateLimitState:
+        """
+        ``HSETNX`` and ``EXPIRE NX`` take their argument only from the request that opens
+        the window, so a later one leaves the limit and the deadline as they stand.
+        """
         batch = Batch(is_atomic=True)
         batch.hincrby(key, "count", 1)
         batch.hsetnx(key, "limit", str(limit))

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -154,7 +154,7 @@ class ValkeyRateLimitClient:
         :param user_id: The user the counter is keyed by.
         :return: The window state, or None when no window is open for the user.
         """
-        return await self._read_window(self._user_window_key(user_id))
+        return await self._read_window_state(self._user_window_key(user_id))
 
     @valkey_rate_limit_resilience.apply()
     async def get_ip_state(self, client_ip: str) -> RateLimitState | None:
@@ -164,11 +164,13 @@ class ValkeyRateLimitClient:
         :param client_ip: The address the counter is keyed by.
         :return: The window state, or None when no window is open for the address.
         """
-        return await self._read_window(self._ip_window_key(client_ip))
+        return await self._read_window_state(self._ip_window_key(client_ip))
 
-    async def _read_window(self, key: str) -> RateLimitState | None:
-        """``consume_*`` fixes the limit in the same atomic batch that opens a window,
-        so an open window always carries one."""
+    async def _read_window_state(self, key: str) -> RateLimitState | None:
+        """
+        ``consume_*`` fixes the limit in the same atomic batch that opens a window,
+        so an open window always carries one.
+        """
         batch = Batch(is_atomic=True)
         batch.hmget(key, ["count", "limit"])
         batch.ttl(key)

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -151,7 +151,7 @@ class ValkeyRateLimitClient:
         )
 
     @valkey_rate_limit_resilience.apply()
-    async def get_user_window_state(self, user_id: UserID) -> RateLimitState | None:
+    async def get_user_rate_limit(self, user_id: UserID) -> RateLimitState | None:
         """
         Read the user's current window without counting a request.
 
@@ -161,7 +161,7 @@ class ValkeyRateLimitClient:
         return await self._read_window_state(self._user_window_key(user_id))
 
     @valkey_rate_limit_resilience.apply()
-    async def get_ip_window_state(self, client_ip: str) -> RateLimitState | None:
+    async def get_ip_rate_limit(self, client_ip: str) -> RateLimitState | None:
         """
         Read the address's current window without counting a request.
 

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -147,17 +147,28 @@ class ValkeyRateLimitClient:
         )
 
     @valkey_rate_limit_resilience.apply()
-    async def get_state(self, user_id: UserID) -> RateLimitState | None:
+    async def get_user_state(self, user_id: UserID) -> RateLimitState | None:
         """
         Read the user's current window without counting a request.
 
         :param user_id: The user the counter is keyed by.
         :return: The window state, or None when no window is open for the user.
-
-        ``consume_user_rate_limit()`` fixes the limit in the same atomic batch that opens a window,
-        so an open window always carries one.
         """
-        key = self._user_window_key(user_id)
+        return await self._read_window(self._user_window_key(user_id))
+
+    @valkey_rate_limit_resilience.apply()
+    async def get_ip_state(self, client_ip: str) -> RateLimitState | None:
+        """
+        Read the address's current window without counting a request.
+
+        :param client_ip: The address the counter is keyed by.
+        :return: The window state, or None when no window is open for the address.
+        """
+        return await self._read_window(self._ip_window_key(client_ip))
+
+    async def _read_window(self, key: str) -> RateLimitState | None:
+        """``consume_*`` fixes the limit in the same atomic batch that opens a window,
+        so an open window always carries one."""
         batch = Batch(is_atomic=True)
         batch.hmget(key, ["count", "limit"])
         batch.ttl(key)

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -151,7 +151,7 @@ class ValkeyRateLimitClient:
         )
 
     @valkey_rate_limit_resilience.apply()
-    async def get_user_state(self, user_id: UserID) -> RateLimitState | None:
+    async def get_user_window_state(self, user_id: UserID) -> RateLimitState | None:
         """
         Read the user's current window without counting a request.
 
@@ -161,7 +161,7 @@ class ValkeyRateLimitClient:
         return await self._read_window_state(self._user_window_key(user_id))
 
     @valkey_rate_limit_resilience.apply()
-    async def get_ip_state(self, client_ip: str) -> RateLimitState | None:
+    async def get_ip_window_state(self, client_ip: str) -> RateLimitState | None:
         """
         Read the address's current window without counting a request.
 

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -94,14 +94,14 @@ class ValkeyRateLimitClient:
         self._closed = True
         await self._client.disconnect()
 
-    def _user_rate_limit_key(self, user_id: UserID) -> str:
+    def _user_rlim_window_key(self, user_id: UserID) -> str:
         return f"user.{user_id}.rate_limit_window"
 
-    def _ip_rate_limit_key(self, client_ip: str) -> str:
+    def _ip_rlim_window_key(self, client_ip: str) -> str:
         return f"ip.{client_ip}.rate_limit_window"
 
     @valkey_rate_limit_resilience.apply()
-    async def consume_user_rate_limit(
+    async def consume_user_rlim_window(
         self, user_id: UserID, window_seconds: int, limit: int
     ) -> RateLimitState:
         """
@@ -112,12 +112,12 @@ class ValkeyRateLimitClient:
         :param limit: The limit to fix for the window, taken only when the request opens one.
         :return: The count, the limit fixed for the window, and the seconds until it ends.
         """
-        return await self._consume_rate_limit(
-            self._user_rate_limit_key(user_id), window_seconds, limit
+        return await self._consume_rlim_window(
+            self._user_rlim_window_key(user_id), window_seconds, limit
         )
 
     @valkey_rate_limit_resilience.apply()
-    async def consume_ip_rate_limit(
+    async def consume_ip_rlim_window(
         self, client_ip: str, window_seconds: int, limit: int
     ) -> RateLimitState:
         """
@@ -128,11 +128,11 @@ class ValkeyRateLimitClient:
         :param limit: The limit to fix for the window, taken only when the request opens one.
         :return: The count, the limit fixed for the window, and the seconds until it ends.
         """
-        return await self._consume_rate_limit(
-            self._ip_rate_limit_key(client_ip), window_seconds, limit
+        return await self._consume_rlim_window(
+            self._ip_rlim_window_key(client_ip), window_seconds, limit
         )
 
-    async def _consume_rate_limit(
+    async def _consume_rlim_window(
         self, key: str, window_seconds: int, limit: int
     ) -> RateLimitState:
         """
@@ -157,26 +157,26 @@ class ValkeyRateLimitClient:
         )
 
     @valkey_rate_limit_resilience.apply()
-    async def get_user_rate_limit(self, user_id: UserID) -> RateLimitState | None:
+    async def get_user_rlim_window(self, user_id: UserID) -> RateLimitState | None:
         """
         Read the user's current window without counting a request.
 
         :param user_id: The user the counter is keyed by.
         :return: The window state, or None when no window is open for the user.
         """
-        return await self._read_rate_limit(self._user_rate_limit_key(user_id))
+        return await self._read_rlim_window(self._user_rlim_window_key(user_id))
 
     @valkey_rate_limit_resilience.apply()
-    async def get_ip_rate_limit(self, client_ip: str) -> RateLimitState | None:
+    async def get_ip_rlim_window(self, client_ip: str) -> RateLimitState | None:
         """
         Read the address's current window without counting a request.
 
         :param client_ip: The address the counter is keyed by.
         :return: The window state, or None when no window is open for the address.
         """
-        return await self._read_rate_limit(self._ip_rate_limit_key(client_ip))
+        return await self._read_rlim_window(self._ip_rlim_window_key(client_ip))
 
-    async def _read_rate_limit(self, key: str) -> RateLimitState | None:
+    async def _read_rlim_window(self, key: str) -> RateLimitState | None:
         """
         ``consume_*`` fixes the limit in the same atomic batch that opens a window,
         so an open window always carries one.

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,8 +206,8 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            state = await valkey_client.get_user_rate_limit(UserID(self.user))
-            return state.count if state is not None else 0
+            rlim_window = await valkey_client.get_user_rate_limit(UserID(self.user))
+            return rlim_window.count if rlim_window is not None else 0
         finally:
             await valkey_client.close()
 

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,7 +206,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            state = await valkey_client.get_state(UserID(self.user))
+            state = await valkey_client.get_user_state(UserID(self.user))
             return state.count if state is not None else 0
         finally:
             await valkey_client.close()

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,7 +206,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            rlim_window = await valkey_client.get_user_rate_limit(UserID(self.user))
+            rlim_window = await valkey_client.get_user_rlim_window(UserID(self.user))
             return rlim_window.count if rlim_window is not None else 0
         finally:
             await valkey_client.close()

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,7 +206,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            state = await valkey_client.get_user_state(UserID(self.user))
+            state = await valkey_client.get_user_window_state(UserID(self.user))
             return state.count if state is not None else 0
         finally:
             await valkey_client.close()

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,7 +206,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            state = await valkey_client.get_user_window_state(UserID(self.user))
+            state = await valkey_client.get_user_rate_limit(UserID(self.user))
             return state.count if state is not None else 0
         finally:
             await valkey_client.close()

--- a/src/ai/backend/manager/api/rest/ratelimit/handler.py
+++ b/src/ai/backend/manager/api/rest/ratelimit/handler.py
@@ -59,9 +59,9 @@ def make_rlim_middleware(
         handler: WebRequestHandler,
     ) -> web.StreamResponse:
         """Global middleware implementing a fixed-window rate limiter."""
-        state: RateLimitState
+        rlim_window: RateLimitState
         if request["is_authorized"]:
-            state = await valkey_client.consume_user_rate_limit(
+            rlim_window = await valkey_client.consume_user_rlim_window(
                 user_id=request["user"]["uuid"],
                 window_seconds=_RATELIMIT_WINDOW_SECONDS,
                 limit=request["user"]["rate_limit"],
@@ -70,7 +70,7 @@ def make_rlim_middleware(
             client_ip = current_client_ip()
             if client_ip is None:
                 raise UnreachableError("a request over a socket always has a peer address")
-            state = await valkey_client.consume_ip_rate_limit(
+            rlim_window = await valkey_client.consume_ip_rlim_window(
                 client_ip=client_ip,
                 window_seconds=_RATELIMIT_WINDOW_SECONDS,
                 limit=_ANONYMOUS_RATELIMIT,
@@ -78,13 +78,13 @@ def make_rlim_middleware(
         reserve_response_headers(
             request,
             RateLimitQuota(
-                limit=state.limit,
-                remaining=max(state.limit - state.count, 0),
-                reset_after_seconds=state.reset_after_seconds,
+                limit=rlim_window.limit,
+                remaining=max(rlim_window.limit - rlim_window.count, 0),
+                reset_after_seconds=rlim_window.reset_after_seconds,
                 window_seconds=_RATELIMIT_WINDOW_SECONDS,
             ),
         )
-        if state.count > state.limit:
+        if rlim_window.count > rlim_window.limit:
             raise RateLimitExceeded
         return await handler(request)
 

--- a/src/ai/backend/web/auth.py
+++ b/src/ai/backend/web/auth.py
@@ -99,9 +99,7 @@ async def get_anonymous_session(
 def get_client_ip(request: web.Request) -> str | None:
     client_ip = request.headers.get("X-Forwarded-For")
     if not client_ip and request.transport:
-        peername = request.transport.get_extra_info("peername")
-        if peername:
-            client_ip = peername[0]
+        client_ip = request.transport.get_extra_info("peername")[0]
     if not client_ip:
         client_ip = request.remote
     return client_ip

--- a/src/ai/backend/web/auth.py
+++ b/src/ai/backend/web/auth.py
@@ -99,7 +99,9 @@ async def get_anonymous_session(
 def get_client_ip(request: web.Request) -> str | None:
     client_ip = request.headers.get("X-Forwarded-For")
     if not client_ip and request.transport:
-        client_ip = request.transport.get_extra_info("peername")[0]
+        peername = request.transport.get_extra_info("peername")
+        if peername:
+            client_ip = peername[0]
     if not client_ip:
         client_ip = request.remote
     return client_ip

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -1,0 +1,66 @@
+"""Per-user rate limiting for requests proxied to the manager.
+
+Reads the window the manager-side limiter (``manager/api/rest/ratelimit``) keeps per
+user; only the manager counts, ``manager_proxy_rate_limited()`` rejects when the count
+has already reached the limit. Without an open window, or one without a limit, the
+request is proxied and the manager alone limits it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from typing import Final
+
+from aiohttp import web
+
+from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.web.session import get_session
+from ai.backend.logging import BraceStyleAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+_RATELIMIT_WINDOW: Final = 60 * 15
+
+type Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
+
+
+def manager_proxy_rate_limited(handler: Handler) -> Handler:
+    """Wrap a manager proxy handler so the web server rejects over-limit requests."""
+
+    async def rlim_handler(request: web.Request) -> web.StreamResponse:
+        session = await get_session(request)
+        if not session.get("authenticated", False):
+            return await handler(request)
+        token = session.get("token") or {}
+        raw_user_id = token.get("user_id")
+        if raw_user_id is None:
+            # A session stored before the login handler started keeping the user id.
+            return await handler(request)
+        user_id = UserID(uuid.UUID(raw_user_id))
+
+        valkey_client: ValkeyRateLimitClient = request.app["valkey_rate_limit"]
+        state = await valkey_client.get_state(user_id)
+        if state is None or state.limit is None:
+            return await handler(request)
+
+        if state.count >= state.limit:
+            return web.HTTPTooManyRequests(
+                text=json.dumps({
+                    "type": "https://api.backend.ai/probs/rate-limit-exceeded",
+                    "title": "You have reached your API query rate limit.",
+                }),
+                content_type="application/problem+json",
+                headers={
+                    "X-RateLimit-Limit": str(state.limit),
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": str(state.reset),
+                    "X-RateLimit-Window": str(_RATELIMIT_WINDOW),
+                },
+            )
+        return await handler(request)
+
+    return rlim_handler

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -44,7 +44,7 @@ def manager_proxy_rate_limited(handler: Handler) -> Handler:
 
         valkey_client: ValkeyRateLimitClient = request.app["valkey_rate_limit"]
         state = await valkey_client.get_state(user_id)
-        if state is None or state.limit is None:
+        if state is None:
             return await handler(request)
 
         if state.count >= state.limit:
@@ -57,7 +57,7 @@ def manager_proxy_rate_limited(handler: Handler) -> Handler:
                 headers={
                     "X-RateLimit-Limit": str(state.limit),
                     "X-RateLimit-Remaining": "0",
-                    "X-RateLimit-Reset": str(state.reset),
+                    "X-RateLimit-Reset": str(state.reset_after_seconds),
                     "X-RateLimit-Window": str(_RATELIMIT_WINDOW),
                 },
             )

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -58,8 +58,8 @@ def manager_proxy_rate_limited(handler: Handler) -> Handler:
     """Wrap a manager proxy handler so the web server rejects over-limit requests."""
 
     async def rlim_handler(request: web.Request) -> web.StreamResponse:
-        state = await _read_ratelimit_window(request)
-        if state is not None and state.count >= state.limit:
+        rlim_window = await _read_ratelimit_window(request)
+        if rlim_window is not None and rlim_window.count >= rlim_window.limit:
             return web.HTTPTooManyRequests(
                 text=json.dumps({
                     "type": "https://api.backend.ai/probs/rate-limit-exceeded",
@@ -67,9 +67,9 @@ def manager_proxy_rate_limited(handler: Handler) -> Handler:
                 }),
                 content_type="application/problem+json",
                 headers={
-                    "X-RateLimit-Limit": str(state.limit),
+                    "X-RateLimit-Limit": str(rlim_window.limit),
                     "X-RateLimit-Remaining": "0",
-                    "X-RateLimit-Reset": str(state.reset_after_seconds),
+                    "X-RateLimit-Reset": str(rlim_window.reset_after_seconds),
                     "X-RateLimit-Window": str(_RATELIMIT_WINDOW),
                 },
             )

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -46,6 +46,8 @@ async def _read_ratelimit_window(request: web.Request) -> RateLimitState | None:
             raise UnreachableError("a request over a socket always has a peer address")
         return await valkey_client.get_ip_rate_limit(client_ip)
     token = session.get("token") or {}
+    # Both login handlers store the user id, but sessions outlive an upgrade in Redis:
+    # one written before they did carries no user id.
     raw_user_id = token.get("user_id")
     if raw_user_id is None:
         return None

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -20,6 +20,7 @@ from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import (
     ValkeyRateLimitClient,
 )
 from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.exception import UnreachableError
 from ai.backend.common.web.session import get_session
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.web.auth import get_client_ip
@@ -34,15 +35,15 @@ type Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 async def _read_ratelimit_window(request: web.Request) -> RateLimitState | None:
     """The window the manager will count this request in.
 
-    None when this server cannot name one: an anonymous caller it can see no address
-    for, a session stored before the login handler kept the user id, or no open window.
+    None when this server cannot name one: a session stored before the login handler
+    kept the user id, or no open window.
     """
     valkey_client: ValkeyRateLimitClient = request.app["valkey_rate_limit"]
     session = await get_session(request)
     if not session.get("authenticated", False):
         client_ip = get_client_ip(request)
         if client_ip is None:
-            return None
+            raise UnreachableError("a request over a socket always has a peer address")
         return await valkey_client.get_ip_rate_limit(client_ip)
     token = session.get("token") or {}
     raw_user_id = token.get("user_id")

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -31,7 +31,7 @@ _RATELIMIT_WINDOW: Final = 60 * 15
 type Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
 
-async def _open_window(request: web.Request) -> RateLimitState | None:
+async def _read_ratelimit_window(request: web.Request) -> RateLimitState | None:
     """The window the manager will count this request in.
 
     None when this server cannot name one: an anonymous caller it can see no address
@@ -55,7 +55,7 @@ def manager_proxy_rate_limited(handler: Handler) -> Handler:
     """Wrap a manager proxy handler so the web server rejects over-limit requests."""
 
     async def rlim_handler(request: web.Request) -> web.StreamResponse:
-        state = await _open_window(request)
+        state = await _read_ratelimit_window(request)
         if state is not None and state.count >= state.limit:
             return web.HTTPTooManyRequests(
                 text=json.dumps({

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -1,13 +1,8 @@
 """Rate limiting for requests proxied to the manager.
 
-Reads the window the manager-side limiter (``manager/api/rest/ratelimit``) keeps, keyed
-by user for a signed-in caller and by address for an anonymous one; only the manager
-counts, ``manager_proxy_rate_limited()`` rejects when the count has already reached the
-limit. Without an open window the request is proxied and the manager alone limits it.
-
-The address is the one this server forwards, so a manager that resolves a different one
-(``trusted-proxies`` naming hops in front of it) opens a window this check does not
-find: the request is proxied and the manager limits it as before.
+Reads the window the manager-side limiter keeps — by user for a signed-in caller, by
+address otherwise — and refuses once the count has reached the limit. Only the manager
+counts.
 """
 
 from __future__ import annotations

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -44,14 +44,14 @@ async def _read_ratelimit_window(request: web.Request) -> RateLimitState | None:
         client_ip = get_client_ip(request)
         if client_ip is None:
             raise UnreachableError("a request over a socket always has a peer address")
-        return await valkey_client.get_ip_rate_limit(client_ip)
+        return await valkey_client.get_ip_rlim_window(client_ip)
     token = session.get("token") or {}
     # Both login handlers store the user id, but sessions outlive an upgrade in Redis:
     # one written before they did carries no user id.
     raw_user_id = token.get("user_id")
     if raw_user_id is None:
         return None
-    return await valkey_client.get_user_rate_limit(UserID(uuid.UUID(raw_user_id)))
+    return await valkey_client.get_user_rlim_window(UserID(uuid.UUID(raw_user_id)))
 
 
 def manager_proxy_rate_limited(handler: Handler) -> Handler:

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -36,30 +36,32 @@ _RATELIMIT_WINDOW: Final = 60 * 15
 type Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
 
+async def _open_window(request: web.Request) -> RateLimitState | None:
+    """The window the manager will count this request in.
+
+    None when this server cannot name one: an anonymous caller it can see no address
+    for, a session stored before the login handler kept the user id, or no open window.
+    """
+    valkey_client: ValkeyRateLimitClient = request.app["valkey_rate_limit"]
+    session = await get_session(request)
+    if not session.get("authenticated", False):
+        client_ip = get_client_ip(request)
+        if client_ip is None:
+            return None
+        return await valkey_client.get_ip_state(client_ip)
+    token = session.get("token") or {}
+    raw_user_id = token.get("user_id")
+    if raw_user_id is None:
+        return None
+    return await valkey_client.get_user_state(UserID(uuid.UUID(raw_user_id)))
+
+
 def manager_proxy_rate_limited(handler: Handler) -> Handler:
     """Wrap a manager proxy handler so the web server rejects over-limit requests."""
 
     async def rlim_handler(request: web.Request) -> web.StreamResponse:
-        valkey_client: ValkeyRateLimitClient = request.app["valkey_rate_limit"]
-        state: RateLimitState | None
-        session = await get_session(request)
-        if session.get("authenticated", False):
-            token = session.get("token") or {}
-            raw_user_id = token.get("user_id")
-            if raw_user_id is None:
-                # A session stored before the login handler started keeping the user id.
-                # The manager counts this caller by user, which this server cannot name.
-                return await handler(request)
-            state = await valkey_client.get_user_state(UserID(uuid.UUID(raw_user_id)))
-        else:
-            client_ip = get_client_ip(request)
-            if client_ip is None:
-                return await handler(request)
-            state = await valkey_client.get_ip_state(client_ip)
-        if state is None:
-            return await handler(request)
-
-        if state.count >= state.limit:
+        state = await _open_window(request)
+        if state is not None and state.count >= state.limit:
             return web.HTTPTooManyRequests(
                 text=json.dumps({
                     "type": "https://api.backend.ai/probs/rate-limit-exceeded",

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -1,9 +1,13 @@
-"""Per-user rate limiting for requests proxied to the manager.
+"""Rate limiting for requests proxied to the manager.
 
-Reads the window the manager-side limiter (``manager/api/rest/ratelimit``) keeps per
-user; only the manager counts, ``manager_proxy_rate_limited()`` rejects when the count
-has already reached the limit. Without an open window, or one without a limit, the
-request is proxied and the manager alone limits it.
+Reads the window the manager-side limiter (``manager/api/rest/ratelimit``) keeps, keyed
+by user for a signed-in caller and by address for an anonymous one; only the manager
+counts, ``manager_proxy_rate_limited()`` rejects when the count has already reached the
+limit. Without an open window the request is proxied and the manager alone limits it.
+
+The address is the one this server forwards, so a manager that resolves a different one
+(``trusted-proxies`` naming hops in front of it) opens a window this check does not
+find: the request is proxied and the manager limits it as before.
 """
 
 from __future__ import annotations
@@ -16,10 +20,14 @@ from typing import Final
 
 from aiohttp import web
 
-from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
+from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import (
+    RateLimitState,
+    ValkeyRateLimitClient,
+)
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.web.session import get_session
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.web.auth import get_client_ip
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -32,18 +40,22 @@ def manager_proxy_rate_limited(handler: Handler) -> Handler:
     """Wrap a manager proxy handler so the web server rejects over-limit requests."""
 
     async def rlim_handler(request: web.Request) -> web.StreamResponse:
-        session = await get_session(request)
-        if not session.get("authenticated", False):
-            return await handler(request)
-        token = session.get("token") or {}
-        raw_user_id = token.get("user_id")
-        if raw_user_id is None:
-            # A session stored before the login handler started keeping the user id.
-            return await handler(request)
-        user_id = UserID(uuid.UUID(raw_user_id))
-
         valkey_client: ValkeyRateLimitClient = request.app["valkey_rate_limit"]
-        state = await valkey_client.get_state(user_id)
+        state: RateLimitState | None
+        session = await get_session(request)
+        if session.get("authenticated", False):
+            token = session.get("token") or {}
+            raw_user_id = token.get("user_id")
+            if raw_user_id is None:
+                # A session stored before the login handler started keeping the user id.
+                # The manager counts this caller by user, which this server cannot name.
+                return await handler(request)
+            state = await valkey_client.get_user_state(UserID(uuid.UUID(raw_user_id)))
+        else:
+            client_ip = get_client_ip(request)
+            if client_ip is None:
+                return await handler(request)
+            state = await valkey_client.get_ip_state(client_ip)
         if state is None:
             return await handler(request)
 

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -43,12 +43,12 @@ async def _open_window(request: web.Request) -> RateLimitState | None:
         client_ip = get_client_ip(request)
         if client_ip is None:
             return None
-        return await valkey_client.get_ip_state(client_ip)
+        return await valkey_client.get_ip_window_state(client_ip)
     token = session.get("token") or {}
     raw_user_id = token.get("user_id")
     if raw_user_id is None:
         return None
-    return await valkey_client.get_user_state(UserID(uuid.UUID(raw_user_id)))
+    return await valkey_client.get_user_window_state(UserID(uuid.UUID(raw_user_id)))
 
 
 def manager_proxy_rate_limited(handler: Handler) -> Handler:

--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -43,12 +43,12 @@ async def _open_window(request: web.Request) -> RateLimitState | None:
         client_ip = get_client_ip(request)
         if client_ip is None:
             return None
-        return await valkey_client.get_ip_window_state(client_ip)
+        return await valkey_client.get_ip_rate_limit(client_ip)
     token = session.get("token") or {}
     raw_user_id = token.get("user_id")
     if raw_user_id is None:
         return None
-    return await valkey_client.get_user_window_state(UserID(uuid.UUID(raw_user_id)))
+    return await valkey_client.get_user_rate_limit(UserID(uuid.UUID(raw_user_id)))
 
 
 def manager_proxy_rate_limited(handler: Handler) -> Handler:

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -47,8 +47,9 @@ from ai.backend.client.v2.config import ClientConfig as V2ClientConfig
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common import config
 from ai.backend.common.clients.http_client.client_pool import ClientPool
+from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
 from ai.backend.common.clients.valkey_client.valkey_session.client import ValkeySessionClient
-from ai.backend.common.defs import REDIS_STATISTICS_DB, RedisRole
+from ai.backend.common.defs import REDIS_RATE_LIMIT_DB, REDIS_STATISTICS_DB, RedisRole
 from ai.backend.common.dto.internal.health import (
     ConnectivityCheckResponse,
     HealthResponse,
@@ -92,6 +93,7 @@ from ai.backend.web.clients.manager_pool import (
     ManagerPoolGateHealthChecker,
 )
 from ai.backend.web.config.unified import EventLoopType, ServiceMode, WebServerUnifiedConfig
+from ai.backend.web.ratelimit import manager_proxy_rate_limited
 from ai.backend.web.security import SecurityPolicy, csp_nonce_var, security_policy_middleware
 
 from . import __version__, user_agent
@@ -855,6 +857,13 @@ async def redis_ctx(
     # Keep app["redis"] key for compatibility
     app["redis"] = valkey_session_client
 
+    valkey_rate_limit_client = await ValkeyRateLimitClient.create(
+        valkey_target=valkey_profile_target.profile_target(RedisRole.RATE_LIMIT),
+        db_id=REDIS_RATE_LIMIT_DB,
+        human_readable_name="web.ratelimit",
+    )
+    app["valkey_rate_limit"] = valkey_rate_limit_client
+
     if pidx == 0 and config.session.flush_on_startup:
         await valkey_session_client.flush_all_sessions()
         log.info("flushed session storage.")
@@ -870,6 +879,7 @@ async def redis_ctx(
     try:
         yield
     finally:
+        await valkey_rate_limit_client.close()
         await valkey_session_client.close()
 
 
@@ -1041,11 +1051,14 @@ async def webapp_ctx(
 
     manager_pool = cast(HealthyEndpointPool, app["manager_pool"])
 
-    manager_web_handler = partial(web_handler, endpoint_pool=manager_pool)
-    manager_websocket_handler = partial(websocket_handler, endpoint_pool=manager_pool)
+    manager_proxy_handler = partial(web_handler, endpoint_pool=manager_pool)
+    manager_web_handler = manager_proxy_rate_limited(manager_proxy_handler)
+    manager_websocket_handler = manager_proxy_rate_limited(
+        partial(websocket_handler, endpoint_pool=manager_pool)
+    )
     manager_web_plugin_handler = partial(web_plugin_handler, endpoint_pool=manager_pool)
 
-    anon_web_handler = partial(manager_web_handler, is_anonymous=True)
+    anon_web_handler = partial(manager_proxy_handler, is_anonymous=True)
     anon_web_plugin_handler = partial(manager_web_plugin_handler, is_anonymous=True)
 
     # Pipeline is a separate upstream — no health-aware pool here. A follow-up
@@ -1120,9 +1133,11 @@ async def webapp_ctx(
 
     # Feature flag for using Apollo Router(Graphql Federation)
     if config.apollo_router.enabled:
-        supergraph_handler = partial(
-            apollo_router_handler,
-            endpoint_pool=cast(HealthyEndpointPool, app["apollo_router_pool"]),
+        supergraph_handler = manager_proxy_rate_limited(
+            partial(
+                apollo_router_handler,
+                endpoint_pool=cast(HealthyEndpointPool, app["apollo_router_pool"]),
+            )
         )
         cors.add(app.router.add_route("GET", "/func/admin/gql", supergraph_handler))
         cors.add(app.router.add_route("POST", "/func/admin/gql", supergraph_handler))

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -1058,9 +1058,7 @@ async def webapp_ctx(
     )
     manager_web_plugin_handler = partial(web_plugin_handler, endpoint_pool=manager_pool)
 
-    anon_web_handler = manager_proxy_rate_limited(
-        partial(manager_proxy_handler, is_anonymous=True)
-    )
+    anon_web_handler = manager_proxy_rate_limited(partial(manager_proxy_handler, is_anonymous=True))
     anon_web_plugin_handler = manager_proxy_rate_limited(
         partial(manager_web_plugin_handler, is_anonymous=True)
     )

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -1058,8 +1058,12 @@ async def webapp_ctx(
     )
     manager_web_plugin_handler = partial(web_plugin_handler, endpoint_pool=manager_pool)
 
-    anon_web_handler = partial(manager_proxy_handler, is_anonymous=True)
-    anon_web_plugin_handler = partial(manager_web_plugin_handler, is_anonymous=True)
+    anon_web_handler = manager_proxy_rate_limited(
+        partial(manager_proxy_handler, is_anonymous=True)
+    )
+    anon_web_plugin_handler = manager_proxy_rate_limited(
+        partial(manager_web_plugin_handler, is_anonymous=True)
+    )
 
     # Pipeline is a separate upstream — no health-aware pool here. A follow-up
     # will introduce one alongside ApolloRouterClientPool.

--- a/tests/unit/common/clients/valkey_client/test_valkey_rate_limit_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_rate_limit_client.py
@@ -15,7 +15,7 @@ async def test_first_request_opens_the_window(
 ) -> None:
     key = UserID(uuid.uuid4())
 
-    state = await test_valkey_rate_limit.consume_user_rate_limit(
+    state = await test_valkey_rate_limit.consume_user_rlim_window(
         key, window_seconds=60, limit=30000
     )
 
@@ -26,10 +26,10 @@ async def test_later_requests_keep_the_window(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     key = UserID(uuid.uuid4())
-    await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=30000)
+    await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=30000)
     await asyncio.sleep(1.1)
 
-    state = await test_valkey_rate_limit.consume_user_rate_limit(
+    state = await test_valkey_rate_limit.consume_user_rlim_window(
         key, window_seconds=60, limit=30000
     )
 
@@ -42,9 +42,9 @@ async def test_count_keeps_growing_past_the_limit(
 ) -> None:
     key = UserID(uuid.uuid4())
     for _ in range(3):
-        await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=2)
+        await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=2)
 
-    state = await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=2)
+    state = await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=2)
 
     assert state.count == 4
     assert state.limit == 2
@@ -54,10 +54,10 @@ async def test_a_new_window_takes_the_limit_it_opens_with(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     key = UserID(uuid.uuid4())
-    await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=1, limit=30000)
+    await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=1, limit=30000)
     await asyncio.sleep(1.1)
 
-    state = await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=10)
+    state = await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=10)
 
     assert state == RateLimitState(count=1, limit=10, reset_after_seconds=60)
 
@@ -66,9 +66,9 @@ async def test_the_limit_of_the_open_user_window_stands(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     key = UserID(uuid.uuid4())
-    await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=30000)
+    await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=30000)
 
-    state = await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=10)
+    state = await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=10)
 
     assert state.limit == 30000
 
@@ -77,9 +77,9 @@ async def test_the_limit_of_the_open_ip_window_stands(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     key = "10.0.0.1"
-    await test_valkey_rate_limit.consume_ip_rate_limit(key, window_seconds=60, limit=1000)
+    await test_valkey_rate_limit.consume_ip_rlim_window(key, window_seconds=60, limit=1000)
 
-    state = await test_valkey_rate_limit.consume_ip_rate_limit(key, window_seconds=60, limit=10)
+    state = await test_valkey_rate_limit.consume_ip_rlim_window(key, window_seconds=60, limit=10)
 
     assert state.limit == 1000
 
@@ -89,9 +89,9 @@ async def test_user_windows_are_keyed_by_the_user(
 ) -> None:
     key = UserID(uuid.uuid4())
     other_key = UserID(uuid.uuid4())
-    await test_valkey_rate_limit.consume_user_rate_limit(key, window_seconds=60, limit=30000)
+    await test_valkey_rate_limit.consume_user_rlim_window(key, window_seconds=60, limit=30000)
 
-    state = await test_valkey_rate_limit.consume_user_rate_limit(
+    state = await test_valkey_rate_limit.consume_user_rlim_window(
         other_key, window_seconds=60, limit=30000
     )
 
@@ -103,9 +103,9 @@ async def test_ip_windows_are_keyed_by_the_address(
 ) -> None:
     key = "10.0.1.1"
     other_key = "10.0.1.2"
-    await test_valkey_rate_limit.consume_ip_rate_limit(key, window_seconds=60, limit=1000)
+    await test_valkey_rate_limit.consume_ip_rlim_window(key, window_seconds=60, limit=1000)
 
-    state = await test_valkey_rate_limit.consume_ip_rate_limit(
+    state = await test_valkey_rate_limit.consume_ip_rlim_window(
         other_key, window_seconds=60, limit=1000
     )
 
@@ -116,11 +116,11 @@ async def test_a_user_and_an_address_of_the_same_id_hold_separate_windows(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     shared_id = uuid.uuid4()
-    await test_valkey_rate_limit.consume_user_rate_limit(
+    await test_valkey_rate_limit.consume_user_rlim_window(
         UserID(shared_id), window_seconds=60, limit=30000
     )
 
-    state = await test_valkey_rate_limit.consume_ip_rate_limit(
+    state = await test_valkey_rate_limit.consume_ip_rlim_window(
         str(shared_id), window_seconds=60, limit=1000
     )
 

--- a/tests/unit/manager/api/test_ratelimit.py
+++ b/tests/unit/manager/api/test_ratelimit.py
@@ -45,8 +45,8 @@ class TestRlimMiddleware:
     def mock_valkey_client(self) -> MagicMock:
         """Mock ValkeyRateLimitClient."""
         client = MagicMock(spec=ValkeyRateLimitClient)
-        client.consume_user_rate_limit = AsyncMock()
-        client.consume_ip_rate_limit = AsyncMock()
+        client.consume_user_rlim_window = AsyncMock()
+        client.consume_ip_rlim_window = AsyncMock()
         return client
 
     @pytest.fixture
@@ -102,10 +102,10 @@ class TestRlimMiddleware:
     ) -> None:
         """The two windows stand apart, so the limit reported says which one governed."""
         # Arrange
-        mock_valkey_client.consume_ip_rate_limit.return_value = RateLimitState(
+        mock_valkey_client.consume_ip_rlim_window.return_value = RateLimitState(
             count=1, limit=_ANONYMOUS_RATELIMIT, reset_after_seconds=_RESET_AFTER_SECONDS
         )
-        mock_valkey_client.consume_user_rate_limit.return_value = RateLimitState(
+        mock_valkey_client.consume_user_rlim_window.return_value = RateLimitState(
             count=1, limit=_RATE_LIMIT, reset_after_seconds=_RESET_AFTER_SECONDS
         )
 
@@ -144,7 +144,7 @@ class TestRlimMiddleware:
     ) -> None:
         """The headers report the window as it stands, whatever limit the request carried."""
         # Arrange
-        mock_valkey_client.consume_user_rate_limit.return_value = RateLimitState(
+        mock_valkey_client.consume_user_rlim_window.return_value = RateLimitState(
             count=case.count, limit=case.limit, reset_after_seconds=_RESET_AFTER_SECONDS
         )
 
@@ -168,7 +168,7 @@ class TestRlimMiddleware:
     ) -> None:
         """One request past the limit is refused, and the quota survives the raise."""
         # Arrange
-        mock_valkey_client.consume_user_rate_limit.return_value = RateLimitState(
+        mock_valkey_client.consume_user_rlim_window.return_value = RateLimitState(
             count=_RATE_LIMIT + 1, limit=_RATE_LIMIT, reset_after_seconds=_RESET_AFTER_SECONDS
         )
 

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+from pytest_mock import MockerFixture
+
+from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import (
+    RateLimitState,
+    ValkeyRateLimitClient,
+)
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.web import ratelimit
+from ai.backend.web.ratelimit import manager_proxy_rate_limited
+
+_USER_ID = UserID(uuid.UUID("12345678-1234-5678-1234-567812345678"))
+_RATE_LIMIT = 1000
+_RESET = 500
+_AUTHENTICATED_SESSION = {"authenticated": True, "token": {"user_id": str(_USER_ID)}}
+
+
+@pytest.fixture
+def mock_valkey_rate_limit_client() -> AsyncMock:
+    client = AsyncMock(spec=ValkeyRateLimitClient)
+    client.get_state.return_value = RateLimitState(count=0, limit=_RATE_LIMIT, reset=_RESET)
+    return client
+
+
+@pytest.fixture
+def proxied_request(mock_valkey_rate_limit_client: AsyncMock) -> web.Request:
+    return make_mocked_request(
+        "GET", "/func/session", app={"valkey_rate_limit": mock_valkey_rate_limit_client}
+    )
+
+
+@pytest.fixture
+def handler_response() -> web.Response:
+    return web.Response(text="ok")
+
+
+@pytest.fixture
+def handler(handler_response: web.Response) -> AsyncMock:
+    return AsyncMock(return_value=handler_response)
+
+
+@dataclass(frozen=True)
+class _PassThroughCase:
+    id: str
+    session: dict[str, Any]
+    state: RateLimitState | None = RateLimitState(count=0, limit=_RATE_LIMIT, reset=_RESET)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # No login session: nothing to count against, the manager rejects it anyway.
+        _PassThroughCase(
+            id="unauthenticated",
+            session={},
+        ),
+        # Session created before login stored the user id: no counter key, so exempt.
+        _PassThroughCase(
+            id="session-stored-before-user-id",
+            session={"authenticated": True, "token": {"access_key": "AKTEST"}},
+        ),
+        # No window open for the user: proxied, the manager opens one.
+        _PassThroughCase(
+            id="no-open-window",
+            session=_AUTHENTICATED_SESSION,
+            state=None,
+        ),
+        # Window without a limit: proxied unlimited.
+        _PassThroughCase(
+            id="window-without-limit",
+            session=_AUTHENTICATED_SESSION,
+            state=RateLimitState(count=5000, limit=None, reset=_RESET),
+        ),
+    ],
+    ids=lambda case: case.id,
+)
+async def test_pass_through_without_rate_limiting(
+    case: _PassThroughCase,
+    mocker: MockerFixture,
+    mock_valkey_rate_limit_client: AsyncMock,
+    proxied_request: web.Request,
+    handler: AsyncMock,
+    handler_response: web.Response,
+) -> None:
+    mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=case.session))
+    mock_valkey_rate_limit_client.get_state.return_value = case.state
+
+    response = await manager_proxy_rate_limited(handler)(proxied_request)
+
+    assert response is handler_response
+    handler.assert_awaited_once_with(proxied_request)
+    assert "X-RateLimit-Limit" not in response.headers
+
+
+@dataclass(frozen=True)
+class _LimitCase:
+    id: str
+    count: int
+    expected_status: int
+    expected_content_type: str
+    expected_handler_awaits: int
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        # Nothing counted yet in the window: proxied, the manager counts it.
+        _LimitCase(
+            id="count-below-limit-is-proxied",
+            count=0,
+            expected_status=200,
+            expected_content_type="text/plain",
+            expected_handler_awaits=1,
+        ),
+        # One slot left: still proxied, the manager takes the last slot.
+        _LimitCase(
+            id="count-one-below-limit-is-still-proxied",
+            count=_RATE_LIMIT - 1,
+            expected_status=200,
+            expected_content_type="text/plain",
+            expected_handler_awaits=1,
+        ),
+        # Limit already reached: 429 from the web server, the handler never runs.
+        _LimitCase(
+            id="count-at-limit-gets-429-without-reaching-the-handler",
+            count=_RATE_LIMIT,
+            expected_status=429,
+            expected_content_type="application/problem+json",
+            expected_handler_awaits=0,
+        ),
+    ],
+    ids=lambda case: case.id,
+)
+async def test_gates_on_the_user_count(
+    case: _LimitCase,
+    mocker: MockerFixture,
+    mock_valkey_rate_limit_client: AsyncMock,
+    proxied_request: web.Request,
+    handler: AsyncMock,
+) -> None:
+    mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
+    mock_valkey_rate_limit_client.get_state.return_value = RateLimitState(
+        count=case.count, limit=_RATE_LIMIT, reset=_RESET
+    )
+
+    response = await manager_proxy_rate_limited(handler)(proxied_request)
+
+    assert response.status == case.expected_status
+    assert response.content_type == case.expected_content_type
+    assert handler.await_count == case.expected_handler_awaits
+    mock_valkey_rate_limit_client.get_state.assert_awaited_once_with(_USER_ID)
+    mock_valkey_rate_limit_client.consume.assert_not_called()
+
+
+async def test_429_carries_the_rate_limit_headers(
+    mocker: MockerFixture,
+    mock_valkey_rate_limit_client: AsyncMock,
+    proxied_request: web.Request,
+    handler: AsyncMock,
+) -> None:
+    mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
+    mock_valkey_rate_limit_client.get_state.return_value = RateLimitState(
+        count=_RATE_LIMIT, limit=_RATE_LIMIT, reset=_RESET
+    )
+
+    response = await manager_proxy_rate_limited(handler)(proxied_request)
+
+    assert response.headers["X-RateLimit-Limit"] == str(_RATE_LIMIT)
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert response.headers["X-RateLimit-Reset"] == str(_RESET)
+    assert response.headers["X-RateLimit-Window"] == str(ratelimit._RATELIMIT_WINDOW)

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -156,7 +156,8 @@ async def test_gates_on_the_user_count(
     assert response.content_type == case.expected_content_type
     assert handler.await_count == case.expected_handler_awaits
     mock_valkey_rate_limit_client.get_state.assert_awaited_once_with(_USER_ID)
-    mock_valkey_rate_limit_client.consume_rate_limit.assert_not_called()
+    mock_valkey_rate_limit_client.consume_user_rate_limit.assert_not_called()
+    mock_valkey_rate_limit_client.consume_ip_rate_limit.assert_not_called()
 
 
 async def test_429_carries_the_rate_limit_headers(

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -29,7 +29,7 @@ _AUTHENTICATED_SESSION = {"authenticated": True, "token": {"user_id": str(_USER_
 @pytest.fixture
 def mock_valkey_rate_limit_client() -> AsyncMock:
     client = AsyncMock(spec=ValkeyRateLimitClient)
-    client.get_user_window_state.return_value = RateLimitState(
+    client.get_user_rate_limit.return_value = RateLimitState(
         count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
     return client
@@ -87,7 +87,7 @@ async def test_pass_through_without_rate_limiting(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=case.session))
-    mock_valkey_rate_limit_client.get_user_window_state.return_value = case.state
+    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = case.state
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)
 
@@ -143,7 +143,7 @@ async def test_gates_on_the_user_count(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_user_window_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = RateLimitState(
         count=case.count, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -152,7 +152,7 @@ async def test_gates_on_the_user_count(
     assert response.status == case.expected_status
     assert response.content_type == case.expected_content_type
     assert handler.await_count == case.expected_handler_awaits
-    mock_valkey_rate_limit_client.get_user_window_state.assert_awaited_once_with(_USER_ID)
+    mock_valkey_rate_limit_client.get_user_rate_limit.assert_awaited_once_with(_USER_ID)
     mock_valkey_rate_limit_client.consume_user_rate_limit.assert_not_called()
     mock_valkey_rate_limit_client.consume_ip_rate_limit.assert_not_called()
 
@@ -164,7 +164,7 @@ async def test_429_carries_the_rate_limit_headers(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_user_window_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = RateLimitState(
         count=_RATE_LIMIT, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -195,7 +195,7 @@ async def test_an_anonymous_query_is_judged_by_the_address_window(
 ) -> None:
     """The two windows stand apart, so the limit reported says which one governed."""
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_window_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_ip_rate_limit.return_value = RateLimitState(
         count=_ANONYMOUS_LIMIT, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -214,7 +214,7 @@ async def test_an_anonymous_query_below_the_address_limit_is_proxied(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_window_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_ip_rate_limit.return_value = RateLimitState(
         count=_ANONYMOUS_LIMIT - 1, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -232,7 +232,7 @@ async def test_an_anonymous_query_without_an_open_window_is_proxied(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_window_state.return_value = None
+    mock_valkey_rate_limit_client.get_ip_rate_limit.return_value = None
 
     response = await manager_proxy_rate_limited(handler)(anonymous_request)
 

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -21,13 +21,15 @@ from ai.backend.web.ratelimit import manager_proxy_rate_limited
 _USER_ID = UserID(uuid.UUID("12345678-1234-5678-1234-567812345678"))
 _RATE_LIMIT = 1000
 _RESET = 500
+_ANONYMOUS_LIMIT = 7
+_CLIENT_IP = "10.0.0.1"
 _AUTHENTICATED_SESSION = {"authenticated": True, "token": {"user_id": str(_USER_ID)}}
 
 
 @pytest.fixture
 def mock_valkey_rate_limit_client() -> AsyncMock:
     client = AsyncMock(spec=ValkeyRateLimitClient)
-    client.get_state.return_value = RateLimitState(
+    client.get_user_state.return_value = RateLimitState(
         count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
     return client
@@ -35,6 +37,7 @@ def mock_valkey_rate_limit_client() -> AsyncMock:
 
 @pytest.fixture
 def proxied_request(mock_valkey_rate_limit_client: AsyncMock) -> web.Request:
+    """A proxied request the server can name no address for."""
     return make_mocked_request(
         "GET", "/func/session", app={"valkey_rate_limit": mock_valkey_rate_limit_client}
     )
@@ -62,9 +65,9 @@ class _PassThroughCase:
 @pytest.mark.parametrize(
     "case",
     [
-        # No login session: nothing to count against, the manager rejects it anyway.
+        # No login session and no address to key by: the manager limits it alone.
         _PassThroughCase(
-            id="unauthenticated",
+            id="unauthenticated-without-an-address",
             session={},
         ),
         # Session created before login stored the user id: no counter key, so exempt.
@@ -90,7 +93,7 @@ async def test_pass_through_without_rate_limiting(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=case.session))
-    mock_valkey_rate_limit_client.get_state.return_value = case.state
+    mock_valkey_rate_limit_client.get_user_state.return_value = case.state
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)
 
@@ -146,7 +149,7 @@ async def test_gates_on_the_user_count(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_state.return_value = RateLimitState(
         count=case.count, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -155,7 +158,7 @@ async def test_gates_on_the_user_count(
     assert response.status == case.expected_status
     assert response.content_type == case.expected_content_type
     assert handler.await_count == case.expected_handler_awaits
-    mock_valkey_rate_limit_client.get_state.assert_awaited_once_with(_USER_ID)
+    mock_valkey_rate_limit_client.get_user_state.assert_awaited_once_with(_USER_ID)
     mock_valkey_rate_limit_client.consume_user_rate_limit.assert_not_called()
     mock_valkey_rate_limit_client.consume_ip_rate_limit.assert_not_called()
 
@@ -167,7 +170,7 @@ async def test_429_carries_the_rate_limit_headers(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_state.return_value = RateLimitState(
         count=_RATE_LIMIT, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -177,3 +180,67 @@ async def test_429_carries_the_rate_limit_headers(
     assert response.headers["X-RateLimit-Remaining"] == "0"
     assert response.headers["X-RateLimit-Reset"] == str(_RESET)
     assert response.headers["X-RateLimit-Window"] == str(ratelimit._RATELIMIT_WINDOW)
+
+
+@pytest.fixture
+def anonymous_request(mock_valkey_rate_limit_client: AsyncMock) -> web.Request:
+    """A proxied request with no login session, arriving from _CLIENT_IP."""
+    return make_mocked_request(
+        "GET",
+        "/func/session",
+        headers={"X-Forwarded-For": _CLIENT_IP},
+        app={"valkey_rate_limit": mock_valkey_rate_limit_client},
+    )
+
+
+async def test_an_anonymous_query_is_judged_by_the_address_window(
+    mocker: MockerFixture,
+    mock_valkey_rate_limit_client: AsyncMock,
+    anonymous_request: web.Request,
+    handler: AsyncMock,
+) -> None:
+    """The two windows stand apart, so the limit reported says which one governed."""
+    mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
+    mock_valkey_rate_limit_client.get_ip_state.return_value = RateLimitState(
+        count=_ANONYMOUS_LIMIT, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
+    )
+
+    response = await manager_proxy_rate_limited(handler)(anonymous_request)
+
+    assert response.status == 429
+    assert response.headers["X-RateLimit-Limit"] == str(_ANONYMOUS_LIMIT)
+    handler.assert_not_awaited()
+
+
+async def test_an_anonymous_query_below_the_address_limit_is_proxied(
+    mocker: MockerFixture,
+    mock_valkey_rate_limit_client: AsyncMock,
+    anonymous_request: web.Request,
+    handler: AsyncMock,
+    handler_response: web.Response,
+) -> None:
+    mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
+    mock_valkey_rate_limit_client.get_ip_state.return_value = RateLimitState(
+        count=_ANONYMOUS_LIMIT - 1, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
+    )
+
+    response = await manager_proxy_rate_limited(handler)(anonymous_request)
+
+    assert response is handler_response
+    handler.assert_awaited_once_with(anonymous_request)
+
+
+async def test_an_anonymous_query_without_an_open_window_is_proxied(
+    mocker: MockerFixture,
+    mock_valkey_rate_limit_client: AsyncMock,
+    anonymous_request: web.Request,
+    handler: AsyncMock,
+    handler_response: web.Response,
+) -> None:
+    mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
+    mock_valkey_rate_limit_client.get_ip_state.return_value = None
+
+    response = await manager_proxy_rate_limited(handler)(anonymous_request)
+
+    assert response is handler_response
+    handler.assert_awaited_once_with(anonymous_request)

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -56,7 +56,7 @@ def handler(handler_response: web.Response) -> AsyncMock:
 class _PassThroughCase:
     id: str
     session: dict[str, Any]
-    state: RateLimitState | None = RateLimitState(
+    rlim_window: RateLimitState | None = RateLimitState(
         count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -73,7 +73,7 @@ class _PassThroughCase:
         _PassThroughCase(
             id="no-open-window",
             session=_AUTHENTICATED_SESSION,
-            state=None,
+            rlim_window=None,
         ),
     ],
     ids=lambda case: case.id,
@@ -87,7 +87,7 @@ async def test_pass_through_without_rate_limiting(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=case.session))
-    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = case.state
+    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = case.rlim_window
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)
 

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -29,7 +29,7 @@ _AUTHENTICATED_SESSION = {"authenticated": True, "token": {"user_id": str(_USER_
 @pytest.fixture
 def mock_valkey_rate_limit_client() -> AsyncMock:
     client = AsyncMock(spec=ValkeyRateLimitClient)
-    client.get_user_rate_limit.return_value = RateLimitState(
+    client.get_user_rlim_window.return_value = RateLimitState(
         count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
     return client
@@ -87,7 +87,7 @@ async def test_pass_through_without_rate_limiting(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=case.session))
-    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = case.rlim_window
+    mock_valkey_rate_limit_client.get_user_rlim_window.return_value = case.rlim_window
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)
 
@@ -143,7 +143,7 @@ async def test_gates_on_the_user_count(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_rlim_window.return_value = RateLimitState(
         count=case.count, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -152,9 +152,9 @@ async def test_gates_on_the_user_count(
     assert response.status == case.expected_status
     assert response.content_type == case.expected_content_type
     assert handler.await_count == case.expected_handler_awaits
-    mock_valkey_rate_limit_client.get_user_rate_limit.assert_awaited_once_with(_USER_ID)
-    mock_valkey_rate_limit_client.consume_user_rate_limit.assert_not_called()
-    mock_valkey_rate_limit_client.consume_ip_rate_limit.assert_not_called()
+    mock_valkey_rate_limit_client.get_user_rlim_window.assert_awaited_once_with(_USER_ID)
+    mock_valkey_rate_limit_client.consume_user_rlim_window.assert_not_called()
+    mock_valkey_rate_limit_client.consume_ip_rlim_window.assert_not_called()
 
 
 async def test_429_carries_the_rate_limit_headers(
@@ -164,7 +164,7 @@ async def test_429_carries_the_rate_limit_headers(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_user_rate_limit.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_rlim_window.return_value = RateLimitState(
         count=_RATE_LIMIT, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -195,7 +195,7 @@ async def test_an_anonymous_query_is_judged_by_the_address_window(
 ) -> None:
     """The two windows stand apart, so the limit reported says which one governed."""
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_rate_limit.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_ip_rlim_window.return_value = RateLimitState(
         count=_ANONYMOUS_LIMIT, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -214,7 +214,7 @@ async def test_an_anonymous_query_below_the_address_limit_is_proxied(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_rate_limit.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_ip_rlim_window.return_value = RateLimitState(
         count=_ANONYMOUS_LIMIT - 1, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -232,7 +232,7 @@ async def test_an_anonymous_query_without_an_open_window_is_proxied(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_rate_limit.return_value = None
+    mock_valkey_rate_limit_client.get_ip_rlim_window.return_value = None
 
     response = await manager_proxy_rate_limited(handler)(anonymous_request)
 

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -29,7 +29,7 @@ _AUTHENTICATED_SESSION = {"authenticated": True, "token": {"user_id": str(_USER_
 @pytest.fixture
 def mock_valkey_rate_limit_client() -> AsyncMock:
     client = AsyncMock(spec=ValkeyRateLimitClient)
-    client.get_user_state.return_value = RateLimitState(
+    client.get_user_window_state.return_value = RateLimitState(
         count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
     return client
@@ -87,7 +87,7 @@ async def test_pass_through_without_rate_limiting(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=case.session))
-    mock_valkey_rate_limit_client.get_user_state.return_value = case.state
+    mock_valkey_rate_limit_client.get_user_window_state.return_value = case.state
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)
 
@@ -143,7 +143,7 @@ async def test_gates_on_the_user_count(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_user_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_window_state.return_value = RateLimitState(
         count=case.count, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -152,7 +152,7 @@ async def test_gates_on_the_user_count(
     assert response.status == case.expected_status
     assert response.content_type == case.expected_content_type
     assert handler.await_count == case.expected_handler_awaits
-    mock_valkey_rate_limit_client.get_user_state.assert_awaited_once_with(_USER_ID)
+    mock_valkey_rate_limit_client.get_user_window_state.assert_awaited_once_with(_USER_ID)
     mock_valkey_rate_limit_client.consume_user_rate_limit.assert_not_called()
     mock_valkey_rate_limit_client.consume_ip_rate_limit.assert_not_called()
 
@@ -164,7 +164,7 @@ async def test_429_carries_the_rate_limit_headers(
     handler: AsyncMock,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
-    mock_valkey_rate_limit_client.get_user_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_user_window_state.return_value = RateLimitState(
         count=_RATE_LIMIT, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -195,7 +195,7 @@ async def test_an_anonymous_query_is_judged_by_the_address_window(
 ) -> None:
     """The two windows stand apart, so the limit reported says which one governed."""
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_ip_window_state.return_value = RateLimitState(
         count=_ANONYMOUS_LIMIT, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -214,7 +214,7 @@ async def test_an_anonymous_query_below_the_address_limit_is_proxied(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_state.return_value = RateLimitState(
+    mock_valkey_rate_limit_client.get_ip_window_state.return_value = RateLimitState(
         count=_ANONYMOUS_LIMIT - 1, limit=_ANONYMOUS_LIMIT, reset_after_seconds=_RESET
     )
 
@@ -232,7 +232,7 @@ async def test_an_anonymous_query_without_an_open_window_is_proxied(
     handler_response: web.Response,
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value={}))
-    mock_valkey_rate_limit_client.get_ip_state.return_value = None
+    mock_valkey_rate_limit_client.get_ip_window_state.return_value = None
 
     response = await manager_proxy_rate_limited(handler)(anonymous_request)
 

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -27,7 +27,9 @@ _AUTHENTICATED_SESSION = {"authenticated": True, "token": {"user_id": str(_USER_
 @pytest.fixture
 def mock_valkey_rate_limit_client() -> AsyncMock:
     client = AsyncMock(spec=ValkeyRateLimitClient)
-    client.get_state.return_value = RateLimitState(count=0, limit=_RATE_LIMIT, reset=_RESET)
+    client.get_state.return_value = RateLimitState(
+        count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
+    )
     return client
 
 
@@ -52,7 +54,9 @@ def handler(handler_response: web.Response) -> AsyncMock:
 class _PassThroughCase:
     id: str
     session: dict[str, Any]
-    state: RateLimitState | None = RateLimitState(count=0, limit=_RATE_LIMIT, reset=_RESET)
+    state: RateLimitState | None = RateLimitState(
+        count=0, limit=_RATE_LIMIT, reset_after_seconds=_RESET
+    )
 
 
 @pytest.mark.parametrize(
@@ -73,12 +77,6 @@ class _PassThroughCase:
             id="no-open-window",
             session=_AUTHENTICATED_SESSION,
             state=None,
-        ),
-        # Window without a limit: proxied unlimited.
-        _PassThroughCase(
-            id="window-without-limit",
-            session=_AUTHENTICATED_SESSION,
-            state=RateLimitState(count=5000, limit=None, reset=_RESET),
         ),
     ],
     ids=lambda case: case.id,
@@ -149,7 +147,7 @@ async def test_gates_on_the_user_count(
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
     mock_valkey_rate_limit_client.get_state.return_value = RateLimitState(
-        count=case.count, limit=_RATE_LIMIT, reset=_RESET
+        count=case.count, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)
@@ -158,7 +156,7 @@ async def test_gates_on_the_user_count(
     assert response.content_type == case.expected_content_type
     assert handler.await_count == case.expected_handler_awaits
     mock_valkey_rate_limit_client.get_state.assert_awaited_once_with(_USER_ID)
-    mock_valkey_rate_limit_client.consume.assert_not_called()
+    mock_valkey_rate_limit_client.consume_rate_limit.assert_not_called()
 
 
 async def test_429_carries_the_rate_limit_headers(
@@ -169,7 +167,7 @@ async def test_429_carries_the_rate_limit_headers(
 ) -> None:
     mocker.patch.object(ratelimit, "get_session", AsyncMock(return_value=_AUTHENTICATED_SESSION))
     mock_valkey_rate_limit_client.get_state.return_value = RateLimitState(
-        count=_RATE_LIMIT, limit=_RATE_LIMIT, reset=_RESET
+        count=_RATE_LIMIT, limit=_RATE_LIMIT, reset_after_seconds=_RESET
     )
 
     response = await manager_proxy_rate_limited(handler)(proxied_request)

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -37,7 +37,6 @@ def mock_valkey_rate_limit_client() -> AsyncMock:
 
 @pytest.fixture
 def proxied_request(mock_valkey_rate_limit_client: AsyncMock) -> web.Request:
-    """A proxied request the server can name no address for."""
     return make_mocked_request(
         "GET", "/func/session", app={"valkey_rate_limit": mock_valkey_rate_limit_client}
     )
@@ -65,11 +64,6 @@ class _PassThroughCase:
 @pytest.mark.parametrize(
     "case",
     [
-        # No login session and no address to key by: the manager limits it alone.
-        _PassThroughCase(
-            id="unauthenticated-without-an-address",
-            session={},
-        ),
         # Session created before login stored the user id: no counter key, so exempt.
         _PassThroughCase(
             id="session-stored-before-user-id",


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the web server per-user rate limiting stack (epic BA-7361). **Merge in order (bottom-up):**

1. ✅ #13777 — `feat(BA-7364)`: deliver the login user id in the auth response
2. ✅ #13778 — `feat(BA-7365)`: key the rate limit counter by user id
3. ✅ #14211 — `feat(BA-7648)`: count requests in a per-user fixed window instead of a sorted set
4. ✅ #14307 — `feat(BA-127)`: rate limit unauthenticated requests by client address
5. 👉 **#13771 — `feat(BA-7603)`: add a per-user rate limit middleware to the web server** ← you are here

⛔ #13779 — `feat(BA-7362): move the per-user API rate limit to the user resource policy` is closed (not planned); the limit stays on the keypair.

Resolves #14140 (BA-7603)

Rebased onto `main` as the stack below it merged. Two renames landed while this branch waited and are carried here: `RateLimitState` lost its optional limit and renamed `reset` to `reset_after_seconds` (#14211), and `consume_rate_limit()` split into `consume_user_rate_limit()` and `consume_ip_rate_limit()` (#14307). The web server still only reads, through `get_state()`.

## Summary

- The limit the manager stores with the window (#14211) is the user's **default keypair** limit, whichever keypair signed the request, read in the same query that resolves the access key (`AuthenticatedUser.rate_limit`).
- The web server wraps the signed manager proxy handlers with `manager_proxy_rate_limited()`: it reads `count`, `limit` and the TTL of the window in one call (`ValkeyRateLimitClient.get_state()`) and answers 429 with the rate limit headers once the count has reached the limit, without proxying. Only the manager counts.
- An unauthenticated request is judged by the address window the manager keeps for it (#14307), keyed on the address this server forwards. A manager with `trusted-proxies` configured may resolve a different address and open a window this check does not find; the request is then proxied and the manager limits it, as before.
- Not gated: sessions without a user id (the manager counts them by user, which this server cannot name), requests with no address to key by, and handlers the manager does not count (web server routes, the pipeline proxy, TUS uploads).
- The web server connects to the manager's rate limit Redis DB (`RedisRole.RATE_LIMIT`) with the same `[session].redis` settings it already uses for sessions.

## Test plan

- [x] Unit tests for the web server middleware: pass-through without a session, a user id or an open window; proxied below the limit; 429 with `X-RateLimit-Limit`, `Remaining`, `Reset` and `Window` at the limit without reaching the handler
- [ ] Live check with a keypair limit of 3: requests 1–3 pass, 4 and 5 get 429 from the web server and never reach the manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEsyc7pNsff3fa9j73vS54


<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13771.org.readthedocs.build/ko/13771/

<!-- readthedocs-preview sorna-ko end -->

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13771.org.readthedocs.build/en/13771/

<!-- readthedocs-preview sorna end -->


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13771.org.readthedocs.build/en/13771/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13771.org.readthedocs.build/ko/13771/

<!-- readthedocs-preview sorna-ko end -->