### PR TITLE
feat(BA-7410): allow binding idle checkers to a user scope

### DIFF
--- a/changes/13852.feature.md
+++ b/changes/13852.feature.md
@@ -1,0 +1,1 @@
+Add `user` as an idle checker assignment scope type so a checker can be bound to an individual user's sessions

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8445,6 +8445,7 @@ enum IdleCheckerScopeType
   DOMAIN @join__enumValue(graph: STRAWBERRY)
   PROJECT @join__enumValue(graph: STRAWBERRY)
   RESOURCE_GROUP @join__enumValue(graph: STRAWBERRY)
+  USER @join__enumValue(graph: STRAWBERRY)
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5822,6 +5822,7 @@ enum IdleCheckerScopeType {
   DOMAIN
   PROJECT
   RESOURCE_GROUP
+  USER
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -10547,7 +10547,8 @@
         "enum": [
           "domain",
           "project",
-          "resource_group"
+          "resource_group",
+          "user"
         ],
         "title": "IdleCheckerScopeTypeDTO",
         "type": "string"

--- a/src/ai/backend/common/dto/manager/v2/idle_checker_assignment/types.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker_assignment/types.py
@@ -11,6 +11,7 @@ class IdleCheckerScopeTypeDTO(StrEnum):
     DOMAIN = "domain"
     PROJECT = "project"
     RESOURCE_GROUP = "resource_group"
+    USER = "user"
 
 
 class ScopeTypeFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/gql/idle_checker_assignment/types.py
+++ b/src/ai/backend/manager/api/gql/idle_checker_assignment/types.py
@@ -80,6 +80,7 @@ class IdleCheckerScopeTypeGQL(StrEnum):
     DOMAIN = "domain"
     PROJECT = "project"
     RESOURCE_GROUP = "resource_group"
+    USER = "user"
 
 
 @gql_pydantic_input(

--- a/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/idle_checker/db_source/db_source.py
@@ -47,6 +47,7 @@ from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.models.session.row import SessionRow
 from ai.backend.manager.models.specs.pagination import NoPagination, OffsetPagination
+from ai.backend.manager.models.user.row import UserRow
 from ai.backend.manager.repositories.base import (
     BatchPurger,
     BatchQuerier,
@@ -156,6 +157,9 @@ class IdleCheckerDBSource:
                     )
                     result = await w.batch_query_in_global(sa.select(ScalingGroupRow), querier)
                     scope_exists = bool(result.rows)
+                case ScopeType.USER:
+                    user_row = await w.query(Querier(row_class=UserRow, pk_value=spec.scope_id))
+                    scope_exists = user_row is not None
                 case _:
                     scope_exists = False
             if not scope_exists:
@@ -359,6 +363,10 @@ class IdleCheckerDBSource:
             sa.and_(
                 IdleCheckerBindingRow.scope_type == ScopeType.DOMAIN.value,
                 IdleCheckerBindingRow.scope_id == SessionRow.domain_id,
+            ),
+            sa.and_(
+                IdleCheckerBindingRow.scope_type == ScopeType.USER.value,
+                IdleCheckerBindingRow.scope_id == SessionRow.user_uuid,
             ),
         )
         desired_query = (

--- a/tests/component/idle_checker_assignment/conftest.py
+++ b/tests/component/idle_checker_assignment/conftest.py
@@ -80,6 +80,7 @@ class AssignmentSeedData:
     domain_assignment_id: uuid.UUID
     project_assignment_id: uuid.UUID
     other_project_assignment_id: uuid.UUID
+    user_assignment_id: uuid.UUID
 
 
 @pytest.fixture()
@@ -159,6 +160,7 @@ async def user_v2_registry(
 async def assignment_seed(
     database_engine: ExtendedAsyncSAEngine,
     database_fixture: None,
+    regular_user_fixture: UserFixtureData,
 ) -> AsyncIterator[AssignmentSeedData]:
     """Seed a domain and two projects, one checker, and one assignment per scope.
 
@@ -231,14 +233,22 @@ async def assignment_seed(
             idle_checker_id=checker_id,
             enabled=True,
         )
+        user_assignment = IdleCheckerBindingRow(
+            scope_type=ScopeType.USER,
+            scope_id=regular_user_fixture.user_uuid,
+            idle_checker_id=checker_id,
+            enabled=True,
+        )
         db_sess.add(domain_assignment)
         db_sess.add(project_assignment)
         db_sess.add(other_project_assignment)
+        db_sess.add(user_assignment)
         await db_sess.flush()
         assignment_scopes = [
             (domain_assignment.id, ScopeType.DOMAIN, str(domain_id)),
             (project_assignment.id, ScopeType.PROJECT, str(project_id)),
             (other_project_assignment.id, ScopeType.PROJECT, str(other_project_id)),
+            (user_assignment.id, ScopeType.USER, str(regular_user_fixture.user_uuid)),
         ]
         for assignment_id, scope_type, scope_id in assignment_scopes:
             db_sess.add(
@@ -258,6 +268,7 @@ async def assignment_seed(
             domain_assignment_id=domain_assignment.id,
             project_assignment_id=project_assignment.id,
             other_project_assignment_id=other_project_assignment.id,
+            user_assignment_id=user_assignment.id,
         )
     yield seed
     async with database_engine.begin() as conn:
@@ -268,6 +279,7 @@ async def assignment_seed(
                     str(seed.domain_assignment_id),
                     str(seed.project_assignment_id),
                     str(seed.other_project_assignment_id),
+                    str(seed.user_assignment_id),
                 ])
             )
         )
@@ -373,3 +385,78 @@ async def project_assignment_manage_permission(
             UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
         )
         await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+@pytest.fixture()
+async def user_self_scope_permission(
+    database_engine: ExtendedAsyncSAEngine,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[None]:
+    """Grant the regular user UPDATE/PURGE on entity type USER at their own user scope.
+
+    This mirrors what a user's system self-role carries. It must not reach idle checker
+    assignments bound to that same user scope.
+    """
+    role_id = uuid.uuid4()
+    async with database_engine.begin_session() as db_sess:
+        db_sess.add(
+            RoleRow(
+                id=role_id,
+                name=f"icb-self-role-{role_id.hex[:8]}",
+                description="idle checker assignment self scope test role",
+            )
+        )
+        await db_sess.flush()
+        db_sess.add(UserRoleRow(user_id=regular_user_fixture.user_uuid, role_id=role_id))
+        for operation in (OperationType.UPDATE, OperationType.HARD_DELETE):
+            db_sess.add(
+                PermissionRow(
+                    role_id=role_id,
+                    scope_type=ScopeType.USER,
+                    scope_id=str(regular_user_fixture.user_uuid),
+                    entity_type=EntityType.USER,
+                    operation=operation,
+                    permission=Permission.from_operation(operation),
+                )
+            )
+        await db_sess.flush()
+    yield
+    async with database_engine.begin() as conn:
+        await conn.execute(
+            PermissionRow.__table__.delete().where(PermissionRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(
+            UserRoleRow.__table__.delete().where(UserRoleRow.__table__.c.role_id == role_id)
+        )
+        await conn.execute(RoleRow.__table__.delete().where(RoleRow.__table__.c.id == role_id))
+
+
+@pytest.fixture()
+async def user_in_seeded_project(
+    database_engine: ExtendedAsyncSAEngine,
+    regular_user_fixture: UserFixtureData,
+    assignment_seed: AssignmentSeedData,
+) -> AsyncIterator[None]:
+    """Place the regular user under the seeded project via an AUTO scope edge."""
+    async with database_engine.begin_session() as db_sess:
+        db_sess.add(
+            AssociationScopesEntitiesRow(
+                scope_type=ScopeType.PROJECT,
+                scope_id=str(assignment_seed.project_id),
+                entity_type=EntityType.USER,
+                entity_id=str(regular_user_fixture.user_uuid),
+                relation_type=RelationType.AUTO,
+            )
+        )
+        await db_sess.flush()
+    yield
+    async with database_engine.begin() as conn:
+        await conn.execute(
+            AssociationScopesEntitiesRow.__table__.delete().where(
+                AssociationScopesEntitiesRow.__table__.c.entity_type == EntityType.USER,
+                AssociationScopesEntitiesRow.__table__.c.entity_id
+                == str(regular_user_fixture.user_uuid),
+                AssociationScopesEntitiesRow.__table__.c.scope_id
+                == str(assignment_seed.project_id),
+            )
+        )

--- a/tests/component/idle_checker_assignment/test_scoped_search_permissions.py
+++ b/tests/component/idle_checker_assignment/test_scoped_search_permissions.py
@@ -207,3 +207,48 @@ class TestIdleCheckerAssignmentMutationPermissions:
         )
 
         assert result.idle_checker_assignment.enabled is False
+
+    async def test_user_cannot_update_assignment_bound_to_own_user_scope(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        user_self_scope_permission: None,
+    ) -> None:
+        """Owning the user scope does not grant managing the idle check bound to it."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.idle_checker_assignment.update(
+                assignment_seed.user_assignment_id,
+                UpdateIdleCheckerAssignmentInput(
+                    id=IdleCheckerAssignmentID(assignment_seed.user_assignment_id),
+                    enabled=False,
+                ),
+            )
+
+    async def test_user_cannot_purge_assignment_bound_to_own_user_scope(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        user_self_scope_permission: None,
+    ) -> None:
+        """Same for purge — a user must not be able to drop their own idle check."""
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.idle_checker_assignment.purge(assignment_seed.user_assignment_id)
+
+    async def test_project_manager_updates_user_scope_assignment_of_project_member(
+        self,
+        user_v2_registry: V2ClientRegistry,
+        assignment_seed: AssignmentSeedData,
+        user_in_seeded_project: None,
+        project_assignment_manage_permission: None,
+    ) -> None:
+        """The scope chain walks user -> project, so project-scope manage rights reach a
+        member's user-scope assignment. Domain-scope grants reach it the same way."""
+        result = await user_v2_registry.idle_checker_assignment.update(
+            assignment_seed.user_assignment_id,
+            UpdateIdleCheckerAssignmentInput(
+                id=IdleCheckerAssignmentID(assignment_seed.user_assignment_id),
+                enabled=False,
+            ),
+        )
+
+        assert result.idle_checker_assignment.enabled is False

--- a/tests/unit/manager/repositories/idle_checker/test_assignment_crud.py
+++ b/tests/unit/manager/repositories/idle_checker/test_assignment_crud.py
@@ -14,11 +14,13 @@ from ai.backend.common.data.idle_checker.types import (
 from ai.backend.common.data.permission.types import (
     ScopeType,
 )
+from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.identifier.domain import DomainID
 from ai.backend.common.identifier.idle_checker import IdleCheckerAssignmentID, IdleCheckerID
 from ai.backend.common.identifier.resource_group import ResourceGroupID
 from ai.backend.common.types import ResourceSlot, SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckerAssignmentData, IdleCheckerData
+from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.errors.idle_checker import (
     IdleCheckerAssignmentAlreadyExists,
     IdleCheckerAssignmentNotFound,
@@ -37,9 +39,11 @@ from ai.backend.manager.models.rbac_models.permission.permission import Permissi
 from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.resource_policy import (
     ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
 )
 from ai.backend.manager.models.scaling_group import ScalingGroupOpts, ScalingGroupRow
 from ai.backend.manager.models.specs.pagination import NoPagination
+from ai.backend.manager.models.user.row import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import (
     BatchQuerier,
@@ -71,7 +75,9 @@ class TestIdleCheckerAssignmentRepository:
             [
                 DomainRow,
                 ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
                 GroupRow,
+                UserRow,
                 ScalingGroupRow,
                 RoleRow,
                 PermissionRow,
@@ -155,6 +161,42 @@ class TestIdleCheckerAssignmentRepository:
                 )
             )
         return project_id
+
+    @pytest.fixture
+    async def user_id(
+        self,
+        database: ExtendedAsyncSAEngine,
+        domain_id: DomainID,
+    ) -> uuid.UUID:
+        user_id = uuid.uuid4()
+        policy_name = f"urp-{user_id.hex[:8]}"
+        async with database.begin_session() as db_sess:
+            db_sess.add(
+                UserResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_session_count_per_model_session=0,
+                    max_customized_image_count=0,
+                )
+            )
+            await db_sess.flush()
+            db_sess.add(
+                UserRow(
+                    uuid=user_id,
+                    username=f"user-{user_id.hex[:8]}",
+                    email=f"{user_id.hex[:8]}@example.com",
+                    password=None,
+                    need_password_change=False,
+                    status=UserStatus.ACTIVE,
+                    status_info="active",
+                    domain_name=f"domain-{domain_id.hex[:8]}",
+                    role=UserRole.USER,
+                    resource_policy=policy_name,
+                    domain_id=domain_id,
+                )
+            )
+        return user_id
 
     @pytest.fixture
     async def checker(self, repository: IdleCheckerRepository) -> IdleCheckerData:
@@ -262,6 +304,65 @@ class TestIdleCheckerAssignmentRepository:
                     scope_id=uuid.uuid4(),
                     idle_checker_id=checker.id,
                     enabled=True,
+                )
+            )
+
+    async def test_create_assignment_on_user_scope(
+        self,
+        repository: IdleCheckerRepository,
+        checker: IdleCheckerData,
+        user_id: uuid.UUID,
+    ) -> None:
+        assignment = await repository.create_assignment(
+            IdleCheckerAssignmentCreatorSpec(
+                scope_type=ScopeType.USER,
+                scope_id=user_id,
+                idle_checker_id=checker.id,
+                enabled=True,
+            )
+        )
+
+        assert assignment.scope_type is ScopeType.USER
+        assert assignment.scope_id == user_id
+        assert assignment.enabled is True
+
+    async def test_create_assignment_missing_user_scope_raises(
+        self,
+        repository: IdleCheckerRepository,
+        checker: IdleCheckerData,
+    ) -> None:
+        with pytest.raises(IdleCheckerAssignmentScopeNotFound):
+            await repository.create_assignment(
+                IdleCheckerAssignmentCreatorSpec(
+                    scope_type=ScopeType.USER,
+                    scope_id=uuid.uuid4(),
+                    idle_checker_id=checker.id,
+                    enabled=True,
+                )
+            )
+
+    async def test_create_duplicate_user_scope_assignment_raises(
+        self,
+        repository: IdleCheckerRepository,
+        checker: IdleCheckerData,
+        user_id: uuid.UUID,
+    ) -> None:
+        await repository.create_assignment(
+            IdleCheckerAssignmentCreatorSpec(
+                scope_type=ScopeType.USER,
+                scope_id=user_id,
+                idle_checker_id=checker.id,
+                enabled=True,
+            )
+        )
+
+        with pytest.raises(IdleCheckerAssignmentAlreadyExists):
+            await repository.create_assignment(
+                IdleCheckerAssignmentCreatorSpec(
+                    scope_type=ScopeType.USER,
+                    scope_id=user_id,
+                    idle_checker_id=checker.id,
+                    enabled=False,
                 )
             )
 

--- a/tests/unit/manager/repositories/idle_checker/test_repository.py
+++ b/tests/unit/manager/repositories/idle_checker/test_repository.py
@@ -133,19 +133,21 @@ def _expired_check_session_row(
     scope: ScopeFixture,
     session_id: SessionId,
     status: SessionStatus,
+    user_uuid: uuid.UUID | None = None,
+    session_type: SessionTypes = SessionTypes.INTERACTIVE,
 ) -> SessionRow:
     return SessionRow(
         id=session_id,
         creation_id=str(session_id)[:32],
         name=f"session-{session_id}",
-        session_type=SessionTypes.INTERACTIVE,
+        session_type=session_type,
         cluster_mode=ClusterMode.SINGLE_NODE,
         cluster_size=1,
         domain_name=scope.domain_name,
         domain_id=scope.domain_id,
         resource_group_id=scope.scaling_group_id,
         group_id=scope.project_id,
-        user_uuid=uuid.uuid4(),
+        user_uuid=user_uuid if user_uuid is not None else uuid.uuid4(),
         access_key=None,
         tag=None,
         status=status,
@@ -1511,3 +1513,176 @@ class TestSessionIdleCheckExclusion:
         assert user_row is not None
         assert user_row.is_manual is True
         assert system_row is None
+
+
+@dataclass(frozen=True)
+class UserScopeRows:
+    bound_user_id: uuid.UUID
+    bound_user_session_id: SessionId
+    other_user_session_id: SessionId
+    batch_session_id: SessionId
+    user_only_checker_id: IdleCheckerID
+    domain_checker_id: IdleCheckerID
+    interactive_only_checker_id: IdleCheckerID
+
+
+class TestUserScopeAssignments:
+    @pytest.fixture
+    async def database(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+        async with with_tables(
+            database_connection,
+            [
+                ProjectResourcePolicyRow,
+                DomainRow,
+                UserResourcePolicyRow,
+                UserRow,
+                GroupRow,
+                ScalingGroupRow,
+                SessionRow,
+                IdleCheckerRow,
+                IdleCheckerBindingRow,
+                SessionIdleCheckRow,
+            ],
+        ):
+            yield database_connection
+
+    @pytest.fixture
+    def repository(self, database: ExtendedAsyncSAEngine) -> IdleCheckerRepository:
+        return IdleCheckerRepository(DBOpsProvider(database))
+
+    @pytest.fixture
+    async def user_scope_rows(
+        self,
+        database: ExtendedAsyncSAEngine,
+    ) -> UserScopeRows:
+        scope = _expired_check_scope_fixture("user-scope")
+        bound_user_id = uuid.uuid4()
+        other_user_id = uuid.uuid4()
+        bound_user_session_id = SessionId(uuid.uuid4())
+        other_user_session_id = SessionId(uuid.uuid4())
+        batch_session_id = SessionId(uuid.uuid4())
+        user_only_checker_id = IdleCheckerID(uuid.uuid4())
+        domain_checker_id = IdleCheckerID(uuid.uuid4())
+        interactive_only_checker_id = IdleCheckerID(uuid.uuid4())
+        async with database.begin_session() as db_sess:
+            for scope_row in _expired_check_scope_rows(scope):
+                db_sess.add(scope_row)
+            db_sess.add(
+                _expired_check_session_row(
+                    scope,
+                    bound_user_session_id,
+                    SessionStatus.RUNNING,
+                    user_uuid=bound_user_id,
+                )
+            )
+            db_sess.add(
+                _expired_check_session_row(
+                    scope,
+                    other_user_session_id,
+                    SessionStatus.RUNNING,
+                    user_uuid=other_user_id,
+                )
+            )
+            db_sess.add(
+                _expired_check_session_row(
+                    scope,
+                    batch_session_id,
+                    SessionStatus.RUNNING,
+                    user_uuid=bound_user_id,
+                    session_type=SessionTypes.BATCH,
+                )
+            )
+            db_sess.add(_expired_check_checker_row(user_only_checker_id))
+            db_sess.add(_expired_check_checker_row(domain_checker_id))
+            db_sess.add(_expired_check_checker_row(interactive_only_checker_id))
+            await db_sess.flush()
+            db_sess.add(
+                IdleCheckerBindingRow(
+                    scope_type=ScopeType.USER.value,
+                    scope_id=bound_user_id,
+                    idle_checker_id=user_only_checker_id,
+                    enabled=True,
+                )
+            )
+            db_sess.add(
+                IdleCheckerBindingRow(
+                    scope_type=ScopeType.DOMAIN.value,
+                    scope_id=scope.domain_id,
+                    idle_checker_id=domain_checker_id,
+                    enabled=True,
+                )
+            )
+            # A disabled narrower binding must not subtract the domain-inherited checker.
+            db_sess.add(
+                IdleCheckerBindingRow(
+                    scope_type=ScopeType.USER.value,
+                    scope_id=bound_user_id,
+                    idle_checker_id=domain_checker_id,
+                    enabled=False,
+                )
+            )
+            db_sess.add(
+                IdleCheckerBindingRow(
+                    scope_type=ScopeType.USER.value,
+                    scope_id=bound_user_id,
+                    idle_checker_id=interactive_only_checker_id,
+                    enabled=True,
+                )
+            )
+        return UserScopeRows(
+            bound_user_id=bound_user_id,
+            bound_user_session_id=bound_user_session_id,
+            other_user_session_id=other_user_session_id,
+            batch_session_id=batch_session_id,
+            user_only_checker_id=user_only_checker_id,
+            domain_checker_id=domain_checker_id,
+            interactive_only_checker_id=interactive_only_checker_id,
+        )
+
+    async def test_user_binding_attaches_only_to_that_users_sessions(
+        self,
+        repository: IdleCheckerRepository,
+        user_scope_rows: UserScopeRows,
+    ) -> None:
+        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
+
+        sessions_of_user_only_checker = {
+            pair.session_id
+            for pair in assignments.desired_pairs
+            if pair.checker_id == user_scope_rows.user_only_checker_id
+        }
+        assert sessions_of_user_only_checker == {user_scope_rows.bound_user_session_id}
+
+    async def test_disabled_user_binding_keeps_domain_inherited_checker(
+        self,
+        repository: IdleCheckerRepository,
+        user_scope_rows: UserScopeRows,
+    ) -> None:
+        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
+
+        assert (
+            SessionIdleCheckPair(
+                user_scope_rows.bound_user_session_id,
+                user_scope_rows.domain_checker_id,
+            )
+            in assignments.desired_pairs
+        )
+
+    async def test_user_binding_respects_target_session_types(
+        self,
+        repository: IdleCheckerRepository,
+        user_scope_rows: UserScopeRows,
+    ) -> None:
+        assignments = await repository.fetch_session_idle_check_assignments([SessionStatus.RUNNING])
+
+        sessions_of_interactive_only_checker = {
+            pair.session_id
+            for pair in assignments.desired_pairs
+            if pair.checker_id == user_scope_rows.interactive_only_checker_id
+        }
+        # The binding is live for this user, so only the session-type filter can exclude the
+        # batch session.
+        assert sessions_of_interactive_only_checker == {user_scope_rows.bound_user_session_id}


### PR DESCRIPTION
## Summary

- Add `USER` to `IdleCheckerScopeTypeDTO` / `IdleCheckerScopeTypeGQL`, so a checker can be bound to an individual user in addition to domain / project / resource group.
- Resolve `UserRow` in the create-time scope existence check (`IdleCheckerDBSource.create_assignment`); without it the `case _` fallback would raise `IdleCheckerAssignmentScopeNotFound` for every user scope.
- OR a fourth branch into `scope_matches` in `fetch_session_idle_check_assignments` (`scope_type == user AND scope_id == SessionRow.user_uuid`), so the binding attaches to that user's sessions.
- Regenerate `docs/manager/graphql-reference/*.graphql` and `docs/manager/rest-reference/openapi.json`.

Semantics are union, identical to the existing three scope types. A user-scope binding can only ADD a checker; a disabled one cannot subtract a checker inherited from a broader scope, since the desired-pair query ORs the scopes and filters on `enabled = true`. Per-user exemption stays out of scope and is served by the session idle-check exclusion API (BA-7243 / BA-7244).

Write authorization is deliberately not widened. Assignment create and admin search stay on superadmin-only routes; update / purge keep the existing RBAC validator. A user cannot enable or disable their own idle check — their system self-role carries entity type `user`, not `idle_checker_assignment`, so the scope-chain check finds no grant. Read access through `scoped_search` for a caller's own user scope is intentionally left as is.

## Test plan

- [x] `pants test tests/unit/manager/repositories/idle_checker::` — user-scope create success / missing user scope / duplicate pair; assignment sync attaches to the bound user's sessions only, keeps domain-inherited checkers under a disabled user binding, and respects `target_session_types`
- [x] `pants test tests/component/idle_checker_assignment::` — non-superadmin PATCH and DELETE on a user-scope assignment bound to their own user id return 403 even when holding `user`-entity update/purge rights at that same user scope
- [x] `pants fmt / fix / lint / check` on the changed files
- [x] Live server (`./bai`): create with `--scope-type user` returns the node with `scope_type: user`; non-existent user id -> 404 `IdleCheckerAssignmentScopeNotFound`; duplicate pair -> 409 `IdleCheckerAssignmentAlreadyExists`; non-superadmin PATCH / DELETE / admin create -> 403
- [x] Live end-to-end: two RUNNING sessions owned by different users, checker bound to one user only -> `session_idle_checks` row created for that user's session only; disabling the binding removes it

Resolves BA-7410

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13852.org.readthedocs.build/en/13852/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13852.org.readthedocs.build/ko/13852/

<!-- readthedocs-preview sorna-ko end -->