### PR TITLE
feat(BA-7366): stop project member enrollment from cascading into member scopes

### DIFF
--- a/changes/13782.feature.md
+++ b/changes/13782.feature.md
@@ -1,0 +1,1 @@
+Add scope membership as a relation separate from permission cascade, so that a project's permissions no longer reach the entities its member users own

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -395,7 +395,7 @@ class ContainerRegistryRepository:
         scope reach the registry's own entities."""
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
         await ops.ensure_scope(project_scope)
-        await ops.add_bulk_subscopes(
+        await ops.add_bulk_inheriting_members(
             EntityMembersAddition(
                 scope=project_scope,
                 members=[

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -395,7 +395,7 @@ class ContainerRegistryRepository:
         scope reach the registry's own entities."""
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
         await ops.ensure_scope(project_scope)
-        await ops.add_bulk_members(
+        await ops.add_bulk_subscopes(
             EntityMembersAddition(
                 scope=project_scope,
                 members=[

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -162,8 +162,8 @@ class GroupDBSource:
 
         Domain/resource-policy existence and name-uniqueness are enforced by the group
         row's DB constraints, mapped to domain errors via the spec's
-        integrity_error_checks. The new project is nested under its domain scope, so
-        domain-scoped permissions reach the project's entities.
+        integrity_error_checks. The new project joins its domain scope as an inheriting
+        member, so domain-scoped permissions reach the project's entities.
         """
         spec = cast(GroupCreatorSpec, creator.spec)
         async with self._rbac_ops_provider.write_ops() as w:
@@ -172,7 +172,7 @@ class GroupDBSource:
             domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id)
             data = (await w.create_scope(creation)).row.to_data()
             await w.ensure_scope(domain_scope)
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=domain_scope,
                     members=[

--- a/src/ai/backend/manager/repositories/group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/group/db_source/db_source.py
@@ -162,7 +162,8 @@ class GroupDBSource:
 
         Domain/resource-policy existence and name-uniqueness are enforced by the group
         row's DB constraints, mapped to domain errors via the spec's
-        integrity_error_checks. The new project joins its domain scope as a member.
+        integrity_error_checks. The new project is nested under its domain scope, so
+        domain-scoped permissions reach the project's entities.
         """
         spec = cast(GroupCreatorSpec, creator.spec)
         async with self._rbac_ops_provider.write_ops() as w:
@@ -171,7 +172,7 @@ class GroupDBSource:
             domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id)
             data = (await w.create_scope(creation)).row.to_data()
             await w.ensure_scope(domain_scope)
-            await w.add_bulk_members(
+            await w.add_bulk_subscopes(
                 EntityMembersAddition(
                     scope=domain_scope,
                     members=[

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -1034,7 +1034,7 @@ class RBACWriteOps(WriteOps):
         member = ScopeUserMember(user_id=user_id)
         domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=full_creation.domain_id)
         await self.ensure_scope(domain_scope)
-        await self.add_bulk_members(EntityMembersAddition(scope=domain_scope, members=[member]))
+        await self.add_bulk_subscopes(EntityMembersAddition(scope=domain_scope, members=[member]))
         for project_id in await self._domain_member_project_ids(
             full_creation.domain_id, full_creation.project_ids
         ):
@@ -1074,14 +1074,14 @@ class RBACWriteOps(WriteOps):
         addition: EntityMembersAddition,
         permission_cap: Permission | None = None,
     ) -> None:
-        """Attach each member under the scope: membership in the scope's virtual scope,
-        the legacy scope association, and the scope's binding into the member's own
-        virtual scope — never the reverse binding, which would widen every
-        member-scoped role at once. Grants the scope's auto_assign roles to members
-        whose ``assign_role_on`` returns a user id.
+        """Attach each member under the scope: membership in the scope's virtual scope
+        and the legacy scope association. The scope reaches the member entities
+        themselves, not the entities they own — use :meth:`add_bulk_subscopes` when the
+        member's own virtual scope must inherit the scope's permissions. Grants the
+        scope's auto_assign roles to members whose ``assign_role_on`` returns a user id.
 
-        Raises :class:`VirtualScopeNotFound` for any missing virtual scope. Idempotent:
-        existing rows keep their ``permission_cap``.
+        Raises :class:`VirtualScopeNotFound` if the scope has no virtual scope.
+        Idempotent: existing rows keep their ``permission_cap``.
         """
         members = list(addition.members)
         if not members:
@@ -1089,11 +1089,35 @@ class RBACWriteOps(WriteOps):
         scope = addition.scope
         virtual_scope_id = await self._resolve_virtual_scope_id(scope)
         entity_refs = [member.entity_ref() for member in members]
-        member_scopes = [self._member_scope_ref(ref) for ref in entity_refs]
         await self._enroll_members_in_scope_vs(virtual_scope_id, entity_refs, permission_cap)
         await self._associate_entities_with_scope(scope, entity_refs)
-        await self._bind_scope_to_member_vs(scope, member_scopes, permission_cap)
         await self._grant_member_auto_assign_roles(scope, members)
+
+    async def add_bulk_subscopes(
+        self,
+        addition: EntityMembersAddition,
+        permission_cap: Permission | None = None,
+    ) -> None:
+        """Nest each member's own scope under the scope: everything
+        :meth:`add_bulk_members` writes, plus the binding that lets the scope's
+        permissions reach every entity the member owns.
+
+        Only for relations where that cascade is intended — a domain over its projects
+        and users, a project over the container registries it contains. A member that
+        merely participates in the scope, such as a user in a project, is an ordinary
+        member: binding its virtual scope would expose everything it owns elsewhere.
+        The binding stays unidirectional; the reverse would widen every member-scoped
+        role at once.
+
+        Raises :class:`VirtualScopeNotFound` for any missing virtual scope. Idempotent:
+        existing rows keep their ``permission_cap``.
+        """
+        members = list(addition.members)
+        if not members:
+            return
+        await self.add_bulk_members(addition, permission_cap)
+        member_scopes = [self._member_scope_ref(member.entity_ref()) for member in members]
+        await self._bind_scope_to_member_vs(addition.scope, member_scopes, permission_cap)
 
     async def add_bulk_members_partial(
         self,
@@ -1119,9 +1143,6 @@ class RBACWriteOps(WriteOps):
                     ref = member.entity_ref()
                     await self._enroll_members_in_scope_vs(virtual_scope_id, [ref], permission_cap)
                     await self._associate_entities_with_scope(scope, [ref])
-                    await self._bind_scope_to_member_vs(
-                        scope, [self._member_scope_ref(ref)], permission_cap
-                    )
                 successes.append(member)
             except Exception as e:
                 errors.append(EntityMemberCreationError(member=member, exception=e, index=index))
@@ -1212,9 +1233,12 @@ class RBACWriteOps(WriteOps):
         scope: ScopeRef,
         entities: Collection[EntityRef],
     ) -> None:
-        """Delete each member's membership, association, and the scope's binding in the
-        member's own virtual scope; role mappings are left untouched. Missing virtual
-        scopes (legacy data) never raise — whatever exists is deleted.
+        """Detach each member from the scope, undoing both :meth:`add_bulk_members` and
+        :meth:`add_bulk_subscopes`: the membership, the association, and the scope's
+        binding in the member's own virtual scope — a no-op for members added without
+        that binding, since the delete matches the scope exactly. Role mappings are left
+        untouched. Missing virtual scopes (legacy data) never raise — whatever exists is
+        deleted.
         """
         entity_refs = list(entities)
         if not entity_refs:

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -1034,7 +1034,9 @@ class RBACWriteOps(WriteOps):
         member = ScopeUserMember(user_id=user_id)
         domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=full_creation.domain_id)
         await self.ensure_scope(domain_scope)
-        await self.add_bulk_subscopes(EntityMembersAddition(scope=domain_scope, members=[member]))
+        await self.add_bulk_inheriting_members(
+            EntityMembersAddition(scope=domain_scope, members=[member])
+        )
         for project_id in await self._domain_member_project_ids(
             full_creation.domain_id, full_creation.project_ids
         ):
@@ -1076,9 +1078,10 @@ class RBACWriteOps(WriteOps):
     ) -> None:
         """Attach each member under the scope: membership in the scope's virtual scope
         and the legacy scope association. The scope reaches the member entities
-        themselves, not the entities they own — use :meth:`add_bulk_subscopes` when the
-        member's own virtual scope must inherit the scope's permissions. Grants the
-        scope's auto_assign roles to members whose ``assign_role_on`` returns a user id.
+        themselves, not the entities they own — use
+        :meth:`add_bulk_inheriting_members` when the member must inherit the scope's
+        permissions over what it owns. Grants the scope's auto_assign roles to members
+        whose ``assign_role_on`` returns a user id.
 
         Raises :class:`VirtualScopeNotFound` if the scope has no virtual scope.
         Idempotent: existing rows keep their ``permission_cap``.
@@ -1093,21 +1096,21 @@ class RBACWriteOps(WriteOps):
         await self._associate_entities_with_scope(scope, entity_refs)
         await self._grant_member_auto_assign_roles(scope, members)
 
-    async def add_bulk_subscopes(
+    async def add_bulk_inheriting_members(
         self,
         addition: EntityMembersAddition,
         permission_cap: Permission | None = None,
     ) -> None:
-        """Nest each member's own scope under the scope: everything
-        :meth:`add_bulk_members` writes, plus the binding that lets the scope's
-        permissions reach every entity the member owns.
+        """Attach each member so that it inherits the scope's permissions: everything
+        :meth:`add_bulk_members` writes, plus the binding that carries those permissions
+        onto every entity the member owns.
 
-        Only for relations where that cascade is intended — a domain over its projects
-        and users, a project over the container registries it contains. A member that
-        merely participates in the scope, such as a user in a project, is an ordinary
-        member: binding its virtual scope would expose everything it owns elsewhere.
-        The binding stays unidirectional; the reverse would widen every member-scoped
-        role at once.
+        Only for relations where that inheritance is intended — a domain over its
+        projects and users, a project over the container registries it contains. A
+        member that merely participates in the scope, such as a user in a project, is an
+        ordinary member: binding its virtual scope would expose everything it owns
+        elsewhere. Inheritance stays unidirectional; the reverse would widen every
+        member-scoped role at once.
 
         Raises :class:`VirtualScopeNotFound` for any missing virtual scope. Idempotent:
         existing rows keep their ``permission_cap``.
@@ -1234,7 +1237,7 @@ class RBACWriteOps(WriteOps):
         entities: Collection[EntityRef],
     ) -> None:
         """Detach each member from the scope, undoing both :meth:`add_bulk_members` and
-        :meth:`add_bulk_subscopes`: the membership, the association, and the scope's
+        :meth:`add_bulk_inheriting_members`: the membership, the association, and the scope's
         binding in the member's own virtual scope — a no-op for members added without
         that binding, since the delete matches the scope exactly. Role mappings are left
         untouched. Missing virtual scopes (legacy data) never raise — whatever exists is

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -425,7 +425,7 @@ class ScalingGroupDBSource:
         accessor_scope: ScopeRef,
         resource_group_ids: list[ResourceGroupID],
     ) -> None:
-        """Nest resource groups under ``accessor_scope`` via ``add_bulk_subscopes``:
+        """Enroll resource groups under ``accessor_scope`` as inheriting members:
         membership, the legacy scope association, and the scope's binding into each
         resource group's virtual scope. The virtual scopes are ensured first, since
         rows created before the virtual-scope rollout may not have one."""
@@ -434,7 +434,7 @@ class ScalingGroupDBSource:
         await w.ensure_scope(accessor_scope)
         for resource_group_id in resource_group_ids:
             await w.ensure_scope(self._resource_group_scope(resource_group_id))
-        await w.add_bulk_subscopes(
+        await w.add_bulk_inheriting_members(
             EntityMembersAddition(
                 scope=accessor_scope,
                 members=[

--- a/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scaling_group/db_source/db_source.py
@@ -425,7 +425,7 @@ class ScalingGroupDBSource:
         accessor_scope: ScopeRef,
         resource_group_ids: list[ResourceGroupID],
     ) -> None:
-        """Enroll resource groups under ``accessor_scope`` via ``add_bulk_members``:
+        """Nest resource groups under ``accessor_scope`` via ``add_bulk_subscopes``:
         membership, the legacy scope association, and the scope's binding into each
         resource group's virtual scope. The virtual scopes are ensured first, since
         rows created before the virtual-scope rollout may not have one."""
@@ -434,7 +434,7 @@ class ScalingGroupDBSource:
         await w.ensure_scope(accessor_scope)
         for resource_group_id in resource_group_ids:
             await w.ensure_scope(self._resource_group_scope(resource_group_id))
-        await w.add_bulk_members(
+        await w.add_bulk_subscopes(
             EntityMembersAddition(
                 scope=accessor_scope,
                 members=[

--- a/src/ai/backend/manager/repositories/user/creators.py
+++ b/src/ai/backend/manager/repositories/user/creators.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 class UserScopeCreation(ScopeCreation[UserRow]):
     """Creates a user row and the scope the user becomes; the user is granted its own
     scope's roles. Domain/project scope associations are written by the enrollment
-    step (``add_bulk_members``), not by this creator."""
+    step, not by this creator."""
 
     spec: CreatorSpec[UserRow]
 

--- a/src/ai/backend/testutils/virtual_scope.py
+++ b/src/ai/backend/testutils/virtual_scope.py
@@ -64,23 +64,15 @@ class VirtualScopeSeeder:
         self, sess: AsyncSession, group_id: uuid.UUID, user_id: uuid.UUID
     ) -> None:
         """Write the chain rows the enrollment path creates for a user-project
-        membership: the user joins the project's virtual scope and the project is
-        bound into the user's own virtual scope."""
+        membership: the user joins the project's virtual scope. The project is not bound
+        into the user's own virtual scope — a member does not hand the project its
+        personal entities."""
         project_scope_id = await self.get_or_create_scope(sess, ScopeType.PROJECT, group_id)
-        user_scope_id = await self.get_or_create_scope(sess, ScopeType.USER, user_id)
         sess.add(
             EntityMembershipRow(
                 virtual_scope_id=project_scope_id,
                 entity_type=EntityType.USER,
                 entity_id=user_id,
-                permission_cap=None,
-            )
-        )
-        sess.add(
-            ScopeBindingRow(
-                virtual_scope_id=user_scope_id,
-                scope_type=ScopeType.PROJECT,
-                scope_id=group_id,
                 permission_cap=None,
             )
         )

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -852,8 +852,9 @@ class VirtualScopeSeeder:
         self, conn: AsyncConnection, group_id: uuid.UUID, user_uuid: UserID
     ) -> None:
         """Write the virtual-scope chain rows the enrollment path creates for a
-        user-project membership: the user joins the project's virtual scope and the
-        project is bound into the user's own virtual scope."""
+        user-project membership: the user joins the project's virtual scope. The project
+        is not bound into the user's own virtual scope — a member does not hand the
+        project its personal entities."""
         project_scope_id = (
             await conn.execute(
                 sa.select(VirtualScopeRow.__table__.c.id).where(
@@ -862,27 +863,11 @@ class VirtualScopeSeeder:
                 )
             )
         ).scalar_one()
-        user_scope_id = (
-            await conn.execute(
-                sa.select(VirtualScopeRow.__table__.c.id).where(
-                    VirtualScopeRow.__table__.c.scope_type == ScopeType.USER,
-                    VirtualScopeRow.__table__.c.scope_id == str(user_uuid),
-                )
-            )
-        ).scalar_one()
         await conn.execute(
             sa.insert(EntityMembershipRow.__table__).values(
                 virtual_scope_id=project_scope_id,
                 entity_type=EntityType.USER,
                 entity_id=str(user_uuid),
-                permission_cap=None,
-            )
-        )
-        await conn.execute(
-            sa.insert(ScopeBindingRow.__table__).values(
-                virtual_scope_id=user_scope_id,
-                scope_type=ScopeType.PROJECT,
-                scope_id=group_id,
                 permission_cap=None,
             )
         )

--- a/tests/unit/manager/repositories/group/test_assign_users_to_project.py
+++ b/tests/unit/manager/repositories/group/test_assign_users_to_project.py
@@ -460,6 +460,52 @@ class TestAssignUsersToProject:
             ).all()
             assert len(rows) == 1
 
+    async def test_assign_does_not_bind_project_into_user_scope(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        group_db_source: GroupDBSource,
+        test_project: ProjectID,
+        test_role: uuid.UUID,
+        same_domain_user_1: UserID,
+    ) -> None:
+        """Assigned users become members of the project's virtual scope, and the project
+        is not bound into theirs — project-scoped permissions must not reach the entities
+        a member owns."""
+        await group_db_source.assign_users_to_project(test_project, [same_domain_user_1], test_role)
+
+        async with db_with_cleanup.begin_readonly_session() as session:
+            user_vs_id = await session.scalar(
+                sa.select(VirtualScopeRow.id).where(
+                    VirtualScopeRow.scope_type == ScopeType.USER.value,
+                    VirtualScopeRow.scope_id == same_domain_user_1,
+                )
+            )
+            project_vs_id = await session.scalar(
+                sa.select(VirtualScopeRow.id).where(
+                    VirtualScopeRow.scope_type == ScopeType.PROJECT.value,
+                    VirtualScopeRow.scope_id == test_project,
+                )
+            )
+            bindings_into_user_scope = (
+                await session.scalars(
+                    sa.select(ScopeBindingRow.scope_id).where(
+                        ScopeBindingRow.virtual_scope_id == user_vs_id,
+                        ScopeBindingRow.scope_id == test_project,
+                    )
+                )
+            ).all()
+            memberships_in_project_scope = (
+                await session.scalars(
+                    sa.select(EntityMembershipRow.entity_id).where(
+                        EntityMembershipRow.virtual_scope_id == project_vs_id,
+                        EntityMembershipRow.entity_id == same_domain_user_1,
+                    )
+                )
+            ).all()
+
+        assert list(bindings_into_user_scope) == []
+        assert list(memberships_in_project_scope) == [same_domain_user_1]
+
 
 class TestUnassignUsersFromProject:
     """Tests for GroupDBSource.unassign_users_from_project"""

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -916,8 +916,8 @@ class TestAddBulkMembers:
         assert binding_count == 1  # the self binding from ensure_scope
 
 
-class TestAddBulkSubscopes:
-    """add_bulk_subscopes writes everything add_bulk_members does and additionally binds
+class TestAddBulkInheritingMembers:
+    """add_bulk_inheriting_members writes everything add_bulk_members does and additionally binds
     the scope into the member's own VS — never the reverse binding."""
 
     async def test_writes_membership_association_and_binding(
@@ -936,7 +936,7 @@ class TestAddBulkSubscopes:
             await w.ensure_scope(scope)
             for mid in member_ids:
                 await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=mid) for mid in member_ids],
@@ -1006,8 +1006,8 @@ class TestAddBulkSubscopes:
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(member_scope)
-            await w.add_bulk_subscopes(addition, permission_cap=Permission.READ)
-            await w.add_bulk_subscopes(addition, permission_cap=Permission.full())
+            await w.add_bulk_inheriting_members(addition, permission_cap=Permission.READ)
+            await w.add_bulk_inheriting_members(addition, permission_cap=Permission.full())
 
         async with database_connection.begin_session_read_committed() as sess:
             scope_vs = (
@@ -1068,7 +1068,7 @@ class TestAddBulkSubscopes:
 
         with pytest.raises(VirtualScopeNotFound):
             async with provider.write_ops() as w:
-                await w.add_bulk_subscopes(
+                await w.add_bulk_inheriting_members(
                     EntityMembersAddition(
                         scope=scope,
                         members=[
@@ -1102,7 +1102,7 @@ class TestAddBulkSubscopes:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.add_bulk_subscopes(EntityMembersAddition(scope=scope, members=[]))
+            await w.add_bulk_inheriting_members(EntityMembersAddition(scope=scope, members=[]))
 
         async with database_connection.begin_session_read_committed() as sess:
             binding_count = await sess.scalar(
@@ -1123,7 +1123,7 @@ class TestRemoveBulkMembers:
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """The removed subscope loses all three rows — its own VS keeps only the self
+        """The removed member loses all three rows — its own VS keeps only the self
         binding — while the other one keeps all of them."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
@@ -1133,7 +1133,7 @@ class TestRemoveBulkMembers:
             await w.ensure_scope(scope)
             for mid in (removed_id, kept_id):
                 await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=removed_id), StubMember(member_id=kept_id)],
@@ -1462,7 +1462,7 @@ class TestScopeDeletionVirtualScopeCleanup:
             await w.create_scope(single_scope.creation)
             await w.ensure_scope(other)
             # Two-way membership leaves scope's binding and membership in other's VS.
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=scope,
                     members=[
@@ -1472,7 +1472,7 @@ class TestScopeDeletionVirtualScopeCleanup:
                     ],
                 )
             )
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=other,
                     members=[
@@ -1524,7 +1524,7 @@ class TestScopeDeletionVirtualScopeCleanup:
             await w.ensure_scope(other)
             # Two-way membership leaves each scope's binding and membership in other's VS.
             for scope in scopes:
-                await w.add_bulk_subscopes(
+                await w.add_bulk_inheriting_members(
                     EntityMembersAddition(
                         scope=scope,
                         members=[
@@ -1536,7 +1536,7 @@ class TestScopeDeletionVirtualScopeCleanup:
                         ],
                     )
                 )
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=other,
                     members=[

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -730,9 +730,195 @@ class TestBulkPurgeScopedPartial:
 
 
 class TestAddBulkMembers:
-    """add_bulk_members enrolls each member into the scope's VS (with its scope
-    association) and binds the scope into the member's own VS — never the reverse
-    binding."""
+    """add_bulk_members enrolls each member into the scope's VS with its scope
+    association, and leaves the member's own VS untouched — the scope reaches the
+    member entities, not what they own."""
+
+    async def test_writes_membership_and_association_without_binding(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """Each member gets membership and association, and no binding is written into
+        its own VS — nor a reverse binding in the scope's VS."""
+        scope_id = uuid.uuid4()
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+        member_ids = [uuid.uuid4(), uuid.uuid4()]
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            for mid in member_ids:
+                await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=scope,
+                    members=[StubMember(member_id=mid) for mid in member_ids],
+                ),
+                permission_cap=Permission.READ,
+            )
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            binding_rows = (await sess.execute(sa.select(ScopeBindingRow))).scalars().all()
+            vs_by_scope = {vs.scope_id: vs.id for vs in vs_rows}
+            membership_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(EntityMembershipRow.entity_id).where(
+                            EntityMembershipRow.virtual_scope_id == vs_by_scope[scope_id],
+                            EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
+                        )
+                    )
+                ).all()
+            )
+            assoc_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                            AssociationScopesEntitiesRow.scope_id == str(scope_id),
+                            AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                        )
+                    )
+                ).all()
+            )
+
+        assert membership_ids == set(member_ids)
+        assert assoc_ids == {str(mid) for mid in member_ids}
+
+        for mid in member_ids:
+            member_bindings = {
+                (b.scope_type, b.scope_id)
+                for b in binding_rows
+                if b.virtual_scope_id == vs_by_scope[mid]
+            }
+            assert member_bindings == {(_TEST_MEMBER_SCOPE_TYPE, mid)}  # self binding only
+        scope_vs_bindings = {
+            (b.scope_type, b.scope_id)
+            for b in binding_rows
+            if b.virtual_scope_id == vs_by_scope[scope_id]
+        }
+        assert scope_vs_bindings == {(_TEST_SCOPE_TYPE, scope_id)}  # self binding only
+
+    async def test_member_without_own_virtual_scope_is_added(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """Only the scope's VS is required: a member that has none of its own is still
+        enrolled, since nothing is written on the member side."""
+        scope_id = uuid.uuid4()
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+        member_id = uuid.uuid4()
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.add_bulk_members(
+                EntityMembersAddition(scope=scope, members=[StubMember(member_id=member_id)])
+            )
+
+        async with database_connection.begin_session_read_committed() as sess:
+            scope_vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
+                )
+            ).scalar_one()
+            membership_ids = set(
+                (
+                    await sess.scalars(
+                        sa.select(EntityMembershipRow.entity_id).where(
+                            EntityMembershipRow.virtual_scope_id == scope_vs.id,
+                            EntityMembershipRow.entity_type == _TEST_MEMBER_ENTITY_TYPE,
+                        )
+                    )
+                ).all()
+            )
+            member_vs_count = await sess.scalar(
+                sa.select(sa.func.count())
+                .select_from(VirtualScopeRow)
+                .where(VirtualScopeRow.scope_id == member_id)
+            )
+
+        assert membership_ids == {member_id}
+        assert member_vs_count == 0
+
+    async def test_readd_is_idempotent(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """Re-adding the same member is a no-op — no duplicate membership or
+        association."""
+        scope_id = uuid.uuid4()
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
+        member_id = uuid.uuid4()
+        member_scope = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=member_id)
+        addition = EntityMembersAddition(scope=scope, members=[StubMember(member_id=member_id)])
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(member_scope)
+            await w.add_bulk_members(addition, permission_cap=Permission.READ)
+            await w.add_bulk_members(addition, permission_cap=Permission.full())
+
+        async with database_connection.begin_session_read_committed() as sess:
+            scope_vs = (
+                await sess.execute(
+                    sa.select(VirtualScopeRow).where(VirtualScopeRow.scope_id == scope_id)
+                )
+            ).scalar_one()
+            membership_rows = (
+                (
+                    await sess.execute(
+                        sa.select(EntityMembershipRow).where(
+                            EntityMembershipRow.virtual_scope_id == scope_vs.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assoc_count = await sess.scalar(
+                sa.select(sa.func.count())
+                .select_from(AssociationScopesEntitiesRow)
+                .where(AssociationScopesEntitiesRow.entity_id == str(member_id))
+            )
+
+        # the scope's self membership and the member's
+        assert len(membership_rows) == 2
+        assert assoc_count == 1
+        caps_by_entity = {(m.entity_type, m.entity_id): m.permission_cap for m in membership_rows}
+        assert caps_by_entity == {
+            (_TEST_ENTITY_TYPE, scope_id): None,  # self membership
+            (_TEST_MEMBER_ENTITY_TYPE, member_id): Permission.READ,
+        }
+
+    async def test_empty_members_is_noop(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        entity_member_tables: None,
+    ) -> None:
+        """An empty member collection writes nothing."""
+        scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.add_bulk_members(EntityMembersAddition(scope=scope, members=[]))
+
+        async with database_connection.begin_session_read_committed() as sess:
+            binding_count = await sess.scalar(
+                sa.select(sa.func.count()).select_from(ScopeBindingRow)
+            )
+
+        assert binding_count == 1  # the self binding from ensure_scope
+
+
+class TestAddBulkSubscopes:
+    """add_bulk_subscopes writes everything add_bulk_members does and additionally binds
+    the scope into the member's own VS — never the reverse binding."""
 
     async def test_writes_membership_association_and_binding(
         self,
@@ -750,7 +936,7 @@ class TestAddBulkMembers:
             await w.ensure_scope(scope)
             for mid in member_ids:
                 await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
-            await w.add_bulk_members(
+            await w.add_bulk_subscopes(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=mid) for mid in member_ids],
@@ -820,8 +1006,8 @@ class TestAddBulkMembers:
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(member_scope)
-            await w.add_bulk_members(addition, permission_cap=Permission.READ)
-            await w.add_bulk_members(addition, permission_cap=Permission.full())
+            await w.add_bulk_subscopes(addition, permission_cap=Permission.READ)
+            await w.add_bulk_subscopes(addition, permission_cap=Permission.full())
 
         async with database_connection.begin_session_read_committed() as sess:
             scope_vs = (
@@ -882,7 +1068,7 @@ class TestAddBulkMembers:
 
         with pytest.raises(VirtualScopeNotFound):
             async with provider.write_ops() as w:
-                await w.add_bulk_members(
+                await w.add_bulk_subscopes(
                     EntityMembersAddition(
                         scope=scope,
                         members=[
@@ -916,7 +1102,7 @@ class TestAddBulkMembers:
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
-            await w.add_bulk_members(EntityMembersAddition(scope=scope, members=[]))
+            await w.add_bulk_subscopes(EntityMembersAddition(scope=scope, members=[]))
 
         async with database_connection.begin_session_read_committed() as sess:
             binding_count = await sess.scalar(
@@ -937,8 +1123,8 @@ class TestRemoveBulkMembers:
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """The removed member loses all three rows — its own VS keeps only the self
-        binding — while the other member keeps all of them."""
+        """The removed subscope loses all three rows — its own VS keeps only the self
+        binding — while the other one keeps all of them."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
         removed_id, kept_id = uuid.uuid4(), uuid.uuid4()
@@ -947,7 +1133,7 @@ class TestRemoveBulkMembers:
             await w.ensure_scope(scope)
             for mid in (removed_id, kept_id):
                 await w.ensure_scope(ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=mid))
-            await w.add_bulk_members(
+            await w.add_bulk_subscopes(
                 EntityMembersAddition(
                     scope=scope,
                     members=[StubMember(member_id=removed_id), StubMember(member_id=kept_id)],
@@ -1137,31 +1323,30 @@ class TestAddBulkMembersPartial:
         }
         assert assoc_ids == {str(valid.member_id)}
 
-    async def test_missing_member_vs_is_isolated(
+    async def test_members_without_own_vs_are_added(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """The member without a VS lands in errors with nothing written for it; the
-        valid member gets its membership, association, and binding."""
+        """Members are enrolled whether or not they have a VS of their own, and no
+        binding is written into the one that does."""
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-        valid = StubMember(member_id=uuid.uuid4())
-        missing = StubMember(member_id=uuid.uuid4())
+        with_vs = StubMember(member_id=uuid.uuid4())
+        without_vs = StubMember(member_id=uuid.uuid4())
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(
-                ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=valid.member_id)
+                ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=with_vs.member_id)
             )
             result = await w.add_bulk_members_partial(
-                EntityMembersAddition(scope=scope, members=[valid, missing]),
+                EntityMembersAddition(scope=scope, members=[with_vs, without_vs]),
                 permission_cap=Permission.READ,
             )
 
-        assert result.successes == [valid]
-        assert [error.member for error in result.errors] == [missing]
-        assert isinstance(result.errors[0].exception, VirtualScopeNotFound)
+        assert result.successes == [with_vs, without_vs]
+        assert result.errors == []
 
         async with database_connection.begin_session_read_committed() as sess:
             vs_rows = (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
@@ -1178,17 +1363,14 @@ class TestAddBulkMembersPartial:
                 ).all()
             )
 
-        assert missing.member_id not in vs_by_scope
-        assert membership_ids == {valid.member_id}
-        valid_bindings = {
-            (b.scope_type, b.scope_id): b.permission_cap
+        assert without_vs.member_id not in vs_by_scope
+        assert membership_ids == {with_vs.member_id, without_vs.member_id}
+        member_bindings = {
+            (b.scope_type, b.scope_id)
             for b in binding_rows
-            if b.virtual_scope_id == vs_by_scope[valid.member_id]
+            if b.virtual_scope_id == vs_by_scope[with_vs.member_id]
         }
-        assert valid_bindings == {
-            (_TEST_MEMBER_SCOPE_TYPE, valid.member_id): None,  # self binding
-            (_TEST_SCOPE_TYPE, scope.scope_id): Permission.READ,
-        }
+        assert member_bindings == {(_TEST_MEMBER_SCOPE_TYPE, with_vs.member_id)}  # self only
 
 
 # =============================================================================
@@ -1280,7 +1462,7 @@ class TestScopeDeletionVirtualScopeCleanup:
             await w.create_scope(single_scope.creation)
             await w.ensure_scope(other)
             # Two-way membership leaves scope's binding and membership in other's VS.
-            await w.add_bulk_members(
+            await w.add_bulk_subscopes(
                 EntityMembersAddition(
                     scope=scope,
                     members=[
@@ -1290,7 +1472,7 @@ class TestScopeDeletionVirtualScopeCleanup:
                     ],
                 )
             )
-            await w.add_bulk_members(
+            await w.add_bulk_subscopes(
                 EntityMembersAddition(
                     scope=other,
                     members=[
@@ -1342,7 +1524,7 @@ class TestScopeDeletionVirtualScopeCleanup:
             await w.ensure_scope(other)
             # Two-way membership leaves each scope's binding and membership in other's VS.
             for scope in scopes:
-                await w.add_bulk_members(
+                await w.add_bulk_subscopes(
                     EntityMembersAddition(
                         scope=scope,
                         members=[
@@ -1354,7 +1536,7 @@ class TestScopeDeletionVirtualScopeCleanup:
                         ],
                     )
                 )
-            await w.add_bulk_members(
+            await w.add_bulk_subscopes(
                 EntityMembersAddition(
                     scope=other,
                     members=[

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -12,8 +12,11 @@ from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
 
 import pytest
+import sqlalchemy as sa
 
-from ai.backend.common.data.entity.types import EntityRef, EntityType, ScopeType
+from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityRef, EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.entity import EntityID
@@ -57,6 +60,11 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.ops.rbac.provider import (
+    EntityMembersAddition,
+    RBACOpsProvider,
+    ScopeUserMember,
+)
 from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
     PermissionDBSource,
 )
@@ -454,3 +462,191 @@ class TestCheckPermissionViaVirtualScope:
             key, Permission.READ
         )
         assert result is False
+
+
+class TestScopeMemberEnrollmentCascade:
+    """Enrolling a member under a scope only cascades the scope's permissions onto the
+    member's own entities when the member is attached as a subscope."""
+
+    @pytest.fixture
+    async def db_with_rbac_tables(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+                PermissionRow,
+                ObjectPermissionRow,
+                AssociationScopesEntitiesRow,
+                VirtualScopeRow,
+                ScopeBindingRow,
+                EntityMembershipRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def db_source(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+    ) -> PermissionDBSource:
+        return PermissionDBSource(db_with_rbac_tables)
+
+    @pytest.fixture
+    def ops_provider(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+    ) -> RBACOpsProvider:
+        return RBACOpsProvider(db_with_rbac_tables)
+
+    @pytest.fixture
+    def ids(self) -> VSChainFixture:
+        return VSChainFixture()
+
+    async def _grant_vfolder_read_on_project(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ids: VSChainFixture,
+        project_id: uuid.UUID,
+    ) -> None:
+        """Give the user a role holding vfolder READ on the project scope."""
+        async with db.begin_session() as db_sess:
+            domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
+            domain_id = DomainID(uuid.uuid4())
+            db_sess.add(
+                DomainRow(id=domain_id, name=domain_name, total_resource_slots=ResourceSlot())
+            )
+            db_sess.add(
+                UserResourcePolicyRow(
+                    name="test-rbac-policy",
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=0,
+                    max_customized_image_count=0,
+                )
+            )
+            db_sess.add(
+                UserRow(
+                    uuid=ids.user_id,
+                    username=f"user-{ids.user_id.hex[:8]}",
+                    email="member@test.com",
+                    resource_policy="test-rbac-policy",
+                    status=UserStatus.ACTIVE,
+                    need_password_change=False,
+                    sudo_session_enabled=False,
+                    domain_name=domain_name,
+                    domain_id=domain_id,
+                )
+            )
+            await db_sess.flush()
+
+            db_sess.add(RoleRow(id=ids.role_id, name="project-role", status=RoleStatus.ACTIVE))
+            await db_sess.flush()
+            db_sess.add(UserRoleRow(user_id=ids.user_id, role_id=ids.role_id))
+            db_sess.add(
+                PermissionRow(
+                    role_id=ids.role_id,
+                    scope_type=PermScopeType.PROJECT,
+                    scope_id=str(project_id),
+                    entity_type=PermEntityType.VFOLDER,
+                    operation=OperationType.READ,
+                    permission=Permission.READ,
+                )
+            )
+            await db_sess.flush()
+
+    async def _own_vfolder_in_user_vs(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ids: VSChainFixture,
+    ) -> None:
+        """Enroll the user's personal vfolder in the user's own virtual scope, as the
+        virtual-scope backfill does for ordinary resource entities."""
+        async with db.begin_session() as db_sess:
+            user_vs_id = await db_sess.scalar(
+                sa.select(VirtualScopeRow.id).where(
+                    VirtualScopeRow.scope_type == USER_SCOPE_TYPE,
+                    VirtualScopeRow.scope_id == ids.user_id,
+                )
+            )
+            db_sess.add(
+                EntityMembershipRow(
+                    virtual_scope_id=user_vs_id,
+                    entity_type=_TARGET_ENTITY_TYPE,
+                    entity_id=ids.entity_id,
+                    permission_cap=None,
+                )
+            )
+            await db_sess.flush()
+
+    async def test_project_member_keeps_own_entities_out_of_reach(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        db_source: PermissionDBSource,
+        ops_provider: RBACOpsProvider,
+        ids: VSChainFixture,
+    ) -> None:
+        """A project-scope grant must not resolve onto a vfolder the member user owns:
+        joining a project makes the user a member of the project, not a subscope of it."""
+        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
+        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        await self._grant_vfolder_read_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
+
+        async with ops_provider.write_ops() as w:
+            await w.ensure_scope(project_scope)
+            await w.ensure_scope(user_scope)
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=project_scope, members=[ScopeUserMember(user_id=ids.user_id)]
+                )
+            )
+        await self._own_vfolder_in_user_vs(db_with_rbac_tables, ids)
+
+        key = EntityPermissionCheckKey(
+            user_id=ids.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=ids.entity_id),
+        )
+        result = await db_source.check_single_entity_permission_via_virtual_scope(
+            key, Permission.READ
+        )
+        assert result is False
+
+    async def test_subscope_enrollment_does_cascade(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        db_source: PermissionDBSource,
+        ops_provider: RBACOpsProvider,
+        ids: VSChainFixture,
+    ) -> None:
+        """The same topology attached as a subscope does reach the user's vfolder, so
+        the check above fails for the intended reason and not by accident."""
+        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
+        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        await self._grant_vfolder_read_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
+
+        async with ops_provider.write_ops() as w:
+            await w.ensure_scope(project_scope)
+            await w.ensure_scope(user_scope)
+            await w.add_bulk_subscopes(
+                EntityMembersAddition(
+                    scope=project_scope, members=[ScopeUserMember(user_id=ids.user_id)]
+                )
+            )
+        await self._own_vfolder_in_user_vs(db_with_rbac_tables, ids)
+
+        key = EntityPermissionCheckKey(
+            user_id=ids.user_id,
+            entity=EntityRef(entity_type=_TARGET_ENTITY_TYPE, entity_id=ids.entity_id),
+        )
+        result = await db_source.check_single_entity_permission_via_virtual_scope(
+            key, Permission.READ
+        )
+        assert result is True

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -466,7 +466,7 @@ class TestCheckPermissionViaVirtualScope:
 
 class TestScopeMemberEnrollmentCascade:
     """Enrolling a member under a scope only cascades the scope's permissions onto the
-    member's own entities when the member is attached as a subscope."""
+    member's own entities when the member is attached as an inheriting member."""
 
     @pytest.fixture
     async def db_with_rbac_tables(
@@ -595,7 +595,7 @@ class TestScopeMemberEnrollmentCascade:
         ids: VSChainFixture,
     ) -> None:
         """A project-scope grant must not resolve onto a vfolder the member user owns:
-        joining a project makes the user a member of the project, not a subscope of it."""
+        joining a project makes the user an ordinary member, not an inheriting one."""
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
         user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
         await self._grant_vfolder_read_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
@@ -619,14 +619,14 @@ class TestScopeMemberEnrollmentCascade:
         )
         assert result is False
 
-    async def test_subscope_enrollment_does_cascade(
+    async def test_inheriting_enrollment_does_cascade(
         self,
         db_with_rbac_tables: ExtendedAsyncSAEngine,
         db_source: PermissionDBSource,
         ops_provider: RBACOpsProvider,
         ids: VSChainFixture,
     ) -> None:
-        """The same topology attached as a subscope does reach the user's vfolder, so
+        """The same topology attached as an inheriting member does reach the vfolder, so
         the check above fails for the intended reason and not by accident."""
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
         user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
@@ -635,7 +635,7 @@ class TestScopeMemberEnrollmentCascade:
         async with ops_provider.write_ops() as w:
             await w.ensure_scope(project_scope)
             await w.ensure_scope(user_scope)
-            await w.add_bulk_subscopes(
+            await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=project_scope, members=[ScopeUserMember(user_id=ids.user_id)]
                 )

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -369,6 +369,51 @@ class TestRoleAssignment:
             )
             assert len(assoc.fetchall()) == 1
 
+    async def test_bind_user_to_project_does_not_bind_project_into_user_scope(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        group_db_source: GroupDBSource,
+        user_1: uuid.UUID,
+        test_project: uuid.UUID,
+    ) -> None:
+        """Joining a project leaves the user's own virtual scope unbound: the user is a
+        member of the project, not a subscope of it, so project-scoped permissions never
+        reach the entities the user owns."""
+        await group_db_source.bind_user_to_project(UserID(user_1), ProjectID(test_project))
+
+        async with db_with_cleanup.begin_readonly_session() as session:
+            user_vs_id = await session.scalar(
+                sa.select(VirtualScopeRow.id).where(
+                    VirtualScopeRow.scope_type == ScopeType.USER.value,
+                    VirtualScopeRow.scope_id == user_1,
+                )
+            )
+            project_vs_id = await session.scalar(
+                sa.select(VirtualScopeRow.id).where(
+                    VirtualScopeRow.scope_type == ScopeType.PROJECT.value,
+                    VirtualScopeRow.scope_id == test_project,
+                )
+            )
+            bindings_into_user_scope = (
+                await session.scalars(
+                    sa.select(ScopeBindingRow.scope_id).where(
+                        ScopeBindingRow.virtual_scope_id == user_vs_id,
+                        ScopeBindingRow.scope_id == test_project,
+                    )
+                )
+            ).all()
+            memberships_in_project_scope = (
+                await session.scalars(
+                    sa.select(EntityMembershipRow.entity_id).where(
+                        EntityMembershipRow.virtual_scope_id == project_vs_id,
+                        EntityMembershipRow.entity_id == user_1,
+                    )
+                )
+            ).all()
+
+        assert list(bindings_into_user_scope) == []
+        assert list(memberships_in_project_scope) == [user_1]
+
     async def test_bind_user_to_project_skips_if_already_bound(
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -377,7 +377,7 @@ class TestRoleAssignment:
         test_project: uuid.UUID,
     ) -> None:
         """Joining a project leaves the user's own virtual scope unbound: the user is a
-        member of the project, not a subscope of it, so project-scoped permissions never
+        ordinary member of the project, not an inheriting one, so project permissions never
         reach the entities the user owns."""
         await group_db_source.bind_user_to_project(UserID(user_1), ProjectID(test_project))
 


### PR DESCRIPTION
## Summary

- Member enrollment wrote a `scope_bindings` row into each member's own virtual scope, opening the whole member scope. That binding carries the enrolling scope's permissions onto everything the member owns, but it was created by every enrollment — including project → user, where a project-scope role would resolve onto a member's personal entities once ordinary resource entities land in `entity_memberships`.
- Split it into two entry points: `add_bulk_members` writes the membership and the legacy association only, while `add_bulk_inheriting_members` adds the binding for the relations that want it (domain → user, domain → project, project → container registry, accessor scope → resource group). The five project → user call sites keep the plain one.
- `remove_bulk_members` is unchanged — its binding delete matches the scope exactly, so it stays correct for both. Both virtual-scope test seeders stopped writing the project → user binding, which was seeding a state enrollment no longer produces.

Note: the non-cascading path no longer resolves the member's own virtual scope, so a member without one is enrolled instead of raising `VirtualScopeNotFound`.

## Test plan

- [x] `TestAddBulkMembers` — enrollment writes membership and association, and leaves the member's virtual scope with only its self binding
- [x] `TestAddBulkInheritingMembers` — the inheriting path still writes the binding with its `permission_cap`, stays idempotent, and fails the whole call on a missing member virtual scope
- [x] `TestScopeMemberEnrollmentCascade` — a project-scope grant does not resolve onto a vfolder the member user owns, while the same topology attached as an inheriting member does
- [x] `test_bind_user_to_project_does_not_bind_project_into_user_scope` and `test_assign_does_not_bind_project_into_user_scope` — the repository call sites enroll the member without binding the project into their scope
- [x] Existing container-registry, resource-group, and scope-deletion suites still pass on the inheriting path

Resolves BA-7366

🤖 Generated with [Claude Code](https://claude.com/claude-code)
