### PR TITLE
ci(BA-7433): detect edits to already-merged alembic migrations

### DIFF
--- a/.github/scripts/check-migration-edits.sh
+++ b/.github/scripts/check-migration-edits.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Report the alembic migrations a pull request rewrites, deletes or renames
+# rather than adds. A migration another database has already applied cannot be
+# changed in place -- the change never reaches that database.
+#
+#   check-migration-edits.sh --base-sha <sha> --head-sha <sha> [options]
+#
+#     --base-sha <sha>  the commit the pull request would be merged into
+#     --head-sha <sha>  the commit it would be merged from
+#     --base-ref <ref>  the branch it is opened against, which decides how far
+#                       the release marker below is trusted (default: main)
+#     --labels <csv>    its labels, carrying the override below
+#     --label <name>    the label that lets a finding through
+#                       (default: allow:migration-edit)
+#
+# One finding per line on stdout, tab separated, worst first:
+#
+#   <severity>	<verb>	<path>	<what the migration is>
+#
+# `released` names a migration that has been through a release cut, `unreleased`
+# one merged during the current development cycle, and `allowed` either of the
+# two on a pull request carrying the override label. Exit 1 when a finding
+# stands, 0 when there is none or the label carries them all.
+#
+# Whether a migration has been released is read off its `# Part of:` comment,
+# which `scripts/freeze_release_version.py` rewrites from NEXT_RELEASE_VERSION
+# to the version being cut.
+#
+# Run it against your own checkout to reproduce a decision:
+#
+#   .github/scripts/check-migration-edits.sh \
+#     --base-sha origin/main --head-sha HEAD
+
+set -e
+
+usage() {
+  echo "Usage: $0 --base-sha <sha> --head-sha <sha> [options]"
+  echo "  --base-sha <sha>  the commit the pull request would be merged into"
+  echo "  --head-sha <sha>  the commit it would be merged from"
+  echo "  --base-ref <ref>  the branch it is opened against"
+  echo "                    (default: main)"
+  echo "  --labels <csv>    its labels"
+  echo "  --label <name>    the label that lets a finding through"
+  echo "                    (default: allow:migration-edit)"
+}
+
+base_sha=""
+head_sha=""
+base_ref="main"
+pr_labels=""
+override_label="allow:migration-edit"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    *) [ "$#" -ge 2 ] || { echo "Error: $1 requires a value" >&2; usage >&2; exit 2; } ;;
+  esac
+  case "$1" in
+    --base-sha) base_sha="$2"; shift ;;
+    --head-sha) head_sha="$2"; shift ;;
+    --base-ref) base_ref="$2"; shift ;;
+    --labels) pr_labels="$2"; shift ;;
+    --label) override_label="$2"; shift ;;
+    *) echo "Error: unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
+  echo "Error: --base-sha and --head-sha are required" >&2
+  usage >&2
+  exit 2
+fi
+if [ -z "$override_label" ]; then
+  echo "Error: --label must not be empty" >&2
+  usage >&2
+  exit 2
+fi
+
+# A release branch carries the version in its name and takes no release cut of
+# its own, so the `# Part of:` marker on it is left unfrozen and says nothing.
+trust_marker=false
+case "$base_ref" in
+  main) trust_marker=true ;;
+esac
+
+overridden=false
+case ",${pr_labels}," in
+  *",${override_label},"*) overridden=true ;;
+esac
+
+# The release the pre-image went out in, empty while the placeholder stands.
+describe_migration() {
+  marker=$(git show "$base_sha:$1" 2>/dev/null | grep -m1 '^# Part of:' || true)
+  case "$marker" in
+    "") echo "released before the # Part of: marker" ;;
+    *NEXT_RELEASE_VERSION*) echo "" ;;
+    *) echo "released in ${marker#\# Part of: }" ;;
+  esac
+}
+
+released=""
+unreleased=""
+
+while IFS="$(printf '\t')" read -r status old new; do
+  # A diff that found nothing still reaches the loop as one empty line.
+  [ -n "$status" ] || continue
+  case "${status%%[0-9]*}" in
+    A) continue ;;
+    M) verb="rewrites"; path="$old" ;;
+    D) verb="deletes"; path="$old" ;;
+    R) verb="renames"; path="$old" ;;
+    *) verb="changes"; path="$old" ;;
+  esac
+  case "$path" in
+    */__init__.py) continue ;;
+  esac
+
+  description=$(describe_migration "$path")
+  if [ -n "$description" ] || [ "$trust_marker" = false ]; then
+    [ -n "$description" ] || description="released on $base_ref"
+    released="${released}released	${verb}	${path}	${description}
+"
+  else
+    unreleased="${unreleased}unreleased	${verb}	${path}	merged in the current development cycle
+"
+  fi
+done <<EOF
+$(git diff --name-status --find-renames "$base_sha...$head_sha" \
+  -- ':(glob)src/ai/backend/**/alembic/versions/*.py')
+EOF
+
+findings="${released}${unreleased}"
+if [ -z "$findings" ]; then
+  echo "The pull request edits no existing migration." >&2
+  exit 0
+fi
+
+if [ "$overridden" = true ]; then
+  printf '%s' "$findings" | sed 's/^[a-z]*/allowed/'
+  echo "The pull request carries '$override_label'; the findings above stand as a record." >&2
+  exit 0
+fi
+
+printf '%s' "$findings"
+echo "A migration already applied elsewhere cannot be changed in place -- add a new migration instead, or carry '$override_label' to record why this one has to change. See src/ai/backend/manager/models/alembic/AGENTS.md." >&2
+exit 1

--- a/.github/workflows/migration-edit-check.yml
+++ b/.github/workflows/migration-edit-check.yml
@@ -1,0 +1,52 @@
+name: migration-edit-check
+
+# Advisory only: this workflow is deliberately kept out of the required status
+# checks, so a red run asks a reviewer to look rather than blocking the merge.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches:
+      - 'main'
+      - '[0-9][0-9].[0-9]'
+      - '[0-9][0-9].[0-9][0-9]'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-migration-edits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the revision
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          # The check diffs against the merge base and reads the base revision
+          # of every migration it finds edited, so it needs the history. The
+          # filter keeps that from fetching every blob behind it.
+          fetch-depth: 0
+          filter: blob:none
+      - name: Check whether an existing migration is edited
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          status=0
+          findings=$(.github/scripts/check-migration-edits.sh \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --base-ref "$BASE_REF" \
+            --labels "$PR_LABELS") || status=$?
+          while IFS=$'\t' read -r severity verb path what; do
+            [ -n "$path" ] || continue
+            if [ "$severity" = released ]; then level=error; else level=warning; fi
+            echo "::${level} file=${path},title=Edited migration::This pull request ${verb} a migration ${what}."
+          done <<< "$findings"
+          exit $status

--- a/changes/13877.misc.md
+++ b/changes/13877.misc.md
@@ -1,0 +1,1 @@
+Detect a pull request that rewrites, deletes or renames an already-merged alembic migration, in an advisory CI check.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,6 +55,8 @@ current, see `AGENTS.md` in this directory.
 | `knowledge/check.py` | Validates `KNOWLEDGE.md` frontmatter, paths, and body links | auto — `knowledge-check.yml`; person |
 | `get-platform-suffix.py` | Prints the `<os>-<arch>` suffix used in artifact names | auto — `ci.yml`, `build-test.yml` |
 | `.github/scripts/decide-backport-targets.sh` | Reads `.github/maintained-versions.yml` and the `Backport:` trailer to decide the target branches | auto — `backport.yml` |
+| `.github/scripts/check-backport-migration.sh` | Warns when a pull request both carries a `Backport:` trailer and changes the database schema, since both migrations then have to be idempotent | auto — `backport-migration-check.yml` |
+| `.github/scripts/check-migration-edits.sh` | Reports the already-merged alembic migrations a pull request rewrites, deletes or renames; `allow:migration-edit` records an intended one | auto — `migration-edit-check.yml` |
 | `update-default-seccomp.sh` | Refreshes `default-seccomp.json` from the upstream moby profile | auto — `update-seccomp-profile.yml` (monthly); person |
 | `check-docs-label.sh` | Skips a Read the Docs PR preview build unless the PR carries `area:docs`. **Currently unreferenced** — `.readthedocs.yaml` does the same check inline | — |
 


### PR DESCRIPTION
## Summary

- `.github/scripts/check-migration-edits.sh` reports the alembic migrations a pull request rewrites, deletes or renames rather than adds — a migration another database has already applied cannot be changed in place, and nothing enforced `alembic/AGENTS.md` on this so far.
- Detection is the diff status against the merge base. A migration the pull request **adds** is never a finding, so repointing your own unmerged migration's `down_revision` and inserting a backport into the main chain before merge both stay green with no exception logic.
- Whether a migration has been released decides the **severity only**: the `# Part of:` marker (frozen by `scripts/freeze_release_version.py` at each release cut) separates `released` → `::error` from `unreleased` → `::warning`. Every merged migration is reported either way. On a release branch the marker is left unfrozen, so everything there counts as released.
- `.github/workflows/migration-edit-check.yml` is **advisory** — deliberately kept out of the required status checks, like `backport-migration-check.yml`. An `allow:migration-edit` label records an edit that genuinely has to happen rather than blocking it.

One `:(glob)` pathspec covers `manager`, `account_manager` and `appproxy/coordinator`, and any alembic tree added later.

## Test plan

Verified against real repository history and a fixture repository:

- [x] Rewrites a released migration (`f444d1d`, `0f74504`) → `released`, exit 1
- [x] Rewrites a migration merged in the current cycle (`2951084`) → `unreleased`, exit 1
- [x] Deletes a released migration (fixture) → `released deletes`, exit 1
- [x] Renames a migration (`R098`, real commit) → reported under the pre-image path
- [x] Adds a migration only (`1333621b`) → exit 0
- [x] Adds a migration, then repoints its own `down_revision` (fixture) → exit 0
- [x] Touches no migration (`115d4154`) → exit 0
- [x] `--base-ref 26.8` → an unfrozen marker counts as released
- [x] `--labels ...,allow:migration-edit` → findings stand as `allowed`, exit 0
- [x] Missing arguments → exit 2 with usage

Resolves BA-7433