### PR TITLE
docs: correct the agent `id` config description

### DIFF
--- a/changes/13832.doc.md
+++ b/changes/13832.doc.md
@@ -1,0 +1,1 @@
+Correct the `[agent].id` configuration description: an unset ID is auto-detected on startup (`i-<hostname>` on-premise, the cloud instance ID on AWS/Azure/GCP) rather than being a random UUID, which also means renaming the host changes the agent ID.

--- a/configs/agent/sample.toml
+++ b/configs/agent/sample.toml
@@ -13,11 +13,15 @@
 # can override.
 # Added in 25.12.0
 [agent]
-  # Unique identifier for this agent instance. If not specified, a random UUID
-  # is generated. In multi-agent mode, each agent must have a unique ID. Used
-  # for tracking, logging, and management.
+  # Unique identifier for this agent instance. If not specified, it is detected
+  # automatically on startup: the cloud instance ID on AWS, Azure and GCP, or
+  # 'i-<hostname>' otherwise. Because that value follows the host identity,
+  # renaming the host changes the agent ID and the manager registers it as a
+  # separate new agent; set this field explicitly to pin the ID. In multi-agent
+  # mode, each agent must have a unique ID. Used for tracking, logging, and
+  # management.
   # Added in 25.12.0
-  ## id = "agent-prod-001"
+  ## id = "i-node01"
   # Port number for the agent's socket communication with containers. Containers
   # connect to this port for the kernel runner protocol. In multi-agent mode,
   # each agent must use a unique port.

--- a/src/ai/backend/agent/config/unified.py
+++ b/src/ai/backend/agent/config/unified.py
@@ -1166,11 +1166,16 @@ class OverridableAgentConfig(BaseConfigSchema):
         BackendAIConfigMeta(
             description=(
                 "Unique identifier for this agent instance. "
-                "If not specified, a random UUID is generated. In multi-agent mode, "
-                "each agent must have a unique ID. Used for tracking, logging, and management."
+                "If not specified, it is detected automatically on startup: the cloud "
+                "instance ID on AWS, Azure and GCP, or 'i-<hostname>' otherwise. "
+                "Because that value follows the host identity, renaming the host changes "
+                "the agent ID and the manager registers it as a separate new agent; "
+                "set this field explicitly to pin the ID. "
+                "In multi-agent mode, each agent must have a unique ID. "
+                "Used for tracking, logging, and management."
             ),
             added_version="25.12.0",
-            example=ConfigExample(local="agent-local-1", prod="agent-prod-001"),
+            example=ConfigExample(local="i-local-agent-01", prod="i-node01"),
         ),
     ]
     agent_sock_port: Annotated[


### PR DESCRIPTION
## Problem

`configs/agent/sample.toml` documents `[agent].id` as:

> Unique identifier for this agent instance. If not specified, a random UUID is generated.

This is not what happens. On startup, `auto_detect_agent_identity()` fills the ID with `identity.get_instance_id()` before anything reads it:

- `src/ai/backend/agent/server.py:1443-1450` — sets `id` when `agent.id` is unset
- `src/ai/backend/common/identity.py:385` — on-premise (no cloud provider detected) returns `f"i-{socket.gethostname()}"`; AWS returns the EC2 instance ID (falling back to `i-<hostname>`), Azure/GCP return `i-<vm-name>-<vm-id-hash>`

The `uuid4()` fallback in `OverridableAgentConfig.defaulted_id` does exist, but since `server_main()` runs `auto_detect_agent_identity()` before `defaulted_id` is ever accessed, that branch is unreachable in the normal startup path. So the documented behavior describes dead code.

This matters operationally: because the auto-detected ID follows the host identity, **renaming a host silently changes its agent ID**, and the manager registers it as a separate new agent while the old one goes stale. Anyone reading the current description would reasonably assume the ID is stable and unrelated to the hostname.

## Changes

- Rewrite the `id` description in `src/ai/backend/agent/config/unified.py` to state the actual auto-detection behavior and warn about the hostname coupling.
- Change the `ConfigExample` values from `agent-prod-001` / `agent-local-1` to the real-world format (`i-node01` / `i-local-agent-01`).
- Regenerate `configs/agent/sample.toml`.

Documentation only — no behavior change.

## Follow-ups (not in this PR)

- `OverridableAgentConfig.defaulted_id`'s `uuid4()` fallback is dead in the server path; worth either removing or making it reachable-by-design.
- Persisting the auto-detected ID on first startup (or at least warning when the detected ID differs from the previously registered one) would prevent the hostname-rename failure mode outright. Same auto-detection default also applies to the manager, storage-proxy and app-proxy node IDs.
