### PR TITLE
fix(BA-7391): pass an explicit pids limit to the krunner extractor (#13821)

### DIFF
--- a/changes/13821.fix.md
+++ b/changes/13821.fix.md
@@ -1,0 +1,1 @@
+Pass an explicit `--pids-limit` when extracting the krunner environment so the extractor can fork under Podman's Docker-compatible API.

--- a/src/ai/backend/agent/docker/kernel.py
+++ b/src/ai/backend/agent/docker/kernel.py
@@ -43,6 +43,11 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 DEFAULT_CHUNK_SIZE: Final = 256 * 1024  # 256 KiB
 DEFAULT_INFLIGHT_CHUNKS: Final = 8
 
+# Podman's Docker-compatible API takes the `PidsLimit: 0` that the Docker CLI always sends
+# literally and writes it into cgroup v2 `pids.max`, allowing a single process.
+# Pass an explicit limit so the extractor can fork.
+_KRUNNER_EXTRACTOR_PIDS_LIMIT: Final = 2048
+
 
 class DockerKernel(AbstractKernel):
     network_driver: str
@@ -556,6 +561,8 @@ async def prepare_krunner_env_impl(distro: str, entrypoint_name: str) -> tuple[s
                     "run",
                     "--rm",
                     "-i",
+                    "--pids-limit",
+                    str(_KRUNNER_EXTRACTOR_PIDS_LIMIT),
                     "-v",
                     f"{archive_path}:/root/archive.tar.xz",
                     "-v",


### PR DESCRIPTION
This is an auto-generated backport of #13821 to the 26.4 release.