### PR TITLE
fix(BA-7394): attach GPUs through CDI device requests on Podman (#13829)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,15 @@ Requirements
 
 ### Infrastructure
 
+**Container engine** (one of):
+
+| Engine | Supported | Accelerator requirements |
+|---|---|---|
+| Docker | 20.10+ | The nvidia runtime registered with the daemon (`nvidia-ctk runtime configure --runtime=docker`) |
+| Podman | 5.4.0+ | A CDI spec for the accelerator under `/etc/cdi` or `/var/run/cdi` (`nvidia-ctk cdi generate` for NVIDIA GPUs) |
+
 **Required**:
-- Docker 20.10+ (with Compose v2)
+- Docker Compose v2
 - PostgreSQL 16+ (tested with 16.3)
 - Valkey 9.1+ (tested with 9.1.0; Redis-compatible)
 - etcd 3.5+ (tested with 3.5.14)

--- a/changes/13829.fix.md
+++ b/changes/13829.fix.md
@@ -1,0 +1,1 @@
+Attach GPUs via CDI device requests on Podman, whose Docker-compatible API silently ignores both the nvidia runtime and nvidia device requests.

--- a/src/ai/backend/accelerator/cuda_open/plugin.py
+++ b/src/ai/backend/accelerator/cuda_open/plugin.py
@@ -1,18 +1,25 @@
 import logging
 import re
 import uuid
+from abc import ABC, abstractmethod
 from collections.abc import Collection, Mapping, MutableMapping, Sequence
 from decimal import Decimal
 from pathlib import Path
 from pprint import pformat
 from typing import (
     Any,
+    Final,
+    override,
 )
 
 import aiodocker
+import yaml
 from aiodocker.exceptions import DockerError
 from aiotools import closing_async
+from pydantic import BaseModel, Field
 
+from ai.backend.agent.data.device import DeviceAllocation
+from ai.backend.agent.errors.resources import InvalidResourceArgument
 from ai.backend.agent.resources import (
     AbstractAllocMap,
     AbstractComputeDevice,
@@ -20,7 +27,6 @@ from ai.backend.agent.resources import (
     DeviceSlotInfo,
     DiscretePropertyAllocMap,
 )
-from ai.backend.agent.utils import update_nested_dict
 from ai.backend.logging import BraceStyleAdapter
 
 try:
@@ -61,6 +67,44 @@ PREFIX = "cuda"
 
 log = BraceStyleAdapter(logging.getLogger("ai.backend.accelerator.cuda"))
 
+rx_triple_version = re.compile(r"(\d+\.\d+\.\d+)")
+
+# Engines that attach devices only through CDI, mapped to the version from which their
+# Docker-compatible API honours a CDI device request. Earlier releases drop it silently.
+# These engines report their own version as a component, apart from the Docker server
+# version they advertise for compatibility.
+CDI_ONLY_ENGINE_COMPONENTS: Final[Mapping[str, tuple[int, ...]]] = {
+    "Podman Engine": (5, 4, 0),
+}
+MIN_DOCKER_DEVICE_REQUEST_VERSION: Final[tuple[int, ...]] = (19, 3, 0)
+CDI_KIND: Final[str] = "nvidia.com/gpu"
+CDI_SPEC_DIRS: Final[tuple[Path, ...]] = (Path("/etc/cdi"), Path("/var/run/cdi"))
+CDI_SPEC_SUFFIXES: Final[frozenset[str]] = frozenset({".json", ".yaml", ".yml"})
+
+
+class EngineComponent(BaseModel):
+    """A component entry of the container engine version API response."""
+
+    name: str = Field(validation_alias="Name")
+    version: str = Field(validation_alias="Version")
+
+
+class EngineVersion(BaseModel):
+    """The part of the container engine version API response the plugin reads."""
+
+    components: list[EngineComponent] = Field(
+        validation_alias="Components",
+        default_factory=list,
+    )
+
+
+def _find_cdi_only_engine(version_info: EngineVersion) -> EngineComponent | None:
+    """The engine that can attach devices only through CDI, if this is one of them."""
+    for component in version_info.components:
+        if component.name in CDI_ONLY_ENGINE_COMPONENTS:
+            return component
+    return None
+
 
 class CUDADevice(AbstractComputeDevice):
     model_name: str
@@ -84,6 +128,152 @@ class CUDADevice(AbstractComputeDevice):
         return str(self)
 
 
+class DeviceRequest(BaseModel):
+    """
+    One entry of the container creation API's device request list.
+
+    Keyed in PascalCase as the API expects, so that dumping by alias is the whole of
+    the rendering.
+    """
+
+    driver: str = Field(serialization_alias="Driver")
+    device_ids: Sequence[str] = Field(serialization_alias="DeviceIDs")
+    # The nvidia driver rejects "all" here, so the capabilities are always spelled out.
+    capabilities: Sequence[Sequence[str]] | None = Field(
+        default=None,
+        serialization_alias="Capabilities",
+    )
+
+
+class HostConfig(BaseModel):
+    """The `HostConfig` fields an injector sets, mirroring where the API nests them."""
+
+    device_requests: Sequence[DeviceRequest] | None = Field(
+        default=None,
+        serialization_alias="DeviceRequests",
+    )
+    runtime: str | None = Field(default=None, serialization_alias="Runtime")
+
+
+class DeviceConfig(BaseModel):
+    """
+    What an injector adds to a container creation request.
+
+    Every field defaults to null and is dropped when it stays that way, so an injector
+    that attaches nothing renders to an empty payload.
+    """
+
+    host_config: HostConfig | None = Field(default=None, serialization_alias="HostConfig")
+    environ: Sequence[str] | None = Field(default=None, serialization_alias="Env")
+
+
+class DeviceInjector(ABC):
+    """How the container engine is told to attach GPUs to a container."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_device_config(
+        self,
+        allocation: DeviceAllocation,
+        devices: Collection[CUDADevice],
+    ) -> DeviceConfig:
+        """What to add to the container creation request to attach the allocated devices."""
+        raise NotImplementedError
+
+
+class LegacyRuntimeInjector(DeviceInjector):
+    """Selects the nvidia runtime shim, which takes the device list from the environment."""
+
+    @property
+    @override
+    def name(self) -> str:
+        return "legacy-runtime"
+
+    @override
+    def build_device_config(
+        self,
+        allocation: DeviceAllocation,
+        devices: Collection[CUDADevice],
+    ) -> DeviceConfig:
+        device_ids = allocation.attached_device_ids
+        return DeviceConfig(
+            host_config=HostConfig(runtime="nvidia"),
+            environ=[
+                "NVIDIA_DRIVER_CAPABILITIES=all",
+                "NVIDIA_VISIBLE_DEVICES={}".format(",".join(device_ids)),
+            ],
+        )
+
+
+class NvidiaDriverInjector(DeviceInjector):
+    """Delegates to the nvidia device driver registered with the Docker daemon."""
+
+    @property
+    @override
+    def name(self) -> str:
+        return "nvidia-driver"
+
+    @override
+    def build_device_config(
+        self,
+        allocation: DeviceAllocation,
+        devices: Collection[CUDADevice],
+    ) -> DeviceConfig:
+        device_ids = allocation.attached_device_ids
+        if not device_ids:
+            return DeviceConfig()
+        return DeviceConfig(
+            host_config=HostConfig(
+                device_requests=[
+                    DeviceRequest(
+                        driver="nvidia",
+                        device_ids=device_ids,
+                        capabilities=[["utility", "compute", "video", "graphics", "display"]],
+                    ),
+                ],
+            ),
+        )
+
+
+class CDIInjector(DeviceInjector):
+    """
+    Names the devices of a CDI kind and lets the engine apply the spec, hooks included.
+    CDI identifies a GPU by its UUID while the alloc map keys it by the CUDA runtime index,
+    and the two enumeration orders are not guaranteed to agree.
+    """
+
+    @property
+    @override
+    def name(self) -> str:
+        return "cdi"
+
+    @override
+    def build_device_config(
+        self,
+        allocation: DeviceAllocation,
+        devices: Collection[CUDADevice],
+    ) -> DeviceConfig:
+        device_ids = allocation.attached_device_ids
+        if not device_ids:
+            return DeviceConfig()
+        device_uuids = {dev.device_id: dev.uuid for dev in devices}
+        cdi_device_ids = []
+        for device_id in device_ids:
+            device_uuid = device_uuids.get(device_id)
+            if device_uuid is None:
+                raise InvalidResourceArgument(f"no CUDA device with the ID {device_id}")
+            cdi_device_ids.append(f"{CDI_KIND}=GPU-{device_uuid}")
+        return DeviceConfig(
+            host_config=HostConfig(
+                device_requests=[DeviceRequest(driver="cdi", device_ids=cdi_device_ids)],
+            ),
+        )
+
+
 class CUDAPlugin(AbstractComputePlugin):
     config_watch_enabled = False
 
@@ -92,38 +282,28 @@ class CUDAPlugin(AbstractComputePlugin):
         (SlotName("cuda.device"), SlotTypes("count")),
     )
 
-    docker_version: tuple[int, ...] = (0, 0, 0)
-
+    _device_injector: DeviceInjector = LegacyRuntimeInjector()
     device_mask: Sequence[str] = []
     enabled: bool = True
 
     async def init(self, context: Any | None = None) -> None:
-        rx_triple_version = re.compile(r"(\d+\.\d+\.\d+)")
-
-        # Basic docker version & nvidia container runtime check
+        # Basic container engine & device access mechanism check
         try:
             async with closing_async(aiodocker.Docker()) as docker:
                 docker_info = await docker.system.info()
+                version_info = EngineVersion.model_validate(await docker.version())
         except DockerError:
             log.info("CUDA acceleration is disabled.")
             self.enabled = False
             return
 
-        if "nvidia" not in docker_info["Runtimes"]:
-            log.error("could not detect valid NVIDIA Container Runtime!")
+        device_injector = self._detect_device_injector(docker_info, version_info)
+        if device_injector is None:
             log.info("CUDA acceleration is disabled.")
             self.enabled = False
             return
-
-        rx_triple_version = re.compile(r"(\d+\.\d+\.\d+)")
-        m = rx_triple_version.search(docker_info["ServerVersion"])
-        if m:
-            self.docker_version = tuple(map(int, m.group(1).split(".")))
-        else:
-            log.error("could not detect docker version!")
-            log.info("CUDA acceleration is disabled.")
-            self.enabled = False
-            return
+        self._device_injector = device_injector
+        log.info("attaching GPUs via the {} mechanism.", device_injector.name)
 
         raw_device_mask = self.plugin_config.get("device_mask")
         if raw_device_mask is not None:
@@ -140,6 +320,68 @@ class CUDAPlugin(AbstractComputePlugin):
             log.warning("CUDA init error: {}", e)
             log.info("CUDA acceleration is disabled.")
             self.enabled = False
+
+    def _detect_device_injector(
+        self,
+        docker_info: Mapping[str, Any],
+        version_info: EngineVersion,
+    ) -> DeviceInjector | None:
+        cdi_only_engine = _find_cdi_only_engine(version_info)
+        if cdi_only_engine is not None:
+            engine_version = self._parse_version(cdi_only_engine.version)
+            if engine_version is None:
+                log.error("could not detect the {} version!", cdi_only_engine.name)
+                return None
+            min_version = CDI_ONLY_ENGINE_COMPONENTS[cdi_only_engine.name]
+            if engine_version < min_version:
+                log.error(
+                    "{} {} ignores CDI device requests; {} or later is required.",
+                    cdi_only_engine.name,
+                    self._format_version(engine_version),
+                    self._format_version(min_version),
+                )
+                return None
+            if not self._has_cdi_spec():
+                log.error("could not find a CDI spec for {}!", CDI_KIND)
+                return None
+            return CDIInjector()
+
+        if "nvidia" not in docker_info["Runtimes"]:
+            log.error("could not detect valid NVIDIA Container Runtime!")
+            return None
+        docker_version = self._parse_version(docker_info["ServerVersion"])
+        if docker_version is None:
+            log.error("could not detect docker version!")
+            return None
+        if docker_version >= MIN_DOCKER_DEVICE_REQUEST_VERSION:
+            return NvidiaDriverInjector()
+        return LegacyRuntimeInjector()
+
+    def _parse_version(self, raw_version: str) -> tuple[int, ...] | None:
+        m = rx_triple_version.search(raw_version)
+        if m is None:
+            return None
+        return tuple(map(int, m.group(1).split(".")))
+
+    def _format_version(self, version: tuple[int, ...]) -> str:
+        return ".".join(map(str, version))
+
+    def _has_cdi_spec(self) -> bool:
+        for spec_dir in CDI_SPEC_DIRS:
+            try:
+                spec_paths = sorted(spec_dir.iterdir())
+            except OSError:
+                continue
+            for spec_path in spec_paths:
+                if spec_path.suffix not in CDI_SPEC_SUFFIXES:
+                    continue
+                try:
+                    spec = yaml.safe_load(spec_path.read_text())
+                except (OSError, yaml.YAMLError):
+                    continue
+                if isinstance(spec, Mapping) and spec.get("kind") == CDI_KIND:
+                    return True
+        return False
 
     async def cleanup(self) -> None:
         pass
@@ -371,52 +613,11 @@ class CUDAPlugin(AbstractComputePlugin):
     ) -> Mapping[str, Any]:
         if not self.enabled:
             return {}
-        assigned_device_ids = []
-        for slot_type, per_device_alloc in device_alloc.items():
-            for device_id, alloc in per_device_alloc.items():
-                if alloc > 0:
-                    assigned_device_ids.append(device_id)
-        docker_config: dict[str, Any] = {}
-        if self.docker_version >= (19, 3, 0):
-            # NOTE: You may put additional Docker container creation API params here.
-            if assigned_device_ids:
-                update_nested_dict(
-                    docker_config,
-                    {
-                        "HostConfig": {
-                            "DeviceRequests": [
-                                {
-                                    "Driver": "nvidia",
-                                    "DeviceIDs": assigned_device_ids,
-                                    # "all" does not work here
-                                    "Capabilities": [
-                                        [
-                                            "utility",
-                                            "compute",
-                                            "video",
-                                            "graphics",
-                                            "display",
-                                        ],
-                                    ],
-                                },
-                            ],
-                        },
-                    },
-                )
-        else:
-            update_nested_dict(
-                docker_config,
-                {
-                    "HostConfig": {
-                        "Runtime": "nvidia",
-                    },
-                    "Env": [
-                        "NVIDIA_DRIVER_CAPABILITIES=all",
-                        "NVIDIA_VISIBLE_DEVICES={}".format(",".join(assigned_device_ids)),
-                    ],
-                },
-            )
-        return docker_config
+        device_config = self._device_injector.build_device_config(
+            DeviceAllocation.from_device_alloc(device_alloc),
+            await self.list_devices(),
+        )
+        return device_config.model_dump(by_alias=True, exclude_none=True)
 
     async def get_attached_devices(
         self,

--- a/src/ai/backend/agent/data/device.py
+++ b/src/ai/backend/agent/data/device.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Self
+
+from ai.backend.common.types import DeviceId, SlotName
+
+
+@dataclass(frozen=True)
+class AllocatedDevice:
+    """
+    One device unit an allocation holds, and how much of it.
+
+    A unit supplies more than one slot when it is metered along more than one axis, as a
+    `cuda` device does with `cuda.device` and `cuda.shares`.
+    """
+
+    device_id: DeviceId
+    amounts: Mapping[SlotName, Decimal]
+
+
+@dataclass(frozen=True)
+class DeviceAllocation:
+    """
+    The device units a compute plugin was asked to attach to a container.
+
+    The agent keys its resource spec by slot and then by unit, which answers "how much of
+    this slot went where". A plugin asks the opposite question - "which units do I attach,
+    and how much of each" - so the units are transposed here once, in a stable order.
+    """
+
+    units: Sequence[AllocatedDevice]
+
+    @classmethod
+    def from_device_alloc(
+        cls,
+        device_alloc: Mapping[SlotName, Mapping[DeviceId, Decimal]],
+    ) -> Self:
+        amounts_by_unit: dict[DeviceId, dict[SlotName, Decimal]] = {}
+        for slot_name, per_unit_alloc in device_alloc.items():
+            for device_id, amount in per_unit_alloc.items():
+                amounts_by_unit.setdefault(device_id, {})[slot_name] = amount
+        return cls(
+            units=[
+                AllocatedDevice(device_id=device_id, amounts=amounts)
+                for device_id, amounts in amounts_by_unit.items()
+            ]
+        )
+
+    @property
+    def attached_device_ids(self) -> list[DeviceId]:
+        """The units holding a non-zero amount of any slot - the ones to attach."""
+        return [
+            unit.device_id
+            for unit in self.units
+            if any(amount > 0 for amount in unit.amounts.values())
+        ]

--- a/tests/unit/accelerator/cuda_open/test_device_injector.py
+++ b/tests/unit/accelerator/cuda_open/test_device_injector.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ai.backend.accelerator.cuda_open.plugin import (
+    CDIInjector,
+    CUDADevice,
+    CUDAPlugin,
+    DeviceConfig,
+    DeviceRequest,
+    EngineVersion,
+    HostConfig,
+    LegacyRuntimeInjector,
+    NvidiaDriverInjector,
+)
+from ai.backend.agent.data.device import DeviceAllocation
+from ai.backend.agent.errors.resources import InvalidResourceArgument
+from ai.backend.common.types import DeviceId, DeviceName, SlotName
+
+DEVICE_0_UUID = "1e826af4-30db-8336-d74d-c958d38334d7"
+DEVICE_1_UUID = "8d1f2c05-9a44-4b17-b2e6-6f0a3c7d9e11"
+
+
+def _make_device(device_id: str, device_uuid: str) -> CUDADevice:
+    return CUDADevice(
+        device_id=DeviceId(device_id),
+        device_name=DeviceName("cuda"),
+        model_name="NVIDIA A100",
+        uuid=device_uuid,
+        hw_location="0000:00:1e.0",
+        numa_node=0,
+        memory_size=1024 * 1024 * 1024 * 8,
+        processing_units=64,
+    )
+
+
+def _version_info(*components: tuple[str, str]) -> EngineVersion:
+    return EngineVersion.model_validate({
+        "Components": [{"Name": name, "Version": version} for name, version in components],
+    })
+
+
+def _docker_info(server_version: str, *, with_nvidia_runtime: bool = True) -> dict[str, Any]:
+    runtimes: dict[str, Any] = {"runc": {}}
+    if with_nvidia_runtime:
+        runtimes["nvidia"] = {}
+    return {"Runtimes": runtimes, "ServerVersion": server_version}
+
+
+class TestDetectDeviceInjector:
+    """Tests for picking the device injector from the container engine."""
+
+    @pytest.fixture
+    def plugin(self) -> CUDAPlugin:
+        return CUDAPlugin.__new__(CUDAPlugin)
+
+    @pytest.fixture
+    def cdi_spec_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(CUDAPlugin, "_has_cdi_spec", lambda self: True)
+
+    @pytest.fixture
+    def cdi_spec_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(CUDAPlugin, "_has_cdi_spec", lambda self: False)
+
+    def test_podman_at_the_minimum_version_uses_cdi(
+        self, plugin: CUDAPlugin, cdi_spec_available: None
+    ) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("5.4.0", with_nvidia_runtime=False),
+            _version_info(("Podman Engine", "5.4.0")),
+        )
+        assert isinstance(mechanism, CDIInjector)
+
+    def test_podman_does_not_require_the_nvidia_runtime(
+        self, plugin: CUDAPlugin, cdi_spec_available: None
+    ) -> None:
+        # Podman selects its OCI runtime from its own configuration, so the nvidia runtime
+        # being absent from the reported runtimes must not disable the plugin.
+        mechanism = plugin._detect_device_injector(
+            _docker_info("5.8.4", with_nvidia_runtime=False),
+            _version_info(("Podman Engine", "5.8.4")),
+        )
+        assert isinstance(mechanism, CDIInjector)
+
+    def test_podman_below_the_minimum_version_is_rejected(
+        self, plugin: CUDAPlugin, cdi_spec_available: None
+    ) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("4.9.3"),
+            _version_info(("Podman Engine", "4.9.3"), ("Conmon", "conmon version 2.1.10")),
+        )
+        assert mechanism is None
+
+    def test_podman_without_a_cdi_spec_is_rejected(
+        self, plugin: CUDAPlugin, cdi_spec_missing: None
+    ) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("5.4.0"),
+            _version_info(("Podman Engine", "5.4.0")),
+        )
+        assert mechanism is None
+
+    def test_docker_above_the_device_request_version_uses_the_nvidia_driver(
+        self, plugin: CUDAPlugin
+    ) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("28.1.1"),
+            _version_info(("Engine", "28.1.1")),
+        )
+        assert isinstance(mechanism, NvidiaDriverInjector)
+
+    def test_docker_below_the_device_request_version_uses_the_legacy_runtime(
+        self, plugin: CUDAPlugin
+    ) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("18.9.0"),
+            _version_info(("Engine", "18.9.0")),
+        )
+        assert isinstance(mechanism, LegacyRuntimeInjector)
+
+    def test_docker_without_the_nvidia_runtime_is_rejected(self, plugin: CUDAPlugin) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("28.1.1", with_nvidia_runtime=False),
+            _version_info(("Engine", "28.1.1")),
+        )
+        assert mechanism is None
+
+    def test_a_cdi_only_engine_with_an_unparsable_version_is_rejected(
+        self, plugin: CUDAPlugin, cdi_spec_available: None
+    ) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("5.4.0"),
+            _version_info(("Podman Engine", "unknown")),
+        )
+        assert mechanism is None
+
+    def test_an_unparsable_docker_version_is_rejected(self, plugin: CUDAPlugin) -> None:
+        mechanism = plugin._detect_device_injector(
+            _docker_info("unknown"),
+            _version_info(("Engine", "unknown")),
+        )
+        assert mechanism is None
+
+
+def _device_alloc(*device_ids: str) -> dict[SlotName, dict[DeviceId, Decimal]]:
+    """The resource-spec form the agent hands to the plugin."""
+    return {SlotName("cuda.device"): {DeviceId(device_id): Decimal(1) for device_id in device_ids}}
+
+
+def _alloc(*device_ids: str) -> DeviceAllocation:
+    """The transposed form a mechanism receives."""
+    return DeviceAllocation.from_device_alloc(_device_alloc(*device_ids))
+
+
+class TestCDIInjector:
+    @pytest.fixture
+    def devices(self) -> list[CUDADevice]:
+        return [
+            _make_device("0", DEVICE_0_UUID),
+            _make_device("1", DEVICE_1_UUID),
+        ]
+
+    def test_names_devices_by_uuid(self, devices: list[CUDADevice]) -> None:
+        # The alloc map keys devices by the CUDA runtime index, which is not guaranteed to
+        # match the index CDI assigns, so the UUID is what must reach the engine.
+        device_config = CDIInjector().build_device_config(_alloc("1"), devices)
+        assert device_config == DeviceConfig(
+            host_config=HostConfig(
+                device_requests=[
+                    DeviceRequest(
+                        driver="cdi",
+                        device_ids=[f"nvidia.com/gpu=GPU-{DEVICE_1_UUID}"],
+                    ),
+                ],
+            ),
+        )
+
+    def test_names_every_allocated_device(self, devices: list[CUDADevice]) -> None:
+        device_config = CDIInjector().build_device_config(_alloc("0", "1"), devices)
+        assert device_config == DeviceConfig(
+            host_config=HostConfig(
+                device_requests=[
+                    DeviceRequest(
+                        driver="cdi",
+                        device_ids=[
+                            f"nvidia.com/gpu=GPU-{DEVICE_0_UUID}",
+                            f"nvidia.com/gpu=GPU-{DEVICE_1_UUID}",
+                        ],
+                    ),
+                ],
+            ),
+        )
+
+    def test_skips_devices_without_an_allocation(self, devices: list[CUDADevice]) -> None:
+        allocation = DeviceAllocation.from_device_alloc({
+            SlotName("cuda.device"): {DeviceId("0"): Decimal(0), DeviceId("1"): Decimal(1)},
+        })
+        device_config = CDIInjector().build_device_config(allocation, devices)
+        assert device_config == DeviceConfig(
+            host_config=HostConfig(
+                device_requests=[
+                    DeviceRequest(
+                        driver="cdi",
+                        device_ids=[f"nvidia.com/gpu=GPU-{DEVICE_1_UUID}"],
+                    ),
+                ],
+            ),
+        )
+
+    def test_requests_nothing_for_an_empty_allocation(self, devices: list[CUDADevice]) -> None:
+        assert CDIInjector().build_device_config(_alloc(), devices) == DeviceConfig()
+
+    def test_rejects_an_allocation_of_an_unknown_device(self, devices: list[CUDADevice]) -> None:
+        # Skipping the device would charge the slot while the container runs without a GPU.
+        with pytest.raises(InvalidResourceArgument):
+            CDIInjector().build_device_config(_alloc("7"), devices)
+
+
+class TestNvidiaDriverInjector:
+    def test_names_devices_by_the_runtime_index(self) -> None:
+        device_config = NvidiaDriverInjector().build_device_config(_alloc("0"), [])
+        assert device_config == DeviceConfig(
+            host_config=HostConfig(
+                device_requests=[
+                    DeviceRequest(
+                        driver="nvidia",
+                        device_ids=["0"],
+                        capabilities=[["utility", "compute", "video", "graphics", "display"]],
+                    ),
+                ],
+            ),
+        )
+
+    def test_requests_nothing_for_an_empty_allocation(self) -> None:
+        assert NvidiaDriverInjector().build_device_config(_alloc(), []) == DeviceConfig()
+
+
+class TestLegacyRuntimeInjector:
+    def test_selects_the_nvidia_runtime_and_lists_devices_in_the_environment(self) -> None:
+        device_config = LegacyRuntimeInjector().build_device_config(_alloc("0", "1"), [])
+        assert device_config == DeviceConfig(
+            host_config=HostConfig(runtime="nvidia"),
+            environ=[
+                "NVIDIA_DRIVER_CAPABILITIES=all",
+                "NVIDIA_VISIBLE_DEVICES=0,1",
+            ],
+        )
+
+    def test_still_selects_the_nvidia_runtime_for_an_empty_allocation(self) -> None:
+        device_config = LegacyRuntimeInjector().build_device_config(_alloc(), [])
+        assert device_config.host_config == HostConfig(runtime="nvidia")
+
+
+class TestGenerateDockerArgs:
+    """Tests for rendering an injector's output into the container creation API's keys."""
+
+    @pytest.fixture
+    def cuda_plugin(self) -> CUDAPlugin:
+        plugin = CUDAPlugin.__new__(CUDAPlugin)
+        plugin.plugin_config = {}
+        plugin.local_config = {}
+        plugin.enabled = True
+        plugin.device_mask = []
+        plugin._device_injector = CDIInjector()
+        plugin.list_devices = AsyncMock(  # type: ignore[method-assign]
+            return_value=[_make_device("0", DEVICE_0_UUID), _make_device("1", DEVICE_1_UUID)],
+        )
+        return plugin
+
+    async def test_renders_a_device_request(self, cuda_plugin: CUDAPlugin) -> None:
+        docker_args = await cuda_plugin.generate_docker_args(AsyncMock(), _device_alloc("1"))
+        assert docker_args == {
+            "HostConfig": {
+                "DeviceRequests": [
+                    {
+                        "Driver": "cdi",
+                        "DeviceIDs": [f"nvidia.com/gpu=GPU-{DEVICE_1_UUID}"],
+                    },
+                ],
+            },
+        }
+
+    async def test_renders_the_capabilities_only_when_the_request_carries_them(
+        self, cuda_plugin: CUDAPlugin
+    ) -> None:
+        cuda_plugin._device_injector = NvidiaDriverInjector()
+        docker_args = await cuda_plugin.generate_docker_args(AsyncMock(), _device_alloc("0"))
+        assert docker_args == {
+            "HostConfig": {
+                "DeviceRequests": [
+                    {
+                        "Driver": "nvidia",
+                        "DeviceIDs": ["0"],
+                        "Capabilities": [
+                            ["utility", "compute", "video", "graphics", "display"],
+                        ],
+                    },
+                ],
+            },
+        }
+
+    async def test_renders_the_runtime_and_the_environment(self, cuda_plugin: CUDAPlugin) -> None:
+        cuda_plugin._device_injector = LegacyRuntimeInjector()
+        docker_args = await cuda_plugin.generate_docker_args(AsyncMock(), _device_alloc("0"))
+        assert docker_args == {
+            "HostConfig": {"Runtime": "nvidia"},
+            "Env": [
+                "NVIDIA_DRIVER_CAPABILITIES=all",
+                "NVIDIA_VISIBLE_DEVICES=0",
+            ],
+        }
+
+    async def test_renders_nothing_for_an_empty_device_config(
+        self, cuda_plugin: CUDAPlugin
+    ) -> None:
+        docker_args = await cuda_plugin.generate_docker_args(AsyncMock(), {})
+        assert docker_args == {}
+
+    async def test_a_disabled_plugin_emits_nothing(self, cuda_plugin: CUDAPlugin) -> None:
+        cuda_plugin.enabled = False
+        docker_args = await cuda_plugin.generate_docker_args(AsyncMock(), _device_alloc("0"))
+        assert docker_args == {}
+        cuda_plugin.list_devices.assert_not_awaited()  # type: ignore[attr-defined]

--- a/tests/unit/agent/data/BUILD
+++ b/tests/unit/agent/data/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/agent/data/test_device.py
+++ b/tests/unit/agent/data/test_device.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from ai.backend.agent.data.device import DeviceAllocation
+from ai.backend.common.types import DeviceId, SlotName
+
+CUDA_DEVICE = SlotName("cuda.device")
+CUDA_SHARES = SlotName("cuda.shares")
+
+
+class TestDeviceAllocation:
+    """Tests for transposing the agent's resource spec into per-unit amounts."""
+
+    def test_transposes_slots_into_units(self) -> None:
+        allocation = DeviceAllocation.from_device_alloc({
+            CUDA_DEVICE: {DeviceId("0"): Decimal(1), DeviceId("1"): Decimal(1)},
+        })
+        assert [unit.device_id for unit in allocation.units] == [DeviceId("0"), DeviceId("1")]
+        assert allocation.units[0].amounts == {CUDA_DEVICE: Decimal(1)}
+
+    def test_keeps_every_slot_a_unit_is_metered_by(self) -> None:
+        # A cuda device is accounted along both axes, and a plugin may read either.
+        allocation = DeviceAllocation.from_device_alloc({
+            CUDA_DEVICE: {DeviceId("0"): Decimal(1)},
+            CUDA_SHARES: {DeviceId("0"): Decimal("0.5")},
+        })
+        assert len(allocation.units) == 1
+        assert allocation.units[0].amounts == {
+            CUDA_DEVICE: Decimal(1),
+            CUDA_SHARES: Decimal("0.5"),
+        }
+
+    def test_attached_device_ids_skip_units_without_an_amount(self) -> None:
+        allocation = DeviceAllocation.from_device_alloc({
+            CUDA_DEVICE: {DeviceId("0"): Decimal(0), DeviceId("1"): Decimal(1)},
+        })
+        assert allocation.attached_device_ids == [DeviceId("1")]
+
+    def test_attached_device_ids_keep_a_unit_metered_by_any_slot(self) -> None:
+        allocation = DeviceAllocation.from_device_alloc({
+            CUDA_DEVICE: {DeviceId("0"): Decimal(0)},
+            CUDA_SHARES: {DeviceId("0"): Decimal("0.5")},
+        })
+        assert allocation.attached_device_ids == [DeviceId("0")]
+
+    def test_an_empty_allocation_attaches_nothing(self) -> None:
+        assert DeviceAllocation.from_device_alloc({}).attached_device_ids == []


### PR DESCRIPTION
This is an auto-generated backport of #13829 to the 26.4 release.