### PR TITLE
fix(BA-7392): omit a wildcard HostIp from kernel port bindings

### DIFF
--- a/changes/.fix.md
+++ b/changes/.fix.md
@@ -1,0 +1,1 @@
+Omit `HostIp` from kernel port bindings when `container.bind-host` is a wildcard address, which netavark otherwise takes literally and turns into a DNAT rule that never matches, leaving every service port unreachable on Podman.

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -191,6 +191,8 @@ _CGROUP_PATH_CACHE_SIZE: Final[int] = 2048
 
 # Docker splits the configured total container-log size across this many files.
 _CONTAINER_LOG_FILE_COUNT: Final[int] = 5
+# Addresses that mean "bind to every interface" rather than a concrete host address.
+_WILDCARD_BIND_HOSTS: Final[frozenset[str]] = frozenset({"", "0.0.0.0", "::", "[::]"})
 # Controllers the intrinsic plugins read, resolved together from a single inspect.
 _TRACKED_CGROUP_CONTROLLERS: Final[tuple[CgroupController, ...]] = (
     CgroupController.CPUACCT,
@@ -307,6 +309,26 @@ async def get_extra_volumes(docker: Docker, lang: str) -> list[VolumeInfo]:
                 lang,
             )
     return mount_list
+
+
+class PortBinding(BaseModel):
+    host_port: str = Field(serialization_alias="HostPort")
+    host_ip: str | None = Field(
+        default=None,
+        serialization_alias="HostIp",
+        description="Host address to bind to; `None` binds to every interface.",
+    )
+
+
+def _make_port_binding(host_port: int, host_ip: str) -> PortBinding:
+    """
+    Drop a wildcard host IP: netavark takes it literally and emits a DNAT rule
+    constrained with `-d 0.0.0.0/32`, which never matches real traffic.
+    """
+    return PortBinding(
+        host_port=str(host_port),
+        host_ip=None if host_ip in _WILDCARD_BIND_HOSTS else host_ip,
+    )
 
 
 def container_from_docker_container(src: DockerContainer) -> Container:
@@ -1288,7 +1310,11 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             "HostConfig": {
                 "Init": True,
                 "PortBindings": {
-                    f"{eport}/tcp": [{"HostPort": str(hport), "HostIp": hip}]
+                    f"{eport}/tcp": [
+                        _make_port_binding(hport, hip).model_dump(
+                            mode="json", by_alias=True, exclude_none=True
+                        )
+                    ]
                     for eport, hport, hip in zip(exposed_ports, host_ports, host_ips, strict=True)
                 },
                 "PublishAllPorts": False,  # we manage port mapping manually!

--- a/tests/unit/agent/test_docker_agent.py
+++ b/tests/unit/agent/test_docker_agent.py
@@ -19,7 +19,9 @@ from ai.backend.agent.config.unified import (
 from ai.backend.agent.docker.agent import (
     DockerKernelCreationContext,
     LogDriverOptions,
+    PortBinding,
     _build_log_config,
+    _make_port_binding,
     _parse_distro_from_ldd_output,
 )
 
@@ -347,3 +349,31 @@ class TestBuildLogConfig:
 
         assert dumped == expected
         assert type(dumped["Type"]) is str
+
+
+class TestMakePortBinding:
+    @pytest.mark.parametrize("host_ip", ["", "0.0.0.0", "::", "[::]"])
+    def test_wildcard_address_drops_host_ip(self, host_ip: str) -> None:
+        """netavark turns an explicit wildcard into a DNAT rule that matches nothing."""
+        assert _make_port_binding(30001, host_ip) == PortBinding(host_port="30001", host_ip=None)
+
+    @pytest.mark.parametrize("host_ip", ["127.0.0.1", "10.0.1.5", "::1"])
+    def test_concrete_address_is_kept(self, host_ip: str) -> None:
+        assert _make_port_binding(30001, host_ip) == PortBinding(host_port="30001", host_ip=host_ip)
+
+    @pytest.mark.parametrize(
+        ("host_ip", "expected"),
+        [
+            ("0.0.0.0", {"HostPort": "30001"}),
+            ("127.0.0.1", {"HostPort": "30001", "HostIp": "127.0.0.1"}),
+        ],
+    )
+    def test_dumped_payload_uses_docker_api_keys(
+        self, host_ip: str, expected: dict[str, Any]
+    ) -> None:
+        """The dump is what actually goes into the container creation request."""
+        dumped = _make_port_binding(30001, host_ip).model_dump(
+            mode="json", by_alias=True, exclude_none=True
+        )
+
+        assert dumped == expected


### PR DESCRIPTION
## Summary

- Every published kernel service port was unreachable on Podman: the host socket listened, the service answered on the container IP, but nothing was forwarded and connections piled up unaccepted in the backlog. No error surfaced anywhere — the container started, the ports appeared published, and the failure showed up only as client-side timeouts, so app proxying failed for every session on the node.
- The agent always sent an explicit `HostIp` in `HostConfig.PortBindings`, taken from `container.bind-host`. netavark reads `"0.0.0.0"` as a literal destination and emits a DNAT rule constrained with `-d 0.0.0.0/32`, which never matches real traffic. Docker's iptables backend accepts the same value, which is why this never showed up before.
- Leaving `container.bind-host` empty does not avoid it: the agent auto-fills an empty value from `agent.rpc-listen-addr.host`, which is `0.0.0.0` whenever the agent listens on all interfaces, as it does in a multi-node deployment. The value reaches the container config even though the operator never wrote it.
- A wildcard is now expressed by leaving `HostIp` out of the payload. A concrete address is still sent verbatim, so the loopback-only repl and protected service ports keep their binding.

Measured on the reporter's environment (Podman 4.9.3, rootful, netavark, Ubuntu 24.04):

| `HostIp` | via loopback | via node IP | generated DNAT rule |
|---|---|---|---|
| omitted | 200 | 200 | no `-d` constraint |
| `""` | 200 | 200 | no `-d` constraint |
| `"0.0.0.0"` | 000 | 000 | `-d 0.0.0.0/32 ...` |
| `"<node IP>"` | 000 | 200 | `-d <node IP>/32 ...` |

## Test plan

Unit — `tests/unit/agent/test_docker_agent.py::TestMakePortBinding`:

- [x] A wildcard host IP (`""`, `0.0.0.0`, `::`, `[::]`) drops `HostIp`
- [x] A concrete address (`127.0.0.1`, `10.0.1.5`, `::1`) is kept
- [x] The serialized payload uses the Docker API keys and omits `HostIp` only for a wildcard

Integration — live agent on the Docker backend (OrbStack, Docker Engine 29.4.0), varying `container.bind-host` and reading both `HostConfig.PortBindings` (what the agent sent) and `NetworkSettings.Ports` (what the engine published), then reading the sshd banner off the published port. Reading the banner rather than opening a bare TCP connection is deliberate: the failure leaves connections unaccepted in the backlog, where a connect alone can still look like success.

| `bind-host` | `HostIp` sent | via loopback | via node IP |
|---|---|---|---|
| `127.0.0.1` | `127.0.0.1` | OK | fails, as intended |
| `0.0.0.0` | omitted | OK | OK |
| `::` | omitted | OK | OK |
| `192.168.139.2` (concrete) | `192.168.139.2` | fails | OK ¹ |

¹ Probed from inside the engine host's network namespace — that address is an interface of the Docker VM, not of the macOS host. This reproduces the `"<node IP>"` row of the table above, confirming a concrete address keeps its binding semantics.

- [x] Reverting to the pre-fix payload on the same setup sends `HostIp: "0.0.0.0"` again, so the live path is what changed. Both are reachable under Docker, matching the 200/200 row above — the difference is the payload, and that is where netavark diverges.
- [x] The repl ports and the protected service ports stay bound to `127.0.0.1` in every case
- [ ] Verify on Podman/netavark — not reproducible on the Docker backend, so the final check belongs on the reporter's environment

## Notes

- Backport target not decided yet — this is a `fix:` PR, so without a `Backport:` trailer it would go to every maintained version (26.8, 26.4).

Resolves BA-7392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
