### PR TITLE
feat(BA-7405): expose the API domain name in the webserver-served config.toml

### DIFF
--- a/changes/13837.feature.md
+++ b/changes/13837.feature.md
@@ -1,0 +1,1 @@
+Expose the webserver's configured API domain name as `general.domainName` in the config.toml served to the WebUI, so pre-login clients can key into per-domain app config documents (e.g. domain branding).

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -1,6 +1,7 @@
 [general]
 {% toml_field "apiEndpoint" endpoint_url %}
 {% toml_field "apiEndpointText" config["api"]["text"] %}
+{% toml_field "domainName" config["api"]["domain"] %}
 {% toml_field "defaultSessionEnvironment" config["ui"]["default-environment"] %}
 {% toml_field "defaultImportEnvironment" config["ui"]["default-import-environment"] %}
 {% toml_field "enableModelFolders" config["ui"]["enable-model-folders"] %}


### PR DESCRIPTION
Resolves #13836 (BA-7405)

## Summary

A webserver deployment is pinned to one Backend.AI domain — `config.api.domain` drives every login and anonymous auth call — but the `config.toml` rendered for the WebUI (`src/ai/backend/web/templates/config.toml.j2`) never carried that name, so the WebUI could not know its domain before login.

This renders the configured API domain into the served `config.toml` as `general.domainName`.

## Motivation (FR-1964)

The WebUI serves per-domain branding from the public `publicConfigByDomain` app config document, keyed by domain name and fetchable anonymously (`POST /v2/app-config/public/get`). With `general.domainName` exposed, the WebUI can slice that document **pre-login** and apply domain branding from the login screen. Deployments without the value (Electron / direct API mode) keep the shipped `theme.json` fallback.

## Changes

- `config.toml.j2`: add `{% toml_field "domainName" config["api"]["domain"] %}` to `[general]`.
