### PR TITLE
feat(BA-7364): deliver the login user id in the auth response

### DIFF
--- a/changes/13777.feature.md
+++ b/changes/13777.feature.md
@@ -1,0 +1,1 @@
+Return the login user's id and rate limit from the authorization API, and keep both in the web server session.

--- a/changes/13777.feature.md
+++ b/changes/13777.feature.md
@@ -1,1 +1,1 @@
-Return the login user's id and rate limit from the authorization API, and keep both in the web server session.
+Return the login user's id from the authorization API and keep it in the web server session.

--- a/src/ai/backend/common/dto/manager/auth/types.py
+++ b/src/ai/backend/common/dto/manager/auth/types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, Self
 
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import BackendAISchema
 
 __all__ = (
@@ -55,9 +56,13 @@ class AuthSuccessResponse(AuthResponse):
     role: str
     status: str
     session_token: str
+    # Optional for wire compatibility with managers that do not send them yet.
+    user_id: UserID | None = None
+    # The keypair rate limit (requests per window); None means unlimited.
+    rate_limit: int | None = None
     type: AuthTokenType = AuthTokenType.KEYPAIR
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, Any]:
         return self.model_dump(mode="json")
 
 

--- a/src/ai/backend/common/dto/manager/auth/types.py
+++ b/src/ai/backend/common/dto/manager/auth/types.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, Self
 
+from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.identifier.user import UserID
-from ai.backend.common.types import BackendAISchema
+from ai.backend.common.types import AccessKey, BackendAISchema, SecretKey
 
 __all__ = (
     "AuthTokenType",
@@ -51,14 +52,12 @@ class AuthResponse(BackendAISchema):
 class AuthSuccessResponse(AuthResponse):
     """Returned when authorization succeeds without requiring 2FA."""
 
-    access_key: str
-    secret_key: str
-    role: str
+    access_key: AccessKey
+    secret_key: SecretKey
+    role: UserRole
     status: str
     session_token: str
-    # Optional for wire compatibility with managers that do not send them yet.
-    user_id: UserID | None = None
-    # The keypair rate limit (requests per window); None means unlimited.
+    user_id: UserID
     rate_limit: int | None = None
     type: AuthTokenType = AuthTokenType.KEYPAIR
 

--- a/src/ai/backend/common/dto/manager/auth/types.py
+++ b/src/ai/backend/common/dto/manager/auth/types.py
@@ -58,7 +58,6 @@ class AuthSuccessResponse(AuthResponse):
     status: str
     session_token: str
     user_id: UserID
-    rate_limit: int | None
     type: AuthTokenType = AuthTokenType.KEYPAIR
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/ai/backend/common/dto/manager/auth/types.py
+++ b/src/ai/backend/common/dto/manager/auth/types.py
@@ -58,7 +58,7 @@ class AuthSuccessResponse(AuthResponse):
     status: str
     session_token: str
     user_id: UserID
-    rate_limit: int | None = None
+    rate_limit: int | None
     type: AuthTokenType = AuthTokenType.KEYPAIR
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -169,7 +169,6 @@ class AuthHandler:
             status=auth_result.status,
             session_token=auth_result.session_token,
             user_id=auth_result.user_id,
-            rate_limit=auth_result.rate_limit,
         )
         resp = AuthorizeResponse(data=data)
         return APIResponse.build(HTTPStatus.OK, resp)

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -46,6 +46,7 @@ from ai.backend.common.dto.manager.auth.types import (
     AuthSuccessResponse,
     AuthTokenType,
 )
+from ai.backend.common.identifier.user import UserID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.middleware.auth import extract_client_ip
 from ai.backend.manager.dto.context import RequestCtx, UserContext
@@ -168,6 +169,8 @@ class AuthHandler:
             role=auth_result.role,
             status=auth_result.status,
             session_token=auth_result.session_token,
+            user_id=UserID(auth_result.user_id),
+            rate_limit=auth_result.rate_limit,
         )
         resp = AuthorizeResponse(data=data)
         return APIResponse.build(HTTPStatus.OK, resp)

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -46,7 +46,6 @@ from ai.backend.common.dto.manager.auth.types import (
     AuthSuccessResponse,
     AuthTokenType,
 )
-from ai.backend.common.identifier.user import UserID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.middleware.auth import extract_client_ip
 from ai.backend.manager.dto.context import RequestCtx, UserContext
@@ -169,7 +168,7 @@ class AuthHandler:
             role=auth_result.role,
             status=auth_result.status,
             session_token=auth_result.session_token,
-            user_id=UserID(auth_result.user_id),
+            user_id=auth_result.user_id,
             rate_limit=auth_result.rate_limit,
         )
         resp = AuthorizeResponse(data=data)

--- a/src/ai/backend/manager/data/auth/types.py
+++ b/src/ai/backend/manager/data/auth/types.py
@@ -29,7 +29,6 @@ class AuthorizationResult:
     role: UserRole
     status: str
     session_token: str
-    rate_limit: int | None
 
 
 @dataclass

--- a/src/ai/backend/manager/data/auth/types.py
+++ b/src/ai/backend/manager/data/auth/types.py
@@ -23,10 +23,10 @@ class SSHKeypair:
 
 @dataclass
 class AuthorizationResult:
-    user_id: uuid.UUID
-    access_key: str
-    secret_key: str
-    role: str
+    user_id: UserID
+    access_key: AccessKey
+    secret_key: SecretKey
+    role: UserRole
     status: str
     session_token: str
     rate_limit: int | None

--- a/src/ai/backend/manager/data/auth/types.py
+++ b/src/ai/backend/manager/data/auth/types.py
@@ -29,6 +29,7 @@ class AuthorizationResult:
     role: str
     status: str
     session_token: str
+    rate_limit: int | None
 
 
 @dataclass

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -416,8 +416,6 @@ class AuthService:
                 role=UserRole(user.role),
                 status=user.status,
                 session_token=session_result.session_token,
-                # TODO: take this from the user resource policy instead of the keypair.
-                rate_limit=keypair_row.rate_limit,
             ),
         )
 

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -18,8 +18,9 @@ from ai.backend.common.clients.valkey_client.valkey_session.types import (
 )
 from ai.backend.common.dto.manager.auth.types import AuthTokenType
 from ai.backend.common.exception import InvalidAPIParameters, UserResourcePolicyNotFound
+from ai.backend.common.identifier.user import UserID
 from ai.backend.common.plugin.hook import ALL_COMPLETED, FIRST_COMPLETED, PASSED, HookPluginContext
-from ai.backend.common.types import AccessKey, SSHPrivateKey, SSHPublicKey
+from ai.backend.common.types import AccessKey, SecretKey, SSHPrivateKey, SSHPublicKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.config.unified import AuthConfig
@@ -409,10 +410,10 @@ class AuthService:
         return AuthorizeActionResult(
             stream_response=None,
             authorization_result=AuthorizationResult(
-                access_key=keypair_row.access_key,
-                secret_key=keypair_row.secret_key or "",
-                user_id=user.uuid,
-                role=user.role,
+                access_key=AccessKey(keypair_row.access_key),
+                secret_key=SecretKey(keypair_row.secret_key),
+                user_id=UserID(user.uuid),
+                role=UserRole(user.role),
                 status=user.status,
                 session_token=session_result.session_token,
                 rate_limit=keypair_row.rate_limit,

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -395,7 +395,7 @@ class AuthService:
                 token=LoginSessionTokenData(
                     type="keypair",
                     access_key=keypair_row.access_key,
-                    secret_key=keypair_row.secret_key or "",
+                    secret_key=keypair_row.secret_key,
                     role=user.role,
                     status=user.status,
                 ),

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -415,6 +415,7 @@ class AuthService:
                 role=user.role,
                 status=user.status,
                 session_token=session_result.session_token,
+                rate_limit=keypair_row.rate_limit,
             ),
         )
 

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -416,6 +416,7 @@ class AuthService:
                 role=UserRole(user.role),
                 status=user.status,
                 session_token=session_result.session_token,
+                # TODO: take this from the user resource policy instead of the keypair.
                 rate_limit=keypair_row.rate_limit,
             ),
         )

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -506,6 +506,8 @@ async def login_handler(request: web.Request) -> web.Response:
                     "secret_key": token.secret_key,
                     "role": token.role,
                     "status": token.status,
+                    "user_id": str(token.user_id) if token.user_id is not None else None,
+                    "rate_limit": token.rate_limit,
                 }
                 public_return = {
                     "access_key": token.access_key,
@@ -767,6 +769,8 @@ async def token_login_handler(request: web.Request) -> web.Response:
             "secret_key": token.secret_key,
             "role": token.role,
             "status": token.status,
+            "user_id": str(token.user_id) if token.user_id is not None else None,
+            "rate_limit": token.rate_limit,
         }
         public_return = {
             "access_key": token.access_key,

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -506,7 +506,7 @@ async def login_handler(request: web.Request) -> web.Response:
                     "secret_key": token.secret_key,
                     "role": token.role,
                     "status": token.status,
-                    "user_id": str(token.user_id) if token.user_id is not None else None,
+                    "user_id": str(token.user_id),
                     "rate_limit": token.rate_limit,
                 }
                 public_return = {
@@ -769,7 +769,7 @@ async def token_login_handler(request: web.Request) -> web.Response:
             "secret_key": token.secret_key,
             "role": token.role,
             "status": token.status,
-            "user_id": str(token.user_id) if token.user_id is not None else None,
+            "user_id": str(token.user_id),
             "rate_limit": token.rate_limit,
         }
         public_return = {

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -507,7 +507,6 @@ async def login_handler(request: web.Request) -> web.Response:
                     "role": token.role,
                     "status": token.status,
                     "user_id": str(token.user_id),
-                    "rate_limit": token.rate_limit,
                 }
                 public_return = {
                     "access_key": token.access_key,
@@ -770,7 +769,6 @@ async def token_login_handler(request: web.Request) -> web.Response:
             "role": token.role,
             "status": token.status,
             "user_id": str(token.user_id),
-            "rate_limit": token.rate_limit,
         }
         public_return = {
             "access_key": token.access_key,

--- a/tests/unit/client_v2/test_auth_client.py
+++ b/tests/unit/client_v2/test_auth_client.py
@@ -82,7 +82,6 @@ class TestAuthClient:
                     "status": "active",
                     "session_token": "test_session_token",
                     "user_id": "12345678-1234-5678-1234-567812345678",
-                    "rate_limit": None,
                     "type": AuthTokenType.KEYPAIR,
                 },
             }

--- a/tests/unit/client_v2/test_auth_client.py
+++ b/tests/unit/client_v2/test_auth_client.py
@@ -82,6 +82,7 @@ class TestAuthClient:
                     "status": "active",
                     "session_token": "test_session_token",
                     "user_id": "12345678-1234-5678-1234-567812345678",
+                    "rate_limit": None,
                     "type": AuthTokenType.KEYPAIR,
                 },
             }

--- a/tests/unit/client_v2/test_auth_client.py
+++ b/tests/unit/client_v2/test_auth_client.py
@@ -81,6 +81,7 @@ class TestAuthClient:
                     "role": "admin",
                     "status": "active",
                     "session_token": "test_session_token",
+                    "user_id": "12345678-1234-5678-1234-567812345678",
                     "type": AuthTokenType.KEYPAIR,
                 },
             }

--- a/tests/unit/common/dto/manager/auth/test_auth_response.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_response.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.auth.response import (
     AuthorizeResponse,
     GetRoleResponse,
@@ -18,16 +21,19 @@ from ai.backend.common.dto.manager.auth.types import (
     AuthSuccessResponse,
     AuthTokenType,
 )
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import AccessKey, SecretKey
 
 
 def test_authorize_response() -> None:
     data = AuthSuccessResponse(
         response_type=AuthResponseType.SUCCESS,
-        access_key="AKIAIOSFODNN7EXAMPLE",
-        secret_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-        role="user",
+        access_key=AccessKey("AKIAIOSFODNN7EXAMPLE"),
+        secret_key=SecretKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+        role=UserRole.USER,
         status="active",
         session_token="test_session_token",
+        user_id=UserID(uuid4()),
         type=AuthTokenType.KEYPAIR,
     )
     resp = AuthorizeResponse(data=data)

--- a/tests/unit/common/dto/manager/auth/test_auth_response.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_response.py
@@ -34,7 +34,6 @@ def test_authorize_response() -> None:
         status="active",
         session_token="test_session_token",
         user_id=UserID(uuid4()),
-        rate_limit=None,
         type=AuthTokenType.KEYPAIR,
     )
     resp = AuthorizeResponse(data=data)

--- a/tests/unit/common/dto/manager/auth/test_auth_response.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_response.py
@@ -34,6 +34,7 @@ def test_authorize_response() -> None:
         status="active",
         session_token="test_session_token",
         user_id=UserID(uuid4()),
+        rate_limit=None,
         type=AuthTokenType.KEYPAIR,
     )
     resp = AuthorizeResponse(data=data)

--- a/tests/unit/common/dto/manager/auth/test_auth_types.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_types.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from uuid import UUID, uuid4
 
+from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.auth.types import (
     AuthResponseType,
     AuthSuccessResponse,
@@ -12,6 +13,7 @@ from ai.backend.common.dto.manager.auth.types import (
     parse_auth_response,
 )
 from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import AccessKey, SecretKey
 
 
 def test_auth_token_type_values() -> None:
@@ -37,11 +39,12 @@ def test_two_factor_type_values() -> None:
 def test_auth_success_response_creation() -> None:
     resp = AuthSuccessResponse(
         response_type=AuthResponseType.SUCCESS,
-        access_key="AKTEST",
-        secret_key="SKTEST",
-        role="user",
+        access_key=AccessKey("AKTEST"),
+        secret_key=SecretKey("SKTEST"),
+        role=UserRole.USER,
         status="active",
         session_token="test_session_token",
+        user_id=UserID(uuid4()),
     )
     assert resp.access_key == "AKTEST"
     assert resp.secret_key == "SKTEST"
@@ -53,11 +56,12 @@ def test_auth_success_response_creation() -> None:
 def test_auth_success_response_to_dict() -> None:
     resp = AuthSuccessResponse(
         response_type=AuthResponseType.SUCCESS,
-        access_key="AK",
-        secret_key="SK",
-        role="admin",
+        access_key=AccessKey("AK"),
+        secret_key=SecretKey("SK"),
+        role=UserRole.ADMIN,
         status="active",
         session_token="test_session_token",
+        user_id=UserID(uuid4()),
         type=AuthTokenType.JWT,
     )
     d = resp.to_dict()
@@ -118,11 +122,11 @@ def test_parse_auth_response_success() -> None:
         "role": "user",
         "status": "active",
         "session_token": "test_token",
+        "user_id": "12345678-1234-5678-1234-567812345678",
     }
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)
     assert result.access_key == "AK"
-    assert result.user_id is None
     assert result.rate_limit is None
 
 
@@ -147,9 +151,9 @@ def test_auth_success_response_to_dict_serializes_user_id_and_rate_limit() -> No
     user_id = UserID(uuid4())
     resp = AuthSuccessResponse(
         response_type=AuthResponseType.SUCCESS,
-        access_key="AK",
-        secret_key="SK",
-        role="user",
+        access_key=AccessKey("AK"),
+        secret_key=SecretKey("SK"),
+        role=UserRole.USER,
         status="active",
         session_token="test_token",
         user_id=user_id,

--- a/tests/unit/common/dto/manager/auth/test_auth_types.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.auth.types import (
@@ -127,41 +127,6 @@ def test_parse_auth_response_success() -> None:
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)
     assert result.access_key == "AK"
-    assert result.rate_limit is None
-
-
-def test_parse_auth_response_success_with_user_id_and_rate_limit() -> None:
-    data = {
-        "response_type": "success",
-        "access_key": "AK",
-        "secret_key": "SK",
-        "role": "user",
-        "status": "active",
-        "session_token": "test_token",
-        "user_id": "12345678-1234-5678-1234-567812345678",
-        "rate_limit": 30000,
-    }
-    result = parse_auth_response(data)
-    assert isinstance(result, AuthSuccessResponse)
-    assert result.user_id == UUID("12345678-1234-5678-1234-567812345678")
-    assert result.rate_limit == 30000
-
-
-def test_auth_success_response_to_dict_serializes_user_id_and_rate_limit() -> None:
-    user_id = UserID(uuid4())
-    resp = AuthSuccessResponse(
-        response_type=AuthResponseType.SUCCESS,
-        access_key=AccessKey("AK"),
-        secret_key=SecretKey("SK"),
-        role=UserRole.USER,
-        status="active",
-        session_token="test_token",
-        user_id=user_id,
-        rate_limit=30000,
-    )
-    d = resp.to_dict()
-    assert d["user_id"] == str(user_id)
-    assert d["rate_limit"] == 30000
 
 
 def test_parse_auth_response_two_factor_registration() -> None:
@@ -193,6 +158,7 @@ def test_parse_auth_response_explicit_success() -> None:
         "role": "user",
         "status": "active",
         "session_token": "test_token",
+        "user_id": "12345678-1234-5678-1234-567812345678",
     }
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)

--- a/tests/unit/common/dto/manager/auth/test_auth_types.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_types.py
@@ -45,7 +45,6 @@ def test_auth_success_response_creation() -> None:
         status="active",
         session_token="test_session_token",
         user_id=UserID(uuid4()),
-        rate_limit=None,
     )
     assert resp.access_key == "AKTEST"
     assert resp.secret_key == "SKTEST"
@@ -63,7 +62,6 @@ def test_auth_success_response_to_dict() -> None:
         status="active",
         session_token="test_session_token",
         user_id=UserID(uuid4()),
-        rate_limit=None,
         type=AuthTokenType.JWT,
     )
     d = resp.to_dict()
@@ -125,7 +123,6 @@ def test_parse_auth_response_success() -> None:
         "status": "active",
         "session_token": "test_token",
         "user_id": "12345678-1234-5678-1234-567812345678",
-        "rate_limit": None,
     }
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)
@@ -162,7 +159,6 @@ def test_parse_auth_response_explicit_success() -> None:
         "status": "active",
         "session_token": "test_token",
         "user_id": "12345678-1234-5678-1234-567812345678",
-        "rate_limit": None,
     }
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)

--- a/tests/unit/common/dto/manager/auth/test_auth_types.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_types.py
@@ -45,6 +45,7 @@ def test_auth_success_response_creation() -> None:
         status="active",
         session_token="test_session_token",
         user_id=UserID(uuid4()),
+        rate_limit=None,
     )
     assert resp.access_key == "AKTEST"
     assert resp.secret_key == "SKTEST"
@@ -62,6 +63,7 @@ def test_auth_success_response_to_dict() -> None:
         status="active",
         session_token="test_session_token",
         user_id=UserID(uuid4()),
+        rate_limit=None,
         type=AuthTokenType.JWT,
     )
     d = resp.to_dict()
@@ -123,6 +125,7 @@ def test_parse_auth_response_success() -> None:
         "status": "active",
         "session_token": "test_token",
         "user_id": "12345678-1234-5678-1234-567812345678",
+        "rate_limit": None,
     }
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)
@@ -159,6 +162,7 @@ def test_parse_auth_response_explicit_success() -> None:
         "status": "active",
         "session_token": "test_token",
         "user_id": "12345678-1234-5678-1234-567812345678",
+        "rate_limit": None,
     }
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)

--- a/tests/unit/common/dto/manager/auth/test_auth_types.py
+++ b/tests/unit/common/dto/manager/auth/test_auth_types.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import UUID, uuid4
+
 from ai.backend.common.dto.manager.auth.types import (
     AuthResponseType,
     AuthSuccessResponse,
@@ -9,6 +11,7 @@ from ai.backend.common.dto.manager.auth.types import (
     TwoFactorType,
     parse_auth_response,
 )
+from ai.backend.common.identifier.user import UserID
 
 
 def test_auth_token_type_values() -> None:
@@ -119,6 +122,42 @@ def test_parse_auth_response_success() -> None:
     result = parse_auth_response(data)
     assert isinstance(result, AuthSuccessResponse)
     assert result.access_key == "AK"
+    assert result.user_id is None
+    assert result.rate_limit is None
+
+
+def test_parse_auth_response_success_with_user_id_and_rate_limit() -> None:
+    data = {
+        "response_type": "success",
+        "access_key": "AK",
+        "secret_key": "SK",
+        "role": "user",
+        "status": "active",
+        "session_token": "test_token",
+        "user_id": "12345678-1234-5678-1234-567812345678",
+        "rate_limit": 30000,
+    }
+    result = parse_auth_response(data)
+    assert isinstance(result, AuthSuccessResponse)
+    assert result.user_id == UUID("12345678-1234-5678-1234-567812345678")
+    assert result.rate_limit == 30000
+
+
+def test_auth_success_response_to_dict_serializes_user_id_and_rate_limit() -> None:
+    user_id = UserID(uuid4())
+    resp = AuthSuccessResponse(
+        response_type=AuthResponseType.SUCCESS,
+        access_key="AK",
+        secret_key="SK",
+        role="user",
+        status="active",
+        session_token="test_token",
+        user_id=user_id,
+        rate_limit=30000,
+    )
+    d = resp.to_dict()
+    assert d["user_id"] == str(user_id)
+    assert d["rate_limit"] == 30000
 
 
 def test_parse_auth_response_two_factor_registration() -> None:

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -33,6 +33,8 @@ from ai.backend.common.dto.manager.auth.request import (
     UploadSSHKeypairRequest,
     VerifyAuthRequest,
 )
+from ai.backend.common.identifier.user import UserID
+from ai.backend.common.types import AccessKey, SecretKey
 from ai.backend.manager.api.rest.auth.handler import AuthHandler
 from ai.backend.manager.api.rest.middleware.auth import (
     TRUSTED_PROXY_NETWORKS_KEY,
@@ -240,9 +242,9 @@ class TestAuthorize:
         return AuthorizeActionResult(
             stream_response=None,
             authorization_result=AuthorizationResult(
-                user_id=uuid.uuid4(),
-                access_key="TESTKEY",
-                secret_key="TESTSECRET",
+                user_id=UserID(uuid.uuid4()),
+                access_key=AccessKey("TESTKEY"),
+                secret_key=SecretKey("TESTSECRET"),
                 role=UserRole.USER,
                 status=UserStatus.ACTIVE,
                 session_token="test_session_token",

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -246,6 +246,7 @@ class TestAuthorize:
                 role=UserRole.USER,
                 status=UserStatus.ACTIVE,
                 session_token="test_session_token",
+                rate_limit=30000,
             ),
         )
 
@@ -279,6 +280,8 @@ class TestAuthorize:
         assert isinstance(data, dict)
         assert data["data"]["access_key"] == authorize_result.authorization_result.access_key
         assert data["data"]["secret_key"] == authorize_result.authorization_result.secret_key
+        assert data["data"]["user_id"] == str(authorize_result.authorization_result.user_id)
+        assert data["data"]["rate_limit"] == authorize_result.authorization_result.rate_limit
 
     async def test_passes_params_to_action(
         self,

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -282,8 +282,6 @@ class TestAuthorize:
         assert isinstance(data, dict)
         assert data["data"]["access_key"] == authorize_result.authorization_result.access_key
         assert data["data"]["secret_key"] == authorize_result.authorization_result.secret_key
-        assert data["data"]["user_id"] == str(authorize_result.authorization_result.user_id)
-        assert data["data"]["rate_limit"] == authorize_result.authorization_result.rate_limit
 
     async def test_passes_params_to_action(
         self,

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -248,7 +248,6 @@ class TestAuthorize:
                 role=UserRole.USER,
                 status=UserStatus.ACTIVE,
                 session_token="test_session_token",
-                rate_limit=30000,
             ),
         )
 

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -124,14 +124,12 @@ def _make_mock_keypair_row(
     *,
     access_key: str = "test_access_key",
     secret_key: str = "test_secret_key",
-    rate_limit: int | None = 30000,
     max_concurrent_sessions: int = 1,
 ) -> MagicMock:
     """Create a mock keypair row with access_key, secret_key, and mapping."""
     mock_keypair = MagicMock()
     mock_keypair.access_key = access_key
     mock_keypair.secret_key = secret_key
-    mock_keypair.rate_limit = rate_limit
     mock_keypair.mapping = {"access_key": access_key}
     mock_keypair.resource_policy_row.max_concurrent_sessions = max_concurrent_sessions
     return mock_keypair
@@ -198,7 +196,6 @@ async def test_authorize_success(
     assert result.authorization_result.access_key == "test_access_key"
     assert result.authorization_result.secret_key == "test_secret_key"
     assert result.authorization_result.session_token == "test_session_token"
-    assert result.authorization_result.rate_limit == 30000
 
 
 async def test_authorize_invalid_token_type(

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -124,12 +124,14 @@ def _make_mock_keypair_row(
     *,
     access_key: str = "test_access_key",
     secret_key: str = "test_secret_key",
+    rate_limit: int | None = 30000,
     max_concurrent_sessions: int = 1,
 ) -> MagicMock:
     """Create a mock keypair row with access_key, secret_key, and mapping."""
     mock_keypair = MagicMock()
     mock_keypair.access_key = access_key
     mock_keypair.secret_key = secret_key
+    mock_keypair.rate_limit = rate_limit
     mock_keypair.mapping = {"access_key": access_key}
     mock_keypair.resource_policy_row.max_concurrent_sessions = max_concurrent_sessions
     return mock_keypair
@@ -196,6 +198,7 @@ async def test_authorize_success(
     assert result.authorization_result.access_key == "test_access_key"
     assert result.authorization_result.secret_key == "test_secret_key"
     assert result.authorization_result.session_token == "test_session_token"
+    assert result.authorization_result.rate_limit == 30000
 
 
 async def test_authorize_invalid_token_type(


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 5-PR stack. **Merge in order:**

1. 👉 **#13777** — `feat(BA-7364): deliver the login user id in the auth response` ← you are here
2. ⬇️ #13778 — `feat(BA-7365): key the rate limit counter by user id`
3. ⬇️ #13779 — `feat(BA-7362): move the per-user API rate limit to the user resource policy`
4. ⬇️ #13784 — `feat(BA-7363): publish the per-user rate limit to the shared Redis DB`
5. ⬇️ #13771 — `feat(BA-7365): add a per-user rate limit middleware to the web server`

Only the final tip (#13771) is guaranteed to build / pass CI; intermediate PRs are logical slices for reviewability.

## Summary
- Add a required `user_id` (`UserID`) field to `AuthSuccessResponse`, filled in the manager REST `authorize` handler, and store it in the web server session token in both login paths. The web server needs the login user's identity to key a per-user rate limit counter without asking the manager again.
- Type the identifiers the auth result already carried: `AuthorizationResult` and `AuthSuccessResponse` now use `UserID`, `AccessKey`, `SecretKey` and `UserRole` instead of bare `uuid.UUID` / `str`.
- Drop the dead `or ""` fallbacks on `keypairs.secret_key`, which is NOT NULL.

The rate limit value is deliberately not part of this response (see #13777 review): it is a resource policy value rather than part of who authenticated, and a session snapshot would go stale — the manager reads the policy per request, while a web server session would hold the login-time value for up to a week. The web server will read it from the shared rate limit Redis DB instead (BA-7363).

Resolves BA-7364.

