### PR TITLE
feat(BA-7365): key the rate limit counter by user id

### DIFF
--- a/changes/13778.feature.md
+++ b/changes/13778.feature.md
@@ -1,0 +1,1 @@
+Count API requests against the requesting user instead of the access key, so holding multiple keypairs no longer multiplies a user's rate limit allowance.

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -9,6 +9,7 @@ from ai.backend.common.clients.valkey_client.client import (
     AbstractValkeyClient,
     create_valkey_client,
 )
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
@@ -44,19 +45,19 @@ _TIME_PRECISION = Decimal("1e-3")  # milliseconds
 
 
 _RATE_LIMIT_SCRIPT: Final[str] = """
-local access_key = KEYS[1]
+local key = KEYS[1]
 local now = tonumber(ARGV[1])
 local window = tonumber(ARGV[2])
 local request_id = tonumber(redis.call('INCR', '__request_id'))
 if request_id >= 1e12 then
     redis.call('SET', '__request_id', 1)
 end
-if redis.call('EXISTS', access_key) == 1 then
-    redis.call('ZREMRANGEBYSCORE', access_key, 0, now - window)
+if redis.call('EXISTS', key) == 1 then
+    redis.call('ZREMRANGEBYSCORE', key, 0, now - window)
 end
-redis.call('ZADD', access_key, now, tostring(request_id))
-redis.call('EXPIRE', access_key, window)
-return redis.call('ZCARD', access_key)
+redis.call('ZADD', key, now, tostring(request_id))
+redis.call('EXPIRE', key, window)
+return redis.call('ZCARD', key)
 """
 
 
@@ -110,14 +111,14 @@ class ValkeyRateLimitClient:
     @valkey_rate_limit_resilience.apply()
     async def execute_rate_limit_logic(
         self,
-        access_key: str,
+        user_id: UserID,
         window: int = _DEFAULT_RATE_LIMIT_EXPIRATION,
     ) -> int:
         """
         Execute the rate limiting logic for rolling counter.
         This replicates the Lua script logic using individual commands.
 
-        :param access_key: The access key to rate limit.
+        :param user_id: The user the rolling counter is keyed by.
         :param window: The time window for rate limiting in seconds.
         :return: The current count.
         """
@@ -127,7 +128,7 @@ class ValkeyRateLimitClient:
         async with self._client.client() as conn:
             result = await conn.invoke_script(
                 Script(_RATE_LIMIT_SCRIPT),
-                keys=[access_key],
+                keys=[f"user.{user_id}"],
                 args=[str(now_float), str(window)],
             )
 
@@ -135,15 +136,15 @@ class ValkeyRateLimitClient:
         return cast(int, result)
 
     @valkey_rate_limit_resilience.apply()
-    async def get_rolling_count(self, access_key: str) -> int:
+    async def get_rolling_count(self, user_id: UserID) -> int:
         """
-        Get the current rolling count for an access key.
+        Get the current rolling count of a user.
 
-        :param access_key: The access key to get the count for.
+        :param user_id: The user the rolling counter is keyed by.
         :return: The current count.
         """
         async with self._client.client() as conn:
-            return await conn.zcard(access_key)
+            return await conn.zcard(f"user.{user_id}")
 
     @valkey_rate_limit_resilience.apply()
     async def set_rate_limit_config(

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,7 +206,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            return await valkey_client.get_rolling_count(self.access_key)
+            return await valkey_client.get_rolling_count(UserID(self.user))
         finally:
             await valkey_client.close()
 

--- a/src/ai/backend/manager/api/rest/ratelimit/handler.py
+++ b/src/ai/backend/manager/api/rest/ratelimit/handler.py
@@ -38,9 +38,8 @@ def make_rlim_middleware(
         """Global middleware implementing a rolling-counter rate limiter."""
         if request["is_authorized"]:
             rate_limit = request["keypair"]["rate_limit"]
-            access_key = request["keypair"]["access_key"]
             rolling_count = await valkey_client.execute_rate_limit_logic(
-                access_key=access_key,
+                user_id=request["user"]["uuid"],
                 window=_rlim_window,
             )
             if rate_limit is not None and rolling_count > rate_limit:

--- a/tests/unit/common/clients/valkey_client/test_valkey_rate_limit_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_rate_limit_client.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-import random
+import uuid
 
 from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import (
     ValkeyRateLimitClient,
 )
+from ai.backend.common.data.entity.user import UserID
 
 
 async def test_valkey_rate_limit_logic_execution(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     """Test rate limiting logic execution."""
-    access_key = f"test-logic-{random.randint(1000, 9999)}"
+    user_id = UserID(uuid.uuid4())
 
     # Execute the rate limiting logic
     result = await test_valkey_rate_limit.execute_rate_limit_logic(
-        access_key=access_key,
+        user_id=user_id,
         window=60,
     )
 
@@ -23,8 +24,10 @@ async def test_valkey_rate_limit_logic_execution(
 
     # Execute again
     result2 = await test_valkey_rate_limit.execute_rate_limit_logic(
-        access_key=access_key,
+        user_id=user_id,
         window=60,
     )
 
     assert result2 == 2  # Second request should return 2
+
+    assert await test_valkey_rate_limit.get_rolling_count(user_id) == 2

--- a/tests/unit/manager/api/test_ratelimit.py
+++ b/tests/unit/manager/api/test_ratelimit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -8,8 +9,11 @@ import pytest
 from aiohttp import web
 
 from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.api.rest.ratelimit.handler import _rlim_window, make_rlim_middleware
 from ai.backend.manager.errors.api import RateLimitExceeded
+
+_USER_ID = UserID(uuid.UUID("12345678-1234-5678-1234-567812345678"))
 
 
 @dataclass
@@ -65,16 +69,16 @@ class TestRlimMiddleware:
     def mock_request_authorized(self) -> web.Request:
         """Mock request for authorized user."""
         request = MagicMock(spec=web.Request)
-        keypair_data = {
-            "rate_limit": 30000,
-            "access_key": "AKIAIOSFODNN7EXAMPLE",
-        }
+        keypair_data = {"rate_limit": 30000}
+        user_data = {"uuid": _USER_ID}
 
         def getitem(key: Any) -> Any:
             if key == "is_authorized":
                 return True
             if key == "keypair":
                 return keypair_data
+            if key == "user":
+                return user_data
             return None
 
         request.__getitem__ = MagicMock(side_effect=getitem)
@@ -162,7 +166,7 @@ class TestRlimMiddleware:
 
         # Valkey should be called for authorized requests
         mock_valkey_client.execute_rate_limit_logic.assert_called_once_with(
-            access_key="AKIAIOSFODNN7EXAMPLE",
+            user_id=_USER_ID,
             window=_rlim_window,
         )
 
@@ -211,6 +215,6 @@ class TestRlimMiddleware:
 
         # Valkey should still be called
         mock_valkey_client.execute_rate_limit_logic.assert_called_once_with(
-            access_key="AKIAIOSFODNN7EXAMPLE",
+            user_id=_USER_ID,
             window=_rlim_window,
         )


### PR DESCRIPTION
## 📚 Stacked PRs

This stack is 2 open PRs. **Merge in order:**

1. ✅ #13777 — `feat(BA-7364): deliver the login user id in the auth response` (merged)
2. 👉 **#13778** — `feat(BA-7365): key the rate limit counter by user id` ← you are here
3. ⬇️ #13771 — `feat(BA-7365): add a per-user rate limit middleware to the web server`

⛔ #13779 — `feat(BA-7362): move the per-user API rate limit to the user resource policy` was part of this stack and is closed (not planned) for now; the limit stays on the keypair.

Only the final tip (#13771) is guaranteed to build / pass CI; intermediate PRs are logical slices for reviewability.

## Summary
- `ValkeyRateLimitClient.execute_rate_limit_logic()` and `get_rolling_count()` take a `UserID` and build the counter key (`user.<user_id>`) themselves, so callers no longer decide the key format.
- The manager's rate limit middleware counts against the authenticated user instead of the access key, so holding multiple keypairs no longer multiplies a user's allowance.
- `KeyPair.rolling_count` in the legacy GraphQL schema resolves against the same per-user counter.

The limit compared against is still the keypair's `rate_limit`. Moving it to the user resource policy (#13779, BA-7362) is deferred, so a user's keypairs may carry different limits while sharing one counter: each request is checked against the limit of the keypair that signed it.

Publishing the limit to the shared Redis DB for the web server (BA-7363, opened as #13784) moved to #13771, which is its only reader.

Relates to BA-7365.
