### PR TITLE
feat(BA-7362): move the per-user API rate limit to the user resource policy

### DIFF
--- a/changes/13779.feature.md
+++ b/changes/13779.feature.md
@@ -1,0 +1,1 @@
+Move the per-user API rate limit from the keypair to the user resource policy field max_api_requests_per_window; the keypair rate limit is deprecated and no longer enforced.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1216,7 +1216,6 @@ type KeyPair implements Item {
   resource_policy: String
   created_at: DateTime
   last_used: DateTime
-  rate_limit: Int
   num_queries: Int
 
   """Added in 24.09.0."""
@@ -1229,6 +1228,7 @@ type KeyPair implements Item {
   concurrency_used: Int
   user_info: UserInfo
   concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  rate_limit: Int @deprecated(reason: "Moved to UserResourcePolicy object as the max_api_requests_per_window field. The value is still stored but no longer enforced.")
 }
 
 type VirtualFolder implements Item {

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5193,6 +5193,11 @@ input CreateUserResourcePolicyInputV2
   """
   maxConcurrentLogins: Int = null
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int = null
+
   """Maximum quota scope size (e.g., '1g', '536870912')."""
   maxQuotaScopeSize: BinarySizeInput!
 
@@ -10170,7 +10175,6 @@ type KeyPair implements Item
   resource_policy: String
   created_at: DateTime
   last_used: DateTime
-  rate_limit: Int
   num_queries: Int
 
   """Added in 24.09.0."""
@@ -10183,6 +10187,7 @@ type KeyPair implements Item
   concurrency_used: Int
   user_info: UserInfo
   concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  rate_limit: Int @deprecated(reason: "Moved to UserResourcePolicy object as the max_api_requests_per_window field. The value is still stored but no longer enforced.")
 }
 
 """
@@ -22761,6 +22766,11 @@ input UpdateUserResourcePolicyInput
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).
+  """
+  maxApiRequestsPerWindow: Int
+
   """Updated max quota scope size."""
   maxQuotaScopeSize: BinarySizeInput = null
 
@@ -23480,6 +23490,11 @@ type UserResourcePolicyV2 implements Node
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int
+
   """Maximum quota scope size."""
   maxQuotaScopeSize: BinarySizeInfo!
 
@@ -23523,6 +23538,9 @@ input UserResourcePolicyV2Filter
   createdAt: DateTimeFilter = null
   maxVfolderCount: IntFilter = null
   maxConcurrentLogins: IntFilter = null
+
+  """Added in 26.9.0. Filter by max API requests per rate limit window."""
+  maxApiRequestsPerWindow: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
@@ -23556,6 +23574,7 @@ enum UserResourcePolicyV2OrderField
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MAX_VFOLDER_COUNT @join__enumValue(graph: STRAWBERRY)
   MAX_CONCURRENT_LOGINS @join__enumValue(graph: STRAWBERRY)
+  MAX_API_REQUESTS_PER_WINDOW @join__enumValue(graph: STRAWBERRY)
   MAX_QUOTA_SCOPE_SIZE @join__enumValue(graph: STRAWBERRY)
   MAX_SESSION_COUNT_PER_MODEL_SESSION @join__enumValue(graph: STRAWBERRY)
   MAX_CUSTOMIZED_IMAGE_COUNT @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5194,7 +5194,7 @@ input CreateUserResourcePolicyInputV2
   maxConcurrentLogins: Int = null
 
   """
-  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Null means unlimited.
   """
   maxApiRequestsPerWindow: Int = null
 
@@ -22767,7 +22767,7 @@ input UpdateUserResourcePolicyInput
   maxConcurrentLogins: Int
 
   """
-  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).
+  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Set to null to clear (unlimited).
   """
   maxApiRequestsPerWindow: Int
 
@@ -23491,7 +23491,7 @@ type UserResourcePolicyV2 implements Node
   maxConcurrentLogins: Int
 
   """
-  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Null means unlimited.
   """
   maxApiRequestsPerWindow: Int
 
@@ -23539,7 +23539,9 @@ input UserResourcePolicyV2Filter
   maxVfolderCount: IntFilter = null
   maxConcurrentLogins: IntFilter = null
 
-  """Added in 26.9.0. Filter by max API requests per rate limit window."""
+  """
+  Added in 26.9.0. Filter by max API requests per rate limit window (a fixed 15-minute sliding window).
+  """
   maxApiRequestsPerWindow: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3550,7 +3550,7 @@ input CreateUserResourcePolicyInputV2 {
   maxConcurrentLogins: Int = null
 
   """
-  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Null means unlimited.
   """
   maxApiRequestsPerWindow: Int = null
 
@@ -16530,7 +16530,7 @@ input UpdateUserResourcePolicyInput {
   maxConcurrentLogins: Int
 
   """
-  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).
+  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Set to null to clear (unlimited).
   """
   maxApiRequestsPerWindow: Int
 
@@ -16988,7 +16988,7 @@ type UserResourcePolicyV2 implements Node {
   maxConcurrentLogins: Int
 
   """
-  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Null means unlimited.
   """
   maxApiRequestsPerWindow: Int
 
@@ -17030,7 +17030,9 @@ input UserResourcePolicyV2Filter {
   maxVfolderCount: IntFilter = null
   maxConcurrentLogins: IntFilter = null
 
-  """Added in 26.9.0. Filter by max API requests per rate limit window."""
+  """
+  Added in 26.9.0. Filter by max API requests per rate limit window (a fixed 15-minute sliding window).
+  """
   maxApiRequestsPerWindow: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3549,6 +3549,11 @@ input CreateUserResourcePolicyInputV2 {
   """
   maxConcurrentLogins: Int = null
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int = null
+
   """Maximum quota scope size (e.g., '1g', '536870912')."""
   maxQuotaScopeSize: BinarySizeInput!
 
@@ -16524,6 +16529,11 @@ input UpdateUserResourcePolicyInput {
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).
+  """
+  maxApiRequestsPerWindow: Int
+
   """Updated max quota scope size."""
   maxQuotaScopeSize: BinarySizeInput = null
 
@@ -16977,6 +16987,11 @@ type UserResourcePolicyV2 implements Node {
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int
+
   """Maximum quota scope size."""
   maxQuotaScopeSize: BinarySizeInfo!
 
@@ -17014,6 +17029,9 @@ input UserResourcePolicyV2Filter {
   createdAt: DateTimeFilter = null
   maxVfolderCount: IntFilter = null
   maxConcurrentLogins: IntFilter = null
+
+  """Added in 26.9.0. Filter by max API requests per rate limit window."""
+  maxApiRequestsPerWindow: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
@@ -17043,6 +17061,7 @@ enum UserResourcePolicyV2OrderField {
   CREATED_AT
   MAX_VFOLDER_COUNT
   MAX_CONCURRENT_LOGINS
+  MAX_API_REQUESTS_PER_WINDOW
   MAX_QUOTA_SCOPE_SIZE
   MAX_SESSION_COUNT_PER_MODEL_SESSION
   MAX_CUSTOMIZED_IMAGE_COUNT

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -12752,7 +12752,8 @@
           },
           "rate_limit": {
             "default": 30000,
-            "description": "API rate limit (requests per minute).",
+            "deprecated": true,
+            "description": "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced.",
             "title": "Rate Limit",
             "type": "integer"
           }
@@ -12821,7 +12822,8 @@
               }
             ],
             "default": null,
-            "description": "New API rate limit.",
+            "deprecated": true,
+            "description": "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced.",
             "title": "Rate Limit"
           }
         },
@@ -22582,6 +22584,18 @@
             "default": null,
             "description": "Filter by max concurrent logins."
           },
+          "max_api_requests_per_window": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IntFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by max API requests per rate limit window."
+          },
           "max_quota_scope_size": {
             "anyOf": [
               {
@@ -22696,6 +22710,7 @@
           "created_at",
           "max_vfolder_count",
           "max_concurrent_logins",
+          "max_api_requests_per_window",
           "max_quota_scope_size",
           "max_session_count_per_model_session",
           "max_customized_image_count"
@@ -22845,6 +22860,20 @@
             "description": "Maximum number of concurrent authenticated login sessions per user. Null means unlimited. Must be >= 1 when set. Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions.",
             "title": "Max Concurrent Logins"
           },
+          "max_api_requests_per_window": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.",
+            "title": "Max Api Requests Per Window"
+          },
           "max_quota_scope_size": {
             "$ref": "#/components/schemas/BinarySizeInput",
             "description": "Maximum quota scope size (e.g., '1g', '536870912')."
@@ -22909,6 +22938,27 @@
             "default": 1,
             "description": "Updated maximum number of concurrent authenticated login sessions per user. Set to null to clear (unlimited). Must be >= 1 when set. Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions.",
             "title": "Max Concurrent Logins"
+          },
+          "max_api_requests_per_window": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Sentinel"
+                  }
+                ],
+                "ge": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 1,
+            "description": "Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).",
+            "title": "Max Api Requests Per Window"
           },
           "max_quota_scope_size": {
             "anyOf": [

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -22594,7 +22594,7 @@
               }
             ],
             "default": null,
-            "description": "Filter by max API requests per rate limit window."
+            "description": "Filter by max API requests per rate limit window (a fixed 15-minute sliding window)."
           },
           "max_quota_scope_size": {
             "anyOf": [
@@ -22871,7 +22871,7 @@
               }
             ],
             "default": null,
-            "description": "Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.",
+            "description": "Maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Null means unlimited.",
             "title": "Max Api Requests Per Window"
           },
           "max_quota_scope_size": {
@@ -22957,7 +22957,7 @@
               }
             ],
             "default": 1,
-            "description": "Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).",
+            "description": "Updated maximum number of API requests allowed per user within the rate limit window: a fixed 15-minute (900-second) sliding window that ends at each request and is reported in the X-RateLimit-Window response header. Set to null to clear (unlimited).",
             "title": "Max Api Requests Per Window"
           },
           "max_quota_scope_size": {

--- a/src/ai/backend/client/cli/v2/admin/resource_policy.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_policy.py
@@ -468,7 +468,10 @@ def user_get(name: str) -> None:
     "--max-api-requests-per-window",
     type=int,
     default=None,
-    help="Maximum API requests per user within the rate limit window (NULL = unlimited).",
+    help=(
+        "Maximum API requests per user within the rate limit window,"
+        " a fixed 15-minute sliding window (NULL = unlimited)."
+    ),
 )
 @click.option("--json", "json_str", default=None, help="Full input as JSON string.")
 @click.option(
@@ -554,7 +557,10 @@ def user_create(
     "--max-api-requests-per-window",
     type=int,
     default=None,
-    help="Maximum API requests per user within the rate limit window (NULL = unlimited).",
+    help=(
+        "Maximum API requests per user within the rate limit window,"
+        " a fixed 15-minute sliding window (NULL = unlimited)."
+    ),
 )
 @click.option("--json", "json_str", default=None, help="Full update input as JSON string.")
 @click.option(

--- a/src/ai/backend/client/cli/v2/admin/resource_policy.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_policy.py
@@ -464,6 +464,12 @@ def user_get(name: str) -> None:
         " Distinct from --max-concurrent-sessions which limits compute sessions."
     ),
 )
+@click.option(
+    "--max-api-requests-per-window",
+    type=int,
+    default=None,
+    help="Maximum API requests per user within the rate limit window (NULL = unlimited).",
+)
 @click.option("--json", "json_str", default=None, help="Full input as JSON string.")
 @click.option(
     "--file",
@@ -479,6 +485,7 @@ def user_create(
     max_session_count_per_model_session: int | None,
     max_customized_image_count: int | None,
     max_concurrent_logins: int | None,
+    max_api_requests_per_window: int | None,
     json_str: str | None,
     file_path: str | None,
 ) -> None:
@@ -504,6 +511,7 @@ def user_create(
         max_session_count_per_model_session=max_session_count_per_model_session,
         max_customized_image_count=max_customized_image_count,
         max_concurrent_logins=max_concurrent_logins,
+        max_api_requests_per_window=max_api_requests_per_window,
     )
     dto = _build_dto(CreateUserResourcePolicyInput, data)
 
@@ -542,6 +550,12 @@ def user_create(
         " Distinct from --max-concurrent-sessions which limits compute sessions."
     ),
 )
+@click.option(
+    "--max-api-requests-per-window",
+    type=int,
+    default=None,
+    help="Maximum API requests per user within the rate limit window (NULL = unlimited).",
+)
 @click.option("--json", "json_str", default=None, help="Full update input as JSON string.")
 @click.option(
     "--file",
@@ -557,6 +571,7 @@ def user_update(
     max_session_count_per_model_session: int | None,
     max_customized_image_count: int | None,
     max_concurrent_logins: int | None,
+    max_api_requests_per_window: int | None,
     json_str: str | None,
     file_path: str | None,
 ) -> None:
@@ -573,6 +588,7 @@ def user_update(
         max_session_count_per_model_session=max_session_count_per_model_session,
         max_customized_image_count=max_customized_image_count,
         max_concurrent_logins=max_concurrent_logins,
+        max_api_requests_per_window=max_api_requests_per_window,
     )
 
     dto = _build_dto(UpdateUserResourcePolicyInput, data)

--- a/src/ai/backend/common/dto/manager/v2/keypair/request.py
+++ b/src/ai/backend/common/dto/manager/v2/keypair/request.py
@@ -138,7 +138,13 @@ class AdminCreateKeypairInput(BaseRequestModel):
     resource_policy: str = Field(description="Name of the resource policy to assign.")
     is_active: bool = Field(default=True, description="Whether the keypair should be active.")
     is_admin: bool = Field(default=False, description="Whether the keypair has admin privileges.")
-    rate_limit: int = Field(default=30000, description="API rate limit (requests per minute).")
+    rate_limit: int = Field(
+        default=30000,
+        deprecated=True,
+        description=(
+            "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced."
+        ),
+    )
 
 
 class AdminUpdateKeypairInput(BaseRequestModel):
@@ -148,7 +154,13 @@ class AdminUpdateKeypairInput(BaseRequestModel):
     is_active: bool | None = Field(default=None, description="New active state.")
     is_admin: bool | None = Field(default=None, description="New admin privilege state.")
     resource_policy: str | None = Field(default=None, description="New resource policy name.")
-    rate_limit: int | None = Field(default=None, description="New API rate limit.")
+    rate_limit: int | None = Field(
+        default=None,
+        deprecated=True,
+        description=(
+            "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced."
+        ),
+    )
 
 
 class AdminDeleteKeypairInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/keypair/response.py
+++ b/src/ai/backend/common/dto/manager/v2/keypair/response.py
@@ -53,7 +53,12 @@ class KeypairNode(BaseResponseModel):
     last_used: datetime | None = Field(
         default=None, description="When the keypair was last used for an API call."
     )
-    rate_limit: int = Field(description="API rate limit (requests per minute).")
+    rate_limit: int = Field(
+        deprecated=True,
+        description=(
+            "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced."
+        ),
+    )
     num_queries: int = Field(description="Total number of API queries made with this keypair.")
     resource_policy: str = Field(
         description="Name of the resource policy assigned to this keypair."

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
@@ -185,8 +185,9 @@ class CreateUserResourcePolicyInput(BaseRequestModel):
         default=None,
         ge=0,
         description=(
-            "Maximum number of API requests allowed per user within the rate limit window."
-            " Null means unlimited."
+            "Maximum number of API requests allowed per user within the rate limit window:"
+            " a fixed 15-minute (900-second) sliding window that ends at each request and is"
+            " reported in the X-RateLimit-Window response header. Null means unlimited."
         ),
     )
     max_quota_scope_size: BinarySizeInput = Field(
@@ -230,7 +231,9 @@ class UpdateUserResourcePolicyInput(BaseRequestModel):
         ge=0,
         description=(
             "Updated maximum number of API requests allowed per user within the rate limit"
-            " window. Set to null to clear (unlimited)."
+            " window: a fixed 15-minute (900-second) sliding window that ends at each"
+            " request and is reported in the X-RateLimit-Window response header."
+            " Set to null to clear (unlimited)."
         ),
     )
     max_quota_scope_size: BinarySizeInput | Sentinel | None = Field(
@@ -367,7 +370,10 @@ class UserResourcePolicyFilter(BaseRequestModel):
         default=None, description="Filter by max concurrent logins."
     )
     max_api_requests_per_window: IntFilter | None = Field(
-        default=None, description="Filter by max API requests per rate limit window."
+        default=None,
+        description=(
+            "Filter by max API requests per rate limit window (a fixed 15-minute sliding window)."
+        ),
     )
     max_quota_scope_size: IntFilter | None = Field(
         default=None, description="Filter by max quota scope size."

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
@@ -181,6 +181,14 @@ class CreateUserResourcePolicyInput(BaseRequestModel):
             " Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions."
         ),
     )
+    max_api_requests_per_window: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Maximum number of API requests allowed per user within the rate limit window."
+            " Null means unlimited."
+        ),
+    )
     max_quota_scope_size: BinarySizeInput = Field(
         description="Maximum quota scope size (e.g., '1g', '536870912').",
     )
@@ -215,6 +223,14 @@ class UpdateUserResourcePolicyInput(BaseRequestModel):
             "Updated maximum number of concurrent authenticated login sessions per user."
             " Set to null to clear (unlimited). Must be >= 1 when set."
             " Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions."
+        ),
+    )
+    max_api_requests_per_window: int | Sentinel | None = Field(
+        default=SENTINEL,
+        ge=0,
+        description=(
+            "Updated maximum number of API requests allowed per user within the rate limit"
+            " window. Set to null to clear (unlimited)."
         ),
     )
     max_quota_scope_size: BinarySizeInput | Sentinel | None = Field(
@@ -349,6 +365,9 @@ class UserResourcePolicyFilter(BaseRequestModel):
     )
     max_concurrent_logins: IntFilter | None = Field(
         default=None, description="Filter by max concurrent logins."
+    )
+    max_api_requests_per_window: IntFilter | None = Field(
+        default=None, description="Filter by max API requests per rate limit window."
     )
     max_quota_scope_size: IntFilter | None = Field(
         default=None, description="Filter by max quota scope size."

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/response.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/response.py
@@ -122,6 +122,13 @@ class UserResourcePolicyNode(BaseResponseModel):
             " Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions."
         ),
     )
+    max_api_requests_per_window: int | None = Field(
+        default=None,
+        description=(
+            "Maximum number of API requests allowed per user within the rate limit window."
+            " Null means unlimited."
+        ),
+    )
     max_quota_scope_size: BinarySizeInfo = Field(
         description="Maximum quota scope size.",
     )

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/response.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/response.py
@@ -125,8 +125,9 @@ class UserResourcePolicyNode(BaseResponseModel):
     max_api_requests_per_window: int | None = Field(
         default=None,
         description=(
-            "Maximum number of API requests allowed per user within the rate limit window."
-            " Null means unlimited."
+            "Maximum number of API requests allowed per user within the rate limit window:"
+            " a fixed 15-minute (900-second) sliding window that ends at each request and is"
+            " reported in the X-RateLimit-Window response header. Null means unlimited."
         ),
     )
     max_quota_scope_size: BinarySizeInfo = Field(

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/types.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/types.py
@@ -39,6 +39,7 @@ class UserResourcePolicyOrderField(StrEnum):
     CREATED_AT = "created_at"
     MAX_VFOLDER_COUNT = "max_vfolder_count"
     MAX_CONCURRENT_LOGINS = "max_concurrent_logins"
+    MAX_API_REQUESTS_PER_WINDOW = "max_api_requests_per_window"
     MAX_QUOTA_SCOPE_SIZE = "max_quota_scope_size"
     MAX_SESSION_COUNT_PER_MODEL_SESSION = "max_session_count_per_model_session"
     MAX_CUSTOMIZED_IMAGE_COUNT = "max_customized_image_count"

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -414,6 +414,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             name=input.name,
             max_vfolder_count=input.max_vfolder_count,
             max_concurrent_logins=input.max_concurrent_logins,
+            max_api_requests_per_window=input.max_api_requests_per_window,
             max_quota_scope_size=input.max_quota_scope_size.bytes,
             max_session_count_per_model_session=input.max_session_count_per_model_session,
             max_customized_image_count=input.max_customized_image_count,
@@ -446,6 +447,13 @@ class ResourcePolicyAdapter(BaseAdapter):
                 else TriState.nullify()
                 if input.max_concurrent_logins is None
                 else TriState.update(input.max_concurrent_logins)
+            ),
+            max_api_requests_per_window=(
+                TriState.nop()
+                if isinstance(input.max_api_requests_per_window, Sentinel)
+                else TriState.nullify()
+                if input.max_api_requests_per_window is None
+                else TriState.update(input.max_api_requests_per_window)
             ),
             max_quota_scope_size=(
                 OptionalState.nop()
@@ -680,6 +688,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             created_at=data.created_at,
             max_vfolder_count=data.max_vfolder_count,
             max_concurrent_logins=data.max_concurrent_logins,
+            max_api_requests_per_window=data.max_api_requests_per_window,
             max_quota_scope_size=BinarySize.to_size_info(data.max_quota_scope_size),
             max_session_count_per_model_session=data.max_session_count_per_model_session,
             max_customized_image_count=data.max_customized_image_count,
@@ -845,6 +854,13 @@ class ResourcePolicyAdapter(BaseAdapter):
             )
             if cond is not None:
                 conditions.append(cond)
+        if filter.max_api_requests_per_window is not None:
+            cond = self.convert_int_filter(
+                filter.max_api_requests_per_window,
+                UserResourcePolicyConditions.by_max_api_requests_per_window,
+            )
+            if cond is not None:
+                conditions.append(cond)
         if filter.max_quota_scope_size is not None:
             cond = self.convert_int_filter(
                 filter.max_quota_scope_size,
@@ -1001,6 +1017,8 @@ def _resolve_user_order(
             return UserResourcePolicyOrders.max_vfolder_count(ascending)
         case UserResourcePolicyOrderField.MAX_CONCURRENT_LOGINS:
             return UserResourcePolicyOrders.max_concurrent_logins(ascending)
+        case UserResourcePolicyOrderField.MAX_API_REQUESTS_PER_WINDOW:
+            return UserResourcePolicyOrders.max_api_requests_per_window(ascending)
         case UserResourcePolicyOrderField.MAX_QUOTA_SCOPE_SIZE:
             return UserResourcePolicyOrders.max_quota_scope_size(ascending)
         case UserResourcePolicyOrderField.MAX_SESSION_COUNT_PER_MODEL_SESSION:

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
@@ -158,6 +158,7 @@ class UserResourcePolicyV2Filter(PydanticInputMixin[UserResourcePolicyFilterDTO]
     created_at: DateTimeFilter | None = None
     max_vfolder_count: IntFilter | None = None
     max_concurrent_logins: IntFilter | None = None
+    max_api_requests_per_window: IntFilter | None = None
     max_quota_scope_size: IntFilter | None = None
     max_session_count_per_model_session: IntFilter | None = None
     max_customized_image_count: IntFilter | None = None
@@ -187,6 +188,7 @@ class UserResourcePolicyV2OrderField(StrEnum):
     CREATED_AT = "created_at"
     MAX_VFOLDER_COUNT = "max_vfolder_count"
     MAX_CONCURRENT_LOGINS = "max_concurrent_logins"
+    MAX_API_REQUESTS_PER_WINDOW = "max_api_requests_per_window"
     MAX_QUOTA_SCOPE_SIZE = "max_quota_scope_size"
     MAX_SESSION_COUNT_PER_MODEL_SESSION = "max_session_count_per_model_session"
     MAX_CUSTOMIZED_IMAGE_COUNT = "max_customized_image_count"

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
@@ -26,6 +26,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.request import (
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
     UserResourcePolicyOrder as UserResourcePolicyOrderDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     IntFilter,
@@ -158,7 +159,13 @@ class UserResourcePolicyV2Filter(PydanticInputMixin[UserResourcePolicyFilterDTO]
     created_at: DateTimeFilter | None = None
     max_vfolder_count: IntFilter | None = None
     max_concurrent_logins: IntFilter | None = None
-    max_api_requests_per_window: IntFilter | None = None
+    max_api_requests_per_window: IntFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by max API requests per rate limit window.",
+        ),
+        default=None,
+    )
     max_quota_scope_size: IntFilter | None = None
     max_session_count_per_model_session: IntFilter | None = None
     max_customized_image_count: IntFilter | None = None

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
@@ -162,7 +162,10 @@ class UserResourcePolicyV2Filter(PydanticInputMixin[UserResourcePolicyFilterDTO]
     max_api_requests_per_window: IntFilter | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
-            description="Filter by max API requests per rate limit window.",
+            description=(
+                "Filter by max API requests per rate limit window"
+                " (a fixed 15-minute sliding window)."
+            ),
         ),
         default=None,
     )

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
@@ -191,7 +191,9 @@ class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePoli
             added_version=NEXT_RELEASE_VERSION,
             description=(
                 "Maximum number of API requests allowed per user within the rate limit"
-                " window. Null means unlimited."
+                " window: a fixed 15-minute (900-second) sliding window that ends at each"
+                " request and is reported in the X-RateLimit-Window response header."
+                " Null means unlimited."
             ),
         ),
         default=None,
@@ -235,7 +237,9 @@ class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePoli
             added_version=NEXT_RELEASE_VERSION,
             description=(
                 "Updated maximum number of API requests allowed per user within the rate"
-                " limit window. Set to null to clear (unlimited)."
+                " limit window: a fixed 15-minute (900-second) sliding window that ends at"
+                " each request and is reported in the X-RateLimit-Window response header."
+                " Set to null to clear (unlimited)."
             ),
         ),
         default=UNSET,

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
@@ -49,6 +49,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.response import (
 from ai.backend.common.dto.manager.v2.resource_policy.response import (
     UpdateUserResourcePolicyPayload as UpdateUserResourcePolicyPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.common_types import (
     BinarySizeInputGQL,
     ResourceSlotEntryInputGQL,
@@ -185,6 +186,16 @@ class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePoli
         ),
         default=None,
     )
+    max_api_requests_per_window: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Maximum number of API requests allowed per user within the rate limit"
+                " window. Null means unlimited."
+            ),
+        ),
+        default=None,
+    )
     max_quota_scope_size: BinarySizeInputGQL = gql_field(
         description="Maximum quota scope size (e.g., '1g', '536870912').",
     )
@@ -215,6 +226,16 @@ class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePoli
                 " Set to null to clear (unlimited)."
                 " Distinct from keypair_resource_policies.max_concurrent_sessions"
                 " which caps compute sessions."
+            ),
+        ),
+        default=UNSET,
+    )
+    max_api_requests_per_window: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Updated maximum number of API requests allowed per user within the rate"
+                " limit window. Set to null to clear (unlimited)."
             ),
         ),
         default=UNSET,

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/node.py
@@ -211,7 +211,9 @@ class UserResourcePolicyV2GQL(PydanticNodeMixin[UserResourcePolicyNode]):
             added_version=NEXT_RELEASE_VERSION,
             description=(
                 "Maximum number of API requests allowed per user within the rate limit"
-                " window. Null means unlimited."
+                " window: a fixed 15-minute (900-second) sliding window that ends at each"
+                " request and is reported in the X-RateLimit-Window response header."
+                " Null means unlimited."
             ),
         ),
     )

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/node.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.response import (
     ProjectResourcePolicyNode,
     UserResourcePolicyNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.common_types import (
     BinarySizeInfoGQL,
     ResourceLimitEntryGQL,
@@ -202,6 +203,15 @@ class UserResourcePolicyV2GQL(PydanticNodeMixin[UserResourcePolicyNode]):
                 " Null means unlimited."
                 " Distinct from keypair_resource_policies.max_concurrent_sessions"
                 " which caps compute sessions."
+            ),
+        ),
+    )
+    max_api_requests_per_window: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Maximum number of API requests allowed per user within the rate limit"
+                " window. Null means unlimited."
             ),
         ),
     )

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -113,7 +113,6 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
     resource_policy = graphene.String()
     created_at = GQLDateTime()
     last_used = GQLDateTime()
-    rate_limit = graphene.Int()
     num_queries = graphene.Int()
     rolling_count = graphene.Int(description="Added in 24.09.0.")
     user = graphene.UUID()
@@ -134,6 +133,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
     concurrency_limit = graphene.Int(
         deprecation_reason=(
             "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field."
+        )
+    )
+    rate_limit = graphene.Int(
+        deprecation_reason=(
+            "Moved to UserResourcePolicy object as the max_api_requests_per_window field."
+            " The value is still stored but no longer enforced."
         )
     )
 

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -31,6 +31,7 @@ class UserResourcePolicyData(EntityData):
     max_session_count_per_model_session: int = 0
     max_customized_image_count: int = 3
     max_concurrent_logins: int | None = None
+    max_api_requests_per_window: int | None = None
 
     @override
     def entity_id(self) -> EntityIdentifier:

--- a/src/ai/backend/manager/models/alembic/versions/f2b48c0d7a19_add_max_api_requests_per_window_to_user_resource_policy.py
+++ b/src/ai/backend/manager/models/alembic/versions/f2b48c0d7a19_add_max_api_requests_per_window_to_user_resource_policy.py
@@ -1,0 +1,40 @@
+"""add max_api_requests_per_window to user_resource_policy
+
+NULL means unlimited; integer N means at most N API requests are allowed per
+user within the rate limit window. Replaces keypairs.rate_limit as the source
+of the per-user API rate limit, which is now deprecated and ignored.
+
+Revision ID: f2b48c0d7a19
+Revises: d4e6f8a0b2c3
+Create Date: 2026-08-14 15:20:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2b48c0d7a19"
+down_revision = "d4e6f8a0b2c3"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("user_resource_policies")}
+    if "max_api_requests_per_window" not in cols:
+        op.add_column(
+            "user_resource_policies",
+            sa.Column("max_api_requests_per_window", sa.Integer(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("user_resource_policies")}
+    if "max_api_requests_per_window" in cols:
+        op.drop_column("user_resource_policies", "max_api_requests_per_window")

--- a/src/ai/backend/manager/models/resource_policy/conditions.py
+++ b/src/ai/backend/manager/models/resource_policy/conditions.py
@@ -247,6 +247,9 @@ class UserResourcePolicyConditions:
 
     by_max_vfolder_count = make_int_conditions(UserResourcePolicyRow.max_vfolder_count)
     by_max_concurrent_logins = make_int_conditions(UserResourcePolicyRow.max_concurrent_logins)
+    by_max_api_requests_per_window = make_int_conditions(
+        UserResourcePolicyRow.max_api_requests_per_window
+    )
     by_max_quota_scope_size = make_int_conditions(UserResourcePolicyRow.max_quota_scope_size)
     by_max_session_count_per_model_session = make_int_conditions(
         UserResourcePolicyRow.max_session_count_per_model_session

--- a/src/ai/backend/manager/models/resource_policy/creators.py
+++ b/src/ai/backend/manager/models/resource_policy/creators.py
@@ -81,6 +81,7 @@ class UserResourcePolicyCreator(GlobalEntityCreator[UserResourcePolicyRow, UserR
     max_session_count_per_model_session: int
     max_customized_image_count: int
     max_concurrent_logins: int | None = None
+    max_api_requests_per_window: int | None = None
 
     @override
     def entity_id(self, row: UserResourcePolicyRow) -> UserResourcePolicyUUID:
@@ -99,6 +100,7 @@ class UserResourcePolicyCreator(GlobalEntityCreator[UserResourcePolicyRow, UserR
             max_session_count_per_model_session=self.max_session_count_per_model_session,
             max_customized_image_count=self.max_customized_image_count,
             max_concurrent_logins=self.max_concurrent_logins,
+            max_api_requests_per_window=self.max_api_requests_per_window,
         )
 
     @override

--- a/src/ai/backend/manager/models/resource_policy/orders.py
+++ b/src/ai/backend/manager/models/resource_policy/orders.py
@@ -93,6 +93,12 @@ class UserResourcePolicyOrders:
         return UserResourcePolicyRow.max_concurrent_logins.desc()
 
     @staticmethod
+    def max_api_requests_per_window(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return UserResourcePolicyRow.max_api_requests_per_window.asc()
+        return UserResourcePolicyRow.max_api_requests_per_window.desc()
+
+    @staticmethod
     def max_quota_scope_size(ascending: bool = True) -> QueryOrder:
         if ascending:
             return UserResourcePolicyRow.max_quota_scope_size.asc()

--- a/src/ai/backend/manager/models/resource_policy/row.py
+++ b/src/ai/backend/manager/models/resource_policy/row.py
@@ -162,6 +162,9 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
     max_concurrent_logins: Mapped[int | None] = mapped_column(
         "max_concurrent_logins", sa.Integer(), nullable=True, default=None
     )
+    max_api_requests_per_window: Mapped[int | None] = mapped_column(
+        "max_api_requests_per_window", sa.Integer(), nullable=True, default=None
+    )
 
     def __init__(
         self,
@@ -171,6 +174,7 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
         max_session_count_per_model_session: int,
         max_customized_image_count: int,
         max_concurrent_logins: int | None = None,
+        max_api_requests_per_window: int | None = None,
     ) -> None:
         self.name = name
         self.max_vfolder_count = max_vfolder_count
@@ -178,6 +182,7 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
         self.max_session_count_per_model_session = max_session_count_per_model_session
         self.max_customized_image_count = max_customized_image_count
         self.max_concurrent_logins = max_concurrent_logins
+        self.max_api_requests_per_window = max_api_requests_per_window
 
     @classmethod
     def from_dataclass(cls, data: UserResourcePolicyData) -> Self:
@@ -200,6 +205,7 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
             max_session_count_per_model_session=self.max_session_count_per_model_session,
             max_customized_image_count=self.max_customized_image_count,
             max_concurrent_logins=self.max_concurrent_logins,
+            max_api_requests_per_window=self.max_api_requests_per_window,
         )
 
 

--- a/src/ai/backend/manager/models/resource_policy/updaters.py
+++ b/src/ai/backend/manager/models/resource_policy/updaters.py
@@ -104,6 +104,7 @@ class UserResourcePolicyUpdater(DataUpdater[UserResourcePolicyRow, UserResourceP
     )
     max_customized_image_count: OptionalState[int] = field(default_factory=OptionalState[int].nop)
     max_concurrent_logins: TriState[int] = field(default_factory=TriState[int].nop)
+    max_api_requests_per_window: TriState[int] = field(default_factory=TriState[int].nop)
 
     @property
     @override
@@ -133,6 +134,7 @@ class UserResourcePolicyUpdater(DataUpdater[UserResourcePolicyRow, UserResourceP
         )
         self.max_customized_image_count.update_dict(to_update, "max_customized_image_count")
         self.max_concurrent_logins.update_dict(to_update, "max_concurrent_logins")
+        self.max_api_requests_per_window.update_dict(to_update, "max_api_requests_per_window")
         return to_update
 
     @override

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -65,7 +65,6 @@ def mock_user_resource_policy_repository() -> AsyncMock:
         max_session_count_per_model_session=5,
         max_customized_image_count=3,
         max_concurrent_logins=None,
-        max_api_requests_per_window=30000,
     )
     return mock_repo
 

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -65,6 +65,7 @@ def mock_user_resource_policy_repository() -> AsyncMock:
         max_session_count_per_model_session=5,
         max_customized_image_count=3,
         max_concurrent_logins=None,
+        max_api_requests_per_window=30000,
     )
     return mock_repo
 


### PR DESCRIPTION
## 📚 Stacked PRs

This stack is 3 open PRs. **Merge in order:**

1. ✅ #13777 — `feat(BA-7364): deliver the login user id in the auth response` (merged)
2. 👉 **#13779** — `feat(BA-7362): move the per-user API rate limit to the user resource policy` ← you are here
3. ⬇️ #13778 — `feat(BA-7365): key the rate limit counter and the published limit by user id`
4. ⬇️ #13771 — `feat(BA-7365): add a per-user rate limit middleware to the web server`

Only the final tip (#13771) is guaranteed to build / pass CI; intermediate PRs are logical slices for reviewability.

## Summary
- Add a nullable `max_api_requests_per_window` column to `user_resource_policies` (NULL means unlimited) and plumb it through the v2 stack: row, data type, creator/updater specs, filters and orders, v2 DTOs, GQL v2 node/mutation/filter types, the adapter, and the admin CLI.
- Nothing enforces the new field yet: the rate limiter still reads `keypairs.rate_limit` at this point of the stack. #13778 switches it to the policy field in the same step that keys the counter by user, so the ceiling and the counter move to the user together.
- `keypairs.rate_limit` is deprecated, not removed: the column and its API fields are still written and returned. The legacy GQL field carries a `deprecation_reason` and the v2 keypair DTO fields are marked `deprecated=True`; their texts describe the end state of the stack.

Existing deployments start with the new column NULL, which means unlimited — an operator must set the policy value to restore a limit.

Resolves BA-7362.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13779.org.readthedocs.build/en/13779/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13779.org.readthedocs.build/ko/13779/

<!-- readthedocs-preview sorna-ko end -->