### PR TITLE
fix: narrow bare excepts in check-docker.py and correct copy-pasted error message

### DIFF
--- a/scripts/check-docker.py
+++ b/scripts/check-docker.py
@@ -54,7 +54,7 @@ async def detect_snap_docker():
         async with sess.get("http://localhost/v2/snaps?names=docker") as r:
             try:
                 r.raise_for_status()
-            except:
+            except aiohttp.ClientResponseError:
                 raise RuntimeError("Failed to query Snapd package information")
             response_data = await r.json()
             for pkg_data in response_data["result"]:
@@ -80,8 +80,8 @@ async def detect_system_docker():
         async with sess.get("http://localhost/version") as r:
             try:
                 r.raise_for_status()
-            except:
-                raise RuntimeError("Failed to query Snapd package information")
+            except aiohttp.ClientResponseError:
+                raise RuntimeError("Failed to query Docker daemon version")
             response_data = await r.json()
             return response_data["Version"]
 


### PR DESCRIPTION
## Summary

Two fixes in `scripts/check-docker.py`:

1. **Copy-pasted error message** — `detect_system_docker()` raised `RuntimeError("Failed to query Snapd package information")` when it is actually querying the Docker daemon's `/version` endpoint (the message was copied from `detect_snap_docker()`). A user hitting this error today gets pointed at Snap when their problem is the Docker socket. Now says `Failed to query Docker daemon version`.

2. **Bare `except:` narrowed** — both sites wrap `r.raise_for_status()`, which raises `aiohttp.ClientResponseError`. The bare form also swallows `KeyboardInterrupt`/`SystemExit` and masks unrelated bugs (ruff E722). Narrowed to the exception that call actually raises.

## Testing
`python -m py_compile` and `ruff check --select E722` pass on the patched file. No behavior change other than the corrected message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)