### PR TITLE
fix(BA-7371): resolve container cgroup paths from /proc/<pid>/cgroup (#13796)

### DIFF
--- a/changes/13796.fix.md
+++ b/changes/13796.fix.md
@@ -1,0 +1,1 @@
+Fix container-level metrics and container-PID mapping failing on Podman by resolving cgroup paths from the container process rather than assuming Docker's cgroup layout.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -88,6 +88,7 @@ from ai.backend.agent.tasks import (
 from ai.backend.common import msgpack
 from ai.backend.common.asyncio import cancel_tasks, current_loop
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
+from ai.backend.common.cgroup import CgroupController
 from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
 from ai.backend.common.clients.valkey_client.valkey_container_log.client import (
     ValkeyContainerLogClient,
@@ -1948,7 +1949,9 @@ class AbstractAgent[
         )
 
     @abstractmethod
-    def get_cgroup_path(self, controller: str, container_id: str) -> Path:
+    async def get_cgroup_path(
+        self, controller: CgroupController, container_id: ContainerId
+    ) -> Path:
         """
         Get the cgroup path for the given controller and container ID.
         This is used to read/write cgroup files for resource management.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -40,6 +40,7 @@ from aiodocker.types import PortInfo
 from aiomonitor.task import preserve_termination_log
 from aiotools import TaskGroup
 from async_timeout import timeout
+from cachetools import LRUCache
 
 from ai.backend.agent.agent import (
     ACTIVE_STATUS_SET,
@@ -108,7 +109,11 @@ from ai.backend.agent.utils import (
     update_nested_dict,
 )
 from ai.backend.common.asyncio import current_loop
-from ai.backend.common.cgroup import get_cgroup_mount_point
+from ai.backend.common.cgroup import (
+    CgroupController,
+    get_cgroup_path_of_pid,
+    get_container_main_pid,
+)
 from ai.backend.common.data.image.types import InstalledImageInfo
 from ai.backend.common.docker import (
     MAX_KERNELSPEC,
@@ -175,6 +180,14 @@ _SECCOMP_PROFILE_FILENAME: Final[str] = "seccomp.json"
 # document, others open it as a path, and neither accepts the other form. These engine
 # components, as reported by the version API, are the ones that require a path.
 _SECCOMP_PATH_ENGINES: Final[frozenset[str]] = frozenset({"Podman Engine"})
+# Cached per container, so the capacity is the number of containers an agent may host.
+_CGROUP_PATH_CACHE_SIZE: Final[int] = 2048
+# Controllers the intrinsic plugins read, resolved together from a single inspect.
+_TRACKED_CGROUP_CONTROLLERS: Final[tuple[CgroupController, ...]] = (
+    CgroupController.CPUACCT,
+    CgroupController.MEMORY,
+    CgroupController.BLKIO,
+)
 
 known_glibc_distros: Final[dict[float, str]] = {
     2.17: "centos7.6",
@@ -1494,6 +1507,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
     gwbridge_subnet: str | None
     checked_invalid_images: set[str]
     _seccomp_profile_as_path: bool
+    _cgroup_path_cache: LRUCache[ContainerId, dict[CgroupController, Path]]
 
     network_plugin_ctx: NetworkPluginContext
 
@@ -1525,6 +1539,7 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         )
         self.checked_invalid_images = set()
         self._seccomp_profile_as_path = False
+        self._cgroup_path_cache = LRUCache(maxsize=_CGROUP_PATH_CACHE_SIZE)
         pickle_loader_writer_creator = PickleBasedLoaderWriterCreator.create(
             PickleBasedKernelRegistryCreatorArgs(
                 scratch_root=local_config.container.scratch_root,
@@ -1684,19 +1699,28 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         await self._kernel_recovery.save_kernel_registry(kernel_registry, metadata)
 
     @override
-    def get_cgroup_path(self, controller: str, container_id: str) -> Path:
-        driver = self.docker_info["CgroupDriver"]
+    async def get_cgroup_path(
+        self, controller: CgroupController, container_id: ContainerId
+    ) -> Path:
+        cached_paths = self._cgroup_path_cache.get(container_id)
+        if cached_paths is not None and (cached_path := cached_paths.get(controller)) is not None:
+            return cached_path
+        # The PID is used immediately and never cached: it changes when the container
+        # restarts, while the resolved cgroup path does not.
+        pid = await get_container_main_pid(container_id)
         version = self.docker_info["CgroupVersion"]
-        mount_point = get_cgroup_mount_point(version, controller)
-        # See https://docs.docker.com/config/containers/runmetrics/#find-the-cgroup-for-a-given-container
-        match driver:
-            case "cgroupfs":
-                cgroup = f"docker/{container_id}"
-            case "systemd":
-                cgroup = f"system.slice/docker-{container_id}.scope"
-            case _:
-                raise ValueError(f"Unsupported cgroup driver: {driver!r}")
-        return mount_point / cgroup
+        resolved = {
+            each_controller: get_cgroup_path_of_pid(version, each_controller, pid)
+            for each_controller in {*_TRACKED_CGROUP_CONTROLLERS, controller}
+        }
+        if cached_paths is None:
+            self._cgroup_path_cache[container_id] = resolved
+        else:
+            cached_paths.update(resolved)
+        return resolved[controller]
+
+    def _invalidate_cgroup_path_cache(self, container_id: ContainerId) -> None:
+        self._cgroup_path_cache.pop(container_id, None)
 
     @override
     def get_cgroup_version(self) -> str:
@@ -2155,6 +2179,8 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
         restarting: bool,
     ) -> None:
         loop = current_loop()
+        if container_id is not None:
+            self._invalidate_cgroup_path_cache(container_id)
         async with closing_async(Docker()) as docker:
             if container_id is not None:
                 container = docker.containers.container(container_id)

--- a/src/ai/backend/agent/docker/intrinsic.py
+++ b/src/ai/backend/agent/docker/intrinsic.py
@@ -44,11 +44,13 @@ from ai.backend.agent.types import Container, MountInfo
 from ai.backend.agent.utils import read_sysfs
 from ai.backend.agent.vendor.linux import libnuma
 from ai.backend.common.asyncio import current_loop
+from ai.backend.common.cgroup import CgroupController, CgroupResolutionFailed
 from ai.backend.common.json import dump_json
 from ai.backend.common.netns import nsenter
 from ai.backend.common.types import (
     AcceleratorMetadata,
     ClusterInfo,
+    ContainerId,
     DeviceId,
     DeviceModelInfo,
     DeviceName,
@@ -287,9 +289,11 @@ class CPUPlugin(AbstractComputePlugin):
             return []
 
         async def sysfs_impl(container_id: str) -> float | None:
-            cpu_path = ctx.agent.get_cgroup_path("cpuacct", container_id)
             version = ctx.agent.docker_info["CgroupVersion"]  # type: ignore[attr-defined]
             try:
+                cpu_path = await ctx.agent.get_cgroup_path(
+                    CgroupController.CPUACCT, ContainerId(container_id)
+                )
                 match version:
                     case "1":
                         cpu_used = read_sysfs(cpu_path / "cpuacct.usage", int) / 1e6
@@ -304,7 +308,7 @@ class CPUPlugin(AbstractComputePlugin):
                         cpu_used = int(cpu_stats["usage_usec"]) / 1e3
                     case _:
                         return None
-            except OSError as e:
+            except (OSError, CgroupResolutionFailed) as e:
                 log.warning(
                     "CPUPlugin: cannot read stats: sysfs unreadable for container {0}\n{1!r}",
                     container_id[:7],
@@ -687,11 +691,15 @@ class MemoryPlugin(AbstractComputePlugin):
         async def sysfs_impl(
             container_id: str,
         ) -> ContainerStatResult | None:
-            mem_path = ctx.agent.get_cgroup_path("memory", container_id)
-            io_path = ctx.agent.get_cgroup_path("blkio", container_id)
             version = ctx.agent.get_cgroup_version()
 
             try:
+                mem_path = await ctx.agent.get_cgroup_path(
+                    CgroupController.MEMORY, ContainerId(container_id)
+                )
+                io_path = await ctx.agent.get_cgroup_path(
+                    CgroupController.BLKIO, ContainerId(container_id)
+                )
                 io_read_bytes = 0
                 io_write_bytes = 0
                 match version:
@@ -757,7 +765,7 @@ class MemoryPlugin(AbstractComputePlugin):
                                     io_write_bytes += int(value)
                     case _:
                         return None
-            except OSError as e:
+            except (OSError, CgroupResolutionFailed) as e:
                 log.warning(
                     "MemoryPlugin: cannot read stats: sysfs unreadable for container {0}\n{1!r}",
                     container_id[:7],

--- a/src/ai/backend/agent/dummy/agent.py
+++ b/src/ai/backend/agent/dummy/agent.py
@@ -26,6 +26,7 @@ from ai.backend.agent.resources import (
     known_slot_types,
 )
 from ai.backend.agent.types import Container, KernelOwnershipData, MountInfo
+from ai.backend.common.cgroup import CgroupController
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.dto.agent.response import PurgeImagesResp
 from ai.backend.common.dto.manager.rpc_request import PurgeImagesReq
@@ -298,7 +299,9 @@ class DummyAgent(
         return "ubuntu16.04"
 
     @override
-    def get_cgroup_path(self, controller: str, container_id: str) -> Path:
+    async def get_cgroup_path(
+        self, controller: CgroupController, container_id: ContainerId
+    ) -> Path:
         #  Dummy agent does not use cgroups, so we return an empty path.
         return Path()
 

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -52,6 +52,7 @@ from ai.backend.agent.resources import (
 )
 from ai.backend.agent.types import Container, KernelOwnershipData, MountInfo, Port
 from ai.backend.common.asyncio import current_loop
+from ai.backend.common.cgroup import CgroupController
 from ai.backend.common.docker import ImageRef, KernelFeatures
 from ai.backend.common.dto.agent.response import PurgeImagesResp
 from ai.backend.common.dto.manager.rpc_request import PurgeImagesReq
@@ -1022,7 +1023,9 @@ class KubernetesAgent(
         await self._kernel_recovery.save_kernel_registry(kernel_registry, metadata)
 
     @override
-    def get_cgroup_path(self, controller: str, container_id: str) -> Path:
+    async def get_cgroup_path(
+        self, controller: CgroupController, container_id: ContainerId
+    ) -> Path:
         # Not implemented yet for K8s Agent
         return Path()
 

--- a/src/ai/backend/agent/utils.py
+++ b/src/ai/backend/agent/utils.py
@@ -31,6 +31,7 @@ from aiodocker.docker import DockerContainer
 from ai.backend.common import identity
 from ai.backend.common.asyncio import current_loop
 from ai.backend.common.cgroup import (
+    CgroupController,
     get_cgroup_of_pid,
     get_container_id_of_cgroup,
     get_container_pids,
@@ -318,7 +319,7 @@ async def host_pid_to_container_pid(container_id: str, host_pid: HostPID) -> Con
                     await docker.close()
 
     try:
-        cgroup = get_cgroup_of_pid("pids", host_pid)
+        cgroup = get_cgroup_of_pid(CgroupController.PIDS, host_pid)
         cgroup_container_id = get_container_id_of_cgroup(cgroup)
         if cgroup_container_id is None:
             return NotContainerPID

--- a/src/ai/backend/agent/vendor/linux.py
+++ b/src/ai/backend/agent/vendor/linux.py
@@ -8,7 +8,11 @@ from collections.abc import Iterator
 import aiohttp
 import aiotools
 
-from ai.backend.common.cgroup import get_cgroup_mount_point
+from ai.backend.common.cgroup import (
+    CgroupController,
+    CgroupResolutionFailed,
+    get_cgroup_mount_point,
+)
 from ai.backend.common.docker import get_docker_connector
 from ai.backend.logging import BraceStyleAdapter
 
@@ -77,8 +81,8 @@ class libnuma:
             driver = data["CgroupDriver"]
             version = data["CgroupVersion"]
             try:
-                mount_point = get_cgroup_mount_point(version, "cpuset")
-            except RuntimeError:
+                mount_point = get_cgroup_mount_point(version, CgroupController.CPUSET)
+            except CgroupResolutionFailed:
                 return None
             match driver:
                 case "cgroupfs":

--- a/src/ai/backend/common/cgroup.py
+++ b/src/ai/backend/common/cgroup.py
@@ -10,19 +10,62 @@
 # https://docs.kernel.org/admin-guide/cgroup-v2.html
 
 import asyncio
+import enum
 import logging
+import re
 from dataclasses import dataclass
+from http import HTTPStatus
 from pathlib import Path
-from typing import Literal
+from typing import Final, Literal, override
 
 import aiohttp
+from aiohttp import web
 
 from ai.backend.logging import BraceStyleAdapter
 
 from .docker import get_docker_connector
+from .exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
 from .types import PID, ContainerId
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+# Leaf cgroups that container runtimes may interpose between the container scope and
+# its processes. They carry no container identity of their own.
+_CGROUP_SUBTREE_NAMES: Final[frozenset[str]] = frozenset({"container", "conmon", "supervisor"})
+_CONTAINER_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^(?:docker-|libpod-payload-|libpod-|crio-)?(?P<id>[0-9a-f]{12,64})(?:\.scope)?$"
+)
+
+
+class CgroupController(enum.StrEnum):
+    """A cgroup resource controller, as named in /proc/cgroups and /proc/mounts."""
+
+    CPUACCT = "cpuacct"
+    CPUSET = "cpuset"
+    MEMORY = "memory"
+    BLKIO = "blkio"
+    PIDS = "pids"
+
+
+class CgroupResolutionFailed(BackendAIError, web.HTTPInternalServerError):
+    """Raised when the cgroup of a process or a container cannot be determined."""
+
+    error_type = "https://api.backend.ai/probs/cgroup-resolution-failed"
+    error_title = "Failed to resolve the cgroup."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )
 
 
 @dataclass
@@ -39,32 +82,32 @@ async def get_docker_cgroup_version() -> CgroupVersion:
             return CgroupVersion(data["CgroupVersion"], data["CgroupDriver"])
 
 
-def get_cgroup_mount_point(version: str, controller: str) -> Path:
+def get_cgroup_mount_point(version: str, controller: CgroupController) -> Path:
     for line in Path("/proc/mounts").read_text().splitlines():
         device, mount_point, fstype, options, _ = line.split(" ", 4)
         match version:
             case "1":
                 if fstype == "cgroup":
-                    if controller in options.split(","):
+                    if controller.value in options.split(","):
                         return Path(mount_point)
             case "2":
                 if fstype == "cgroup2":
                     return Path(mount_point)
-    raise RuntimeError("could not find the cgroup mount point")
+    raise CgroupResolutionFailed("could not find the cgroup mount point")
 
 
-def get_cgroup_controller_id(controller: str) -> str:
+def get_cgroup_controller_id(controller: CgroupController) -> str:
     # example data
     # cpu <tab> 1 <tab> ...
     # cpuacct <tab> 1 <tab> ...
     for line in Path("/proc/cgroups").read_text().splitlines():
         name, id, _ = line.split("\t", 2)
-        if name == controller:
+        if name == controller.value:
             return id
-    raise RuntimeError(f"could not find the cgroup controller {controller}")
+    raise CgroupResolutionFailed(f"could not find the cgroup controller {controller}")
 
 
-def get_cgroup_of_pid(controller: str, pid: PID) -> str:
+def get_cgroup_of_pid(controller: CgroupController, pid: PID) -> str:
     # example data
     # 1:cpu,cpuacct:/<cgroup>
     controller_id = get_cgroup_controller_id(controller)
@@ -72,32 +115,61 @@ def get_cgroup_of_pid(controller: str, pid: PID) -> str:
         id, name, cgroup = line.split(":", 2)
         if id == controller_id:
             return cgroup.removeprefix("/")
-    raise RuntimeError(f"could not find the cgroup of PID {pid}")
+    raise CgroupResolutionFailed(f"could not find the cgroup of PID {pid}")
 
 
 def get_container_id_of_cgroup(cgroup: str) -> str | None:
     # cgroupfs driver: docker/<id>
-    cgroupfs_prefix = "docker/"
-    if cgroup.startswith(cgroupfs_prefix):
-        return cgroup.removeprefix(cgroupfs_prefix)
     # systemd driver: system.slice/docker-<id>.scope
-    systemd_prefix = "system.slice/docker-"
-    systemd_suffix = ".scope"
-    if cgroup.startswith(systemd_prefix) and cgroup.endswith(systemd_suffix):
-        return cgroup.removeprefix(systemd_prefix).removesuffix(systemd_suffix)
-    return None
+    # podman: machine.slice/libpod-<id>.scope, optionally with a /container leaf
+    # podman with split cgroups: <parent>/libpod-payload-<id>
+    segments = [segment for segment in cgroup.strip("/").split("/") if segment]
+    while segments and segments[-1] in _CGROUP_SUBTREE_NAMES:
+        segments.pop()
+    if not segments:
+        return None
+    if (matched := _CONTAINER_ID_PATTERN.match(segments[-1])) is None:
+        return None
+    return matched.group("id")
+
+
+async def get_container_main_pid(cid: ContainerId) -> PID:
+    connector = get_docker_connector()
+    async with aiohttp.ClientSession(connector=connector.connector) as sess:
+        async with sess.get(connector.docker_host / f"containers/{cid}/json") as resp:
+            if resp.status != HTTPStatus.OK:
+                # The container may have been removed since the caller observed it.
+                raise CgroupResolutionFailed(
+                    f"could not inspect container {cid} (HTTP {resp.status})"
+                )
+            data = await resp.json()
+    state = data.get("State")
+    if state is None or not state.get("Pid"):
+        raise CgroupResolutionFailed(f"container {cid} has no running process")
+    return PID(state["Pid"])
+
+
+def get_cgroup_path_of_pid(version: str, controller: CgroupController, pid: PID) -> Path:
+    return get_cgroup_mount_point(version, controller) / get_cgroup_of_pid(controller, pid)
+
+
+async def get_container_cgroup_path(
+    version: str, controller: CgroupController, cid: ContainerId
+) -> Path:
+    """
+    Resolve the cgroup path of a container from the cgroup its main process actually
+    belongs to, instead of assembling a runtime-specific path.
+    """
+    pid = await get_container_main_pid(cid)
+    return get_cgroup_path_of_pid(version, controller, pid)
 
 
 async def get_container_pids(cid: ContainerId) -> list[int]:
     cgroup_version = await get_docker_cgroup_version()
     log.debug("Cgroup version: {}, {}", cgroup_version.version, cgroup_version.driver)
-    tasks_path: Path
-    match (cgroup_version.version, cgroup_version.driver):
-        case ("2", "systemd"):
-            tasks_path = Path(f"/sys/fs/cgroup/system.slice/docker-{cid}.scope/cgroup.procs")
-        case ("2", "cgroupfs"):
-            tasks_path = Path(f"/sys/fs/cgroup/docker/{cid}/cgroup.procs")
-        case ("1", _):
-            tasks_path = Path(f"/sys/fs/cgroup/pids/docker/{cid}/tasks")
+    cgroup_path = await get_container_cgroup_path(
+        cgroup_version.version, CgroupController.PIDS, cid
+    )
+    tasks_path = cgroup_path / ("cgroup.procs" if cgroup_version.version == "2" else "tasks")
     tasks = await asyncio.get_running_loop().run_in_executor(None, tasks_path.read_text)
     return [*map(int, tasks.splitlines())]

--- a/tests/unit/agent/test_docker_intrinsic.py
+++ b/tests/unit/agent/test_docker_intrinsic.py
@@ -92,7 +92,7 @@ class TestCPUPluginDockerClientLifecycle(BaseDockerIntrinsicTest):
         """CGROUP stat context with CPU cgroup v2 path mocks."""
         cgroup_stat_context.agent.docker_info = {"CgroupVersion": "2"}
 
-        def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
+        async def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
             path = MagicMock()
             stat_file = MagicMock()
             stat_file.read_text.return_value = "usage_usec 1000000\n"
@@ -167,7 +167,7 @@ class TestMemoryPluginDockerClientLifecycle(BaseDockerIntrinsicTest):
         io_stat.read_text.return_value = ""
         io_path.__truediv__ = MagicMock(return_value=io_stat)
 
-        def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
+        async def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
             if subsys == "memory":
                 return mem_path
             return io_path
@@ -277,7 +277,7 @@ class TestMemoryPluginContainerPidValidation(BaseDockerIntrinsicTest):
         io_stat.read_text.return_value = ""
         io_path.__truediv__ = MagicMock(return_value=io_stat)
 
-        def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
+        async def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
             if subsys == "memory":
                 return mem_path
             return io_path
@@ -410,7 +410,11 @@ class TestMemoryPluginSysfsTimeoutAndErrorIsolation(BaseDockerIntrinsicTest):
         io_stat = MagicMock()
         io_stat.read_text.return_value = ""
         io_path.__truediv__ = MagicMock(return_value=io_stat)
-        ctx.agent.get_cgroup_path = lambda subsys, cid: mem_path if subsys == "memory" else io_path
+
+        async def mock_get_cgroup_path(subsys: str, cid: str) -> MagicMock:
+            return mem_path if subsys == "memory" else io_path
+
+        ctx.agent.get_cgroup_path = mock_get_cgroup_path
 
         container_data: dict[str, Any] = {
             "State": {"Pid": 12345},

--- a/tests/unit/common/test_cgroup.py
+++ b/tests/unit/common/test_cgroup.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+from typing import Literal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ai.backend.common.cgroup import (
+    CgroupController,
+    CgroupResolutionFailed,
+    CgroupVersion,
+    get_container_cgroup_path,
+    get_container_id_of_cgroup,
+    get_container_pids,
+)
+from ai.backend.common.types import PID, ContainerId
+
+CONTAINER_ID = "cd458569541d4a337965ba2be53c3685a0eea188e3c362e9c8fd5de499e4d62d"
+
+
+class TestGetContainerIdOfCgroup:
+    @pytest.mark.parametrize(
+        ("cgroup", "description"),
+        [
+            (f"docker/{CONTAINER_ID}", "docker with the cgroupfs driver"),
+            (f"system.slice/docker-{CONTAINER_ID}.scope", "docker with the systemd driver"),
+            (f"machine.slice/libpod-{CONTAINER_ID}.scope", "rootful podman"),
+            (
+                f"machine.slice/libpod-{CONTAINER_ID}.scope/container",
+                "podman with a container leaf",
+            ),
+            (f"machine.slice/libpod-{CONTAINER_ID}.scope/conmon", "podman with a conmon leaf"),
+            (
+                f"user.slice/user-1000.slice/session-1.scope/libpod-payload-{CONTAINER_ID}",
+                "podman with split cgroups",
+            ),
+            (f"/system.slice/docker-{CONTAINER_ID}.scope", "a leading slash"),
+            (f"crio-{CONTAINER_ID}.scope", "cri-o"),
+        ],
+    )
+    def test_extracts_container_id(self, cgroup: str, description: str) -> None:
+        assert get_container_id_of_cgroup(cgroup) == CONTAINER_ID
+
+    @pytest.mark.parametrize(
+        ("cgroup", "description"),
+        [
+            ("system.slice/sshd.service", "a cgroup owned by a host service"),
+            ("/", "the root cgroup"),
+            ("", "an empty cgroup path"),
+            ("machine.slice/libpod-not-a-hex-id.scope", "a non-hexadecimal identifier"),
+            ("machine.slice/libpod-abc.scope", "an identifier shorter than 12 characters"),
+            ("container", "only an interposed leaf name"),
+        ],
+    )
+    def test_returns_none_for_non_container_cgroup(self, cgroup: str, description: str) -> None:
+        assert get_container_id_of_cgroup(cgroup) is None
+
+
+class TestGetContainerCgroupPath:
+    async def test_joins_mount_point_with_the_cgroup_of_the_main_process(self) -> None:
+        with (
+            patch(
+                "ai.backend.common.cgroup.get_container_main_pid",
+                AsyncMock(return_value=PID(1234)),
+            ),
+            patch(
+                "ai.backend.common.cgroup.get_cgroup_mount_point",
+                return_value=Path("/sys/fs/cgroup"),
+            ),
+            patch(
+                "ai.backend.common.cgroup.get_cgroup_of_pid",
+                return_value=f"machine.slice/libpod-{CONTAINER_ID}.scope",
+            ),
+        ):
+            resolved = await get_container_cgroup_path(
+                "2", CgroupController.MEMORY, ContainerId(CONTAINER_ID)
+            )
+
+        assert resolved == Path(f"/sys/fs/cgroup/machine.slice/libpod-{CONTAINER_ID}.scope")
+
+    async def test_passes_the_controller_through_to_both_lookups(self) -> None:
+        with (
+            patch(
+                "ai.backend.common.cgroup.get_container_main_pid",
+                AsyncMock(return_value=PID(1234)),
+            ),
+            patch(
+                "ai.backend.common.cgroup.get_cgroup_mount_point",
+                return_value=Path("/sys/fs/cgroup"),
+            ) as mount_point_mock,
+            patch("ai.backend.common.cgroup.get_cgroup_of_pid", return_value="docker/x") as of_pid,
+        ):
+            await get_container_cgroup_path("1", CgroupController.BLKIO, ContainerId(CONTAINER_ID))
+
+        mount_point_mock.assert_called_once_with("1", CgroupController.BLKIO)
+        of_pid.assert_called_once_with(CgroupController.BLKIO, PID(1234))
+
+    async def test_propagates_resolution_failure(self) -> None:
+        with patch(
+            "ai.backend.common.cgroup.get_container_main_pid",
+            AsyncMock(side_effect=CgroupResolutionFailed("no running process")),
+        ):
+            with pytest.raises(CgroupResolutionFailed):
+                await get_container_cgroup_path(
+                    "2", CgroupController.MEMORY, ContainerId(CONTAINER_ID)
+                )
+
+
+class TestGetContainerPids:
+    @pytest.mark.parametrize(
+        ("version", "driver", "procs_filename"),
+        [
+            ("2", "systemd", "cgroup.procs"),
+            ("2", "cgroupfs", "cgroup.procs"),
+            ("1", "systemd", "tasks"),
+            ("1", "cgroupfs", "tasks"),
+        ],
+    )
+    async def test_reads_the_pid_list_of_the_resolved_cgroup(
+        self,
+        tmp_path: Path,
+        version: Literal["1", "2"],
+        driver: Literal["systemd", "cgroupfs"],
+        procs_filename: str,
+    ) -> None:
+        (tmp_path / procs_filename).write_text("101\n202\n303\n")
+        with (
+            patch(
+                "ai.backend.common.cgroup.get_docker_cgroup_version",
+                AsyncMock(return_value=CgroupVersion(version, driver)),
+            ),
+            patch(
+                "ai.backend.common.cgroup.get_container_cgroup_path",
+                AsyncMock(return_value=tmp_path),
+            ),
+        ):
+            pids = await get_container_pids(ContainerId(CONTAINER_ID))
+
+        assert pids == [101, 202, 303]
+
+    async def test_resolves_the_cgroup_with_the_pids_controller(self, tmp_path: Path) -> None:
+        (tmp_path / "cgroup.procs").write_text("")
+        with (
+            patch(
+                "ai.backend.common.cgroup.get_docker_cgroup_version",
+                AsyncMock(return_value=CgroupVersion("2", "systemd")),
+            ),
+            patch(
+                "ai.backend.common.cgroup.get_container_cgroup_path",
+                AsyncMock(return_value=tmp_path),
+            ) as cgroup_path_mock,
+        ):
+            await get_container_pids(ContainerId(CONTAINER_ID))
+
+        cgroup_path_mock.assert_called_once_with(
+            "2", CgroupController.PIDS, ContainerId(CONTAINER_ID)
+        )


### PR DESCRIPTION
This is an auto-generated backport of #13796 to the 26.8 release.