### PR TITLE
fix(install): register local Harbor with a reachable host:port registry name (#13288)

### DIFF
--- a/changes/13288.fix.md
+++ b/changes/13288.fix.md
@@ -1,0 +1,1 @@
+Fix the TUI installer to register the local Harbor container registry under its reachable `host:port` instead of the unresolvable `local-harbor` label, which docker parsed as a Docker Hub namespace and failed pushes with `insufficient_scope: authorization failed`

--- a/src/ai/backend/install/app.py
+++ b/src/ai/backend/install/app.py
@@ -459,9 +459,11 @@ class InstallReport(Static):
                 - Password: `{service.harbor_admin_password}`
 
                 The Harbor instance is also pre-registered as a Backend.AI
-                container registry named `local-harbor` (project `library`)
-                with the same admin credentials, so it appears in
-                `mgr image rescan` / the manager UI as soon as you start it.
+                container registry named `{harbor.hostname}:{harbor.http_port}`
+                (project `library`) with the same admin credentials, so it
+                appears in `mgr image rescan` / the manager UI as soon as you
+                start it. Push images to it with
+                `docker push {harbor.hostname}:{harbor.http_port}/library/<image>:<tag>`.
 
                 Note: Harbor may take 30-60 seconds to become fully ready
                 after `./dev harbor start`.

--- a/src/ai/backend/install/app.py
+++ b/src/ai/backend/install/app.py
@@ -459,11 +459,11 @@ class InstallReport(Static):
                 - Password: `{service.harbor_admin_password}`
 
                 The Harbor instance is also pre-registered as a Backend.AI
-                container registry named `{harbor.hostname}:{harbor.http_port}`
+                container registry named `{service.harbor_hostname}:{service.harbor_http_port}`
                 (project `library`) with the same admin credentials, so it
                 appears in `mgr image rescan` / the manager UI as soon as you
                 start it. Push images to it with
-                `docker push {harbor.hostname}:{harbor.http_port}/library/<image>:<tag>`.
+                `docker push {service.harbor_hostname}:{service.harbor_http_port}/library/<image>:<tag>`.
 
                 Note: Harbor may take 30-60 seconds to become fully ready
                 after `./dev harbor start`.

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -1680,9 +1680,19 @@ class Context(metaclass=ABCMeta):
         manager's fixture loader treats a matching primary key as
         idempotent.
         """
+<<<<<<< HEAD
         service = self.install_info.service_config
         harbor_url = f"http://{service.harbor_hostname}:{service.harbor_http_port}"
         registry_name = "local-harbor"
+=======
+        harbor_url = f"http://{harbor.hostname}:{harbor.http_port}"
+        # The registry name becomes the prefix of every image canonical
+        # (``{registry_name}/{image}:{tag}``) that docker pushes/pulls
+        # against, so it must be the actual reachable ``host:port`` — a bare
+        # label without a dot or colon would be parsed by docker as a Docker
+        # Hub namespace.
+        registry_name = f"{harbor.hostname}:{harbor.http_port}"
+>>>>>>> 2f6b75c5 (fix(install): register local Harbor with a reachable host:port registry name (#13288))
         project = "library"
         registry_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{harbor_url}/{project}"))
         fixture = {

--- a/src/ai/backend/install/context.py
+++ b/src/ai/backend/install/context.py
@@ -1680,19 +1680,14 @@ class Context(metaclass=ABCMeta):
         manager's fixture loader treats a matching primary key as
         idempotent.
         """
-<<<<<<< HEAD
         service = self.install_info.service_config
         harbor_url = f"http://{service.harbor_hostname}:{service.harbor_http_port}"
-        registry_name = "local-harbor"
-=======
-        harbor_url = f"http://{harbor.hostname}:{harbor.http_port}"
         # The registry name becomes the prefix of every image canonical
         # (``{registry_name}/{image}:{tag}``) that docker pushes/pulls
         # against, so it must be the actual reachable ``host:port`` — a bare
         # label without a dot or colon would be parsed by docker as a Docker
         # Hub namespace.
-        registry_name = f"{harbor.hostname}:{harbor.http_port}"
->>>>>>> 2f6b75c5 (fix(install): register local Harbor with a reachable host:port registry name (#13288))
+        registry_name = f"{service.harbor_hostname}:{service.harbor_http_port}"
         project = "library"
         registry_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{harbor_url}/{project}"))
         fixture = {


### PR DESCRIPTION
This is an auto-generated backport of #13288 to the 26.4 release.