### PR TITLE
feat(BA-7182): name the over-quota slots in scheduling history

### DIFF
--- a/changes/13815.enhance.md
+++ b/changes/13815.enhance.md
@@ -1,0 +1,1 @@
+Name the resource slots that exceeded a quota in scheduling history, along with the current usage, the requested amount, and how far over the limit each one is

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
@@ -51,10 +51,10 @@ class SchedulingValidationError(SchedulingError, web.HTTPPreconditionFailed):
 def _format_excesses(excesses: Sequence[SlotExcess]) -> str:
     """One indented line per over-quota slot, with the numbers that made it fail."""
     lines: list[str] = []
-    for excess in excesses:
+    for exceeded in excesses:
         lines.append(
-            f"  - {excess.slot_name}: used {excess.used} + requested {excess.requested}"
-            f" > limit {excess.limit} (over by {excess.excess})"
+            f"  - {exceeded.slot_name}: used {exceeded.used} + requested {exceeded.requested}"
+            f" > limit {exceeded.limit} (over by {exceeded.excess})"
         )
     return "\n".join(lines)
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Sequence
 from datetime import datetime
+from decimal import Decimal
 from typing import override
 
 from aiohttp import web
@@ -48,13 +49,21 @@ class SchedulingValidationError(SchedulingError, web.HTTPPreconditionFailed):
         raise NotImplementedError
 
 
+def _format_amount(amount: Decimal) -> str:
+    """Drop the trailing zeros the DB numeric type carries, without going scientific."""
+    return f"{amount.normalize():f}"
+
+
 def _format_excesses(excesses: Sequence[SlotExcess]) -> str:
     """One indented line per over-quota slot, with the numbers that made it fail."""
     lines: list[str] = []
     for exceeded in excesses:
         lines.append(
-            f"  - {exceeded.slot_name}: used {exceeded.used} + requested {exceeded.requested}"
-            f" > limit {exceeded.limit} (over by {exceeded.excess})"
+            f"  - {exceeded.slot_name}:"
+            f" used {_format_amount(exceeded.used)}"
+            f" + requested {_format_amount(exceeded.requested)}"
+            f" > limit {_format_amount(exceeded.limit)}"
+            f" (over by {_format_amount(exceeded.excess)})"
         )
     return "\n".join(lines)
 

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/exceptions.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from datetime import datetime
-from decimal import Decimal
 from typing import override
 
 from aiohttp import web
@@ -16,8 +15,8 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
-from ai.backend.common.identifier.resource_slot import ResourceSlotName
 from ai.backend.manager.sokovan.scheduler.exceptions import SchedulingError
+from ai.backend.manager.views.sokovan.snapshot import SlotExcess
 
 
 class SchedulingValidationError(SchedulingError, web.HTTPPreconditionFailed):
@@ -49,8 +48,15 @@ class SchedulingValidationError(SchedulingError, web.HTTPPreconditionFailed):
         raise NotImplementedError
 
 
-def _format_slots(slots: Mapping[ResourceSlotName, Decimal]) -> str:
-    return " ".join(f"{k}={v}" for k, v in slots.items() if v)
+def _format_excesses(excesses: Sequence[SlotExcess]) -> str:
+    """One indented line per over-quota slot, with the numbers that made it fail."""
+    lines: list[str] = []
+    for excess in excesses:
+        lines.append(
+            f"  - {excess.slot_name}: used {excess.used} + requested {excess.requested}"
+            f" > limit {excess.limit} (over by {excess.excess})"
+        )
+    return "\n".join(lines)
 
 
 class ConcurrencyLimitExceeded(SchedulingValidationError):
@@ -112,16 +118,16 @@ class UserResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/user-resource-quota-exceeded"
     error_title = "User resource quota exceeded."
 
-    _quota_slots: Mapping[ResourceSlotName, Decimal]
+    _excesses: Sequence[SlotExcess]
 
-    def __init__(self, *, quota_slots: Mapping[ResourceSlotName, Decimal]) -> None:
-        self._quota_slots = quota_slots
+    def __init__(self, *, excesses: Sequence[SlotExcess]) -> None:
+        self._excesses = list(excesses)
         super().__init__(self.summary())
 
     @override
     def summary(self) -> str:
         return (
-            f"Your default-keypair resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+            f"Your default-keypair resource quota is exceeded.\n{_format_excesses(self._excesses)}"
         )
 
     @override
@@ -139,15 +145,15 @@ class ProjectResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/group-resource-quota-exceeded"
     error_title = "Project resource quota exceeded."
 
-    _quota_slots: Mapping[ResourceSlotName, Decimal]
+    _excesses: Sequence[SlotExcess]
 
-    def __init__(self, *, quota_slots: Mapping[ResourceSlotName, Decimal]) -> None:
-        self._quota_slots = quota_slots
+    def __init__(self, *, excesses: Sequence[SlotExcess]) -> None:
+        self._excesses = list(excesses)
         super().__init__(self.summary())
 
     @override
     def summary(self) -> str:
-        return f"Your project resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+        return f"Your project resource quota is exceeded.\n{_format_excesses(self._excesses)}"
 
     @override
     def error_code(self) -> ErrorCode:
@@ -164,15 +170,15 @@ class DomainResourceQuotaExceeded(SchedulingValidationError):
     error_type = "https://api.backend.ai/probs/domain-resource-quota-exceeded"
     error_title = "Domain resource quota exceeded."
 
-    _quota_slots: Mapping[ResourceSlotName, Decimal]
+    _excesses: Sequence[SlotExcess]
 
-    def __init__(self, *, quota_slots: Mapping[ResourceSlotName, Decimal]) -> None:
-        self._quota_slots = quota_slots
+    def __init__(self, *, excesses: Sequence[SlotExcess]) -> None:
+        self._excesses = list(excesses)
         super().__init__(self.summary())
 
     @override
     def summary(self) -> str:
-        return f"Your domain resource quota is exceeded. ({_format_slots(self._quota_slots)})"
+        return f"Your domain resource quota is exceeded.\n{_format_excesses(self._excesses)}"
 
     @override
     def error_code(self) -> ErrorCode:

--- a/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/resource_policy.py
+++ b/src/ai/backend/manager/sokovan/scheduler/provisioner/validators/resource_policy.py
@@ -54,8 +54,9 @@ class ResourcePolicyValidator(ValidatorRule):
             user_allocation = occupancy.by_user.get(
                 workload.meta.owner.user_uuid, UserResourceAllocation.empty()
             )
-            if user_allocation.exceeds(request, user_limit):
-                errors.append(UserResourceQuotaExceeded(quota_slots=user_limit.slots))
+            user_excesses = user_allocation.exceeded_slots(request, user_limit)
+            if user_excesses:
+                errors.append(UserResourceQuotaExceeded(excesses=user_excesses))
             if user_allocation.count_exceeds(request, user_limit):
                 if workload.is_private:
                     max_count, session_type = user_limit.max_sftp_session_count, "SFTP"
@@ -73,16 +74,18 @@ class ResourcePolicyValidator(ValidatorRule):
             project_allocation = occupancy.by_project.get(
                 workload.meta.owner.project_id, ResourceAllocation.empty()
             )
-            if project_allocation.exceeds(request, project_limit):
-                errors.append(ProjectResourceQuotaExceeded(quota_slots=project_limit.slots))
+            project_excesses = project_allocation.exceeded_slots(request, project_limit)
+            if project_excesses:
+                errors.append(ProjectResourceQuotaExceeded(excesses=project_excesses))
 
         domain_limit = policy.by_domain.get(workload.meta.owner.domain_id)
         if domain_limit is not None:
             domain_allocation = occupancy.by_domain.get(
                 workload.meta.owner.domain_id, ResourceAllocation.empty()
             )
-            if domain_allocation.exceeds(request, domain_limit):
-                errors.append(DomainResourceQuotaExceeded(quota_slots=domain_limit.slots))
+            domain_excesses = domain_allocation.exceeded_slots(request, domain_limit)
+            if domain_excesses:
+                errors.append(DomainResourceQuotaExceeded(excesses=domain_excesses))
 
         if errors:
             if len(errors) == 1:

--- a/src/ai/backend/manager/views/sokovan/snapshot.py
+++ b/src/ai/backend/manager/views/sokovan/snapshot.py
@@ -50,6 +50,20 @@ class SlotAllocation:
 
 
 @dataclass(frozen=True)
+class SlotExcess:
+    """One slot whose occupancy plus the new request passes a scope's quota."""
+
+    slot_name: ResourceSlotName
+    used: Decimal
+    requested: Decimal
+    limit: Decimal
+
+    @property
+    def excess(self) -> Decimal:
+        return self.used + self.requested - self.limit
+
+
+@dataclass(frozen=True)
 class ResourceLimit:
     """Slot quota owned by one scope (project/domain)."""
 
@@ -76,20 +90,29 @@ class ResourceAllocation:
     def empty(cls) -> ResourceAllocation:
         return ResourceAllocation(slots={})
 
-    def exceeds(self, request: ResourceRequest, limit: ResourceLimit) -> bool:
-        """True if allocated + requested exceeds the slot quota on any slot.
+    def exceeded_slots(self, request: ResourceRequest, limit: ResourceLimit) -> list[SlotExcess]:
+        """Every slot where allocated + requested exceeds the slot quota.
 
-        Missing keys count as zero on every side, matching the previous
-        ``ResourceSlot`` union-key comparison semantics.
+        Empty when the request fits. Missing keys count as zero on every side,
+        matching the previous ``ResourceSlot`` union-key comparison semantics.
         """
         slot_names = self.slots.keys() | request.slots.keys() | limit.slots.keys()
-        for slot_name in slot_names:
+        excesses: list[SlotExcess] = []
+        for slot_name in sorted(slot_names):
             allocation = self.slots.get(slot_name)
             allocated = allocation.allocated if allocation is not None else Decimal(0)
             requested = request.slots.get(slot_name, Decimal(0))
-            if allocated + requested > limit.slots.get(slot_name, Decimal(0)):
-                return True
-        return False
+            quota = limit.slots.get(slot_name, Decimal(0))
+            if allocated + requested > quota:
+                excesses.append(
+                    SlotExcess(
+                        slot_name=slot_name,
+                        used=allocated,
+                        requested=requested,
+                        limit=quota,
+                    )
+                )
+        return excesses
 
     def _merged_slots(self, request: ResourceRequest) -> dict[ResourceSlotName, SlotAllocation]:
         """Requested slots accumulate as reservations (the session is not running yet)."""

--- a/tests/unit/manager/sokovan/scheduler/provisioner/validators/test_resource_policy.py
+++ b/tests/unit/manager/sokovan/scheduler/provisioner/validators/test_resource_policy.py
@@ -83,6 +83,26 @@ class TestUserSlotQuota:
         with pytest.raises(UserResourceQuotaExceeded):
             validator.validate(snapshot, workload)
 
+    def test_message_reports_only_the_exceeded_slot(
+        self,
+        validator: ResourcePolicyValidator,
+        workload_factory: WorkloadFactory,
+        snapshot_factory: SnapshotFactory,
+        occupancy_factory: OccupancyFactory,
+    ) -> None:
+        """The recorded detail names the slot, its occupancy, and the amount over."""
+        workload = workload_factory(slots={"cpu": "4", "mem": "8192"})
+        snapshot = snapshot_factory(
+            user_limit=_user_limit({"cpu": "10", "mem": "20480"}),
+            occupancy=occupancy_factory(user_slots={"cpu": ("4", "3"), "mem": ("8192", "0")}),
+        )
+
+        with pytest.raises(UserResourceQuotaExceeded) as exc_info:
+            validator.validate(snapshot, workload)
+        summary = exc_info.value.summary()
+        assert "\n  - cpu: used 7 + requested 4 > limit 10 (over by 1)" in summary
+        assert "mem" not in summary
+
     def test_passes_when_no_policy(
         self,
         validator: ResourcePolicyValidator,


### PR DESCRIPTION
## Summary

- Quota failures in scheduling history reported only the scope's whole slot quota (`cpu=10 mem=20480`), so user could not tell **which** slot blocked the session, nor by how much.
- `ResourceAllocation.exceeds()` → `exceeded_slots()`, returning a `SlotExcess` per over-quota slot (name, current usage, requested amount, limit, excess). The user / project / domain quota exceptions render one indented line per slot.
- Before: `Your default-keypair resource quota is exceeded. (cpu=10 mem=20480)`
- After:
  ```
  Your default-keypair resource quota is exceeded.
    - cpu: used 7 + requested 4 > limit 10 (over by 1)
    - cuda.device: used 0 + requested 2 > limit 1 (over by 1)
  ```
- Accelerator slots are covered automatically (the check iterates every slot name). `used` is the scope's current occupancy — reservations plus reported usage — so the message now carries the current allocation next to the limit.

## Test plan

- [x] `pants test tests/unit/manager/sokovan/scheduler/provisioner/validators/::`
- [x] `pants check` (mypy) on the changed files
- [ ] Verify the rendered detail on a live scheduling-history entry for a quota-blocked session

Resolves BA-7182