### PR TITLE
fix(BA-7377): take the kernel container log driver from configuration

### DIFF
--- a/changes/13817.fix.md
+++ b/changes/13817.fix.md
@@ -1,0 +1,1 @@
+Allow configuring the kernel container log driver instead of hardcoding the Docker-only `local` driver.

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -78,7 +78,6 @@ class ContainerSandboxType(enum.StrEnum):
 class ContainerLogDriver(enum.StrEnum):
     LOCAL = "local"
     JSON_FILE = "json-file"
-    JOURNALD = "journald"
 
 
 class ScratchType(enum.StrEnum):
@@ -1933,9 +1932,7 @@ class ContainerLogsConfig(BaseConfigSchema):
                 "'local' is Docker-only and stores logs in an efficient binary format. "
                 "'json-file' is accepted by both Docker and Podman, but Podman keeps a "
                 "single size-capped log per container, so only 'max-length' takes effect "
-                "there while file count and compression have no equivalent. "
-                "'journald' does not support size-based rotation, "
-                "so 'max-length' is not applied to it."
+                "there while file count and compression have no equivalent."
             ),
             added_version="26.4.10",
             example=ConfigExample(local="local", prod="local"),

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -75,6 +75,12 @@ class ContainerSandboxType(enum.StrEnum):
     JAIL = "jail"
 
 
+class ContainerLogDriver(enum.StrEnum):
+    LOCAL = "local"
+    JSON_FILE = "json-file"
+    JOURNALD = "journald"
+
+
 class ScratchType(enum.StrEnum):
     HOSTDIR = "hostdir"
     HOSTFILE = "hostfile"
@@ -1916,6 +1922,25 @@ class ResourceConfig(BaseConfigSchema):
 
 
 class ContainerLogsConfig(BaseConfigSchema):
+    driver: Annotated[
+        ContainerLogDriver,
+        Field(
+            default=ContainerLogDriver.LOCAL,
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Log driver used for kernel containers. "
+                "'local' is Docker-only and stores logs in an efficient binary format. "
+                "'json-file' is accepted by both Docker and Podman, but Podman keeps a "
+                "single size-capped log per container, so only 'max-length' takes effect "
+                "there while file count and compression have no equivalent. "
+                "'journald' does not support size-based rotation, "
+                "so 'max-length' is not applied to it."
+            ),
+            added_version="26.4.10",
+            example=ConfigExample(local="local", prod="local"),
+        ),
+    ]
     max_length: Annotated[
         BinarySizeField,
         Field(

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -41,7 +41,7 @@ from aiomonitor.task import preserve_termination_log
 from aiotools import TaskGroup
 from async_timeout import timeout
 from cachetools import LRUCache
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field
 
 from ai.backend.agent.agent import (
     ACTIVE_STATUS_SET,
@@ -211,8 +211,8 @@ known_glibc_distros: Final[dict[float, str]] = {
 
 class LogDriverOptions(BaseModel):
     """
-    Rotation options for the drivers that keep their own on-disk log files.
-    The Docker API takes every value as a string, under kebab-case keys.
+    Log rotation options. The Docker API takes every value as a string,
+    under kebab-case keys.
     """
 
     max_size: str = Field(serialization_alias="max-size")
@@ -224,34 +224,23 @@ class LogConfig(BaseModel):
     """
     The ``HostConfig.LogConfig`` payload of a container creation request,
     keyed in PascalCase as the Docker API expects.
-    Drivers that delegate log storage to the host carry no options at all.
     """
 
     type: ContainerLogDriver = Field(serialization_alias="Type")
-    config: LogDriverOptions | None = Field(default=None, serialization_alias="Config")
-
-    @field_serializer("config")
-    def _serialize_config(self, config: LogDriverOptions | None) -> dict[str, str]:
-        """Keep ``Config`` present as an empty object rather than dropping the key."""
-        if config is None:
-            return {}
-        return config.model_dump(by_alias=True)
+    config: LogDriverOptions = Field(serialization_alias="Config")
 
 
 def _build_log_config(local_config: AgentUnifiedConfig) -> LogConfig:
     """
     Build the ``HostConfig.LogConfig`` payload for a kernel container.
 
-    Only the drivers that keep their own on-disk files honor size-based rotation;
-    the others delegate log storage to the host and take no rotation options.
+    Every supported driver keeps its own on-disk log files, so the configured
+    total size is split across a fixed number of rotated files.
     """
     container_logs = local_config.container_logs
-    driver = container_logs.driver
-    if driver not in (ContainerLogDriver.LOCAL, ContainerLogDriver.JSON_FILE):
-        return LogConfig(type=driver)
     file_size = BinarySize(container_logs.max_length // _CONTAINER_LOG_FILE_COUNT)
     return LogConfig(
-        type=driver,
+        type=container_logs.driver,
         config=LogDriverOptions(
             max_size=f"{file_size:s}",
             max_file=str(_CONTAINER_LOG_FILE_COUNT),

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -41,6 +41,7 @@ from aiomonitor.task import preserve_termination_log
 from aiotools import TaskGroup
 from async_timeout import timeout
 from cachetools import LRUCache
+from pydantic import BaseModel, Field, field_serializer
 
 from ai.backend.agent.agent import (
     ACTIVE_STATUS_SET,
@@ -49,7 +50,12 @@ from ai.backend.agent.agent import (
     AgentClass,
     ScanImagesResult,
 )
-from ai.backend.agent.config.unified import AgentUnifiedConfig, ContainerSandboxType, ScratchType
+from ai.backend.agent.config.unified import (
+    AgentUnifiedConfig,
+    ContainerLogDriver,
+    ContainerSandboxType,
+    ScratchType,
+)
 from ai.backend.agent.errors import (
     ContainerCreationError,
     InvalidArgumentError,
@@ -182,6 +188,9 @@ _SECCOMP_PROFILE_FILENAME: Final[str] = "seccomp.json"
 _SECCOMP_PATH_ENGINES: Final[frozenset[str]] = frozenset({"Podman Engine"})
 # Cached per container, so the capacity is the number of containers an agent may host.
 _CGROUP_PATH_CACHE_SIZE: Final[int] = 2048
+
+# Docker splits the configured total container-log size across this many files.
+_CONTAINER_LOG_FILE_COUNT: Final[int] = 5
 # Controllers the intrinsic plugins read, resolved together from a single inspect.
 _TRACKED_CGROUP_CONTROLLERS: Final[tuple[CgroupController, ...]] = (
     CgroupController.CPUACCT,
@@ -198,6 +207,57 @@ known_glibc_distros: Final[dict[float, str]] = {
     2.35: "ubuntu22.04",
     2.39: "ubuntu24.04",
 }
+
+
+class LogDriverOptions(BaseModel):
+    """
+    Rotation options for the drivers that keep their own on-disk log files.
+    The Docker API takes every value as a string, under kebab-case keys.
+    """
+
+    max_size: str = Field(serialization_alias="max-size")
+    max_file: str = Field(serialization_alias="max-file")
+    compress: str = Field(serialization_alias="compress")
+
+
+class LogConfig(BaseModel):
+    """
+    The ``HostConfig.LogConfig`` payload of a container creation request,
+    keyed in PascalCase as the Docker API expects.
+    Drivers that delegate log storage to the host carry no options at all.
+    """
+
+    type: ContainerLogDriver = Field(serialization_alias="Type")
+    config: LogDriverOptions | None = Field(default=None, serialization_alias="Config")
+
+    @field_serializer("config")
+    def _serialize_config(self, config: LogDriverOptions | None) -> dict[str, str]:
+        """Keep ``Config`` present as an empty object rather than dropping the key."""
+        if config is None:
+            return {}
+        return config.model_dump(by_alias=True)
+
+
+def _build_log_config(local_config: AgentUnifiedConfig) -> LogConfig:
+    """
+    Build the ``HostConfig.LogConfig`` payload for a kernel container.
+
+    Only the drivers that keep their own on-disk files honor size-based rotation;
+    the others delegate log storage to the host and take no rotation options.
+    """
+    container_logs = local_config.container_logs
+    driver = container_logs.driver
+    if driver not in (ContainerLogDriver.LOCAL, ContainerLogDriver.JSON_FILE):
+        return LogConfig(type=driver)
+    file_size = BinarySize(container_logs.max_length // _CONTAINER_LOG_FILE_COUNT)
+    return LogConfig(
+        type=driver,
+        config=LogDriverOptions(
+            max_size=f"{file_size:s}",
+            max_file=str(_CONTAINER_LOG_FILE_COUNT),
+            compress="false",
+        ),
+    )
 
 
 def _parse_distro_from_ldd_output(log_chunks: Sequence[str]) -> str | None:
@@ -1208,10 +1268,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     ],
                 )
 
-        container_log_size = self.local_config.container_logs.max_length
-        container_log_file_count = 5
-        container_log_file_size = BinarySize(container_log_size // container_log_file_count)
-
         if self.image_ref.is_local:
             image = self.image_ref.short
         else:
@@ -1255,16 +1311,9 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     get_safe_ulimit("nofile", 1048576, 1048576),
                     get_safe_ulimit("memlock", -1, -1),
                 ],
-                "LogConfig": {
-                    "Type": "local",  # for efficient docker-specific storage
-                    "Config": {
-                        # these fields must be str
-                        # (ref: https://docs.docker.com/config/containers/logging/local/)
-                        "max-size": f"{container_log_file_size:s}",
-                        "max-file": str(container_log_file_count),
-                        "compress": "false",
-                    },
-                },
+                "LogConfig": _build_log_config(self.local_config).model_dump(
+                    mode="json", by_alias=True
+                ),
             },
         }
 

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -11,8 +11,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiodocker.exceptions import DockerError
 
+from ai.backend.agent.config.unified import (
+    AgentUnifiedConfig,
+    ContainerLogDriver,
+    ContainerLogsConfig,
+)
 from ai.backend.agent.docker.agent import (
     DockerKernelCreationContext,
+    LogDriverOptions,
+    _build_log_config,
     _parse_distro_from_ldd_output,
 )
 
@@ -287,3 +294,56 @@ class TestAttachAdditionalNetworks:
 
         with pytest.raises(DockerError):
             await context._attach_additional_networks(docker, container, {"bridge"})
+
+
+def _log_config(driver: ContainerLogDriver) -> AgentUnifiedConfig:
+    """Only ``container_logs`` is read, so leave the rest of the schema unpopulated."""
+    fields: dict[str, Any] = {
+        "container_logs": ContainerLogsConfig.model_validate({
+            "driver": driver,
+            "max_length": "10M",
+        }),
+    }
+    return AgentUnifiedConfig.model_construct(**fields)
+
+
+class TestBuildLogConfig:
+    @pytest.mark.parametrize(
+        "driver",
+        [ContainerLogDriver.LOCAL, ContainerLogDriver.JSON_FILE],
+    )
+    def test_rotating_drivers_carry_size_options(self, driver: ContainerLogDriver) -> None:
+        log_config = _build_log_config(_log_config(driver))
+
+        assert log_config.type == driver
+        assert log_config.config == LogDriverOptions(max_size="2m", max_file="5", compress="false")
+
+    def test_journald_takes_no_options(self) -> None:
+        log_config = _build_log_config(_log_config(ContainerLogDriver.JOURNALD))
+
+        assert log_config.type == ContainerLogDriver.JOURNALD
+        assert log_config.config is None
+
+    @pytest.mark.parametrize(
+        ("driver", "expected"),
+        [
+            (
+                ContainerLogDriver.JSON_FILE,
+                {
+                    "Type": "json-file",
+                    "Config": {"max-size": "2m", "max-file": "5", "compress": "false"},
+                },
+            ),
+            (ContainerLogDriver.JOURNALD, {"Type": "journald", "Config": {}}),
+        ],
+    )
+    def test_dumped_payload_uses_docker_api_keys(
+        self, driver: ContainerLogDriver, expected: dict[str, Any]
+    ) -> None:
+        """The dump is what actually goes into the container creation request."""
+        log_config = _build_log_config(_log_config(driver))
+
+        dumped = log_config.model_dump(mode="json", by_alias=True)
+
+        assert dumped == expected
+        assert type(dumped["Type"]) is str

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -312,21 +312,22 @@ class TestBuildLogConfig:
         "driver",
         [ContainerLogDriver.LOCAL, ContainerLogDriver.JSON_FILE],
     )
-    def test_rotating_drivers_carry_size_options(self, driver: ContainerLogDriver) -> None:
+    def test_drivers_carry_size_options(self, driver: ContainerLogDriver) -> None:
         log_config = _build_log_config(_log_config(driver))
 
         assert log_config.type == driver
         assert log_config.config == LogDriverOptions(max_size="2m", max_file="5", compress="false")
 
-    def test_journald_takes_no_options(self) -> None:
-        log_config = _build_log_config(_log_config(ContainerLogDriver.JOURNALD))
-
-        assert log_config.type == ContainerLogDriver.JOURNALD
-        assert log_config.config is None
-
     @pytest.mark.parametrize(
         ("driver", "expected"),
         [
+            (
+                ContainerLogDriver.LOCAL,
+                {
+                    "Type": "local",
+                    "Config": {"max-size": "2m", "max-file": "5", "compress": "false"},
+                },
+            ),
             (
                 ContainerLogDriver.JSON_FILE,
                 {
@@ -334,7 +335,6 @@ class TestBuildLogConfig:
                     "Config": {"max-size": "2m", "max-file": "5", "compress": "false"},
                 },
             ),
-            (ContainerLogDriver.JOURNALD, {"Type": "journald", "Config": {}}),
         ],
     )
     def test_dumped_payload_uses_docker_api_keys(


### PR DESCRIPTION
## Summary

- The kernel container config hardcoded `LogConfig.Type = "local"`, a driver only Docker implements. Runtimes serving the Docker-compatible API without it reject the create request, so every compute session fails to start.
- Adds `container-logs.driver` to the agent configuration (`local` | `json-file`), defaulting to `local` so existing Docker deployments are unaffected.
- The payload is now built through a typed `LogConfig` model and dumped to a plain dict at the point it enters the container creation request, so `update_nested_dict` merging and JSON encoding are unchanged.

## Verification matrix

| Driver | Docker | Podman |
|---|---|---|
| `local` (default) | ✅ session runs — `{"Type":"local","Config":{"max-size":"2m","max-file":"5","compress":"false"}}`, identical to the previous hardcoded payload | ❌ rejected at create — `HTTP 500 invalid log driver: invalid argument` (the bug this PR fixes) |
| `json-file` | ✅ session runs — `{"Type":"json-file","Config":{"max-size":"2m","max-file":"5","compress":"false"}}`; `session logs` returns kernel output | ⚠️ accepted at create (`HTTP 201`); full session not re-run here |

### How the rotation options land

| | `max-size` (from `max-length`) | `max-file` | `compress` |
|---|---|---|---|
| Docker, `local` / `json-file` | applied | applied (5 files) | applied |
| Podman, `json-file` | applied (`Size: "2MB"`) | no equivalent | no equivalent |

Podman keeps a single `ctr.log` per container and caps it by size only, so `max-length` takes
effect but the "split 10M across 5 files" half of the intent does not. This is documented on the
`container-logs.driver` config description.

**How each cell was produced**

- **Docker** — Backend.AI agent 26.8.0rc1 on OrbStack (kernel 7.0.14, aarch64). Sessions created through `./bai session enqueue` against a live local stack, then `docker inspect <kernel container> --format '{{json .HostConfig.LogConfig}}'`. `agent.toml` was restored and the agent restarted afterwards.
- **Podman** — the `HTTP 500` / `HTTP 201` results are the create-time driver-acceptance measurements from the BA-7377 report (Podman 4.9.3 via `podman.socket`, Ubuntu 24.04, x86_64). They were not re-run as full sessions for this PR.
- `max-size: 2m` is the `container-logs.max-length` default (10M) split across 5 files.

`journald` was considered and dropped: it takes no size-based rotation options at all, which would
have required the log config to carry an optional-and-usually-empty options block for a driver we
could not verify end to end.

## Test plan

- [x] `pants test tests/unit/agent/test_docker_agent.py::TestBuildLogConfig` — per-driver payload and dump keys
- [x] Docker agent, default config — `LogConfig` unchanged from before this PR
- [x] Docker agent, `driver = "json-file"` — session starts and `./bai session logs` works
- [ ] Podman-backed agent, `driver = "json-file"` — end-to-end session run

Resolves BA-7377
