### PR TITLE
fix(BA-7372): identify and restore running kernel containers on Podman

### DIFF
--- a/changes/13793.fix.md
+++ b/changes/13793.fix.md
@@ -1,0 +1,1 @@
+Fix the agent failing to identify and restore running kernel containers on Podman, which aborted agent startup with a `KeyError` and silently dropped kernels from the registry.

--- a/src/ai/backend/agent/docker/resources.py
+++ b/src/ai/backend/agent/docker/resources.py
@@ -1,8 +1,8 @@
 import logging
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, Sequence
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import aiofiles
 
@@ -18,6 +18,12 @@ from ai.backend.common.types import DeviceName, SlotName
 from ai.backend.logging import BraceStyleAdapter
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+_HOST_CONFIG_FIELD: Final[str] = "HostConfig"
+_MOUNTS_FIELD: Final[str] = "Mounts"
+_MOUNT_TARGET_FIELD: Final[str] = "Target"
+_MOUNT_DESTINATION_FIELD: Final[str] = "Destination"
+_MOUNT_SOURCE_FIELD: Final[str] = "Source"
 
 
 async def load_resources(
@@ -84,12 +90,32 @@ async def scan_available_resources(
     return slots
 
 
+def _get_container_mounts(container_info: Mapping[str, Any]) -> Sequence[Mapping[str, Any]]:
+    host_config_mounts: Sequence[Mapping[str, Any]] | None
+    try:
+        host_config_mounts = container_info[_HOST_CONFIG_FIELD][_MOUNTS_FIELD]
+    except KeyError:
+        host_config_mounts = None
+    if host_config_mounts:
+        return host_config_mounts
+
+    mounts: Sequence[Mapping[str, Any]] | None
+    try:
+        mounts = container_info[_MOUNTS_FIELD]
+    except KeyError:
+        mounts = None
+    return mounts or []
+
+
+def _get_mount_target(mount: Mapping[str, Any]) -> str | None:
+    return mount.get(_MOUNT_TARGET_FIELD) or mount.get(_MOUNT_DESTINATION_FIELD)
+
+
 async def get_resource_spec_from_container(
     container_info: Mapping[str, Any],
 ) -> KernelResourceSpec | None:
-    for mount in container_info["HostConfig"]["Mounts"]:
-        if mount["Target"] == "/home/config":
-            async with aiofiles.open(Path(mount["Source"]) / "resource.txt") as f:
+    for mount in _get_container_mounts(container_info):
+        if _get_mount_target(mount) == "/home/config":
+            async with aiofiles.open(Path(mount[_MOUNT_SOURCE_FIELD]) / "resource.txt") as f:
                 return await KernelResourceSpec.aread_from_file(f)
-    else:
-        return None
+    return None

--- a/src/ai/backend/agent/utils.py
+++ b/src/ai/backend/agent/utils.py
@@ -172,7 +172,7 @@ async def read_tail(path: Path, nbytes: int) -> bytes:
 
 async def get_kernel_id_from_container(val: str | DockerContainer) -> KernelId | None:
     if isinstance(val, DockerContainer):
-        if "Name" not in val._container:
+        if not val._container.get("Name"):
             await val.show()
         name = val["Name"]
     elif isinstance(val, str):


### PR DESCRIPTION
## Summary

- `get_kernel_id_from_container()` looked up the container detail only when the `Name` key was absent. Podman's `/containers/json` always includes `Name` with an empty string value, so the lookup was skipped and the name stayed blank — no running kernel container was ever identified after an agent restart, silently and without an error.
- `get_resource_spec_from_container()` read `HostConfig.Mounts` unconditionally. Podman's inspect response has no such field and exposes the mount list at the top level, naming the in-container path `Destination` instead of `Target`. The resulting `KeyError: 'Mounts'` propagated out of `scan_running_kernels()` and aborted agent startup whenever a kernel container was still running.
- Mount lookup now prefers `HostConfig.Mounts`, falls back to the top-level `Mounts`, and accepts either `Target` or `Destination`. The inspect field names are lifted into module-level constants.

Both paths run during `scan_running_kernels()`, so the first defect masks the second: without the `Name` fix the agent never reaches the mount lookup and instead loses track of every running kernel.

## Test plan

- [x] Verified end-to-end against a Podman-backed agent (Podman 4.9.3, rootful, Docker-compat API): with a kernel container running, restarting the agent previously died with `KeyError: 'Mounts'`; it now starts, logs `detected active containers: [...]` and resumes the kernel with `RESUMING_AGENT_OPERATION`.
- [x] Confirmed the mount resolution against a real Podman inspect payload plus Docker-shaped input, covering empty `HostConfig.Mounts`, a missing `HostConfig` key, and an empty response.
- [x] Regression check on a Docker-backed agent restart with a running kernel.

Resolves BA-7372
Resolves BA-7370
