### PR TITLE
chore(BA-7404): keep unknown config fields instead of dropping them

### DIFF
--- a/changes/13838.misc.md
+++ b/changes/13838.misc.md
@@ -1,0 +1,1 @@
+Keep unknown config fields during validation instead of dropping them.

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -47,8 +47,9 @@ __all__ = (
 class BaseConfigSchema(BackendAISchema):
     """
     Use for a component's config file schema (``configs/``). Unknown fields are
-    warned about and dropped; a schema that takes a wider mapping on purpose opts
-    out with ``ConfigDict(extra="ignore")``.
+    warned about but kept, so that sections consumed by out-of-tree plugins
+    survive validation; a schema that takes a wider mapping on purpose opts out
+    with ``ConfigDict(extra="ignore")``.
     """
 
     @staticmethod
@@ -69,12 +70,10 @@ class BaseConfigSchema(BackendAISchema):
         if extra:
             keys = sorted(extra)
             log.warning(
-                "Ignoring unknown config field(s) in {}: {}",
+                "Unknown config field(s) in {}: {}",
                 type(self).__name__,
                 ", ".join(keys),
             )
-            extra.clear()
-            self.__pydantic_fields_set__.difference_update(keys)
         return self
 
 

--- a/tests/unit/agent/test_config_validation.py
+++ b/tests/unit/agent/test_config_validation.py
@@ -581,7 +581,7 @@ class TestAgentUnifiedConfigValidation:
         assert config.agent.backend == AgentBackend.KUBERNETES
         assert config.container.scratch_type == ScratchType.K8S_NFS
 
-    def test_unknown_agent_field_is_warned_and_dropped(
+    def test_unknown_agent_field_is_warned_and_kept(
         self,
         default_raw_config: RawConfigT,
         caplog: pytest.LogCaptureFixture,
@@ -598,8 +598,8 @@ class TestAgentUnifiedConfigValidation:
 
         warnings = [r.getMessage() for r in caplog.records if r.name == CONFIG_LOGGER]
         assert any("use-experimental-redis-event-dispatcher" in m for m in warnings)
-        assert not hasattr(config.agent, "use_experimental_redis_event_dispatcher")
-        assert "use-experimental-redis-event-dispatcher" not in config.agent.model_fields_set
+        assert config.agent.model_dump()["use-experimental-redis-event-dispatcher"] is True
+        assert "use-experimental-redis-event-dispatcher" in config.agent.model_fields_set
 
     def test_docker_backend_validation_emits_no_unknown_field_warning(
         self,

--- a/tests/unit/manager/config/test_unified.py
+++ b/tests/unit/manager/config/test_unified.py
@@ -23,7 +23,7 @@ class TestUnknownFieldWarning:
         "unknown_key",
         ["use-experimental-redis-event-dispatcher", "totally-made-up-key"],
     )
-    def test_unknown_field_is_warned_and_dropped(
+    def test_unknown_field_is_warned_and_kept(
         self,
         unknown_key: str,
         caplog: pytest.LogCaptureFixture,
@@ -33,9 +33,8 @@ class TestUnknownFieldWarning:
 
         warnings = _unknown_field_warnings(caplog)
         assert any(unknown_key in m and "ManagerConfig" in m for m in warnings)
-        assert not hasattr(config, unknown_key.replace("-", "_"))
-        assert unknown_key not in config.model_dump()
-        assert unknown_key not in config.model_fields_set
+        assert config.model_dump()[unknown_key] is True
+        assert unknown_key in config.model_fields_set
 
     def test_known_field_emits_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         with caplog.at_level("WARNING", logger=CONFIG_LOGGER):


### PR DESCRIPTION
## Summary
- `BaseConfigSchema._warn_unknown_fields` cleared every extra field after validation, so config sections that schemas deliberately pass through with `ConfigDict(extra="allow")` never reached their consumers. Keep the warning, drop the clearing.
- Updated the two tests that asserted the dropping behavior to assert the fields are kept.

## Test plan
- [x] `pants test tests/unit/manager/config/test_unified.py tests/unit/agent/test_config_validation.py`

Resolves BA-7404

🤖 Generated with [Claude Code](https://claude.com/claude-code)