### PR TITLE
fix(install): register local Harbor with a reachable host:port registry name (#13288)

### DIFF
--- a/changes/13288.fix.md
+++ b/changes/13288.fix.md
@@ -1,0 +1,1 @@
+Fix the TUI installer to register the local Harbor container registry under its reachable `host:port` instead of the unresolvable `local-harbor` label, which docker parsed as a Docker Hub namespace and failed pushes with `insufficient_scope: authorization failed`

--- a/src/ai/backend/install/app.py
+++ b/src/ai/backend/install/app.py
@@ -466,9 +466,11 @@ class InstallReport(Static):
                 - Password: `{harbor.admin_password}`
 
                 The Harbor instance is also pre-registered as a Backend.AI
-                container registry named `local-harbor` (project `library`)
-                with the same admin credentials, so it appears in
-                `mgr image rescan` / the manager UI as soon as you start it.
+                container registry named `{harbor.hostname}:{harbor.http_port}`
+                (project `library`) with the same admin credentials, so it
+                appears in `mgr image rescan` / the manager UI as soon as you
+                start it. Push images to it with
+                `docker push {harbor.hostname}:{harbor.http_port}/library/<image>:<tag>`.
 
                 Note: Harbor may take 30-60 seconds to become fully ready
                 after `./dev harbor start`.

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -1789,7 +1789,12 @@ class Context(metaclass=ABCMeta):
         idempotent.
         """
         harbor_url = f"http://{harbor.hostname}:{harbor.http_port}"
-        registry_name = "local-harbor"
+        # The registry name becomes the prefix of every image canonical
+        # (``{registry_name}/{image}:{tag}``) that docker pushes/pulls
+        # against, so it must be the actual reachable ``host:port`` — a bare
+        # label without a dot or colon would be parsed by docker as a Docker
+        # Hub namespace.
+        registry_name = f"{harbor.hostname}:{harbor.http_port}"
         project = "library"
         registry_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{harbor_url}/{project}"))
         fixture = {


### PR DESCRIPTION
This is an auto-generated backport of #13288 to the 26.8 release.