### PR TITLE
fix(BA-7376): hand the seccomp profile to the runtime in the form it accepts

### DIFF
--- a/changes/13805.fix.md
+++ b/changes/13805.fix.md
@@ -1,0 +1,1 @@
+Fix compute session creation failing on container runtimes that read the seccomp profile option as a file path instead of an inline document.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -174,7 +174,7 @@ _SECCOMP_PROFILE_FILENAME: Final[str] = "seccomp.json"
 # Container runtimes disagree on the seccomp option value: some decode it as the profile
 # document, others open it as a path, and neither accepts the other form. These engine
 # components, as reported by the version API, are the ones that require a path.
-_SECCOMP_FILE_ENGINES: Final[frozenset[str]] = frozenset({"Podman Engine"})
+_SECCOMP_PATH_ENGINES: Final[frozenset[str]] = frozenset({"Podman Engine"})
 
 known_glibc_distros: Final[dict[float, str]] = {
     2.17: "centos7.6",
@@ -326,7 +326,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
     resource_lock: asyncio.Lock
     cluster_ssh_port_mapping: ClusterSSHPortMapping | None
     gwbridge_subnet: str | None
-    _require_seccomp_file: bool
+    _seccomp_profile_as_path: bool
 
     network_plugin_ctx: NetworkPluginContext
 
@@ -346,7 +346,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         restarting: bool = False,
         cluster_ssh_port_mapping: ClusterSSHPortMapping | None = None,
         gwbridge_subnet: str | None = None,
-        require_seccomp_file: bool = False,
+        seccomp_profile_as_path: bool = False,
     ) -> None:
         super().__init__(
             ownership_data,
@@ -376,7 +376,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         self.computer_docker_args = {}
 
         self.cluster_ssh_port_mapping = cluster_ssh_port_mapping
-        self._require_seccomp_file = require_seccomp_file
+        self._seccomp_profile_as_path = seccomp_profile_as_path
         self.gwbridge_subnet = gwbridge_subnet
 
         self.network_plugin_ctx = network_plugin_ctx
@@ -1079,7 +1079,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
 
         # Some runtimes decode the option value as the profile document itself, others
         # open it as a path; neither accepts the other's form.
-        if self._require_seccomp_file:
+        if self._seccomp_profile_as_path:
             profile_path = self.scratch_dir / _SECCOMP_PROFILE_FILENAME
             async with aiofiles.open(profile_path, "w") as fp:
                 await fp.write(dump_json_str(seccomp_profile))
@@ -1494,7 +1494,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     docker_ptask_group: aiotools.PersistentTaskGroup
     gwbridge_subnet: str | None
     checked_invalid_images: set[str]
-    _require_seccomp_file: bool
+    _seccomp_profile_as_path: bool
 
     network_plugin_ctx: NetworkPluginContext
 
@@ -1525,7 +1525,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             agent_class=agent_class,
         )
         self.checked_invalid_images = set()
-        self._require_seccomp_file = False
+        self._seccomp_profile_as_path = False
         pickle_loader_writer_creator = PickleBasedLoaderWriterCreator.create(
             PickleBasedKernelRegistryCreatorArgs(
                 scratch_root=local_config.container.scratch_root,
@@ -1581,7 +1581,9 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                 docker_version["ApiVersion"],
                 ", ".join(engine_components),
             )
-            self._require_seccomp_file = not _SECCOMP_FILE_ENGINES.isdisjoint(engine_components)
+            self._seccomp_profile_as_path = any(
+                component in _SECCOMP_PATH_ENGINES for component in engine_components
+            )
             kernel_version = docker_version["KernelVersion"]
             if "linuxkit" in kernel_version:
                 self.local_config.agent.docker_mode = "linuxkit"
@@ -2080,7 +2082,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             restarting=restarting,
             cluster_ssh_port_mapping=cluster_ssh_port_mapping,
             gwbridge_subnet=self.gwbridge_subnet,
-            require_seccomp_file=self._require_seccomp_file,
+            seccomp_profile_as_path=self._seccomp_profile_as_path,
         )
 
     @override

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import json
 import logging
 import os
 import re
@@ -126,6 +125,7 @@ from ai.backend.common.exception import ImageNotAvailable, InvalidImageName, Inv
 from ai.backend.common.files import AsyncFileWriter
 from ai.backend.common.json import (
     dump_json,
+    dump_json_str,
     load_json,
 )
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
@@ -168,6 +168,13 @@ eof_sentinel = Sentinel.TOKEN
 
 LDD_GLIBC_REGEX = re.compile(r"^ldd \([^\)]+\) (\d+(?:\.\d+)?)[\d\.]*$")
 LDD_MUSL_REGEX = re.compile(r"^musl libc .+$")
+
+# The merged seccomp profile written next to a kernel's scratch contents.
+_SECCOMP_PROFILE_FILENAME: Final[str] = "seccomp.json"
+# Container runtimes disagree on the seccomp option value: some decode it as the profile
+# document, others open it as a path, and neither accepts the other form. These engine
+# components, as reported by the version API, are the ones that require a path.
+_SECCOMP_FILE_ENGINES: Final[frozenset[str]] = frozenset({"Podman Engine"})
 
 known_glibc_distros: Final[dict[float, str]] = {
     2.17: "centos7.6",
@@ -319,6 +326,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
     resource_lock: asyncio.Lock
     cluster_ssh_port_mapping: ClusterSSHPortMapping | None
     gwbridge_subnet: str | None
+    _require_seccomp_file: bool
 
     network_plugin_ctx: NetworkPluginContext
 
@@ -338,6 +346,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         restarting: bool = False,
         cluster_ssh_port_mapping: ClusterSSHPortMapping | None = None,
         gwbridge_subnet: str | None = None,
+        require_seccomp_file: bool = False,
     ) -> None:
         super().__init__(
             ownership_data,
@@ -367,6 +376,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         self.computer_docker_args = {}
 
         self.cluster_ssh_port_mapping = cluster_ssh_port_mapping
+        self._require_seccomp_file = require_seccomp_file
         self.gwbridge_subnet = gwbridge_subnet
 
         self.network_plugin_ctx = network_plugin_ctx
@@ -1058,18 +1068,27 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
         async with aiofiles.open(default_seccomp_path) as fp:
             seccomp_profile = load_json(await fp.read())
 
-            additional_allowed_syscalls = self.additional_allowed_syscalls
-            additional_allowed_syscall_rule = {
-                "names": additional_allowed_syscalls,
-                "action": "SCMP_ACT_ALLOW",
-                "args": [],
-                "comment": "Additionally allowed syscalls by Backend.AI Agent",
-            }
-            seccomp_profile["syscalls"].append(additional_allowed_syscall_rule)
+        additional_allowed_syscalls = self.additional_allowed_syscalls
+        additional_allowed_syscall_rule = {
+            "names": additional_allowed_syscalls,
+            "action": "SCMP_ACT_ALLOW",
+            "args": [],
+            "comment": "Additionally allowed syscalls by Backend.AI Agent",
+        }
+        seccomp_profile["syscalls"].append(additional_allowed_syscall_rule)
 
-            container_config["HostConfig"]["SecurityOpt"] = [
-                f"seccomp={json.dumps(seccomp_profile)}"
-            ]
+        # Some runtimes decode the option value as the profile document itself, others
+        # open it as a path; neither accepts the other's form.
+        if self._require_seccomp_file:
+            profile_path = self.scratch_dir / _SECCOMP_PROFILE_FILENAME
+            async with aiofiles.open(profile_path, "w") as fp:
+                await fp.write(dump_json_str(seccomp_profile))
+            await current_loop().run_in_executor(None, profile_path.chmod, 0o644)
+            security_opt = f"seccomp={profile_path}"
+        else:
+            security_opt = f"seccomp={dump_json_str(seccomp_profile)}"
+
+        container_config["HostConfig"]["SecurityOpt"] = [security_opt]
 
     async def _attach_additional_networks(
         self,
@@ -1475,6 +1494,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     docker_ptask_group: aiotools.PersistentTaskGroup
     gwbridge_subnet: str | None
     checked_invalid_images: set[str]
+    _require_seccomp_file: bool
 
     network_plugin_ctx: NetworkPluginContext
 
@@ -1505,6 +1525,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             agent_class=agent_class,
         )
         self.checked_invalid_images = set()
+        self._require_seccomp_file = False
         pickle_loader_writer_creator = PickleBasedLoaderWriterCreator.create(
             PickleBasedKernelRegistryCreatorArgs(
                 scratch_root=local_config.container.scratch_root,
@@ -1549,11 +1570,18 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
                     docker_host = "(unknown)"
             log.info("accessing the local Docker daemon via {}", docker_host)
             docker_version = await docker.version()
+            engine_components = [
+                name
+                for component in docker_version.get("Components") or []
+                if (name := component.get("Name")) is not None
+            ]
             log.info(
-                "running with Docker {0} with API {1}",
+                "running with Docker {0} with API {1} (components: {2})",
                 docker_version["Version"],
                 docker_version["ApiVersion"],
+                ", ".join(engine_components),
             )
+            self._require_seccomp_file = not _SECCOMP_FILE_ENGINES.isdisjoint(engine_components)
             kernel_version = docker_version["KernelVersion"]
             if "linuxkit" in kernel_version:
                 self.local_config.agent.docker_mode = "linuxkit"
@@ -2052,6 +2080,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             restarting=restarting,
             cluster_ssh_port_mapping=cluster_ssh_port_mapping,
             gwbridge_subnet=self.gwbridge_subnet,
+            require_seccomp_file=self._require_seccomp_file,
         )
 
     @override


### PR DESCRIPTION
## Summary

- The agent merges the additionally allowed syscalls into the default seccomp profile and passed the result as an inline JSON document in `HostConfig.SecurityOpt`. Podman opens that value as a path and reports the whole document back as a missing file name, so **every compute session failed to be created**.
- The two forms turn out to be mutually exclusive, so the engine is now identified from the version API the agent already queries at startup, and the merged profile is written to a file when a path is what the runtime expects.

Measured against both daemons through the API the agent uses:

| `HostConfig.SecurityOpt` | Docker | Podman |
|---|---|---|
| `seccomp=<inline JSON>` | applied | HTTP 500 at create |
| `seccomp=<file path>` | HTTP 500 at start — `Decoding seccomp profile failed: invalid character '/' looking for beginning of value` | applied |

Note that Docker validates the profile at **start**, not at create, and that the Docker CLI reads the file itself before calling the API — so neither a `201` from create nor a successful `docker run --security-opt seccomp=<path>` says anything about what the daemon accepts.

The profile is written next to the kernel's scratch contents. It has to be per-kernel because the additionally allowed syscalls follow the devices allocated to that kernel; it sits outside the `config` and `work` directories that are mounted into the container, and it is removed together with the scratch.

## Test plan

- [x] Verified on rootless Podman 4.9.3 with the default profile restored: the runtime is detected, the session reaches `RUNNING`, `HostConfig.SecurityOpt` carries the profile path, and the kernel's main process reports `Seccomp: 2` / `Seccomp_filters: 1`.
- [x] Engine detection checked against the live version API of rootful Podman, rootless Podman and Docker.
- [x] Regression check on a Docker-backed agent (planned on a separate machine). The Docker branch keeps the existing inline form, which was measured to apply correctly (a profile denying `mkdir` yields exit code 1 through the API).

## Dependency

A Podman-backed agent needs BA-7377 as well; the hardcoded `local` log driver rejects container creation before this path is reached.

Resolves BA-7376
