### PR TITLE
chore(BA-7380): import override in the api handler stream tests

### DIFF
--- a/changes/13824.test.md
+++ b/changes/13824.test.md
@@ -1,1 +1,0 @@
-Import `override` in the API handler stream tests, which raised `NameError` at collection time and left the module uncollectable.

--- a/changes/13824.test.md
+++ b/changes/13824.test.md
@@ -1,0 +1,1 @@
+Import `override` in the API handler stream tests, which raised `NameError` at collection time and left the module uncollectable.

--- a/tests/unit/common/test_api_handlers.py
+++ b/tests/unit/common/test_api_handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from http import HTTPStatus
-from typing import Any, Self
+from typing import Any, Self, override
 
 import pytest
 from aiohttp import web


### PR DESCRIPTION
## Summary
* `tests/unit/common/test_api_handlers.py` uses `@override` on `_ChunkStreamReader.read()` and `.content_type()`, but `override` was never imported (added in #13801).
* Decorators are evaluated at runtime, so `from __future__ import annotations` does not help — the module raised `NameError` at collection time and both `ruff` (F821 ×2) and `mypy` (`name-defined`/`misc` ×4) failed on it.
* Adds `override` to the `typing` import.

## Test plan
- [x] `pants test tests/unit/common/test_api_handlers.py` passes
- [x] `pants lint ::` clean on the `26.4` tree
- [x] `pants check ::` clean on the `26.4` tree

backport: none

Resolves BA-7380
