### PR TITLE
feat(BA-7363): publish the per-user rate limit to the shared Redis DB

### DIFF
--- a/changes/13778.feature.md
+++ b/changes/13778.feature.md
@@ -1,0 +1,1 @@
+Count API requests against the requesting user instead of the access key, so holding multiple keypairs no longer multiplies a user's rate limit allowance.

--- a/changes/13779.feature.md
+++ b/changes/13779.feature.md
@@ -1,0 +1,1 @@
+Move the per-user API rate limit from the keypair to the user resource policy field max_api_requests_per_window; the keypair rate limit is deprecated and no longer enforced.

--- a/changes/13784.feature.md
+++ b/changes/13784.feature.md
@@ -1,0 +1,1 @@
+Publish each user's API rate limit to the shared rate limit Redis DB so the web server can enforce it without asking the manager.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1216,7 +1216,6 @@ type KeyPair implements Item {
   resource_policy: String
   created_at: DateTime
   last_used: DateTime
-  rate_limit: Int
   num_queries: Int
 
   """Added in 24.09.0."""
@@ -1229,6 +1228,7 @@ type KeyPair implements Item {
   concurrency_used: Int
   user_info: UserInfo
   concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  rate_limit: Int @deprecated(reason: "Moved to UserResourcePolicy object as the max_api_requests_per_window field. The value is still stored but no longer enforced.")
 }
 
 type VirtualFolder implements Item {

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -5193,6 +5193,11 @@ input CreateUserResourcePolicyInputV2
   """
   maxConcurrentLogins: Int = null
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int = null
+
   """Maximum quota scope size (e.g., '1g', '536870912')."""
   maxQuotaScopeSize: BinarySizeInput!
 
@@ -10170,7 +10175,6 @@ type KeyPair implements Item
   resource_policy: String
   created_at: DateTime
   last_used: DateTime
-  rate_limit: Int
   num_queries: Int
 
   """Added in 24.09.0."""
@@ -10183,6 +10187,7 @@ type KeyPair implements Item
   concurrency_used: Int
   user_info: UserInfo
   concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  rate_limit: Int @deprecated(reason: "Moved to UserResourcePolicy object as the max_api_requests_per_window field. The value is still stored but no longer enforced.")
 }
 
 """
@@ -22761,6 +22766,11 @@ input UpdateUserResourcePolicyInput
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).
+  """
+  maxApiRequestsPerWindow: Int
+
   """Updated max quota scope size."""
   maxQuotaScopeSize: BinarySizeInput = null
 
@@ -23480,6 +23490,11 @@ type UserResourcePolicyV2 implements Node
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int
+
   """Maximum quota scope size."""
   maxQuotaScopeSize: BinarySizeInfo!
 
@@ -23523,6 +23538,9 @@ input UserResourcePolicyV2Filter
   createdAt: DateTimeFilter = null
   maxVfolderCount: IntFilter = null
   maxConcurrentLogins: IntFilter = null
+
+  """Added in 26.9.0. Filter by max API requests per rate limit window."""
+  maxApiRequestsPerWindow: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
@@ -23556,6 +23574,7 @@ enum UserResourcePolicyV2OrderField
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MAX_VFOLDER_COUNT @join__enumValue(graph: STRAWBERRY)
   MAX_CONCURRENT_LOGINS @join__enumValue(graph: STRAWBERRY)
+  MAX_API_REQUESTS_PER_WINDOW @join__enumValue(graph: STRAWBERRY)
   MAX_QUOTA_SCOPE_SIZE @join__enumValue(graph: STRAWBERRY)
   MAX_SESSION_COUNT_PER_MODEL_SESSION @join__enumValue(graph: STRAWBERRY)
   MAX_CUSTOMIZED_IMAGE_COUNT @join__enumValue(graph: STRAWBERRY)

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -3549,6 +3549,11 @@ input CreateUserResourcePolicyInputV2 {
   """
   maxConcurrentLogins: Int = null
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int = null
+
   """Maximum quota scope size (e.g., '1g', '536870912')."""
   maxQuotaScopeSize: BinarySizeInput!
 
@@ -16524,6 +16529,11 @@ input UpdateUserResourcePolicyInput {
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).
+  """
+  maxApiRequestsPerWindow: Int
+
   """Updated max quota scope size."""
   maxQuotaScopeSize: BinarySizeInput = null
 
@@ -16977,6 +16987,11 @@ type UserResourcePolicyV2 implements Node {
   """
   maxConcurrentLogins: Int
 
+  """
+  Added in 26.9.0. Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.
+  """
+  maxApiRequestsPerWindow: Int
+
   """Maximum quota scope size."""
   maxQuotaScopeSize: BinarySizeInfo!
 
@@ -17014,6 +17029,9 @@ input UserResourcePolicyV2Filter {
   createdAt: DateTimeFilter = null
   maxVfolderCount: IntFilter = null
   maxConcurrentLogins: IntFilter = null
+
+  """Added in 26.9.0. Filter by max API requests per rate limit window."""
+  maxApiRequestsPerWindow: IntFilter = null
   maxQuotaScopeSize: IntFilter = null
   maxSessionCountPerModelSession: IntFilter = null
   maxCustomizedImageCount: IntFilter = null
@@ -17043,6 +17061,7 @@ enum UserResourcePolicyV2OrderField {
   CREATED_AT
   MAX_VFOLDER_COUNT
   MAX_CONCURRENT_LOGINS
+  MAX_API_REQUESTS_PER_WINDOW
   MAX_QUOTA_SCOPE_SIZE
   MAX_SESSION_COUNT_PER_MODEL_SESSION
   MAX_CUSTOMIZED_IMAGE_COUNT

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -12752,7 +12752,8 @@
           },
           "rate_limit": {
             "default": 30000,
-            "description": "API rate limit (requests per minute).",
+            "deprecated": true,
+            "description": "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced.",
             "title": "Rate Limit",
             "type": "integer"
           }
@@ -12821,7 +12822,8 @@
               }
             ],
             "default": null,
-            "description": "New API rate limit.",
+            "deprecated": true,
+            "description": "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced.",
             "title": "Rate Limit"
           }
         },
@@ -22582,6 +22584,18 @@
             "default": null,
             "description": "Filter by max concurrent logins."
           },
+          "max_api_requests_per_window": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IntFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by max API requests per rate limit window."
+          },
           "max_quota_scope_size": {
             "anyOf": [
               {
@@ -22696,6 +22710,7 @@
           "created_at",
           "max_vfolder_count",
           "max_concurrent_logins",
+          "max_api_requests_per_window",
           "max_quota_scope_size",
           "max_session_count_per_model_session",
           "max_customized_image_count"
@@ -22845,6 +22860,20 @@
             "description": "Maximum number of concurrent authenticated login sessions per user. Null means unlimited. Must be >= 1 when set. Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions.",
             "title": "Max Concurrent Logins"
           },
+          "max_api_requests_per_window": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Maximum number of API requests allowed per user within the rate limit window. Null means unlimited.",
+            "title": "Max Api Requests Per Window"
+          },
           "max_quota_scope_size": {
             "$ref": "#/components/schemas/BinarySizeInput",
             "description": "Maximum quota scope size (e.g., '1g', '536870912')."
@@ -22909,6 +22938,27 @@
             "default": 1,
             "description": "Updated maximum number of concurrent authenticated login sessions per user. Set to null to clear (unlimited). Must be >= 1 when set. Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions.",
             "title": "Max Concurrent Logins"
+          },
+          "max_api_requests_per_window": {
+            "anyOf": [
+              {
+                "anyOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Sentinel"
+                  }
+                ],
+                "ge": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 1,
+            "description": "Updated maximum number of API requests allowed per user within the rate limit window. Set to null to clear (unlimited).",
+            "title": "Max Api Requests Per Window"
           },
           "max_quota_scope_size": {
             "anyOf": [

--- a/src/ai/backend/client/cli/v2/admin/resource_policy.py
+++ b/src/ai/backend/client/cli/v2/admin/resource_policy.py
@@ -464,6 +464,12 @@ def user_get(name: str) -> None:
         " Distinct from --max-concurrent-sessions which limits compute sessions."
     ),
 )
+@click.option(
+    "--max-api-requests-per-window",
+    type=int,
+    default=None,
+    help="Maximum API requests per user within the rate limit window (NULL = unlimited).",
+)
 @click.option("--json", "json_str", default=None, help="Full input as JSON string.")
 @click.option(
     "--file",
@@ -479,6 +485,7 @@ def user_create(
     max_session_count_per_model_session: int | None,
     max_customized_image_count: int | None,
     max_concurrent_logins: int | None,
+    max_api_requests_per_window: int | None,
     json_str: str | None,
     file_path: str | None,
 ) -> None:
@@ -504,6 +511,7 @@ def user_create(
         max_session_count_per_model_session=max_session_count_per_model_session,
         max_customized_image_count=max_customized_image_count,
         max_concurrent_logins=max_concurrent_logins,
+        max_api_requests_per_window=max_api_requests_per_window,
     )
     dto = _build_dto(CreateUserResourcePolicyInput, data)
 
@@ -542,6 +550,12 @@ def user_create(
         " Distinct from --max-concurrent-sessions which limits compute sessions."
     ),
 )
+@click.option(
+    "--max-api-requests-per-window",
+    type=int,
+    default=None,
+    help="Maximum API requests per user within the rate limit window (NULL = unlimited).",
+)
 @click.option("--json", "json_str", default=None, help="Full update input as JSON string.")
 @click.option(
     "--file",
@@ -557,6 +571,7 @@ def user_update(
     max_session_count_per_model_session: int | None,
     max_customized_image_count: int | None,
     max_concurrent_logins: int | None,
+    max_api_requests_per_window: int | None,
     json_str: str | None,
     file_path: str | None,
 ) -> None:
@@ -573,6 +588,7 @@ def user_update(
         max_session_count_per_model_session=max_session_count_per_model_session,
         max_customized_image_count=max_customized_image_count,
         max_concurrent_logins=max_concurrent_logins,
+        max_api_requests_per_window=max_api_requests_per_window,
     )
 
     dto = _build_dto(UpdateUserResourcePolicyInput, data)

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -9,6 +9,7 @@ from ai.backend.common.clients.valkey_client.client import (
     AbstractValkeyClient,
     create_valkey_client,
 )
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience import (
@@ -44,19 +45,19 @@ _TIME_PRECISION = Decimal("1e-3")  # milliseconds
 
 
 _RATE_LIMIT_SCRIPT: Final[str] = """
-local access_key = KEYS[1]
+local key = KEYS[1]
 local now = tonumber(ARGV[1])
 local window = tonumber(ARGV[2])
 local request_id = tonumber(redis.call('INCR', '__request_id'))
 if request_id >= 1e12 then
     redis.call('SET', '__request_id', 1)
 end
-if redis.call('EXISTS', access_key) == 1 then
-    redis.call('ZREMRANGEBYSCORE', access_key, 0, now - window)
+if redis.call('EXISTS', key) == 1 then
+    redis.call('ZREMRANGEBYSCORE', key, 0, now - window)
 end
-redis.call('ZADD', access_key, now, tostring(request_id))
-redis.call('EXPIRE', access_key, window)
-return redis.call('ZCARD', access_key)
+redis.call('ZADD', key, now, tostring(request_id))
+redis.call('EXPIRE', key, window)
+return redis.call('ZCARD', key)
 """
 
 
@@ -110,14 +111,14 @@ class ValkeyRateLimitClient:
     @valkey_rate_limit_resilience.apply()
     async def execute_rate_limit_logic(
         self,
-        access_key: str,
+        user_id: UserID,
         window: int = _DEFAULT_RATE_LIMIT_EXPIRATION,
     ) -> int:
         """
         Execute the rate limiting logic for rolling counter.
         This replicates the Lua script logic using individual commands.
 
-        :param access_key: The access key to rate limit.
+        :param user_id: The user the rolling counter is keyed by.
         :param window: The time window for rate limiting in seconds.
         :return: The current count.
         """
@@ -127,7 +128,7 @@ class ValkeyRateLimitClient:
         async with self._client.client() as conn:
             result = await conn.invoke_script(
                 Script(_RATE_LIMIT_SCRIPT),
-                keys=[access_key],
+                keys=[f"user.{user_id}"],
                 args=[str(now_float), str(window)],
             )
 
@@ -135,15 +136,15 @@ class ValkeyRateLimitClient:
         return cast(int, result)
 
     @valkey_rate_limit_resilience.apply()
-    async def get_rolling_count(self, access_key: str) -> int:
+    async def get_rolling_count(self, user_id: UserID) -> int:
         """
-        Get the current rolling count for an access key.
+        Get the current rolling count of a user.
 
-        :param access_key: The access key to get the count for.
+        :param user_id: The user the rolling counter is keyed by.
         :return: The current count.
         """
         async with self._client.client() as conn:
-            return await conn.zcard(access_key)
+            return await conn.zcard(f"user.{user_id}")
 
     @valkey_rate_limit_resilience.apply()
     async def set_rate_limit_config(

--- a/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
+++ b/src/ai/backend/common/clients/valkey_client/valkey_rate_limit/client.py
@@ -43,6 +43,8 @@ valkey_rate_limit_resilience = Resilience(
 _DEFAULT_RATE_LIMIT_EXPIRATION = 60 * 15  # 15 minutes
 _TIME_PRECISION = Decimal("1e-3")  # milliseconds
 
+_USER_RATE_LIMIT_KEY_PREFIX: Final = "user-rate-limit."
+
 
 _RATE_LIMIT_SCRIPT: Final[str] = """
 local key = KEYS[1]
@@ -145,6 +147,39 @@ class ValkeyRateLimitClient:
         """
         async with self._client.client() as conn:
             return await conn.zcard(f"user.{user_id}")
+
+    @valkey_rate_limit_resilience.apply()
+    async def set_user_rate_limit(
+        self,
+        user_id: UserID,
+        rate_limit: int,
+        expiration: int = _DEFAULT_RATE_LIMIT_EXPIRATION,
+    ) -> None:
+        """
+        Publish the rate limit of a user so that other components can read it.
+
+        :param user_id: The user to publish the limit for.
+        :param rate_limit: The allowed number of requests per rate limit window.
+        :param expiration: The expiration time in seconds.
+        """
+        async with self._client.client() as conn:
+            await conn.set(
+                key=f"{_USER_RATE_LIMIT_KEY_PREFIX}{user_id}",
+                value=str(rate_limit),
+                expiry=ExpirySet(ExpiryType.SEC, expiration),
+            )
+
+    @valkey_rate_limit_resilience.apply()
+    async def get_user_rate_limit(self, user_id: UserID) -> int | None:
+        """
+        Get the published rate limit of a user.
+
+        :param user_id: The user to look up.
+        :return: The rate limit, or None if nothing is published for the user.
+        """
+        async with self._client.client() as conn:
+            result = await conn.get(f"{_USER_RATE_LIMIT_KEY_PREFIX}{user_id}")
+        return int(result.decode("utf-8")) if result is not None else None
 
     @valkey_rate_limit_resilience.apply()
     async def set_rate_limit_config(

--- a/src/ai/backend/common/dto/manager/v2/keypair/request.py
+++ b/src/ai/backend/common/dto/manager/v2/keypair/request.py
@@ -138,7 +138,13 @@ class AdminCreateKeypairInput(BaseRequestModel):
     resource_policy: str = Field(description="Name of the resource policy to assign.")
     is_active: bool = Field(default=True, description="Whether the keypair should be active.")
     is_admin: bool = Field(default=False, description="Whether the keypair has admin privileges.")
-    rate_limit: int = Field(default=30000, description="API rate limit (requests per minute).")
+    rate_limit: int = Field(
+        default=30000,
+        deprecated=True,
+        description=(
+            "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced."
+        ),
+    )
 
 
 class AdminUpdateKeypairInput(BaseRequestModel):
@@ -148,7 +154,13 @@ class AdminUpdateKeypairInput(BaseRequestModel):
     is_active: bool | None = Field(default=None, description="New active state.")
     is_admin: bool | None = Field(default=None, description="New admin privilege state.")
     resource_policy: str | None = Field(default=None, description="New resource policy name.")
-    rate_limit: int | None = Field(default=None, description="New API rate limit.")
+    rate_limit: int | None = Field(
+        default=None,
+        deprecated=True,
+        description=(
+            "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced."
+        ),
+    )
 
 
 class AdminDeleteKeypairInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/keypair/response.py
+++ b/src/ai/backend/common/dto/manager/v2/keypair/response.py
@@ -53,7 +53,12 @@ class KeypairNode(BaseResponseModel):
     last_used: datetime | None = Field(
         default=None, description="When the keypair was last used for an API call."
     )
-    rate_limit: int = Field(description="API rate limit (requests per minute).")
+    rate_limit: int = Field(
+        deprecated=True,
+        description=(
+            "Deprecated: superseded by the user resource policy field max_api_requests_per_window, which is what the rate limiter reads. This value is stored but no longer enforced."
+        ),
+    )
     num_queries: int = Field(description="Total number of API queries made with this keypair.")
     resource_policy: str = Field(
         description="Name of the resource policy assigned to this keypair."

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/request.py
@@ -181,6 +181,14 @@ class CreateUserResourcePolicyInput(BaseRequestModel):
             " Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions."
         ),
     )
+    max_api_requests_per_window: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Maximum number of API requests allowed per user within the rate limit window."
+            " Null means unlimited."
+        ),
+    )
     max_quota_scope_size: BinarySizeInput = Field(
         description="Maximum quota scope size (e.g., '1g', '536870912').",
     )
@@ -215,6 +223,14 @@ class UpdateUserResourcePolicyInput(BaseRequestModel):
             "Updated maximum number of concurrent authenticated login sessions per user."
             " Set to null to clear (unlimited). Must be >= 1 when set."
             " Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions."
+        ),
+    )
+    max_api_requests_per_window: int | Sentinel | None = Field(
+        default=SENTINEL,
+        ge=0,
+        description=(
+            "Updated maximum number of API requests allowed per user within the rate limit"
+            " window. Set to null to clear (unlimited)."
         ),
     )
     max_quota_scope_size: BinarySizeInput | Sentinel | None = Field(
@@ -349,6 +365,9 @@ class UserResourcePolicyFilter(BaseRequestModel):
     )
     max_concurrent_logins: IntFilter | None = Field(
         default=None, description="Filter by max concurrent logins."
+    )
+    max_api_requests_per_window: IntFilter | None = Field(
+        default=None, description="Filter by max API requests per rate limit window."
     )
     max_quota_scope_size: IntFilter | None = Field(
         default=None, description="Filter by max quota scope size."

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/response.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/response.py
@@ -122,6 +122,13 @@ class UserResourcePolicyNode(BaseResponseModel):
             " Distinct from keypair_resource_policies.max_concurrent_sessions which caps compute sessions."
         ),
     )
+    max_api_requests_per_window: int | None = Field(
+        default=None,
+        description=(
+            "Maximum number of API requests allowed per user within the rate limit window."
+            " Null means unlimited."
+        ),
+    )
     max_quota_scope_size: BinarySizeInfo = Field(
         description="Maximum quota scope size.",
     )

--- a/src/ai/backend/common/dto/manager/v2/resource_policy/types.py
+++ b/src/ai/backend/common/dto/manager/v2/resource_policy/types.py
@@ -39,6 +39,7 @@ class UserResourcePolicyOrderField(StrEnum):
     CREATED_AT = "created_at"
     MAX_VFOLDER_COUNT = "max_vfolder_count"
     MAX_CONCURRENT_LOGINS = "max_concurrent_logins"
+    MAX_API_REQUESTS_PER_WINDOW = "max_api_requests_per_window"
     MAX_QUOTA_SCOPE_SIZE = "max_quota_scope_size"
     MAX_SESSION_COUNT_PER_MODEL_SESSION = "max_session_count_per_model_session"
     MAX_CUSTOMIZED_IMAGE_COUNT = "max_customized_image_count"

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -414,6 +414,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             name=input.name,
             max_vfolder_count=input.max_vfolder_count,
             max_concurrent_logins=input.max_concurrent_logins,
+            max_api_requests_per_window=input.max_api_requests_per_window,
             max_quota_scope_size=input.max_quota_scope_size.bytes,
             max_session_count_per_model_session=input.max_session_count_per_model_session,
             max_customized_image_count=input.max_customized_image_count,
@@ -446,6 +447,13 @@ class ResourcePolicyAdapter(BaseAdapter):
                 else TriState.nullify()
                 if input.max_concurrent_logins is None
                 else TriState.update(input.max_concurrent_logins)
+            ),
+            max_api_requests_per_window=(
+                TriState.nop()
+                if isinstance(input.max_api_requests_per_window, Sentinel)
+                else TriState.nullify()
+                if input.max_api_requests_per_window is None
+                else TriState.update(input.max_api_requests_per_window)
             ),
             max_quota_scope_size=(
                 OptionalState.nop()
@@ -680,6 +688,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             created_at=data.created_at,
             max_vfolder_count=data.max_vfolder_count,
             max_concurrent_logins=data.max_concurrent_logins,
+            max_api_requests_per_window=data.max_api_requests_per_window,
             max_quota_scope_size=BinarySize.to_size_info(data.max_quota_scope_size),
             max_session_count_per_model_session=data.max_session_count_per_model_session,
             max_customized_image_count=data.max_customized_image_count,
@@ -845,6 +854,13 @@ class ResourcePolicyAdapter(BaseAdapter):
             )
             if cond is not None:
                 conditions.append(cond)
+        if filter.max_api_requests_per_window is not None:
+            cond = self.convert_int_filter(
+                filter.max_api_requests_per_window,
+                UserResourcePolicyConditions.by_max_api_requests_per_window,
+            )
+            if cond is not None:
+                conditions.append(cond)
         if filter.max_quota_scope_size is not None:
             cond = self.convert_int_filter(
                 filter.max_quota_scope_size,
@@ -1001,6 +1017,8 @@ def _resolve_user_order(
             return UserResourcePolicyOrders.max_vfolder_count(ascending)
         case UserResourcePolicyOrderField.MAX_CONCURRENT_LOGINS:
             return UserResourcePolicyOrders.max_concurrent_logins(ascending)
+        case UserResourcePolicyOrderField.MAX_API_REQUESTS_PER_WINDOW:
+            return UserResourcePolicyOrders.max_api_requests_per_window(ascending)
         case UserResourcePolicyOrderField.MAX_QUOTA_SCOPE_SIZE:
             return UserResourcePolicyOrders.max_quota_scope_size(ascending)
         case UserResourcePolicyOrderField.MAX_SESSION_COUNT_PER_MODEL_SESSION:

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
@@ -158,6 +158,7 @@ class UserResourcePolicyV2Filter(PydanticInputMixin[UserResourcePolicyFilterDTO]
     created_at: DateTimeFilter | None = None
     max_vfolder_count: IntFilter | None = None
     max_concurrent_logins: IntFilter | None = None
+    max_api_requests_per_window: IntFilter | None = None
     max_quota_scope_size: IntFilter | None = None
     max_session_count_per_model_session: IntFilter | None = None
     max_customized_image_count: IntFilter | None = None
@@ -187,6 +188,7 @@ class UserResourcePolicyV2OrderField(StrEnum):
     CREATED_AT = "created_at"
     MAX_VFOLDER_COUNT = "max_vfolder_count"
     MAX_CONCURRENT_LOGINS = "max_concurrent_logins"
+    MAX_API_REQUESTS_PER_WINDOW = "max_api_requests_per_window"
     MAX_QUOTA_SCOPE_SIZE = "max_quota_scope_size"
     MAX_SESSION_COUNT_PER_MODEL_SESSION = "max_session_count_per_model_session"
     MAX_CUSTOMIZED_IMAGE_COUNT = "max_customized_image_count"

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/filters.py
@@ -26,6 +26,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.request import (
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
     UserResourcePolicyOrder as UserResourcePolicyOrderDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     IntFilter,
@@ -158,7 +159,13 @@ class UserResourcePolicyV2Filter(PydanticInputMixin[UserResourcePolicyFilterDTO]
     created_at: DateTimeFilter | None = None
     max_vfolder_count: IntFilter | None = None
     max_concurrent_logins: IntFilter | None = None
-    max_api_requests_per_window: IntFilter | None = None
+    max_api_requests_per_window: IntFilter | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Filter by max API requests per rate limit window.",
+        ),
+        default=None,
+    )
     max_quota_scope_size: IntFilter | None = None
     max_session_count_per_model_session: IntFilter | None = None
     max_customized_image_count: IntFilter | None = None

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/mutations.py
@@ -49,6 +49,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.response import (
 from ai.backend.common.dto.manager.v2.resource_policy.response import (
     UpdateUserResourcePolicyPayload as UpdateUserResourcePolicyPayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.common_types import (
     BinarySizeInputGQL,
     ResourceSlotEntryInputGQL,
@@ -185,6 +186,16 @@ class CreateUserResourcePolicyInputGQL(PydanticInputMixin[CreateUserResourcePoli
         ),
         default=None,
     )
+    max_api_requests_per_window: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Maximum number of API requests allowed per user within the rate limit"
+                " window. Null means unlimited."
+            ),
+        ),
+        default=None,
+    )
     max_quota_scope_size: BinarySizeInputGQL = gql_field(
         description="Maximum quota scope size (e.g., '1g', '536870912').",
     )
@@ -215,6 +226,16 @@ class UpdateUserResourcePolicyInputGQL(PydanticInputMixin[UpdateUserResourcePoli
                 " Set to null to clear (unlimited)."
                 " Distinct from keypair_resource_policies.max_concurrent_sessions"
                 " which caps compute sessions."
+            ),
+        ),
+        default=UNSET,
+    )
+    max_api_requests_per_window: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Updated maximum number of API requests allowed per user within the rate"
+                " limit window. Set to null to clear (unlimited)."
             ),
         ),
         default=UNSET,

--- a/src/ai/backend/manager/api/gql/resource_policy_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/resource_policy_v2/types/node.py
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.resource_policy.response import (
     ProjectResourcePolicyNode,
     UserResourcePolicyNode,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.common_types import (
     BinarySizeInfoGQL,
     ResourceLimitEntryGQL,
@@ -202,6 +203,15 @@ class UserResourcePolicyV2GQL(PydanticNodeMixin[UserResourcePolicyNode]):
                 " Null means unlimited."
                 " Distinct from keypair_resource_policies.max_concurrent_sessions"
                 " which caps compute sessions."
+            ),
+        ),
+    )
+    max_api_requests_per_window: int | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Maximum number of API requests allowed per user within the rate limit"
+                " window. Null means unlimited."
             ),
         ),
     )

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -206,7 +206,7 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
             human_readable_name="ratelimit",
         )
         try:
-            return await valkey_client.get_rolling_count(self.access_key)
+            return await valkey_client.get_rolling_count(UserID(self.user))
         finally:
             await valkey_client.close()
 

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -113,7 +113,6 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
     resource_policy = graphene.String()
     created_at = GQLDateTime()
     last_used = GQLDateTime()
-    rate_limit = graphene.Int()
     num_queries = graphene.Int()
     rolling_count = graphene.Int(description="Added in 24.09.0.")
     user = graphene.UUID()
@@ -134,6 +133,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
     concurrency_limit = graphene.Int(
         deprecation_reason=(
             "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field."
+        )
+    )
+    rate_limit = graphene.Int(
+        deprecation_reason=(
+            "Moved to UserResourcePolicy object as the max_api_requests_per_window field."
+            " The value is still stored but no longer enforced."
         )
     )
 

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -637,7 +637,6 @@ async def _query_auth_context_by_access_key(
                     KeyPairRow.access_key,
                     KeyPairRow.secret_key,
                     KeyPairRow.is_admin,
-                    KeyPairRow.rate_limit,
                 ),
                 load_only(
                     UserRow.uuid,
@@ -680,7 +679,6 @@ async def _query_auth_context_by_access_key(
                     )
                 ),
                 is_admin=bool(keypair_row.is_admin),
-                rate_limit=keypair_row.rate_limit,
                 resource_policy=keypair_policy_row.to_dataclass(),
             ),
         )

--- a/src/ai/backend/manager/api/rest/ratelimit/handler.py
+++ b/src/ai/backend/manager/api/rest/ratelimit/handler.py
@@ -38,9 +38,8 @@ def make_rlim_middleware(
         """Global middleware implementing a rolling-counter rate limiter."""
         if request["is_authorized"]:
             rate_limit = request["keypair"]["rate_limit"]
-            access_key = request["keypair"]["access_key"]
             rolling_count = await valkey_client.execute_rate_limit_logic(
-                access_key=access_key,
+                user_id=request["user"]["uuid"],
                 window=_rlim_window,
             )
             if rate_limit is not None and rolling_count > rate_limit:

--- a/src/ai/backend/manager/api/rest/ratelimit/handler.py
+++ b/src/ai/backend/manager/api/rest/ratelimit/handler.py
@@ -3,6 +3,11 @@
 This module provides the ``rlim_middleware`` function which is installed
 as a global aiohttp middleware.  There are no route handlers — rate
 limiting is applied transparently to all authorized requests.
+
+The middleware is also what keeps the published limit fresh for the web
+server: it resolves the policy value per request anyway, so it republishes it
+on every authorized request. A limit that stops being republished expires
+within the window, which is also when its counter would expire.
 """
 
 from __future__ import annotations
@@ -38,8 +43,13 @@ def make_rlim_middleware(
         """Global middleware implementing a rolling-counter rate limiter."""
         if request["is_authorized"]:
             rate_limit = request["user"]["resource_policy"]["max_api_requests_per_window"]
+            user_id = request["user"]["uuid"]
+            if rate_limit is not None:
+                await valkey_client.set_user_rate_limit(
+                    user_id, rate_limit, expiration=_rlim_window
+                )
             rolling_count = await valkey_client.execute_rate_limit_logic(
-                user_id=request["user"]["uuid"],
+                user_id=user_id,
                 window=_rlim_window,
             )
             if rate_limit is not None and rolling_count > rate_limit:

--- a/src/ai/backend/manager/api/rest/ratelimit/handler.py
+++ b/src/ai/backend/manager/api/rest/ratelimit/handler.py
@@ -37,7 +37,7 @@ def make_rlim_middleware(
     ) -> web.StreamResponse:
         """Global middleware implementing a rolling-counter rate limiter."""
         if request["is_authorized"]:
-            rate_limit = request["keypair"]["rate_limit"]
+            rate_limit = request["user"]["resource_policy"]["max_api_requests_per_window"]
             rolling_count = await valkey_client.execute_rate_limit_logic(
                 user_id=request["user"]["uuid"],
                 window=_rlim_window,

--- a/src/ai/backend/manager/data/auth/types.py
+++ b/src/ai/backend/manager/data/auth/types.py
@@ -115,5 +115,4 @@ class AuthenticatedKeypair:
     access_key: AccessKey
     secret_key: SecretKey
     is_admin: bool
-    rate_limit: int | None
     resource_policy: KeyPairResourcePolicyData

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -31,6 +31,7 @@ class UserResourcePolicyData(EntityData):
     max_session_count_per_model_session: int = 0
     max_customized_image_count: int = 3
     max_concurrent_logins: int | None = None
+    max_api_requests_per_window: int | None = None
 
     @override
     def entity_id(self) -> EntityIdentifier:

--- a/src/ai/backend/manager/models/alembic/versions/f2b48c0d7a19_add_max_api_requests_per_window_to_user_resource_policy.py
+++ b/src/ai/backend/manager/models/alembic/versions/f2b48c0d7a19_add_max_api_requests_per_window_to_user_resource_policy.py
@@ -1,0 +1,40 @@
+"""add max_api_requests_per_window to user_resource_policy
+
+NULL means unlimited; integer N means at most N API requests are allowed per
+user within the rate limit window. Replaces keypairs.rate_limit as the source
+of the per-user API rate limit, which is now deprecated and ignored.
+
+Revision ID: f2b48c0d7a19
+Revises: d4e6f8a0b2c3
+Create Date: 2026-08-14 15:20:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2b48c0d7a19"
+down_revision = "d4e6f8a0b2c3"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("user_resource_policies")}
+    if "max_api_requests_per_window" not in cols:
+        op.add_column(
+            "user_resource_policies",
+            sa.Column("max_api_requests_per_window", sa.Integer(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("user_resource_policies")}
+    if "max_api_requests_per_window" in cols:
+        op.drop_column("user_resource_policies", "max_api_requests_per_window")

--- a/src/ai/backend/manager/models/resource_policy/conditions.py
+++ b/src/ai/backend/manager/models/resource_policy/conditions.py
@@ -247,6 +247,9 @@ class UserResourcePolicyConditions:
 
     by_max_vfolder_count = make_int_conditions(UserResourcePolicyRow.max_vfolder_count)
     by_max_concurrent_logins = make_int_conditions(UserResourcePolicyRow.max_concurrent_logins)
+    by_max_api_requests_per_window = make_int_conditions(
+        UserResourcePolicyRow.max_api_requests_per_window
+    )
     by_max_quota_scope_size = make_int_conditions(UserResourcePolicyRow.max_quota_scope_size)
     by_max_session_count_per_model_session = make_int_conditions(
         UserResourcePolicyRow.max_session_count_per_model_session

--- a/src/ai/backend/manager/models/resource_policy/creators.py
+++ b/src/ai/backend/manager/models/resource_policy/creators.py
@@ -81,6 +81,7 @@ class UserResourcePolicyCreator(GlobalEntityCreator[UserResourcePolicyRow, UserR
     max_session_count_per_model_session: int
     max_customized_image_count: int
     max_concurrent_logins: int | None = None
+    max_api_requests_per_window: int | None = None
 
     @override
     def entity_id(self, row: UserResourcePolicyRow) -> UserResourcePolicyUUID:
@@ -99,6 +100,7 @@ class UserResourcePolicyCreator(GlobalEntityCreator[UserResourcePolicyRow, UserR
             max_session_count_per_model_session=self.max_session_count_per_model_session,
             max_customized_image_count=self.max_customized_image_count,
             max_concurrent_logins=self.max_concurrent_logins,
+            max_api_requests_per_window=self.max_api_requests_per_window,
         )
 
     @override

--- a/src/ai/backend/manager/models/resource_policy/orders.py
+++ b/src/ai/backend/manager/models/resource_policy/orders.py
@@ -93,6 +93,12 @@ class UserResourcePolicyOrders:
         return UserResourcePolicyRow.max_concurrent_logins.desc()
 
     @staticmethod
+    def max_api_requests_per_window(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return UserResourcePolicyRow.max_api_requests_per_window.asc()
+        return UserResourcePolicyRow.max_api_requests_per_window.desc()
+
+    @staticmethod
     def max_quota_scope_size(ascending: bool = True) -> QueryOrder:
         if ascending:
             return UserResourcePolicyRow.max_quota_scope_size.asc()

--- a/src/ai/backend/manager/models/resource_policy/row.py
+++ b/src/ai/backend/manager/models/resource_policy/row.py
@@ -162,6 +162,9 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
     max_concurrent_logins: Mapped[int | None] = mapped_column(
         "max_concurrent_logins", sa.Integer(), nullable=True, default=None
     )
+    max_api_requests_per_window: Mapped[int | None] = mapped_column(
+        "max_api_requests_per_window", sa.Integer(), nullable=True, default=None
+    )
 
     def __init__(
         self,
@@ -171,6 +174,7 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
         max_session_count_per_model_session: int,
         max_customized_image_count: int,
         max_concurrent_logins: int | None = None,
+        max_api_requests_per_window: int | None = None,
     ) -> None:
         self.name = name
         self.max_vfolder_count = max_vfolder_count
@@ -178,6 +182,7 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
         self.max_session_count_per_model_session = max_session_count_per_model_session
         self.max_customized_image_count = max_customized_image_count
         self.max_concurrent_logins = max_concurrent_logins
+        self.max_api_requests_per_window = max_api_requests_per_window
 
     @classmethod
     def from_dataclass(cls, data: UserResourcePolicyData) -> Self:
@@ -200,6 +205,7 @@ class UserResourcePolicyRow(CreatedAtMixin, Base):
             max_session_count_per_model_session=self.max_session_count_per_model_session,
             max_customized_image_count=self.max_customized_image_count,
             max_concurrent_logins=self.max_concurrent_logins,
+            max_api_requests_per_window=self.max_api_requests_per_window,
         )
 
 

--- a/src/ai/backend/manager/models/resource_policy/updaters.py
+++ b/src/ai/backend/manager/models/resource_policy/updaters.py
@@ -104,6 +104,7 @@ class UserResourcePolicyUpdater(DataUpdater[UserResourcePolicyRow, UserResourceP
     )
     max_customized_image_count: OptionalState[int] = field(default_factory=OptionalState[int].nop)
     max_concurrent_logins: TriState[int] = field(default_factory=TriState[int].nop)
+    max_api_requests_per_window: TriState[int] = field(default_factory=TriState[int].nop)
 
     @property
     @override
@@ -133,6 +134,7 @@ class UserResourcePolicyUpdater(DataUpdater[UserResourcePolicyRow, UserResourceP
         )
         self.max_customized_image_count.update_dict(to_update, "max_customized_image_count")
         self.max_concurrent_logins.update_dict(to_update, "max_concurrent_logins")
+        self.max_api_requests_per_window.update_dict(to_update, "max_api_requests_per_window")
         return to_update
 
     @override

--- a/tests/unit/common/clients/valkey_client/test_valkey_rate_limit_client.py
+++ b/tests/unit/common/clients/valkey_client/test_valkey_rate_limit_client.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-import random
+import uuid
 
 from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import (
     ValkeyRateLimitClient,
 )
+from ai.backend.common.data.entity.user import UserID
 
 
 async def test_valkey_rate_limit_logic_execution(
     test_valkey_rate_limit: ValkeyRateLimitClient,
 ) -> None:
     """Test rate limiting logic execution."""
-    access_key = f"test-logic-{random.randint(1000, 9999)}"
+    user_id = UserID(uuid.uuid4())
 
     # Execute the rate limiting logic
     result = await test_valkey_rate_limit.execute_rate_limit_logic(
-        access_key=access_key,
+        user_id=user_id,
         window=60,
     )
 
@@ -23,8 +24,10 @@ async def test_valkey_rate_limit_logic_execution(
 
     # Execute again
     result2 = await test_valkey_rate_limit.execute_rate_limit_logic(
-        access_key=access_key,
+        user_id=user_id,
         window=60,
     )
 
     assert result2 == 2  # Second request should return 2
+
+    assert await test_valkey_rate_limit.get_rolling_count(user_id) == 2

--- a/tests/unit/manager/api/test_ratelimit.py
+++ b/tests/unit/manager/api/test_ratelimit.py
@@ -69,14 +69,14 @@ class TestRlimMiddleware:
     def mock_request_authorized(self) -> web.Request:
         """Mock request for authorized user."""
         request = MagicMock(spec=web.Request)
-        keypair_data = {"rate_limit": 30000}
-        user_data = {"uuid": _USER_ID}
+        user_data = {
+            "uuid": _USER_ID,
+            "resource_policy": {"max_api_requests_per_window": 30000},
+        }
 
         def getitem(key: Any) -> Any:
             if key == "is_authorized":
                 return True
-            if key == "keypair":
-                return keypair_data
             if key == "user":
                 return user_data
             return None
@@ -148,7 +148,9 @@ class TestRlimMiddleware:
     ) -> None:
         """Authorized requests within rate limit succeed and return correct headers."""
         # Arrange
-        mock_request_authorized["keypair"]["rate_limit"] = test_case.rate_limit
+        mock_request_authorized["user"]["resource_policy"]["max_api_requests_per_window"] = (
+            test_case.rate_limit
+        )
         mock_valkey_client.execute_rate_limit_logic = AsyncMock(
             return_value=test_case.rolling_count
         )
@@ -201,7 +203,9 @@ class TestRlimMiddleware:
     ) -> None:
         """Authorized requests exceeding rate limit raise RateLimitExceeded."""
         # Arrange
-        mock_request_authorized["keypair"]["rate_limit"] = test_case.rate_limit
+        mock_request_authorized["user"]["resource_policy"]["max_api_requests_per_window"] = (
+            test_case.rate_limit
+        )
         mock_valkey_client.execute_rate_limit_logic = AsyncMock(
             return_value=test_case.rolling_count
         )

--- a/tests/unit/manager/api/test_ratelimit.py
+++ b/tests/unit/manager/api/test_ratelimit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -24,6 +24,7 @@ class RateLimitSuccessCase:
     rolling_count: int
     expected_limit: str
     expected_remaining: str
+    expected_published: list[int] = field(default_factory=list)
     description: str = ""
 
 
@@ -42,6 +43,7 @@ class TestRlimMiddleware:
         """Mock ValkeyRateLimitClient."""
         client = MagicMock(spec=ValkeyRateLimitClient)
         client.execute_rate_limit_logic = AsyncMock()
+        client.set_user_rate_limit = AsyncMock()
         return client
 
     @pytest.fixture
@@ -112,6 +114,7 @@ class TestRlimMiddleware:
                 rolling_count=10,
                 expected_limit="30000",
                 expected_remaining="29990",
+                expected_published=[30000],
                 description="within limit",
             ),
             RateLimitSuccessCase(
@@ -119,6 +122,7 @@ class TestRlimMiddleware:
                 rolling_count=30000,
                 expected_limit="30000",
                 expected_remaining="0",
+                expected_published=[30000],
                 description="exactly at limit",
             ),
             RateLimitSuccessCase(
@@ -171,6 +175,10 @@ class TestRlimMiddleware:
             user_id=_USER_ID,
             window=_rlim_window,
         )
+        published = [
+            call.args[1] for call in mock_valkey_client.set_user_rate_limit.await_args_list
+        ]
+        assert published == test_case.expected_published
 
     @pytest.mark.parametrize(
         "test_case",

--- a/tests/unit/manager/api/test_ratelimit.py
+++ b/tests/unit/manager/api/test_ratelimit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -8,8 +9,11 @@ import pytest
 from aiohttp import web
 
 from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.api.rest.ratelimit.handler import _rlim_window, make_rlim_middleware
 from ai.backend.manager.errors.api import RateLimitExceeded
+
+_USER_ID = UserID(uuid.UUID("12345678-1234-5678-1234-567812345678"))
 
 
 @dataclass
@@ -65,16 +69,16 @@ class TestRlimMiddleware:
     def mock_request_authorized(self) -> web.Request:
         """Mock request for authorized user."""
         request = MagicMock(spec=web.Request)
-        keypair_data = {
-            "rate_limit": 30000,
-            "access_key": "AKIAIOSFODNN7EXAMPLE",
-        }
+        keypair_data = {"rate_limit": 30000}
+        user_data = {"uuid": _USER_ID}
 
         def getitem(key: Any) -> Any:
             if key == "is_authorized":
                 return True
             if key == "keypair":
                 return keypair_data
+            if key == "user":
+                return user_data
             return None
 
         request.__getitem__ = MagicMock(side_effect=getitem)
@@ -162,7 +166,7 @@ class TestRlimMiddleware:
 
         # Valkey should be called for authorized requests
         mock_valkey_client.execute_rate_limit_logic.assert_called_once_with(
-            access_key="AKIAIOSFODNN7EXAMPLE",
+            user_id=_USER_ID,
             window=_rlim_window,
         )
 
@@ -211,6 +215,6 @@ class TestRlimMiddleware:
 
         # Valkey should still be called
         mock_valkey_client.execute_rate_limit_logic.assert_called_once_with(
-            access_key="AKIAIOSFODNN7EXAMPLE",
+            user_id=_USER_ID,
             window=_rlim_window,
         )

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -65,7 +65,6 @@ def mock_user_resource_policy_repository() -> AsyncMock:
         max_session_count_per_model_session=5,
         max_customized_image_count=3,
         max_concurrent_logins=None,
-        max_api_requests_per_window=30000,
     )
     return mock_repo
 

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -65,6 +65,7 @@ def mock_user_resource_policy_repository() -> AsyncMock:
         max_session_count_per_model_session=5,
         max_customized_image_count=3,
         max_concurrent_logins=None,
+        max_api_requests_per_window=30000,
     )
     return mock_repo
 


### PR DESCRIPTION
## 📚 Stacked PRs

This stack is 3 open PRs. **Merge in order:**

1. ✅ #13777 — `feat(BA-7364): deliver the login user id in the auth response` (merged)
2. ⬇️ #13778 — `feat(BA-7365): key the rate limit counter and the published limit by user id`
3. ⬇️ #13779 — `feat(BA-7362): move the per-user API rate limit to the user resource policy`
4. ⬇️ #13771 — `feat(BA-7365): add a per-user rate limit middleware to the web server`

This PR was folded into #13778 and closed. Both halves extend the same `ValkeyRateLimitClient` and its one caller, the manager rate limit middleware. The commit below now sits on #13778 unchanged, and this PR's news fragment was merged into `changes/13778.feature.md`.

Only the final tip (#13771) is guaranteed to build / pass CI; intermediate PRs are logical slices for reviewability.

## Summary
- Add `set_user_rate_limit()` / `get_user_rate_limit()` to `ValkeyRateLimitClient`, storing the value under a `user-rate-limit.<user_id>` key in the rate limit DB that already holds the rolling counters.
- The manager's rate limit middleware republishes the user's policy value on every authorized request. It resolves that value per request anyway, so the published copy never goes stale: a lowered limit reaches the web server on the user's next proxied request.
- The TTL is the rate limit window, so a limit that stops being republished expires at the same time its rolling counter would.

The web server reads this value instead of carrying the limit in its session token, which would have frozen it at login time for up to a week.

Resolves BA-7363.


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13784.org.readthedocs.build/en/13784/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13784.org.readthedocs.build/ko/13784/

<!-- readthedocs-preview sorna-ko end -->


