### PR TITLE
feat(BA-7157): add the vLLM --enable-prompt-tokens-details preset

### DIFF
--- a/changes/13816.feature.md
+++ b/changes/13816.feature.md
@@ -1,0 +1,1 @@
+Add a `--enable-prompt-tokens-details` runtime variant preset for vLLM so prefix cache hits can be reported in the usage payload

--- a/fixtures/manager/example-runtime-variant-presets.json
+++ b/fixtures/manager/example-runtime-variant-presets.json
@@ -780,6 +780,21 @@
       }
     },
     {
+      "runtime_variant_name": "vllm",
+      "name": "enable-prompt-tokens-details",
+      "description": "Report prompt token details (e.g. prefix cache hits) in usage.",
+      "rank": 3000,
+      "preset_target": "args",
+      "value_type": "flag",
+      "default_value": null,
+      "key": "--enable-prompt-tokens-details",
+      "category": "monitoring",
+      "display_name": "Enable Prompt Tokens Details",
+      "ui_option": {
+        "ui_type": "checkbox"
+      }
+    },
+    {
       "runtime_variant_name": "sglang",
       "name": "model",
       "description": "HuggingFace model name or local path.",

--- a/src/ai/backend/install/fixtures/example-runtime-variant-presets.json
+++ b/src/ai/backend/install/fixtures/example-runtime-variant-presets.json
@@ -780,6 +780,21 @@
       }
     },
     {
+      "runtime_variant_name": "vllm",
+      "name": "enable-prompt-tokens-details",
+      "description": "Report prompt token details (e.g. prefix cache hits) in usage.",
+      "rank": 3000,
+      "preset_target": "args",
+      "value_type": "flag",
+      "default_value": null,
+      "key": "--enable-prompt-tokens-details",
+      "category": "monitoring",
+      "display_name": "Enable Prompt Tokens Details",
+      "ui_option": {
+        "ui_type": "checkbox"
+      }
+    },
+    {
       "runtime_variant_name": "sglang",
       "name": "model",
       "description": "HuggingFace model name or local path.",

--- a/src/ai/backend/manager/models/alembic/versions/f1a7c3e9b482_seed_vllm_enable_prompt_tokens_details_preset.py
+++ b/src/ai/backend/manager/models/alembic/versions/f1a7c3e9b482_seed_vllm_enable_prompt_tokens_details_preset.py
@@ -1,0 +1,57 @@
+"""seed the vLLM --enable-prompt-tokens-details preset
+
+Adds the single ``enable-prompt-tokens-details`` row for the ``vllm`` runtime
+variant. ``e7b3a1f9c2d4`` seeded the rest of the presets but has already been
+stamped on every existing install, so a new revision is the only way the row
+reaches a running cluster.
+
+Revision ID: f1a7c3e9b482
+Revises: e7b2c9f04d31
+Create Date: 2026-08-19
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a7c3e9b482"
+down_revision = "e7b2c9f04d31"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.get_bind().execute(
+        sa.text("""
+            INSERT INTO runtime_variant_presets
+                (runtime_variant, name, description, rank, preset_target, value_type,
+                 default_value, key, category, display_name, ui_option)
+            SELECT
+                rv.id,
+                'enable-prompt-tokens-details',
+                'Report prompt token details (e.g. prefix cache hits) in usage.',
+                3000,
+                'args',
+                'flag',
+                NULL,
+                '--enable-prompt-tokens-details',
+                'monitoring',
+                'Enable Prompt Tokens Details',
+                CAST('{"ui_type": "checkbox"}' AS JSONB)
+            FROM runtime_variants rv
+            WHERE rv.name = 'vllm'
+            ON CONFLICT ON CONSTRAINT uq_runtime_variant_presets_variant_name DO NOTHING
+        """)
+    )
+
+
+def downgrade() -> None:
+    op.get_bind().execute(
+        sa.text("""
+            DELETE FROM runtime_variant_presets
+            WHERE name = 'enable-prompt-tokens-details'
+              AND runtime_variant = (SELECT id FROM runtime_variants WHERE name = 'vllm')
+        """)
+    )


### PR DESCRIPTION
## Summary

- Seed one `RuntimeVariantPreset` row for the `vllm` runtime variant — `--enable-prompt-tokens-details`, rank 3000, category `monitoring`, `value_type: flag` / `ui_type: checkbox` — so the flag renders as a checkbox in the WebUI runtime parameter form. No WebUI change needed; `RuntimeParameterFormSection` renders whatever `runtimeVariantPresets` returns.
- With the flag on, vLLM fills `usage.prompt_tokens_details.cached_tokens`, which is the only way to see whether `--enable-prefix-caching` (already a preset) is actually hitting. Until now the only way to set it was `VLLM_EXTRA_ARGS=--enable-prompt-tokens-details` — an unvalidated free-form string that fails at vLLM process startup on a typo, routed through the legacy `LegacyInferenceEnvTranslator` path.
- Ships as a new alembic revision (`f1a7c3e9b482`) rather than an edit to the existing seed revision `e7b3a1f9c2d4`, which shipped in 26.4.4 and is already stamped on every install — editing it would reach fresh installs only.
- Same row added to both example fixtures so fresh `fixture populate` installs match; the migration insert is `ON CONFLICT DO NOTHING`, so the two paths never collide.

## Test plan

- [x] `alembic heads` — single head
- [x] `alembic upgrade head` → row present; `downgrade -1` → row gone; re-`upgrade` → row back
- [x] Re-running the insert hits `ON CONFLICT DO NOTHING` (`INSERT 0 0`, no duplicate)
- [x] `./bai runtime-variant-preset search --name-contains prompt-tokens` returns the row with `value_type: flag`, `ui_type: checkbox`
- [x] GQL `runtimeVariantPresets` (the WebUI path) returns `uiOption.uiType: checkbox`, `targetSpec.key: --enable-prompt-tokens-details`
- [x] `pants fmt / lint / check` pass
- [ ] WebUI shows the checkbox in the model service runtime parameter form

Resolves BA-7157