### PR TITLE
fix(BA-7380): respond with an empty body for an empty stream

### DIFF
--- a/changes/13801.fix.md
+++ b/changes/13801.fix.md
@@ -1,0 +1,1 @@
+Respond to a streaming request with an empty body instead of a 500 error when the source produces no data, such as downloading a zero-byte file

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -563,19 +563,24 @@ def stream_api_handler(handler: StreamBaseHandler) -> ParsedRequestHandler:
 
         body_iter = body_stream.read()
 
-        # Send first chunk, and check if it raises an exception
+        # Pull the first chunk before sending headers so that a failing source
+        # can still be reported with an error status code.
         try:
-            first_chunk = await body_iter.__anext__()
-            await resp.prepare(request)
-            await resp.write(first_chunk)
+            first_chunk = await anext(body_iter, None)
         except Exception as e:
             raise web.HTTPInternalServerError(
-                reason=f"Failed to send first chunk from stream: {e!r}"
+                reason=f"Failed to read first chunk from stream: {e!r}"
             ) from e
 
+        if first_chunk is None:
+            resp.content_length = 0
+
         try:
-            async for chunk in body_iter:
-                await resp.write(chunk)
+            await resp.prepare(request)
+            if first_chunk is not None:
+                await resp.write(first_chunk)
+                async for chunk in body_iter:
+                    await resp.write(chunk)
             # Normal completion - send chunked transfer encoding terminator
             await resp.write_eof()
         except Exception:

--- a/src/ai/backend/manager/api/rest/export/handler.py
+++ b/src/ai/backend/manager/api/rest/export/handler.py
@@ -458,18 +458,24 @@ class ExportHandler:
         resp = web.StreamResponse(status=HTTPStatus.OK, headers=headers)
         body_iter = stream_reader.read()
 
+        # Pull the first chunk before sending headers so that a failing source
+        # can still be reported with an error status code.
         try:
-            first_chunk = await body_iter.__anext__()
-            await resp.prepare(request)
-            await resp.write(first_chunk)
+            first_chunk = await anext(body_iter, None)
         except Exception as e:
             raise web.HTTPInternalServerError(
-                reason=f"Failed to send first chunk from stream: {e!r}"
+                reason=f"Failed to read first chunk from stream: {e!r}"
             ) from e
 
+        if first_chunk is None:
+            resp.content_length = 0
+
         try:
-            async for chunk in body_iter:
-                await resp.write(chunk)
+            await resp.prepare(request)
+            if first_chunk is not None:
+                await resp.write(first_chunk)
+                async for chunk in body_iter:
+                    await resp.write(chunk)
             await resp.write_eof()
         except Exception:
             log.exception("Error during streaming response body iteration")

--- a/src/ai/backend/manager/api/rest/routing.py
+++ b/src/ai/backend/manager/api/rest/routing.py
@@ -28,19 +28,25 @@ async def _handle_stream_response(
     resp = web.StreamResponse(status=result.status, headers=result.headers)
     body_iter = result.body.read()
 
+    # Pull the first chunk before sending headers so that a failing source
+    # can still be reported with an error status code.
     try:
-        first_chunk = await body_iter.__anext__()
-        await resp.prepare(request)
-        await resp.write(first_chunk)
+        first_chunk = await anext(body_iter, None)
     except Exception:
-        log.exception("Failed to send first chunk from stream")
+        log.exception("Failed to read first chunk from stream")
         raise web.HTTPInternalServerError(
             reason="Failed to initialize streaming response"
         ) from None
 
+    if first_chunk is None:
+        resp.content_length = 0
+
     try:
-        async for chunk in body_iter:
-            await resp.write(chunk)
+        await resp.prepare(request)
+        if first_chunk is not None:
+            await resp.write(first_chunk)
+            async for chunk in body_iter:
+                await resp.write(chunk)
         await resp.write_eof()
     except Exception:
         log.exception("Error during streaming response body iteration")

--- a/tests/unit/common/test_api_handlers.py
+++ b/tests/unit/common/test_api_handlers.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from http import HTTPStatus
 from typing import Any, Self, override
 
+import pytest
 from aiohttp import web
 from pydantic import AliasChoices, Field
 
 from ai.backend.common.api_handlers import (
     APIResponse,
+    APIStreamResponse,
     BaseRequestModel,
     BaseResponseModel,
     BodyParam,
@@ -18,7 +20,9 @@ from ai.backend.common.api_handlers import (
     PathParam,
     QueryParam,
     api_handler,
+    stream_api_handler,
 )
+from ai.backend.common.types import StreamReader
 
 
 class TestEmptyResponseModel(BaseResponseModel):
@@ -574,3 +578,98 @@ async def test_repeated_uuid_list_query_parameter_via_alias(aiohttp_client: Any)
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
     assert data["group_ids"] == [g1, g2]
+
+
+class _ChunkStreamReader(StreamReader):
+    """Yields the given chunks, optionally raising after `raise_after` chunks."""
+
+    _chunks: list[bytes]
+    _raise_after: int | None
+
+    def __init__(self, chunks: list[bytes], raise_after: int | None = None) -> None:
+        self._chunks = chunks
+        self._raise_after = raise_after
+
+    @override
+    async def read(self) -> AsyncIterator[bytes]:
+        for idx, chunk in enumerate(self._chunks):
+            if self._raise_after is not None and idx == self._raise_after:
+                raise RuntimeError("stream source failure")
+            yield chunk
+        if self._raise_after is not None and self._raise_after == len(self._chunks):
+            raise RuntimeError("stream source failure")
+
+    @override
+    def content_type(self) -> str | None:
+        return "application/octet-stream"
+
+
+class TestStreamHandler:
+    _reader: StreamReader
+
+    def __init__(self, reader: StreamReader) -> None:
+        self._reader = reader
+
+    @stream_api_handler
+    async def handle_stream(self) -> APIStreamResponse:
+        return APIStreamResponse(body=self._reader, status=HTTPStatus.OK)
+
+
+async def _make_stream_client(aiohttp_client: Any, reader: StreamReader) -> Any:
+    handler = TestStreamHandler(reader)
+    app = web.Application()
+    app.router.add_get("/stream", handler.handle_stream)
+    return await aiohttp_client(app)
+
+
+async def test_empty_stream_returns_empty_body(aiohttp_client: Any) -> None:
+    client = await _make_stream_client(aiohttp_client, _ChunkStreamReader([]))
+    resp = await client.get("/stream")
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b""
+    assert resp.headers["Content-Length"] == "0"
+
+
+async def test_non_empty_stream_delivers_all_chunks(aiohttp_client: Any) -> None:
+    client = await _make_stream_client(aiohttp_client, _ChunkStreamReader([b"foo", b"bar", b"baz"]))
+    resp = await client.get("/stream")
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"foobarbaz"
+
+
+async def test_stream_failing_before_first_chunk_returns_500(aiohttp_client: Any) -> None:
+    client = await _make_stream_client(aiohttp_client, _ChunkStreamReader([b"foo"], raise_after=0))
+    resp = await client.get("/stream")
+
+    assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+async def test_stream_failing_midway_is_not_seen_as_complete(
+    aiohttp_client: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    force_close_calls: list[web.StreamResponse] = []
+    original_force_close = web.StreamResponse.force_close
+
+    def spy_force_close(self: web.StreamResponse) -> None:
+        force_close_calls.append(self)
+        original_force_close(self)
+
+    monkeypatch.setattr(web.StreamResponse, "force_close", spy_force_close)
+
+    client = await _make_stream_client(
+        aiohttp_client, _ChunkStreamReader([b"foo", b"bar"], raise_after=1)
+    )
+    resp = await client.get("/stream")
+
+    # Headers are already sent, so the status stays 200; the connection is force-closed
+    # without `write_eof()` so the client sees a truncated payload instead of a
+    # successfully completed body.
+    # Headers are already sent, so the status stays 200. Only the chunks written
+    # before the failure are delivered and the connection is force-closed instead
+    # of completing normally.
+    assert resp.status == HTTPStatus.OK
+    assert await resp.read() == b"foo"
+    assert force_close_calls

--- a/tests/unit/storage/api/test_file_stream.py
+++ b/tests/unit/storage/api/test_file_stream.py
@@ -10,7 +10,7 @@ This test suite covers:
 from __future__ import annotations
 
 import urllib.parse
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
@@ -21,7 +21,7 @@ import jwt
 import pytest
 from aiohttp import web
 
-from ai.backend.common.api_handlers import APIStreamResponse
+from ai.backend.common.api_handlers import APIStreamResponse, stream_api_handler
 from ai.backend.common.dto.storage.request import (
     ArchiveDownloadTokenData,
     TokenOperationType,
@@ -30,6 +30,7 @@ from ai.backend.common.types import VFolderID
 from ai.backend.storage.api.client import DownloadHandler
 from ai.backend.storage.errors import InvalidAPIParameters
 from ai.backend.storage.services.file_stream.zip import ZipArchiveStreamReader
+from ai.backend.storage.storages.vfs_storage import VFSFileDownloadServerStreamReader
 
 
 class TestJWTTokenForArchiveDownload:
@@ -361,3 +362,60 @@ class TestDownloadArchiveHandler:
         content_disposition = response.headers.get("Content-Disposition")
         assert content_disposition is not None
         assert expected_in_header in content_disposition
+
+
+class TestVFSFileDownloadStreaming:
+    """
+    Test end-to-end streaming of VFS file downloads through ``stream_api_handler``.
+
+    Focus: a zero-byte file must be served as an empty 200 response rather than
+    a 500, since the underlying reader yields no chunk at all.
+    """
+
+    @pytest.fixture
+    def make_client(self, aiohttp_client: Any) -> Callable[[Path], Awaitable[Any]]:
+        """Factory serving the given path via a ``stream_api_handler`` endpoint."""
+
+        async def _make(file_path: Path) -> Any:
+            reader = VFSFileDownloadServerStreamReader(file_path, chunk_size=4)
+
+            class _Handler:
+                @stream_api_handler
+                async def handle(self) -> APIStreamResponse:
+                    return APIStreamResponse(body=reader, status=200)
+
+            app = web.Application()
+            app.router.add_get("/download", _Handler().handle)
+            return await aiohttp_client(app)
+
+        return _make
+
+    async def test_zero_byte_file_returns_empty_body(
+        self,
+        tmp_path: Path,
+        make_client: Callable[[Path], Awaitable[Any]],
+    ) -> None:
+        empty_file = tmp_path / "safetensors-md5sum.txt"
+        empty_file.write_bytes(b"")
+
+        client = await make_client(empty_file)
+        resp = await client.get("/download")
+
+        assert resp.status == 200
+        assert await resp.read() == b""
+        assert resp.headers["Content-Length"] == "0"
+
+    async def test_non_empty_file_is_streamed_fully(
+        self,
+        tmp_path: Path,
+        make_client: Callable[[Path], Awaitable[Any]],
+    ) -> None:
+        content = b"0123456789abcdef"
+        data_file = tmp_path / "model.safetensors"
+        data_file.write_bytes(content)
+
+        client = await make_client(data_file)
+        resp = await client.get("/download")
+
+        assert resp.status == 200
+        assert await resp.read() == content


### PR DESCRIPTION
## Summary

- A streaming response whose source yields no chunk answered 500 instead of an empty 200. The handler pulls the first chunk before sending headers so a failing source can still pick an error status code; an empty source raises `StopAsyncIteration` there, which the surrounding broad `except Exception` turned into `HTTPInternalServerError`. Downloading a zero-byte file (common as a placeholder in Hugging Face model repos) failed, and the consumer stopped at that file without requesting the rest of the model.
- `anext(body_iter, None)` absorbs only `StopAsyncIteration`, so a real IO error still becomes a 500. The empty case sets `Content-Length: 0` for clients that validate the size.
- `prepare()` moves into the write `try` block: a read failure is still before the headers, so a status code is meaningful, while a write failure has already started the body and has no answer other than `force_close()`. The current code mixes the two in one `try`.
- The same block is duplicated in three streaming paths — `stream_api_handler` (storage-proxy downloads), `_handle_stream_response` (manager REST v2 routing), and the CSV export helper — and all three are fixed identically. Deduplicating them is deliberately left to a main-only follow-up so this backport does not conflict on release branches.

## Test plan

- [x] Empty stream -> 200, zero-byte body, `Content-Length: 0`
- [x] Non-empty stream -> unchanged behavior, full content delivered
- [x] Source raising before the first chunk -> still 500
- [x] Source raising mid-transfer -> only the chunks written before the failure are delivered and `force_close()` is taken instead of completing normally
- [x] Zero-byte and regular file download through `VFSFileDownloadServerStreamReader` end-to-end
- [x] `pants fmt / fix / lint / check / test` on the changed targets

Resolves BA-7380