### PR TITLE
fix(BA-7377): take the kernel container log driver from configuration (#13817)

### DIFF
--- a/changes/13817.fix.md
+++ b/changes/13817.fix.md
@@ -1,0 +1,1 @@
+Allow configuring the kernel container log driver instead of hardcoding the Docker-only `local` driver.

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -75,6 +75,11 @@ class ContainerSandboxType(enum.StrEnum):
     JAIL = "jail"
 
 
+class ContainerLogDriver(enum.StrEnum):
+    LOCAL = "local"
+    JSON_FILE = "json-file"
+
+
 class ScratchType(enum.StrEnum):
     HOSTDIR = "hostdir"
     HOSTFILE = "hostfile"
@@ -1922,6 +1927,23 @@ class ResourceConfig(BaseConfigSchema):
 
 
 class ContainerLogsConfig(BaseConfigSchema):
+    driver: Annotated[
+        ContainerLogDriver,
+        Field(
+            default=ContainerLogDriver.LOCAL,
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Log driver used for kernel containers. "
+                "'local' is Docker-only and stores logs in an efficient binary format. "
+                "'json-file' is accepted by both Docker and Podman, but Podman keeps a "
+                "single size-capped log per container, so only 'max-length' takes effect "
+                "there while file count and compression have no equivalent."
+            ),
+            added_version="26.4.10",
+            example=ConfigExample(local="local", prod="local"),
+        ),
+    ]
     max_length: Annotated[
         BinarySizeField,
         Field(

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -41,6 +41,7 @@ from aiomonitor.task import preserve_termination_log
 from aiotools import TaskGroup
 from async_timeout import timeout
 from cachetools import LRUCache
+from pydantic import BaseModel, Field
 
 from ai.backend.agent.agent import (
     ACTIVE_STATUS_SET,
@@ -49,7 +50,12 @@ from ai.backend.agent.agent import (
     AgentClass,
     ScanImagesResult,
 )
-from ai.backend.agent.config.unified import AgentUnifiedConfig, ContainerSandboxType, ScratchType
+from ai.backend.agent.config.unified import (
+    AgentUnifiedConfig,
+    ContainerLogDriver,
+    ContainerSandboxType,
+    ScratchType,
+)
 from ai.backend.agent.errors import (
     ContainerCreationError,
     InvalidArgumentError,
@@ -182,6 +188,9 @@ _SECCOMP_PROFILE_FILENAME: Final[str] = "seccomp.json"
 _SECCOMP_PATH_ENGINES: Final[frozenset[str]] = frozenset({"Podman Engine"})
 # Cached per container, so the capacity is the number of containers an agent may host.
 _CGROUP_PATH_CACHE_SIZE: Final[int] = 2048
+
+# Docker splits the configured total container-log size across this many files.
+_CONTAINER_LOG_FILE_COUNT: Final[int] = 5
 # Controllers the intrinsic plugins read, resolved together from a single inspect.
 _TRACKED_CGROUP_CONTROLLERS: Final[tuple[CgroupController, ...]] = (
     CgroupController.CPUACCT,
@@ -198,6 +207,46 @@ known_glibc_distros: Final[dict[float, str]] = {
     2.35: "ubuntu22.04",
     2.39: "ubuntu24.04",
 }
+
+
+class LogDriverOptions(BaseModel):
+    """
+    Log rotation options. The Docker API takes every value as a string,
+    under kebab-case keys.
+    """
+
+    max_size: str = Field(serialization_alias="max-size")
+    max_file: str = Field(serialization_alias="max-file")
+    compress: str = Field(serialization_alias="compress")
+
+
+class LogConfig(BaseModel):
+    """
+    The ``HostConfig.LogConfig`` payload of a container creation request,
+    keyed in PascalCase as the Docker API expects.
+    """
+
+    type: ContainerLogDriver = Field(serialization_alias="Type")
+    config: LogDriverOptions = Field(serialization_alias="Config")
+
+
+def _build_log_config(local_config: AgentUnifiedConfig) -> LogConfig:
+    """
+    Build the ``HostConfig.LogConfig`` payload for a kernel container.
+
+    Every supported driver keeps its own on-disk log files, so the configured
+    total size is split across a fixed number of rotated files.
+    """
+    container_logs = local_config.container_logs
+    file_size = BinarySize(container_logs.max_length // _CONTAINER_LOG_FILE_COUNT)
+    return LogConfig(
+        type=container_logs.driver,
+        config=LogDriverOptions(
+            max_size=f"{file_size:s}",
+            max_file=str(_CONTAINER_LOG_FILE_COUNT),
+            compress="false",
+        ),
+    )
 
 
 def _parse_distro_from_ldd_output(log_chunks: Sequence[str]) -> str | None:
@@ -1208,10 +1257,6 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     ],
                 )
 
-        container_log_size = self.local_config.container_logs.max_length
-        container_log_file_count = 5
-        container_log_file_size = BinarySize(container_log_size // container_log_file_count)
-
         if self.image_ref.is_local:
             image = self.image_ref.short
         else:
@@ -1255,16 +1300,9 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                     get_safe_ulimit("nofile", 1048576, 1048576),
                     get_safe_ulimit("memlock", -1, -1),
                 ],
-                "LogConfig": {
-                    "Type": "local",  # for efficient docker-specific storage
-                    "Config": {
-                        # these fields must be str
-                        # (ref: https://docs.docker.com/config/containers/logging/local/)
-                        "max-size": f"{container_log_file_size:s}",
-                        "max-file": str(container_log_file_count),
-                        "compress": "false",
-                    },
-                },
+                "LogConfig": _build_log_config(self.local_config).model_dump(
+                    mode="json", by_alias=True
+                ),
             },
         }
 

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -11,8 +11,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiodocker.exceptions import DockerError
 
+from ai.backend.agent.config.unified import (
+    AgentUnifiedConfig,
+    ContainerLogDriver,
+    ContainerLogsConfig,
+)
 from ai.backend.agent.docker.agent import (
     DockerKernelCreationContext,
+    LogDriverOptions,
+    _build_log_config,
     _parse_distro_from_ldd_output,
 )
 
@@ -287,3 +294,56 @@ class TestAttachAdditionalNetworks:
 
         with pytest.raises(DockerError):
             await context._attach_additional_networks(docker, container, {"bridge"})
+
+
+def _log_config(driver: ContainerLogDriver) -> AgentUnifiedConfig:
+    """Only ``container_logs`` is read, so leave the rest of the schema unpopulated."""
+    fields: dict[str, Any] = {
+        "container_logs": ContainerLogsConfig.model_validate({
+            "driver": driver,
+            "max_length": "10M",
+        }),
+    }
+    return AgentUnifiedConfig.model_construct(**fields)
+
+
+class TestBuildLogConfig:
+    @pytest.mark.parametrize(
+        "driver",
+        [ContainerLogDriver.LOCAL, ContainerLogDriver.JSON_FILE],
+    )
+    def test_drivers_carry_size_options(self, driver: ContainerLogDriver) -> None:
+        log_config = _build_log_config(_log_config(driver))
+
+        assert log_config.type == driver
+        assert log_config.config == LogDriverOptions(max_size="2m", max_file="5", compress="false")
+
+    @pytest.mark.parametrize(
+        ("driver", "expected"),
+        [
+            (
+                ContainerLogDriver.LOCAL,
+                {
+                    "Type": "local",
+                    "Config": {"max-size": "2m", "max-file": "5", "compress": "false"},
+                },
+            ),
+            (
+                ContainerLogDriver.JSON_FILE,
+                {
+                    "Type": "json-file",
+                    "Config": {"max-size": "2m", "max-file": "5", "compress": "false"},
+                },
+            ),
+        ],
+    )
+    def test_dumped_payload_uses_docker_api_keys(
+        self, driver: ContainerLogDriver, expected: dict[str, Any]
+    ) -> None:
+        """The dump is what actually goes into the container creation request."""
+        log_config = _build_log_config(_log_config(driver))
+
+        dumped = log_config.model_dump(mode="json", by_alias=True)
+
+        assert dumped == expected
+        assert type(dumped["Type"]) is str


### PR DESCRIPTION
This is an auto-generated backport of #13817 to the 26.4 release.