### PR TITLE
refactor(BA-7406): rename the served config.toml domain key to apiDomainName

### DIFF
--- a/changes/13840.fix.md
+++ b/changes/13840.fix.md
@@ -1,0 +1,1 @@
+Rename the domain key rendered into the WebUI-served config.toml from `general.domainName` to `general.apiDomainName`, so the static deployment-level hint cannot be confused with the business-logic domain name.

--- a/src/ai/backend/web/templates/config.toml.j2
+++ b/src/ai/backend/web/templates/config.toml.j2
@@ -1,7 +1,7 @@
 [general]
 {% toml_field "apiEndpoint" endpoint_url %}
 {% toml_field "apiEndpointText" config["api"]["text"] %}
-{% toml_field "domainName" config["api"]["domain"] %}
+{% toml_field "apiDomainName" config["api"]["domain"] %}
 {% toml_field "defaultSessionEnvironment" config["ui"]["default-environment"] %}
 {% toml_field "defaultImportEnvironment" config["ui"]["default-import-environment"] %}
 {% toml_field "enableModelFolders" config["ui"]["enable-model-folders"] %}


### PR DESCRIPTION
Resolves #13839 (BA-7406)

## Summary

Follow-up to #13837 (BA-7405), which exposed the webserver's configured API domain in the served `config.toml` as `general.domainName`. Review feedback on that key: a bare `domainName` in `[general]` reads like a first-class app setting and collides with the business-logic `domainName` (Domain entity queries, the session's domain), inviting misuse — e.g. future code triggering behavior off a static config copy.

This renames the rendered key to **`general.apiDomainName`**. The prefixed name mirrors its source — webserver.conf's `[api] domain`, the Backend.AI domain this deployment's API access is pinned to — distinguishing it from the session/business-logic domain name. First consumer: pre-login public app config reads (`publicConfigByDomain` branding, FR-1964). The value is still derived from `[api] domain`; there is no second configuration point.

No release has shipped the old key name, so this is a plain rename without a compatibility shim. The WebUI reader adjusts in the FR-1964 PR (lablup/backend.ai-webui#8860).

## Changes

- `config.toml.j2`: `domainName` → `apiDomainName` (still rendered from `config["api"]["domain"]`).
