### PR TITLE
refactor(BA-7422): move the auth actions onto the v2 bases

### DIFF
--- a/changes/13884.enhance.md
+++ b/changes/13884.enhance.md
@@ -1,0 +1,1 @@
+Move the manager's authentication actions onto the v2 action bases, so each one declares the entity it is answered for, the operation it performs and the gate it runs behind.

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -32481,21 +32481,6 @@
         "title": "AuthorizeRequest",
         "type": "object"
       },
-      "LogoutRequest": {
-        "description": "Request to invalidate a login session.",
-        "properties": {
-          "session_token": {
-            "description": "The session token to invalidate",
-            "title": "Session Token",
-            "type": "string"
-          }
-        },
-        "required": [
-          "session_token"
-        ],
-        "title": "LogoutRequest",
-        "type": "object"
-      },
       "SignupRequest": {
         "description": "Request to sign up a new user. Created with INACTIVE status; requires separate activation.",
         "properties": {
@@ -32593,6 +32578,21 @@
           "new_password"
         ],
         "title": "UpdatePasswordNoAuthRequest",
+        "type": "object"
+      },
+      "LogoutRequest": {
+        "description": "Request to invalidate a login session.",
+        "properties": {
+          "session_token": {
+            "description": "The session token to invalidate",
+            "title": "Session Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "session_token"
+        ],
+        "title": "LogoutRequest",
         "type": "object"
       },
       "SignoutRequest": {
@@ -53834,30 +53834,6 @@
         "description": ""
       }
     },
-    "/auth/logout": {
-      "post": {
-        "operationId": "auth.logout",
-        "tags": [
-          "auth"
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful response"
-          }
-        },
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LogoutRequest"
-              }
-            }
-          }
-        },
-        "parameters": [],
-        "description": ""
-      }
-    },
     "/auth/signup": {
       "post": {
         "operationId": "auth.signup",
@@ -53962,6 +53938,35 @@
             "TokenAuth": []
           }
         ],
+        "parameters": [],
+        "description": "\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "operationId": "auth.logout",
+        "tags": [
+          "auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LogoutRequest"
+              }
+            }
+          }
+        },
         "parameters": [],
         "description": "\n**Preconditions:**\n* User privilege required.\n"
       }

--- a/src/ai/backend/common/data/entity/auth.py
+++ b/src/ai/backend/common/data/entity/auth.py
@@ -1,0 +1,8 @@
+from ai.backend.common.data.entity.types import EntityType
+
+__all__ = ("AUTH_ENTITY_TYPE",)
+
+
+# Raw string mirroring the RBAC-managed EntityType.AUTH value. It names the credential
+# and login-session state that answers for no other entity.
+AUTH_ENTITY_TYPE = EntityType("auth")

--- a/src/ai/backend/common/data/entity/login_history.py
+++ b/src/ai/backend/common/data/entity/login_history.py
@@ -4,7 +4,10 @@ from typing import override
 
 from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
 
-__all__ = ("LoginHistoryID",)
+__all__ = (
+    "LOGIN_HISTORY_FIELD_TYPE",
+    "LoginHistoryID",
+)
 
 
 LOGIN_HISTORY_FIELD_TYPE = FieldType("login_history")

--- a/src/ai/backend/common/data/entity/login_session.py
+++ b/src/ai/backend/common/data/entity/login_session.py
@@ -1,0 +1,26 @@
+"""Id of the login session table."""
+
+from typing import override
+
+from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+
+__all__ = (
+    "LOGIN_SESSION_FIELD_TYPE",
+    "LoginSessionID",
+)
+
+
+LOGIN_SESSION_FIELD_TYPE = FieldType("login_session")
+
+
+class LoginSessionID(FieldIdentifier):
+    """A login session's id.
+
+    A session belongs to the user who signed in and is read through them, so the user
+    owns the row and the session declares no scope of its own.
+    """
+
+    @override
+    @classmethod
+    def field_type(cls) -> FieldType:
+        return LOGIN_SESSION_FIELD_TYPE

--- a/src/ai/backend/manager/api/adapters/login_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_history/adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.dto.manager.v2.login_history.request import (
     AdminSearchLoginHistoryInput,
     LoginHistoryFilter,
@@ -26,11 +27,11 @@ from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.auth.login_session_types import LoginHistoryData
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.login_session.row import LoginHistoryRow
+from ai.backend.manager.models.login_session.searchers import LoginHistorySearcher
 from ai.backend.manager.repositories.auth.options import LoginHistoryConditions, LoginHistoryOrders
-from ai.backend.manager.repositories.auth.types import MyLoginHistoryOperationScope
 from ai.backend.manager.repositories.base import combine_conditions_or, negate_conditions
 from ai.backend.manager.services.auth.actions.search_login_history import (
-    AdminSearchLoginHistoryAction,
+    GlobalSearchLoginHistoryAction,
     SearchLoginHistoryAction,
 )
 
@@ -52,7 +53,8 @@ class LoginHistoryAdapter(BaseAdapter):
         """Search login history with admin scope (no scope restriction)."""
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
-        querier = self._build_querier(
+        searcher = self._build_searcher(
+            LoginHistorySearcher,
             conditions=conditions,
             orders=orders,
             pagination_spec=_LOGIN_HISTORY_PAGINATION_SPEC,
@@ -63,14 +65,14 @@ class LoginHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.admin_search_login_history.wait_for_complete(
-            AdminSearchLoginHistoryAction(querier=querier)
+        action_result = await self._processors.auth.global_search_login_history.run(
+            GlobalSearchLoginHistoryAction(searcher=searcher)
         )
         return AdminSearchLoginHistoryPayload(
-            items=[self._data_to_node(item) for item in action_result.result.items],
-            total_count=action_result.result.total_count,
-            has_next_page=action_result.result.has_next_page,
-            has_previous_page=action_result.result.has_previous_page,
+            items=[self._data_to_node(item) for item in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
         )
 
     async def my_search(self, input: MySearchLoginHistoryInput) -> MySearchLoginHistoryPayload:
@@ -81,10 +83,10 @@ class LoginHistoryAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        scope = MyLoginHistoryOperationScope(user_id=me.user_id)
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
-        querier = self._build_querier(
+        searcher = self._build_searcher(
+            LoginHistorySearcher,
             conditions=conditions,
             orders=orders,
             pagination_spec=_LOGIN_HISTORY_PAGINATION_SPEC,
@@ -95,14 +97,14 @@ class LoginHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.search_login_history.wait_for_complete(
-            SearchLoginHistoryAction(scope=scope, querier=querier)
+        action_result = await self._processors.auth.search_login_history.run(
+            SearchLoginHistoryAction(user_id=UserID(me.user_id), searcher=searcher)
         )
         return MySearchLoginHistoryPayload(
-            items=[self._data_to_node(item) for item in action_result.result.items],
-            total_count=action_result.result.total_count,
-            has_next_page=action_result.result.has_next_page,
-            has_previous_page=action_result.result.has_previous_page,
+            items=[self._data_to_node(item) for item in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
         )
 
     def _convert_filter(self, f: LoginHistoryFilter) -> list[QueryCondition]:

--- a/src/ai/backend/manager/api/adapters/login_session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_session/adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.dto.manager.v2.login_session.request import (
     AdminRevokeLoginSessionInput,
     AdminSearchLoginSessionsInput,
@@ -31,18 +32,18 @@ from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.auth.login_session_types import LoginSessionData
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.login_session.row import LoginSessionRow
+from ai.backend.manager.models.login_session.searchers import LoginSessionSearcher
 from ai.backend.manager.repositories.auth.options import LoginSessionConditions, LoginSessionOrders
-from ai.backend.manager.repositories.auth.types import MyLoginSessionOperationScope
 from ai.backend.manager.repositories.base import combine_conditions_or, negate_conditions
 from ai.backend.manager.services.auth.actions.revoke_login_session import (
-    AdminRevokeLoginSessionAction,
-    MyRevokeLoginSessionAction,
+    GlobalRevokeLoginSessionAction,
+    RevokeLoginSessionAction,
 )
 from ai.backend.manager.services.auth.actions.search_login_sessions import (
-    AdminSearchLoginSessionsAction,
+    GlobalSearchLoginSessionsAction,
     SearchLoginSessionsAction,
 )
-from ai.backend.manager.services.auth.actions.unblock_user import AdminUnblockUserAction
+from ai.backend.manager.services.auth.actions.unblock_user import GlobalUnblockUserAction
 
 _LOGIN_SESSION_PAGINATION_SPEC = PaginationSpec(
     forward_order=LoginSessionOrders.created_at(ascending=False),
@@ -62,7 +63,8 @@ class LoginSessionAdapter(BaseAdapter):
         """Search login sessions with admin scope (no scope restriction)."""
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
-        querier = self._build_querier(
+        searcher = self._build_searcher(
+            LoginSessionSearcher,
             conditions=conditions,
             orders=orders,
             pagination_spec=_LOGIN_SESSION_PAGINATION_SPEC,
@@ -73,14 +75,14 @@ class LoginSessionAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.admin_search_login_sessions.wait_for_complete(
-            AdminSearchLoginSessionsAction(querier=querier)
+        action_result = await self._processors.auth.global_search_login_sessions.run(
+            GlobalSearchLoginSessionsAction(searcher=searcher)
         )
         return AdminSearchLoginSessionsPayload(
-            items=[self._data_to_node(item) for item in action_result.result.items],
-            total_count=action_result.result.total_count,
-            has_next_page=action_result.result.has_next_page,
-            has_previous_page=action_result.result.has_previous_page,
+            items=[self._data_to_node(item) for item in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
         )
 
     async def my_search(self, input: MySearchLoginSessionsInput) -> MySearchLoginSessionsPayload:
@@ -91,10 +93,10 @@ class LoginSessionAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        scope = MyLoginSessionOperationScope(user_id=me.user_id)
         conditions = self._convert_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
-        querier = self._build_querier(
+        searcher = self._build_searcher(
+            LoginSessionSearcher,
             conditions=conditions,
             orders=orders,
             pagination_spec=_LOGIN_SESSION_PAGINATION_SPEC,
@@ -105,14 +107,14 @@ class LoginSessionAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.search_login_sessions.wait_for_complete(
-            SearchLoginSessionsAction(scope=scope, querier=querier)
+        action_result = await self._processors.auth.search_login_sessions.run(
+            SearchLoginSessionsAction(user_id=UserID(me.user_id), searcher=searcher)
         )
         return MySearchLoginSessionsPayload(
-            items=[self._data_to_node(item) for item in action_result.result.items],
-            total_count=action_result.result.total_count,
-            has_next_page=action_result.result.has_next_page,
-            has_previous_page=action_result.result.has_previous_page,
+            items=[self._data_to_node(item) for item in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
         )
 
     async def my_revoke(self, input: MyRevokeLoginSessionInput) -> RevokeLoginSessionPayload:
@@ -120,18 +122,18 @@ class LoginSessionAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        action_result = await self._processors.auth.my_revoke_login_session.wait_for_complete(
-            MyRevokeLoginSessionAction(
+        action_result = await self._processors.auth.revoke_login_session.run(
+            RevokeLoginSessionAction(
+                user_id=UserID(me.user_id),
                 session_id=input.session_id,
-                user_id=me.user_id,
             )
         )
         return RevokeLoginSessionPayload(success=action_result.success)
 
     async def admin_revoke(self, input: AdminRevokeLoginSessionInput) -> RevokeLoginSessionPayload:
         """Revoke any login session (admin, no ownership check)."""
-        action_result = await self._processors.auth.admin_revoke_login_session.wait_for_complete(
-            AdminRevokeLoginSessionAction(
+        action_result = await self._processors.auth.global_revoke_login_session.run(
+            GlobalRevokeLoginSessionAction(
                 session_id=input.session_id,
             )
         )
@@ -139,8 +141,8 @@ class LoginSessionAdapter(BaseAdapter):
 
     async def admin_unblock_user(self, input: AdminUnblockUserInput) -> UnblockUserPayload:
         """Clear the failed-login rate limit block for a user (admin only)."""
-        action_result = await self._processors.auth.admin_unblock_user.wait_for_complete(
-            AdminUnblockUserAction(username=input.username)
+        action_result = await self._processors.auth.global_unblock_user.run(
+            GlobalUnblockUserAction(username=input.username)
         )
         return UnblockUserPayload(success=action_result.success)
 

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -15,6 +15,7 @@ from typing import Final
 from aiohttp import web
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam, QueryParam
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.dto.manager.auth.request import (
     AuthorizeRequest,
     GetRoleRequest,
@@ -52,7 +53,7 @@ from ai.backend.manager.dto.context import RequestCtx, UserContext
 from ai.backend.manager.errors.auth import AuthorizationFailed
 from ai.backend.manager.services.auth.actions.authorize import AuthorizeAction
 from ai.backend.manager.services.auth.actions.generate_ssh_keypair import GenerateSSHKeypairAction
-from ai.backend.manager.services.auth.actions.get_role import GetRoleAction
+from ai.backend.manager.services.auth.actions.get_role import PublicGetRoleAction
 from ai.backend.manager.services.auth.actions.get_ssh_keypair import GetSSHKeypairAction
 from ai.backend.manager.services.auth.actions.logout import LogoutAction
 from ai.backend.manager.services.auth.actions.signout import SignoutAction
@@ -114,13 +115,13 @@ class AuthHandler:
             ctx.user_domain,
             params.group,
         )
-        action = GetRoleAction(
+        action = PublicGetRoleAction(
             user_id=ctx.user_uuid,
             group_id=params.group,
             is_superadmin=ctx.is_superadmin,
             is_admin=ctx.is_admin,
         )
-        result = await self._auth.get_role.wait_for_complete(action)
+        result = await self._auth.public_get_role.run(action)
         resp = GetRoleResponse(
             global_role=result.global_role,
             domain_role=result.domain_role,
@@ -153,7 +154,7 @@ class AuthHandler:
             client_type_id=params.client_type_id,
             force=params.force,
         )
-        result = await self._auth.authorize.wait_for_complete(action)
+        result = await self._auth.authorize.run(action)
 
         if result.stream_response is not None:
             return result.stream_response
@@ -177,11 +178,14 @@ class AuthHandler:
     # logout (POST /auth/logout)
     # ------------------------------------------------------------------
 
-    async def logout(self, body: BodyParam[LogoutRequest], ctx: RequestCtx) -> APIResponse:
+    async def logout(self, body: BodyParam[LogoutRequest], ctx: UserContext) -> APIResponse:
         params = body.parsed
         log.info("AUTH.LOGOUT(session_token:{}...)", params.session_token[:8])
-        action = LogoutAction(session_token=params.session_token)
-        await self._auth.logout.wait_for_complete(action)
+        action = LogoutAction(
+            user_id=UserID(ctx.user_uuid),
+            session_token=params.session_token,
+        )
+        await self._auth.logout.run(action)
         return APIResponse.build(HTTPStatus.OK, LogoutResponse())
 
     # ------------------------------------------------------------------
@@ -200,7 +204,7 @@ class AuthHandler:
             full_name=params.full_name,
             description=params.description,
         )
-        result = await self._auth.signup.wait_for_complete(action)
+        result = await self._auth.signup.run(action)
         resp = SignupResponse(
             access_key=result.access_key,
             secret_key=result.secret_key,
@@ -214,9 +218,9 @@ class AuthHandler:
     async def signout(self, body: BodyParam[SignoutRequest], ctx: UserContext) -> APIResponse:
         params = body.parsed
         log.info("AUTH.SIGNOUT(d:{}, email:{})", ctx.user_domain, params.email)
-        await self._auth.signout.wait_for_complete(
+        await self._auth.signout.run(
             SignoutAction(
-                user_id=ctx.user_uuid,
+                user_id=UserID(ctx.user_uuid),
                 domain_name=ctx.user_domain,
                 requester_email=ctx.user_email,
                 email=params.email,
@@ -234,9 +238,9 @@ class AuthHandler:
     ) -> APIResponse:
         params = body.parsed
         log.info("AUTH.UPDATE_FULL_NAME(d:{}, email:{})", ctx.user_domain, ctx.user_email)
-        await self._auth.update_full_name.wait_for_complete(
+        await self._auth.update_full_name.run(
             UpdateFullNameAction(
-                user_id=str(ctx.user_uuid),
+                user_id=UserID(ctx.user_uuid),
                 full_name=params.full_name,
                 domain_name=ctx.user_domain,
                 email=ctx.user_email,
@@ -258,14 +262,14 @@ class AuthHandler:
         log.info("AUTH.UPDATE_PASSWORD(d:{}, email:{})", ctx.user_domain, ctx.user_email)
         action = UpdatePasswordAction(
             request=req.request,
-            user_id=ctx.user_uuid,
+            user_id=UserID(ctx.user_uuid),
             domain_name=ctx.user_domain,
             email=ctx.user_email,
             old_password=params.old_password,
             new_password=params.new_password,
             new_password_confirm=params.new_password2,
         )
-        result = await self._auth.update_password.wait_for_complete(action)
+        result = await self._auth.update_password.run(action)
         if not result.success:
             resp = UpdatePasswordResponse(error_msg="new password mismatch")
             return APIResponse.build(HTTPStatus.BAD_REQUEST, resp)
@@ -291,7 +295,7 @@ class AuthHandler:
             current_password=params.current_password,
             new_password=params.new_password,
         )
-        result = await self._auth.update_password_no_auth.wait_for_complete(action)
+        result = await self._auth.update_password_no_auth.run(action)
         resp = UpdatePasswordNoAuthResponse(
             password_changed_at=result.password_changed_at.isoformat(),
         )
@@ -303,9 +307,9 @@ class AuthHandler:
 
     async def get_ssh_keypair(self, ctx: UserContext) -> APIResponse:
         log.info("AUTH.GET_SSH_KEYPAIR(d:{}, ak:{})", ctx.user_domain, ctx.access_key)
-        result = await self._auth.get_ssh_keypair.wait_for_complete(
+        result = await self._auth.get_ssh_keypair.run(
             GetSSHKeypairAction(
-                user_id=ctx.user_uuid,
+                user_id=UserID(ctx.user_uuid),
                 access_key=ctx.access_key,
             )
         )
@@ -318,9 +322,9 @@ class AuthHandler:
 
     async def generate_ssh_keypair(self, ctx: UserContext) -> APIResponse:
         log.info("AUTH.REFRESH_SSH_KEYPAIR(d:{}, ak:{})", ctx.user_domain, ctx.access_key)
-        result = await self._auth.generate_ssh_keypair.wait_for_complete(
+        result = await self._auth.generate_ssh_keypair.run(
             GenerateSSHKeypairAction(
-                user_id=ctx.user_uuid,
+                user_id=UserID(ctx.user_uuid),
                 access_key=ctx.access_key,
             )
         )
@@ -341,9 +345,9 @@ class AuthHandler:
         pubkey = f"{params.pubkey.rstrip()}\n"
         privkey = f"{params.privkey.rstrip()}\n"
         log.info("AUTH.SAVE_SSH_KEYPAIR(d:{}, ak:{})", ctx.user_domain, ctx.access_key)
-        result = await self._auth.upload_ssh_keypair.wait_for_complete(
+        result = await self._auth.upload_ssh_keypair.run(
             UploadSSHKeypairAction(
-                user_id=ctx.user_uuid,
+                user_id=UserID(ctx.user_uuid),
                 public_key=pubkey,
                 private_key=privkey,
                 access_key=ctx.access_key,

--- a/src/ai/backend/manager/api/rest/auth/registry.py
+++ b/src/ai/backend/manager/api/rest/auth/registry.py
@@ -25,13 +25,13 @@ def register_auth_routes(handler: AuthHandler, route_deps: RouteDeps) -> RouteRe
 
     # Public endpoints (no auth_required)
     reg.add("POST", "/authorize", handler.authorize)
-    reg.add("POST", "/logout", handler.logout)
     reg.add("POST", "/signup", handler.signup)
     reg.add("POST", "/update-password-no-auth", handler.update_password_no_auth)
 
     # Authenticated endpoints
     reg.add("GET", "/role", handler.get_role, middlewares=[auth_required])
     reg.add("GET", "/my-ip", handler.get_my_ip, middlewares=[auth_required])
+    reg.add("POST", "/logout", handler.logout, middlewares=[auth_required])
     reg.add("POST", "/signout", handler.signout, middlewares=[auth_required])
     reg.add("POST", "/update-password", handler.update_password, middlewares=[auth_required])
     reg.add("POST", "/update-full-name", handler.update_full_name, middlewares=[auth_required])

--- a/src/ai/backend/manager/api/rest/service/handler.py
+++ b/src/ai/backend/manager/api/rest/service/handler.py
@@ -86,7 +86,7 @@ from ai.backend.manager.models.runtime_variant.conditions import RuntimeVariantC
 from ai.backend.manager.models.runtime_variant.searchers import RuntimeVariantSearcher
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeAction,
+    PublicResolveAccessKeyScopeAction,
 )
 from ai.backend.manager.services.deployment.actions.create_legacy_deployment import (
     CreateLegacyDeploymentAction,
@@ -644,8 +644,8 @@ class ServiceHandler:
         request: Any,
         params: NewServiceRequestModel,
     ) -> ValidateModelServiceActionResult:
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -103,7 +103,7 @@ from ai.backend.manager.services.agent.actions.sync_agent_registry import (
     SyncAgentRegistryAction,
 )
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeAction,
+    PublicResolveAccessKeyScopeAction,
 )
 from ai.backend.manager.services.project.actions.lookup import LookupProjectAction
 from ai.backend.manager.services.project.processors import ProjectProcessors
@@ -596,8 +596,8 @@ class SessionHandler:
 
         validated_config = await self._normalize_legacy_mounts(validated_config)
 
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -713,8 +713,8 @@ class SessionHandler:
                 )
 
         domain_name = params.domain or request["user"]["domain_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -785,8 +785,8 @@ class SessionHandler:
         params = body.parsed
 
         domain_name = params.domain or request["user"]["domain_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -834,8 +834,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = query.parsed
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -872,8 +872,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = body.parsed
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -918,8 +918,8 @@ class SessionHandler:
     async def get_info(self, ctx: RequestCtx) -> APIResponse:
         request = ctx.request
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -983,8 +983,8 @@ class SessionHandler:
         params = query.parsed
         session_name = request.match_info["session_name"]
         user_role = cast(UserRole, request["user"]["role"])
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1031,8 +1031,8 @@ class SessionHandler:
         request = ctx.request
         params = body.parsed
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1070,8 +1070,8 @@ class SessionHandler:
     async def interrupt(self, ctx: RequestCtx) -> web.Response:
         request = ctx.request
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1110,8 +1110,8 @@ class SessionHandler:
         request = ctx.request
         params = body.parsed
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1183,8 +1183,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1220,8 +1220,8 @@ class SessionHandler:
         request = ctx.request
         reader = await request.multipart()
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1261,8 +1261,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1300,8 +1300,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1339,8 +1339,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1379,8 +1379,8 @@ class SessionHandler:
         params = body.parsed
         session_name = request.match_info["session_name"]
         new_name = params.session_name
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1417,8 +1417,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name: str = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1457,8 +1457,8 @@ class SessionHandler:
         request = ctx.request
         params = body.parsed
         session_name: str = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1502,8 +1502,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         session_name: str = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1543,8 +1543,8 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         session_name: str = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1584,8 +1584,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name: str = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1618,8 +1618,8 @@ class SessionHandler:
     async def get_direct_access_info(self, ctx: RequestCtx) -> APIResponse:
         request = ctx.request
         session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1651,8 +1651,8 @@ class SessionHandler:
         request = ctx.request
         params = query.parsed
         session_name: str = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],
@@ -1730,8 +1730,8 @@ class SessionHandler:
     async def get_dependency_graph(self, ctx: RequestCtx) -> APIResponse:
         request = ctx.request
         root_session_name = request.match_info["session_name"]
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
                 requester_domain=request["user"]["domain_name"],

--- a/src/ai/backend/manager/api/rest/userconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/userconfig/handler.py
@@ -34,7 +34,7 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.dotfile.types import DotfileEntries, DotfileEntry
 from ai.backend.manager.dto.context import UserContext
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeAction,
+    PublicResolveAccessKeyScopeAction,
 )
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.user.actions.bootstrap_script import (
@@ -67,8 +67,8 @@ class UserConfigHandler:
         self._user = user
 
     async def _owner_access_key(self, ctx: UserContext, owner: str | None) -> AccessKey:
-        scope = await self._auth.resolve_access_key_scope.wait_for_complete(
-            ResolveAccessKeyScopeAction(
+        scope = await self._auth.public_resolve_access_key_scope.run(
+            PublicResolveAccessKeyScopeAction(
                 requester_access_key=ctx.access_key,
                 requester_role=ctx.user_role,
                 requester_domain=ctx.user_domain,

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -131,7 +131,7 @@ from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.vfolder.purgers import VFolderPurgerSpec
 from ai.backend.manager.repositories.vfolder.updaters import VFolderAttributeUpdaterSpec
 from ai.backend.manager.services.auth.actions.resolve_user_scope import (
-    ResolveUserScopeAction,
+    PublicResolveUserScopeAction,
 )
 from ai.backend.manager.services.vfolder.actions.base import (
     CloneVFolderAction,
@@ -326,8 +326,8 @@ class VFolderHandler:
             ctx.user_email,
             ctx.access_key,
         )
-        user_scope = await self._auth.resolve_user_scope.wait_for_complete(
-            ResolveUserScopeAction(
+        user_scope = await self._auth.public_resolve_user_scope.run(
+            PublicResolveUserScopeAction(
                 requester_uuid=ctx.user_uuid,
                 requester_role=ctx.user_role,
                 requester_domain=ctx.user_domain,

--- a/src/ai/backend/manager/data/auth/login_session_types.py
+++ b/src/ai/backend/manager/data/auth/login_session_types.py
@@ -5,6 +5,8 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
+from ai.backend.common.data.entity.types import FieldData
+
 
 class LoginSessionStatus(enum.StrEnum):
     ACTIVE = "active"
@@ -28,7 +30,7 @@ class LoginAttemptResult(enum.StrEnum):
 
 
 @dataclass(frozen=True)
-class LoginSessionData:
+class LoginSessionData(FieldData):
     id: uuid.UUID
     session_token: str
     user_id: uuid.UUID
@@ -40,7 +42,7 @@ class LoginSessionData:
 
 
 @dataclass(frozen=True)
-class LoginHistoryData:
+class LoginHistoryData(FieldData):
     id: uuid.UUID
     user_id: uuid.UUID
     domain_name: str

--- a/src/ai/backend/manager/models/keypair/lookups.py
+++ b/src/ai/backend/manager/models/keypair/lookups.py
@@ -12,8 +12,10 @@ import sqlalchemy as sa
 from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
+from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.keypair.row import KeyPairRow
 from ai.backend.manager.models.specs.lookup import (
+    DataLookup,
     FieldOwnerKeyLookup,
     FieldOwnerLookup,
 )
@@ -45,3 +47,22 @@ class KeypairAccessKeyOwnerLookup(FieldOwnerKeyLookup[UserID]):
     @override
     def to_entity_id(self, value: UUID) -> UserID:
         return UserID(value)
+
+
+@dataclass
+class KeypairAccessKeyUserLookup(DataLookup[KeyPairRow, UserID]):
+    """Resolves an access key into the user it authenticates as."""
+
+    access_key: AccessKey
+
+    @override
+    def row_class(self) -> type[KeyPairRow]:
+        return KeyPairRow
+
+    @override
+    def conditions(self) -> Sequence[QueryCondition]:
+        return [lambda: KeyPairRow.access_key == self.access_key]
+
+    @override
+    def to_entity_id(self, row: KeyPairRow) -> UserID:
+        return UserID(row.user)

--- a/src/ai/backend/manager/models/login_session/lookups.py
+++ b/src/ai/backend/manager/models/login_session/lookups.py
@@ -1,0 +1,43 @@
+"""Lookup implementations for the login tables, which are fields of their user."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, override
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.login_history import LoginHistoryID
+from ai.backend.common.data.entity.login_session import LoginSessionID
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
+from ai.backend.manager.models.specs.lookup import FieldOwnerLookup
+
+
+class LoginSessionOwnerLookup(FieldOwnerLookup[LoginSessionID, UserID]):
+    """Reads the user each of the login sessions named belongs to."""
+
+    @override
+    def build_query(self, field_ids: Sequence[LoginSessionID]) -> sa.sql.Select[Any]:
+        return sa.select(LoginSessionRow.id, LoginSessionRow.user_id).where(
+            LoginSessionRow.id.in_(field_ids)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> UserID:
+        return UserID(value)
+
+
+class LoginHistoryOwnerLookup(FieldOwnerLookup[LoginHistoryID, UserID]):
+    """Reads the user each of the login attempts named was recorded against."""
+
+    @override
+    def build_query(self, field_ids: Sequence[LoginHistoryID]) -> sa.sql.Select[Any]:
+        return sa.select(LoginHistoryRow.id, LoginHistoryRow.user_id).where(
+            LoginHistoryRow.id.in_(field_ids)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> UserID:
+        return UserID(value)

--- a/src/ai/backend/manager/models/login_session/searchers.py
+++ b/src/ai/backend/manager/models/login_session/searchers.py
@@ -1,0 +1,34 @@
+"""Searcher specs for the login session and login history tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.auth.login_session_types import LoginHistoryData, LoginSessionData
+from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
+from ai.backend.manager.models.specs.searcher import Searcher
+
+
+@dataclass
+class LoginSessionSearcher(Searcher[LoginSessionRow, LoginSessionData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(LoginSessionRow)
+
+    @override
+    def to_data(self, row: LoginSessionRow) -> LoginSessionData:
+        return row.to_data()
+
+
+@dataclass
+class LoginHistorySearcher(Searcher[LoginHistoryRow, LoginHistoryData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(LoginHistoryRow)
+
+    @override
+    def to_data(self, row: LoginHistoryRow) -> LoginHistoryData:
+        return row.to_data()

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -13,24 +13,19 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import BackendAIError, UserNotFound
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.auth.login_session_types import (
     LoginAttemptResult,
-    LoginHistoryData,
     LoginSessionData,
     LoginSessionStatus,
 )
 from ai.backend.manager.data.auth.types import GroupMembershipData, UserCreationData, UserData
-from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.errors.auth import (
-    AccessKeyNotFound,
     AuthorizationFailed,
     GroupMembershipNotFoundError,
     LoginSessionNotFoundError,
@@ -39,10 +34,9 @@ from ai.backend.manager.errors.common import InternalServerError
 from ai.backend.manager.errors.user import KeyPairNotFound, UserCreationBadRequest
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.hasher.types import HashInfo, PasswordInfo
-from ai.backend.manager.models.keypair import KeyPairRow, keypairs
+from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.keypair.queriers import DefaultKeypairQuerier
 from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
-from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.models.user import (
     UserRole,
@@ -54,7 +48,7 @@ from ai.backend.manager.models.user import (
 )
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_scope.queries import user_scope_membership_exists
-from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
+from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.ops.rbac.provider import FullUserCreation, RBACOpsProvider
 from ai.backend.manager.repositories.user.creators import UserCreatorSpec, UserScopeCreation
 
@@ -288,15 +282,6 @@ class AuthDBSource:
             if row is None:
                 raise ValueError("Unknown owner access key")
             return row.domain_name, row.role
-
-    @auth_db_source_resilience.apply()
-    async def fetch_user_id_by_access_key(self, access_key: AccessKey) -> UserID:
-        async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(KeyPairRow.user).where(KeyPairRow.access_key == access_key)
-            user_id = await db_session.scalar(query)
-            if user_id is None:
-                raise AccessKeyNotFound("Unknown access key")
-            return UserID(user_id)
 
     @auth_db_source_resilience.apply()
     async def fetch_user_info_by_email(self, email: str) -> tuple[UUID, UserRole, str]:
@@ -664,41 +649,6 @@ class AuthDBSource:
             return deleted_tokens
 
     @auth_db_source_resilience.apply()
-    async def admin_search_login_sessions(
-        self,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginSessionData]:
-        """Search all login sessions without scope restriction (admin only)."""
-        async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(LoginSessionRow)
-            result = await execute_batch_querier(db_session, query, querier)
-            items = [row.LoginSessionRow.to_data() for row in result.rows]
-            return SearchResult(
-                items=items,
-                total_count=result.total_count,
-                has_next_page=result.has_next_page,
-                has_previous_page=result.has_previous_page,
-            )
-
-    @auth_db_source_resilience.apply()
-    async def search_login_sessions(
-        self,
-        scope: OperationScope,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginSessionData]:
-        """Search login sessions within a given scope."""
-        async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(LoginSessionRow)
-            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
-            items = [row.LoginSessionRow.to_data() for row in result.rows]
-            return SearchResult(
-                items=items,
-                total_count=result.total_count,
-                has_next_page=result.has_next_page,
-                has_previous_page=result.has_previous_page,
-            )
-
-    @auth_db_source_resilience.apply()
     async def fetch_login_session_by_id(self, session_id: UUID) -> LoginSessionData:
         """Fetch a single login session by its ID.
 
@@ -753,40 +703,3 @@ class AuthDBSource:
             )
             await conn.commit()
             return session_token
-
-    # --- Login History ---
-
-    @auth_db_source_resilience.apply()
-    async def admin_search_login_history(
-        self,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginHistoryData]:
-        """Search all login history without scope restriction (admin only)."""
-        async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(LoginHistoryRow)
-            result = await execute_batch_querier(db_session, query, querier)
-            items = [row.LoginHistoryRow.to_data() for row in result.rows]
-            return SearchResult(
-                items=items,
-                total_count=result.total_count,
-                has_next_page=result.has_next_page,
-                has_previous_page=result.has_previous_page,
-            )
-
-    @auth_db_source_resilience.apply()
-    async def search_login_history(
-        self,
-        scope: OperationScope,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginHistoryData]:
-        """Search login history within a given scope."""
-        async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(LoginHistoryRow)
-            result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
-            items = [row.LoginHistoryRow.to_data() for row in result.rows]
-            return SearchResult(
-                items=items,
-                total_count=result.total_count,
-                has_next_page=result.has_next_page,
-                has_previous_page=result.has_previous_page,
-            )

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -5,24 +5,19 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.resilience import Resilience
-from ai.backend.common.types import AccessKey
 from ai.backend.manager.data.auth.login_session_types import (
     LoginAttemptResult,
-    LoginHistoryData,
     LoginSessionData,
 )
 from ai.backend.manager.data.auth.types import (
     GroupMembershipData,
     UserCreationData,
 )
-from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.models.hasher.types import PasswordInfo
-from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.auth.db_source.db_source import (
@@ -31,7 +26,6 @@ from ai.backend.manager.repositories.auth.db_source.db_source import (
     CredentialVerificationResult,
     LoginSessionCreationResult,
 )
-from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.user.creators import UserCreatorSpec
 
 auth_repository_resilience = Resilience(
@@ -100,10 +94,6 @@ class AuthRepository:
     @auth_repository_resilience.apply()
     async def get_delegation_target_by_access_key(self, access_key: str) -> tuple[str, UserRole]:
         return await self._db_source.fetch_user_info_by_access_key(access_key)
-
-    @auth_repository_resilience.apply()
-    async def get_user_id_by_access_key(self, access_key: AccessKey) -> UserID:
-        return await self._db_source.fetch_user_id_by_access_key(access_key)
 
     @auth_repository_resilience.apply()
     async def get_delegation_target_by_email(self, email: str) -> tuple[UUID, UserRole, str]:
@@ -195,21 +185,6 @@ class AuthRepository:
         return await self._db_source.delete_sessions_by_user(user_id, domain_name, result)
 
     @auth_repository_resilience.apply()
-    async def admin_search_login_sessions(
-        self,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginSessionData]:
-        return await self._db_source.admin_search_login_sessions(querier)
-
-    @auth_repository_resilience.apply()
-    async def search_login_sessions(
-        self,
-        scope: OperationScope,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginSessionData]:
-        return await self._db_source.search_login_sessions(scope, querier)
-
-    @auth_repository_resilience.apply()
     async def get_login_session_by_id(self, session_id: UUID) -> LoginSessionData:
         return await self._db_source.fetch_login_session_by_id(session_id)
 
@@ -227,20 +202,3 @@ class AuthRepository:
         fail_reason: str | None = None,
     ) -> None:
         await self._db_source.record_login_history(user_id, domain_name, result, fail_reason)
-
-    # --- Login History ---
-
-    @auth_repository_resilience.apply()
-    async def admin_search_login_history(
-        self,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginHistoryData]:
-        return await self._db_source.admin_search_login_history(querier)
-
-    @auth_repository_resilience.apply()
-    async def search_login_history(
-        self,
-        scope: OperationScope,
-        querier: BatchQuerier,
-    ) -> SearchResult[LoginHistoryData]:
-        return await self._db_source.search_login_history(scope, querier)

--- a/src/ai/backend/manager/services/auth/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/auth/KNOWLEDGE.md
@@ -1,0 +1,86 @@
+---
+name: auth-service-composition
+type: decision-table
+description: 인증 도메인의 액션이 왜 auth 와 user 두 그룹으로 갈리는지, 게이트 없는 네 배선이 무엇으로 호출자를 확인하는지, 로그인 세션과 SSH 키페어 조작이 왜 사용자 단위로 기록되는지
+scope: src/ai/backend/manager/services/auth
+keywords:
+  - AuthProcessors
+  - AUTH_ENTITY_TYPE
+  - anonymous_global
+  - PublicActionProcessor
+  - RevokeLoginSessionAction
+sources:
+  - src/ai/backend/manager/services/auth/processors.py
+  - src/ai/backend/manager/api/rest/auth/registry.py
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-23
+status: draft
+---
+
+# 인증 서비스
+
+## 그룹이 둘인 이유
+
+`auth` 그룹은 어떤 사용자 행도 답하지 않는 상태 — 자격 증명과 로그인 세션 — 을 맡는다.
+로그인·로그아웃·비밀번호 재설정은 호출자가 아직 주체를 갖지 않은 채 들어오고, 관리자가
+전체 세션에 닿는 조회도 어떤 사용자를 지목하지 않는다. `user` 그룹은 한 사용자의 행,
+자격 증명, 로그인 기록이 답하는 것을 맡는다.
+
+## 게이트 없는 세 배선
+
+`authorize`, `signup`, `update_password_no_auth` 는 `anonymous_global` 로 배선된다.
+셋 다 인증 미들웨어가 없는 라우트(`api/rest/auth/registry.py`)에 걸려 있어 확인할
+호출자 맥락 자체가 없다. 대신 서비스가 호출자를 직접 확인한다 — 비밀번호, 즉 행이
+보관한 비밀과 대조한다. `signup` 은 대조할 행이 아직 없고, 훅 플러그인이 가입 요청을
+판정한다.
+
+`logout` 은 여기 들지 않는다. 로그아웃하는 호출자는 이미 세션을 들고 있으므로
+라우트가 인증을 요구하고, 액션은 그 사용자를 지목한다. 세션 토큰은 그대로 어느 세션을
+끝낼지 고르는 값으로 남는다.
+
+## 인증만 요구하는 세 읽기
+
+`public_get_role`, `public_resolve_access_key_scope`, `public_resolve_user_scope` 는
+호출자 맥락에서 대상이 정해진다. 호출자가 지목할 수 있는 대상이 자기 자신뿐이므로
+권한 확인이 더할 것이 없고, 인증만 확인한다. 위임 대상을 지목하는 경우는 서비스가
+요청자와 대상의 역할·도메인을 비교해 판정한다.
+
+## 로그인 세션과 SSH 키페어는 사용자로 기록된다
+
+두 행 모두 자기 소속을 갖지 않고 소유한 사용자를 통해서만 읽힌다. 그래서 사용자를
+지목한 조작 — 로그아웃, 세션 회수, SSH 키페어 발급·업로드 — 은 `single_entity` 로 그 사용자를
+지목하고 `UPDATE` 를 선언한다. `DELETE` 를 선언하면 사용자 자체를 지운다는 뜻이 되고,
+권한도 그것으로 확인된다. 계정을 비활성화하는 `signout` 만 `DELETE` 다.
+
+관리자 쪽 회수(`global_revoke_login_session`)는 소유자를 읽지 않으므로 사용자를 지목할
+수 없고, SUPERADMIN 게이트 뒤의 global 이다.
+
+## 사용자 도메인의 SSH 키페어 액션과의 관계
+
+`services/user` 의 `admin_get_ssh_keypair` · `admin_register_ssh_keypair` ·
+`admin_delete_ssh_keypair` 는 관리자가 남의 키페어를 지목하는 경로다. 여기의
+`get_ssh_keypair` · `generate_ssh_keypair` · `upload_ssh_keypair` 는 로그인한 사용자가
+자기 세션의 액세스 키에 대해 하는 조작이고, 키 생성은 이쪽에만 있다.
+
+## 액세스 키로 사용자를 찾는 lookup
+
+`lookup_user_by_access_key` 는 액세스 키라는 외부 키를 사용자 id 로 바꾸므로 lookup 이다.
+인증을 먼저 확인하고, 키가 가리킨 사용자에 대한 읽기 권한을 그 다음에 확인한다. 서비스
+메서드 없이 `KeypairAccessKeyUserLookup` 스펙으로 ops 를 탄다. `services/user` 의
+`lookup_keypair_owner_by_access_key` 는 같은 키에서 키페어 행의 소유자를 찾고, 이쪽은
+사용자 자신을 답한다 — 쿼리는 같다.
+
+## 로그인 세션과 이력은 사용자의 field group 이다
+
+두 행 모두 사용자가 소유하는 field row 이므로 조회는 `user_group.field_group(...)` 이
+내주는 하위 그룹에서 나온다. 소유자 lookup 은 그 그룹이 스스로 만들고, 도메인은 조회
+네 건만 배선한다. 네 건 다 서비스 메서드 없이 `LoginSessionSearcher` ·
+`LoginHistorySearcher` 스펙으로 ops 를 탄다.
+
+스코프 조회가 `scope_search_ops` 가 아닌 이유는 그 결과가 답하는 데이터가
+`EntityData` 여야 하기 때문이다. field row 는 엔티티가 아니라서 답할 id 가 없고,
+`ScopedFieldsOpsResult` 가 그 자리를 맡는다.
+
+없는 사용자로 스코프 조회를 하면 ops 가 스코프의 존재 검사를 먼저 돌므로 `UserNotFound`
+가 그대로 난다.

--- a/src/ai/backend/manager/services/auth/actions/authorize.py
+++ b/src/ai/backend/manager/services/auth/actions/authorize.py
@@ -5,14 +5,13 @@ from uuid import UUID
 from aiohttp import web
 
 from ai.backend.common.dto.manager.auth.types import AuthTokenType
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.auth.types import AuthorizationResult
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction
 
 
-@dataclass
-class AuthorizeAction(AuthAction):
+@dataclass(frozen=True)
+class AuthorizeAction(AuthGlobalAction):
     request: web.Request
     type: AuthTokenType
     domain_name: str
@@ -24,13 +23,14 @@ class AuthorizeAction(AuthAction):
     force: bool = False
 
     @override
-    def entity_id(self) -> str | None:
-        return None
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.CREATE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "authorize"
 
     @property
     def hook_params(self) -> dict[str, str]:
@@ -45,11 +45,7 @@ class AuthorizeAction(AuthAction):
         }
 
 
-@dataclass
-class AuthorizeActionResult(BaseActionResult):
+@dataclass(frozen=True)
+class AuthorizeActionResult:
     stream_response: web.StreamResponse | None
     authorization_result: AuthorizationResult | None
-
-    @override
-    def entity_id(self) -> str | None:
-        return str(self.authorization_result.user_id) if self.authorization_result else None

--- a/src/ai/backend/manager/services/auth/actions/base.py
+++ b/src/ai/backend/manager/services/auth/actions/base.py
@@ -1,43 +1,41 @@
+from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import EntityType
-from ai.backend.manager.actions.action import BaseAction
-from ai.backend.manager.actions.action.scope import BaseScopeAction, BaseScopeActionResult
-from ai.backend.manager.actions.action.single_entity import (
-    BaseSingleEntityAction,
-    BaseSingleEntityActionResult,
-)
-from ai.backend.manager.actions.action.types import FieldData
+from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
+from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
 
 
-class AuthAction(BaseAction):
+class AuthGlobalAction(BaseGlobalAction):
+    """Base for an operation over credential or login-session state.
+
+    Names no entity: the caller is not yet known when it runs, or the state it reaches
+    spans every user.
+    """
+
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.AUTH
+        return AUTH_ENTITY_TYPE
 
 
-class KeypairScopeAction(BaseScopeAction):
+class UserGlobalAction(BaseGlobalAction):
+    """Base for an operation reaching the user rows, or their login rows, at large."""
+
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType.KEYPAIR
+        return USER_ENTITY_TYPE
 
 
-class KeypairScopeActionResult(BaseScopeActionResult):
-    pass
+@dataclass(frozen=True)
+class UserEntityAction(BaseSingleEntityAction):
+    """Base for an operation on one user's account, credentials or login rows."""
 
-
-class KeypairSingleEntityAction(BaseSingleEntityAction):
-    @override
-    @classmethod
-    def entity_type(cls) -> EntityType:
-        return EntityType.KEYPAIR
+    user_id: UserID
 
     @override
-    def field_data(self) -> FieldData | None:
-        return None
-
-
-class KeypairSingleEntityActionResult(BaseSingleEntityActionResult):
-    pass
+    def entity_id(self) -> EntityIdentifier:
+        return self.user_id

--- a/src/ai/backend/manager/services/auth/actions/generate_ssh_keypair.py
+++ b/src/ai/backend/manager/services/auth/actions/generate_ssh_keypair.py
@@ -1,49 +1,28 @@
-import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.auth.types import SSHKeypair
-from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.services.auth.actions.base import (
-    KeypairScopeAction,
-    KeypairScopeActionResult,
-)
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class GenerateSSHKeypairAction(KeypairScopeAction):
-    user_id: uuid.UUID
+@dataclass(frozen=True)
+class GenerateSSHKeypairAction(UserEntityAction):
+    """Replace the SSH keypair the named user's keypair carries with a fresh one."""
+
     access_key: str
 
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.CREATE
+        return ActionOperationType.UPDATE
 
     @override
-    def scope_type(self) -> ScopeType:
-        return ScopeType.USER
-
-    @override
-    def scope_id(self) -> str:
-        return str(self.user_id)
-
-    @override
-    def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.USER, str(self.user_id))
+    @classmethod
+    def action_name(cls) -> str:
+        return "generate_ssh_keypair"
 
 
-@dataclass
-class GenerateSSHKeypairActionResult(KeypairScopeActionResult):
+@dataclass(frozen=True)
+class GenerateSSHKeypairActionResult:
     ssh_keypair: SSHKeypair
-    user_id: uuid.UUID
-
-    @override
-    def scope_type(self) -> ScopeType:
-        return ScopeType.USER
-
-    @override
-    def scope_id(self) -> str:
-        return str(self.user_id)

--- a/src/ai/backend/manager/services/auth/actions/get_role.py
+++ b/src/ai/backend/manager/services/auth/actions/get_role.py
@@ -2,34 +2,30 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction
 
 
-@dataclass
-class GetRoleAction(AuthAction):
+@dataclass(frozen=True)
+class PublicGetRoleAction(AuthGlobalAction):
     user_id: uuid.UUID
     group_id: uuid.UUID | None
     is_superadmin: bool
     is_admin: bool
 
     @override
-    def entity_id(self) -> str | None:
-        return str(self.user_id)
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.GET
 
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_get_role"
 
-@dataclass
-class GetRoleActionResult(BaseActionResult):
+
+@dataclass(frozen=True)
+class PublicGetRoleActionResult:
     global_role: str
     domain_role: str
     group_role: str | None
-
-    @override
-    def entity_id(self) -> str | None:
-        return None

--- a/src/ai/backend/manager/services/auth/actions/get_ssh_keypair.py
+++ b/src/ai/backend/manager/services/auth/actions/get_ssh_keypair.py
@@ -1,19 +1,14 @@
-import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.services.auth.actions.base import (
-    KeypairSingleEntityAction,
-    KeypairSingleEntityActionResult,
-)
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class GetSSHKeypairAction(KeypairSingleEntityAction):
-    user_id: uuid.UUID
+@dataclass(frozen=True)
+class GetSSHKeypairAction(UserEntityAction):
+    """Read the SSH public key the named user's keypair carries."""
+
     access_key: str
 
     @override
@@ -22,19 +17,12 @@ class GetSSHKeypairAction(KeypairSingleEntityAction):
         return ActionOperationType.GET
 
     @override
-    def target_entity_id(self) -> str:
-        return self.access_key
-
-    @override
-    def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.KEYPAIR, self.access_key)
+    @classmethod
+    def action_name(cls) -> str:
+        return "get_ssh_keypair"
 
 
-@dataclass
-class GetSSHKeypairActionResult(KeypairSingleEntityActionResult):
+@dataclass(frozen=True)
+class GetSSHKeypairActionResult:
     public_key: str
     access_key: str
-
-    @override
-    def target_entity_id(self) -> str:
-        return self.access_key

--- a/src/ai/backend/manager/services/auth/actions/logout.py
+++ b/src/ai/backend/manager/services/auth/actions/logout.py
@@ -1,29 +1,31 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class LogoutAction(AuthAction):
+@dataclass(frozen=True)
+class LogoutAction(UserEntityAction):
+    """End one of the named user's login sessions.
+
+    The session row belongs to that user, so ending it is an update of the user, the
+    same shape as revoking one by id.
+    """
+
     session_token: str
-
-    @override
-    def entity_id(self) -> str | None:
-        return None
 
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.DELETE
-
-
-@dataclass
-class LogoutActionResult(BaseActionResult):
-    success: bool
+        return ActionOperationType.UPDATE
 
     @override
-    def entity_id(self) -> str | None:
-        return None
+    @classmethod
+    def action_name(cls) -> str:
+        return "logout"
+
+
+@dataclass(frozen=True)
+class LogoutActionResult:
+    success: bool

--- a/src/ai/backend/manager/services/auth/actions/lookup_login_history_owner.py
+++ b/src/ai/backend/manager/services/auth/actions/lookup_login_history_owner.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+from ai.backend.common.data.entity.login_history import LoginHistoryID
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.lookup.base import LookupKey
+from ai.backend.manager.models.login_session.lookups import LoginHistoryOwnerLookup
+
+
+@dataclass(frozen=True)
+class LoginHistoryIDLookupKey(LookupKey):
+    """An attempt's id, resolved into the user it was recorded against."""
+
+    attempt_id: LoginHistoryID
+
+    @override
+    def kind(self) -> str:
+        return "login_history_id"
+
+    @override
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": str(self.attempt_id)}
+
+
+@dataclass
+class LookupLoginHistoryOwnerAction(LookupFieldOwnerOpsAction[LoginHistoryID, UserID]):
+    """The user a login attempt was recorded against."""
+
+    attempt_id: LoginHistoryID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_login_history_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return LoginHistoryIDLookupKey(self.attempt_id)
+
+    @override
+    def field_id(self) -> LoginHistoryID:
+        return self.attempt_id
+
+    @override
+    def to_owner_lookup(self) -> LoginHistoryOwnerLookup:
+        return LoginHistoryOwnerLookup()
+
+
+@dataclass
+class LookupBulkLoginHistoryOwnerAction(LookupBulkFieldOwnerOpsAction[LoginHistoryID, UserID]):
+    """The users several login attempts were recorded against."""
+
+    attempt_ids: Sequence[LoginHistoryID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_login_history_owner"
+
+    @override
+    def to_lookup_key(self, field_id: LoginHistoryID) -> LookupKey:
+        return LoginHistoryIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[LoginHistoryID]:
+        return tuple(self.attempt_ids)
+
+    @override
+    def to_owner_lookup(self) -> LoginHistoryOwnerLookup:
+        return LoginHistoryOwnerLookup()

--- a/src/ai/backend/manager/services/auth/actions/lookup_login_session_owner.py
+++ b/src/ai/backend/manager/services/auth/actions/lookup_login_session_owner.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+from ai.backend.common.data.entity.login_session import LoginSessionID
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.lookup.base import LookupKey
+from ai.backend.manager.models.login_session.lookups import LoginSessionOwnerLookup
+
+
+@dataclass(frozen=True)
+class LoginSessionIDLookupKey(LookupKey):
+    """A session's id, resolved into the user it belongs to."""
+
+    session_id: LoginSessionID
+
+    @override
+    def kind(self) -> str:
+        return "login_session_id"
+
+    @override
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": str(self.session_id)}
+
+
+@dataclass
+class LookupLoginSessionOwnerAction(LookupFieldOwnerOpsAction[LoginSessionID, UserID]):
+    """The user a login session belongs to."""
+
+    session_id: LoginSessionID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_login_session_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return LoginSessionIDLookupKey(self.session_id)
+
+    @override
+    def field_id(self) -> LoginSessionID:
+        return self.session_id
+
+    @override
+    def to_owner_lookup(self) -> LoginSessionOwnerLookup:
+        return LoginSessionOwnerLookup()
+
+
+@dataclass
+class LookupBulkLoginSessionOwnerAction(LookupBulkFieldOwnerOpsAction[LoginSessionID, UserID]):
+    """The users several login sessions belong to."""
+
+    session_ids: Sequence[LoginSessionID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_login_session_owner"
+
+    @override
+    def to_lookup_key(self, field_id: LoginSessionID) -> LookupKey:
+        return LoginSessionIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[LoginSessionID]:
+        return tuple(self.session_ids)
+
+    @override
+    def to_owner_lookup(self) -> LoginSessionOwnerLookup:
+        return LoginSessionOwnerLookup()

--- a/src/ai/backend/manager/services/auth/actions/resolve_access_key_scope.py
+++ b/src/ai/backend/manager/services/auth/actions/resolve_access_key_scope.py
@@ -2,34 +2,30 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.types import AccessKey
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.user import UserRole
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction
 
 
-@dataclass
-class ResolveAccessKeyScopeAction(AuthAction):
+@dataclass(frozen=True)
+class PublicResolveAccessKeyScopeAction(AuthGlobalAction):
     requester_access_key: str
     requester_role: UserRole
     requester_domain: str
     owner_access_key: str | None  # None = self
 
     @override
-    def entity_id(self) -> str | None:
-        return self.requester_access_key
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.GET
 
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_resolve_access_key_scope"
 
-@dataclass
-class ResolveAccessKeyScopeResult(BaseActionResult):
+
+@dataclass(frozen=True)
+class PublicResolveAccessKeyScopeResult:
     requester_access_key: AccessKey
     owner_access_key: AccessKey
-
-    @override
-    def entity_id(self) -> str | None:
-        return None

--- a/src/ai/backend/manager/services/auth/actions/resolve_user_id_by_access_key.py
+++ b/src/ai/backend/manager/services/auth/actions/resolve_user_id_by_access_key.py
@@ -1,31 +1,50 @@
 from dataclasses import dataclass
-from typing import override
+from typing import Any, override
 
-from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
 from ai.backend.common.types import AccessKey
-from ai.backend.manager.actions.action import BaseActionResult
-from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.actions.v2.lookup.base import LookupKey
+from ai.backend.manager.actions.v2.ops.base import LookupEntityOpsAction
+from ai.backend.manager.models.keypair.lookups import KeypairAccessKeyUserLookup
+from ai.backend.manager.models.keypair.row import KeyPairRow
 
 
-@dataclass
-class ResolveUserIDByAccessKeyAction(AuthAction):
+@dataclass(frozen=True)
+class AccessKeyLookupKey(LookupKey):
+    """The access key a request authenticates with."""
+
     access_key: AccessKey
 
     @override
-    def entity_id(self) -> str | None:
-        return str(self.access_key)
+    def kind(self) -> str:
+        return "access_key"
+
+    @override
+    def to_dict(self) -> dict[str, Any]:
+        return {"access_key": str(self.access_key)}
+
+
+@dataclass(frozen=True)
+class ResolveUserIDByAccessKeyAction(LookupEntityOpsAction[KeyPairRow, UserID]):
+    """Resolve an access key into the user it authenticates as."""
+
+    access_key: AccessKey
 
     @override
     @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.GET
-
-
-@dataclass
-class ResolveUserIDByAccessKeyResult(BaseActionResult):
-    user_id: UserID
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
 
     @override
-    def entity_id(self) -> str | None:
-        return str(self.user_id)
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_user_by_access_key"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return AccessKeyLookupKey(self.access_key)
+
+    @override
+    def to_lookup(self) -> KeypairAccessKeyUserLookup:
+        return KeypairAccessKeyUserLookup(access_key=self.access_key)

--- a/src/ai/backend/manager/services/auth/actions/resolve_user_scope.py
+++ b/src/ai/backend/manager/services/auth/actions/resolve_user_scope.py
@@ -2,14 +2,13 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.user import UserRole
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction
 
 
-@dataclass
-class ResolveUserScopeAction(AuthAction):
+@dataclass(frozen=True)
+class PublicResolveUserScopeAction(AuthGlobalAction):
     requester_uuid: uuid.UUID
     requester_role: UserRole
     requester_domain: str
@@ -17,20 +16,17 @@ class ResolveUserScopeAction(AuthAction):
     owner_user_email: str | None  # None = self
 
     @override
-    def entity_id(self) -> str | None:
-        return str(self.requester_uuid)
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.GET
 
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_resolve_user_scope"
 
-@dataclass
-class ResolveUserScopeResult(BaseActionResult):
+
+@dataclass(frozen=True)
+class PublicResolveUserScopeResult:
     owner_uuid: uuid.UUID
     owner_role: UserRole
-
-    @override
-    def entity_id(self) -> str | None:
-        return None

--- a/src/ai/backend/manager/services/auth/actions/revoke_login_session.py
+++ b/src/ai/backend/manager/services/auth/actions/revoke_login_session.py
@@ -2,44 +2,48 @@ from dataclasses import dataclass
 from typing import override
 from uuid import UUID
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction, UserEntityAction
 
 
-@dataclass
-class AdminRevokeLoginSessionAction(AuthAction):
+@dataclass(frozen=True)
+class GlobalRevokeLoginSessionAction(AuthGlobalAction):
+    """Revoke any login session, without reading who owns it."""
+
     session_id: UUID
-
-    @override
-    def entity_id(self) -> str | None:
-        return str(self.session_id)
 
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.DELETE
 
-
-@dataclass
-class MyRevokeLoginSessionAction(AuthAction):
-    session_id: UUID
-    user_id: UUID
-
     @override
-    def entity_id(self) -> str | None:
-        return str(self.session_id)
+    @classmethod
+    def action_name(cls) -> str:
+        return "global_revoke_login_session"
+
+
+@dataclass(frozen=True)
+class RevokeLoginSessionAction(UserEntityAction):
+    """Revoke a login session the named user owns.
+
+    The session row belongs to that user, so the operation is an update of the user and
+    is answered for by them; the service rejects a session owned by anyone else.
+    """
+
+    session_id: UUID
 
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.DELETE
+        return ActionOperationType.UPDATE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "revoke_login_session"
 
 
-@dataclass
-class RevokeLoginSessionActionResult(BaseActionResult):
+@dataclass(frozen=True)
+class RevokeLoginSessionActionResult:
     success: bool
-
-    @override
-    def entity_id(self) -> str | None:
-        return None

--- a/src/ai/backend/manager/services/auth/actions/search_login_history.py
+++ b/src/ai/backend/manager/services/auth/actions/search_login_history.py
@@ -1,35 +1,66 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import SearchActionResult
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE, UserID
+from ai.backend.manager.actions.v2.ops.base import (
+    OperationScopeOpsAction,
+    SearchGlobalOpsAction,
+)
 from ai.backend.manager.data.auth.login_session_types import LoginHistoryData
+from ai.backend.manager.models.login_session.row import LoginHistoryRow
+from ai.backend.manager.models.login_session.searchers import LoginHistorySearcher
 from ai.backend.manager.models.scopes import OperationScope
-from ai.backend.manager.repositories.base.querier import BatchQuerier
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.repositories.auth.types import MyLoginHistoryOperationScope
 
 
-@dataclass
-class AdminSearchLoginHistoryAction(AuthAction):
-    querier: BatchQuerier
+@dataclass(frozen=True)
+class GlobalSearchLoginHistoryAction(SearchGlobalOpsAction[LoginHistoryRow, LoginHistoryData]):
+    """Page through the login attempts of every user."""
 
-    @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
-
-
-@dataclass
-class SearchLoginHistoryAction(AuthAction):
-    scope: OperationScope
-    querier: BatchQuerier
+    searcher: LoginHistorySearcher
 
     @override
     @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "global_search_login_history"
+
+    @override
+    def to_searcher(self) -> LoginHistorySearcher:
+        return self.searcher
 
 
-@dataclass
-class SearchLoginHistoryActionResult(SearchActionResult[LoginHistoryData]):
-    pass
+@dataclass(frozen=True)
+class SearchLoginHistoryAction(OperationScopeOpsAction[LoginHistoryRow, LoginHistoryData]):
+    """Page through the login attempts one user made."""
+
+    user_id: UserID
+    searcher: LoginHistorySearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+
+    @override
+    def operation_scopes(self) -> Sequence[OperationScope]:
+        return (MyLoginHistoryOperationScope(user_id=self.user_id),)
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "search_login_history"
+
+    @override
+    def to_searcher(self) -> LoginHistorySearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/auth/actions/search_login_sessions.py
+++ b/src/ai/backend/manager/services/auth/actions/search_login_sessions.py
@@ -1,35 +1,66 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import SearchActionResult
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE, UserID
+from ai.backend.manager.actions.v2.ops.base import (
+    OperationScopeOpsAction,
+    SearchGlobalOpsAction,
+)
 from ai.backend.manager.data.auth.login_session_types import LoginSessionData
+from ai.backend.manager.models.login_session.row import LoginSessionRow
+from ai.backend.manager.models.login_session.searchers import LoginSessionSearcher
 from ai.backend.manager.models.scopes import OperationScope
-from ai.backend.manager.repositories.base.querier import BatchQuerier
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.repositories.auth.types import MyLoginSessionOperationScope
 
 
-@dataclass
-class AdminSearchLoginSessionsAction(AuthAction):
-    querier: BatchQuerier
+@dataclass(frozen=True)
+class GlobalSearchLoginSessionsAction(SearchGlobalOpsAction[LoginSessionRow, LoginSessionData]):
+    """Page through the login sessions of every user."""
 
-    @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
-
-
-@dataclass
-class SearchLoginSessionsAction(AuthAction):
-    scope: OperationScope
-    querier: BatchQuerier
+    searcher: LoginSessionSearcher
 
     @override
     @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "global_search_login_sessions"
+
+    @override
+    def to_searcher(self) -> LoginSessionSearcher:
+        return self.searcher
 
 
-@dataclass
-class SearchLoginSessionsActionResult(SearchActionResult[LoginSessionData]):
-    pass
+@dataclass(frozen=True)
+class SearchLoginSessionsAction(OperationScopeOpsAction[LoginSessionRow, LoginSessionData]):
+    """Page through the login sessions one user owns."""
+
+    user_id: UserID
+    searcher: LoginSessionSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return USER_ENTITY_TYPE
+
+    @override
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+
+    @override
+    def operation_scopes(self) -> Sequence[OperationScope]:
+        return (MyLoginSessionOperationScope(user_id=self.user_id),)
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "search_login_sessions"
+
+    @override
+    def to_searcher(self) -> LoginSessionSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/auth/actions/signout.py
+++ b/src/ai/backend/manager/services/auth/actions/signout.py
@@ -1,34 +1,28 @@
-import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class SignoutAction(AuthAction):
-    user_id: uuid.UUID
+@dataclass(frozen=True)
+class SignoutAction(UserEntityAction):
     domain_name: str
     requester_email: str
     email: str
     password: str
 
     @override
-    def entity_id(self) -> str | None:
-        return str(self.user_id)
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.DELETE
 
-
-@dataclass
-class SignoutActionResult(BaseActionResult):
-    success: bool
-
     @override
-    def entity_id(self) -> str | None:
-        return None
+    @classmethod
+    def action_name(cls) -> str:
+        return "signout"
+
+
+@dataclass(frozen=True)
+class SignoutActionResult:
+    success: bool

--- a/src/ai/backend/manager/services/auth/actions/signup.py
+++ b/src/ai/backend/manager/services/auth/actions/signup.py
@@ -4,13 +4,12 @@ from typing import override
 
 from aiohttp import web
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import UserGlobalAction
 
 
-@dataclass
-class SignupAction(AuthAction):
+@dataclass(frozen=True)
+class SignupAction(UserGlobalAction):
     request: web.Request
     domain_name: str
     email: str
@@ -20,13 +19,14 @@ class SignupAction(AuthAction):
     description: str | None
 
     @override
-    def entity_id(self) -> str | None:
-        return None
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.CREATE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "signup"
 
     @property
     def hook_params(self) -> dict[str, str]:
@@ -44,12 +44,8 @@ class SignupAction(AuthAction):
         return params
 
 
-@dataclass
-class SignupActionResult(BaseActionResult):
+@dataclass(frozen=True)
+class SignupActionResult:
     user_id: uuid.UUID
     access_key: str
     secret_key: str
-
-    @override
-    def entity_id(self) -> str | None:
-        return str(self.user_id)

--- a/src/ai/backend/manager/services/auth/actions/unblock_user.py
+++ b/src/ai/backend/manager/services/auth/actions/unblock_user.py
@@ -1,29 +1,31 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction
 
 
-@dataclass
-class AdminUnblockUserAction(AuthAction):
+@dataclass(frozen=True)
+class GlobalUnblockUserAction(AuthGlobalAction):
+    """Clear the failed-login block a username carries.
+
+    The block is login state rather than a column on the user, so the operation is an
+    update of what authentication holds against that name.
+    """
+
     username: str
-
-    @override
-    def entity_id(self) -> str | None:
-        return self.username
 
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.DELETE
-
-
-@dataclass
-class AdminUnblockUserActionResult(BaseActionResult):
-    success: bool
+        return ActionOperationType.UPDATE
 
     @override
-    def entity_id(self) -> str | None:
-        return None
+    @classmethod
+    def action_name(cls) -> str:
+        return "global_unblock_user"
+
+
+@dataclass(frozen=True)
+class GlobalUnblockUserActionResult:
+    success: bool

--- a/src/ai/backend/manager/services/auth/actions/update_full_name.py
+++ b/src/ai/backend/manager/services/auth/actions/update_full_name.py
@@ -1,32 +1,27 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class UpdateFullNameAction(AuthAction):
-    user_id: str
+@dataclass(frozen=True)
+class UpdateFullNameAction(UserEntityAction):
     full_name: str
     domain_name: str
     email: str
-
-    @override
-    def entity_id(self) -> str | None:
-        return str(self.user_id)
 
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.UPDATE
 
-
-@dataclass
-class UpdateFullNameActionResult(BaseActionResult):
-    success: bool
-
     @override
-    def entity_id(self) -> str | None:
-        return None
+    @classmethod
+    def action_name(cls) -> str:
+        return "update_full_name"
+
+
+@dataclass(frozen=True)
+class UpdateFullNameActionResult:
+    success: bool

--- a/src/ai/backend/manager/services/auth/actions/update_password.py
+++ b/src/ai/backend/manager/services/auth/actions/update_password.py
@@ -1,18 +1,15 @@
-import uuid
 from dataclasses import dataclass
 from typing import override
 
 from aiohttp import web
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class UpdatePasswordAction(AuthAction):
+@dataclass(frozen=True)
+class UpdatePasswordAction(UserEntityAction):
     request: web.Request
-    user_id: uuid.UUID
     domain_name: str
     email: str
     old_password: str
@@ -20,13 +17,14 @@ class UpdatePasswordAction(AuthAction):
     new_password_confirm: str
 
     @override
-    def entity_id(self) -> str | None:
-        return None
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.UPDATE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "update_password"
 
     @property
     def hook_params(self) -> dict[str, str]:
@@ -37,11 +35,7 @@ class UpdatePasswordAction(AuthAction):
         }
 
 
-@dataclass
-class UpdatePasswordActionResult(BaseActionResult):
+@dataclass(frozen=True)
+class UpdatePasswordActionResult:
     success: bool
     message: str
-
-    @override
-    def entity_id(self) -> str | None:
-        return None

--- a/src/ai/backend/manager/services/auth/actions/update_password_no_auth.py
+++ b/src/ai/backend/manager/services/auth/actions/update_password_no_auth.py
@@ -5,13 +5,12 @@ from typing import override
 
 from aiohttp import web
 
-from ai.backend.manager.actions.action import BaseActionResult
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.auth.actions.base import AuthAction
+from ai.backend.manager.services.auth.actions.base import AuthGlobalAction
 
 
-@dataclass
-class UpdatePasswordNoAuthAction(AuthAction):
+@dataclass(frozen=True)
+class UpdatePasswordNoAuthAction(AuthGlobalAction):
     request: web.Request
     domain_name: str
     email: str
@@ -19,13 +18,14 @@ class UpdatePasswordNoAuthAction(AuthAction):
     new_password: str
 
     @override
-    def entity_id(self) -> str | None:
-        return None
-
-    @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.UPDATE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "update_password_no_auth"
 
     @property
     def hook_params(self) -> dict[str, str]:
@@ -37,11 +37,7 @@ class UpdatePasswordNoAuthAction(AuthAction):
         }
 
 
-@dataclass
-class UpdatePasswordNoAuthActionResult(BaseActionResult):
+@dataclass(frozen=True)
+class UpdatePasswordNoAuthActionResult:
     user_id: uuid.UUID
     password_changed_at: datetime
-
-    @override
-    def entity_id(self) -> str | None:
-        return str(self.user_id)

--- a/src/ai/backend/manager/services/auth/actions/upload_ssh_keypair.py
+++ b/src/ai/backend/manager/services/auth/actions/upload_ssh_keypair.py
@@ -1,20 +1,15 @@
-import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.auth.types import SSHKeypair
-from ai.backend.manager.data.permission.types import RBACElementRef
-from ai.backend.manager.services.auth.actions.base import (
-    KeypairScopeAction,
-    KeypairScopeActionResult,
-)
+from ai.backend.manager.services.auth.actions.base import UserEntityAction
 
 
-@dataclass
-class UploadSSHKeypairAction(KeypairScopeAction):
-    user_id: uuid.UUID
+@dataclass(frozen=True)
+class UploadSSHKeypairAction(UserEntityAction):
+    """Overwrite the SSH keypair the named user's keypair carries with a given one."""
+
     public_key: str
     private_key: str
     access_key: str
@@ -22,30 +17,14 @@ class UploadSSHKeypairAction(KeypairScopeAction):
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.CREATE
+        return ActionOperationType.UPDATE
 
     @override
-    def scope_type(self) -> ScopeType:
-        return ScopeType.USER
-
-    @override
-    def scope_id(self) -> str:
-        return str(self.user_id)
-
-    @override
-    def target_element(self) -> RBACElementRef:
-        return RBACElementRef(RBACElementType.USER, str(self.user_id))
+    @classmethod
+    def action_name(cls) -> str:
+        return "upload_ssh_keypair"
 
 
-@dataclass
-class UploadSSHKeypairActionResult(KeypairScopeActionResult):
+@dataclass(frozen=True)
+class UploadSSHKeypairActionResult:
     ssh_keypair: SSHKeypair
-    user_id: uuid.UUID
-
-    @override
-    def scope_type(self) -> ScopeType:
-        return ScopeType.USER
-
-    @override
-    def scope_id(self) -> str:
-        return str(self.user_id)

--- a/src/ai/backend/manager/services/auth/processors.py
+++ b/src/ai/backend/manager/services/auth/processors.py
@@ -1,8 +1,25 @@
-from ai.backend.manager.actions.monitors.monitor import ActionMonitor
-from ai.backend.manager.actions.processor import ActionProcessor
-from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
-from ai.backend.manager.actions.processor.single_entity import SingleEntityActionProcessor
-from ai.backend.manager.actions.validators import ActionValidators
+from typing import Any
+
+from ai.backend.common.data.entity.login_history import LOGIN_HISTORY_FIELD_TYPE
+from ai.backend.common.data.entity.login_session import LOGIN_SESSION_FIELD_TYPE
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.manager.actions.registry.field import LookupFieldGroup
+from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.registry.types import FieldGroupMeta
+from ai.backend.manager.actions.v2.global_scope.processor import (
+    AnonymousGlobalActionProcessor,
+    GlobalActionProcessor,
+    PublicActionProcessor,
+)
+from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
+from ai.backend.manager.actions.v2.ops.result import (
+    BatchOpsResult,
+    LookupOpsResult,
+    ScopedFieldsOpsResult,
+)
+from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
+from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
+from ai.backend.manager.data.auth.login_session_types import LoginHistoryData, LoginSessionData
 from ai.backend.manager.services.auth.actions.authorize import (
     AuthorizeAction,
     AuthorizeActionResult,
@@ -11,44 +28,52 @@ from ai.backend.manager.services.auth.actions.generate_ssh_keypair import (
     GenerateSSHKeypairAction,
     GenerateSSHKeypairActionResult,
 )
-from ai.backend.manager.services.auth.actions.get_role import GetRoleAction, GetRoleActionResult
+from ai.backend.manager.services.auth.actions.get_role import (
+    PublicGetRoleAction,
+    PublicGetRoleActionResult,
+)
 from ai.backend.manager.services.auth.actions.get_ssh_keypair import (
     GetSSHKeypairAction,
     GetSSHKeypairActionResult,
 )
 from ai.backend.manager.services.auth.actions.logout import LogoutAction, LogoutActionResult
+from ai.backend.manager.services.auth.actions.lookup_login_history_owner import (
+    LookupBulkLoginHistoryOwnerAction,
+    LookupLoginHistoryOwnerAction,
+)
+from ai.backend.manager.services.auth.actions.lookup_login_session_owner import (
+    LookupBulkLoginSessionOwnerAction,
+    LookupLoginSessionOwnerAction,
+)
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeAction,
-    ResolveAccessKeyScopeResult,
+    PublicResolveAccessKeyScopeAction,
+    PublicResolveAccessKeyScopeResult,
 )
 from ai.backend.manager.services.auth.actions.resolve_user_id_by_access_key import (
     ResolveUserIDByAccessKeyAction,
-    ResolveUserIDByAccessKeyResult,
 )
 from ai.backend.manager.services.auth.actions.resolve_user_scope import (
-    ResolveUserScopeAction,
-    ResolveUserScopeResult,
+    PublicResolveUserScopeAction,
+    PublicResolveUserScopeResult,
 )
 from ai.backend.manager.services.auth.actions.revoke_login_session import (
-    AdminRevokeLoginSessionAction,
-    MyRevokeLoginSessionAction,
+    GlobalRevokeLoginSessionAction,
+    RevokeLoginSessionAction,
     RevokeLoginSessionActionResult,
 )
 from ai.backend.manager.services.auth.actions.search_login_history import (
-    AdminSearchLoginHistoryAction,
+    GlobalSearchLoginHistoryAction,
     SearchLoginHistoryAction,
-    SearchLoginHistoryActionResult,
 )
 from ai.backend.manager.services.auth.actions.search_login_sessions import (
-    AdminSearchLoginSessionsAction,
+    GlobalSearchLoginSessionsAction,
     SearchLoginSessionsAction,
-    SearchLoginSessionsActionResult,
 )
 from ai.backend.manager.services.auth.actions.signout import SignoutAction, SignoutActionResult
 from ai.backend.manager.services.auth.actions.signup import SignupAction, SignupActionResult
 from ai.backend.manager.services.auth.actions.unblock_user import (
-    AdminUnblockUserAction,
-    AdminUnblockUserActionResult,
+    GlobalUnblockUserAction,
+    GlobalUnblockUserActionResult,
 )
 from ai.backend.manager.services.auth.actions.update_full_name import (
     UpdateFullNameAction,
@@ -70,90 +95,133 @@ from ai.backend.manager.services.auth.service import AuthService
 
 
 class AuthProcessors:
-    logout: ActionProcessor[LogoutAction, LogoutActionResult]
-    signout: ActionProcessor[SignoutAction, SignoutActionResult]
-    update_full_name: ActionProcessor[UpdateFullNameAction, UpdateFullNameActionResult]
-    get_ssh_keypair: SingleEntityActionProcessor[GetSSHKeypairAction, GetSSHKeypairActionResult]
-    generate_ssh_keypair: ScopeActionProcessor[
-        GenerateSSHKeypairAction, GenerateSSHKeypairActionResult
-    ]
-    upload_ssh_keypair: ScopeActionProcessor[UploadSSHKeypairAction, UploadSSHKeypairActionResult]
-    get_role: ActionProcessor[GetRoleAction, GetRoleActionResult]
-    authorize: ActionProcessor[AuthorizeAction, AuthorizeActionResult]
-    signup: ActionProcessor[SignupAction, SignupActionResult]
-    update_password: ActionProcessor[UpdatePasswordAction, UpdatePasswordActionResult]
-    update_password_no_auth: ActionProcessor[
+    """Every auth operation, split by what answers for it.
+
+    Neither group is typed on one ``EntityData``: the login rows a user owns are read
+    through the user group, so its ops wirings answer with more than one kind.
+
+    ``auth_group`` holds the credential and login-session state that names no entity:
+    the caller of a sign-in, a sign-out or a password reset holds no principal yet, and
+    an administrator reaching every session names none either. ``user_group`` holds what
+    one user's row, credentials or login rows answer for.
+
+    The three anonymous wirings are the sign-in path itself. Each authenticates its caller
+    inside the service, against the password the row stores or the hook plugins' verdict,
+    which is what a gate would otherwise have done.
+    """
+
+    authorize: AnonymousGlobalActionProcessor[AuthorizeAction, AuthorizeActionResult]
+    signup: AnonymousGlobalActionProcessor[SignupAction, SignupActionResult]
+    update_password_no_auth: AnonymousGlobalActionProcessor[
         UpdatePasswordNoAuthAction, UpdatePasswordNoAuthActionResult
     ]
-    resolve_access_key_scope: ActionProcessor[
-        ResolveAccessKeyScopeAction, ResolveAccessKeyScopeResult
+    public_get_role: PublicActionProcessor[PublicGetRoleAction, PublicGetRoleActionResult]
+    public_resolve_access_key_scope: PublicActionProcessor[
+        PublicResolveAccessKeyScopeAction, PublicResolveAccessKeyScopeResult
     ]
-    resolve_user_scope: ActionProcessor[ResolveUserScopeAction, ResolveUserScopeResult]
-    resolve_user_id_by_access_key: ActionProcessor[
-        ResolveUserIDByAccessKeyAction, ResolveUserIDByAccessKeyResult
+    public_resolve_user_scope: PublicActionProcessor[
+        PublicResolveUserScopeAction, PublicResolveUserScopeResult
     ]
-    admin_search_login_sessions: ActionProcessor[
-        AdminSearchLoginSessionsAction, SearchLoginSessionsActionResult
+    global_revoke_login_session: GlobalActionProcessor[
+        GlobalRevokeLoginSessionAction, RevokeLoginSessionActionResult
     ]
-    search_login_sessions: ActionProcessor[
-        SearchLoginSessionsAction, SearchLoginSessionsActionResult
+    global_unblock_user: GlobalActionProcessor[
+        GlobalUnblockUserAction, GlobalUnblockUserActionResult
     ]
-    admin_search_login_history: ActionProcessor[
-        AdminSearchLoginHistoryAction, SearchLoginHistoryActionResult
+    logout: SingleEntityActionProcessor[LogoutAction, LogoutActionResult]
+    signout: SingleEntityActionProcessor[SignoutAction, SignoutActionResult]
+    update_full_name: SingleEntityActionProcessor[UpdateFullNameAction, UpdateFullNameActionResult]
+    update_password: SingleEntityActionProcessor[UpdatePasswordAction, UpdatePasswordActionResult]
+    get_ssh_keypair: SingleEntityActionProcessor[GetSSHKeypairAction, GetSSHKeypairActionResult]
+    generate_ssh_keypair: SingleEntityActionProcessor[
+        GenerateSSHKeypairAction, GenerateSSHKeypairActionResult
     ]
-    search_login_history: ActionProcessor[SearchLoginHistoryAction, SearchLoginHistoryActionResult]
-    admin_revoke_login_session: ActionProcessor[
-        AdminRevokeLoginSessionAction, RevokeLoginSessionActionResult
+    upload_ssh_keypair: SingleEntityActionProcessor[
+        UploadSSHKeypairAction, UploadSSHKeypairActionResult
     ]
-    my_revoke_login_session: ActionProcessor[
-        MyRevokeLoginSessionAction, RevokeLoginSessionActionResult
+    revoke_login_session: SingleEntityActionProcessor[
+        RevokeLoginSessionAction, RevokeLoginSessionActionResult
     ]
-    admin_unblock_user: ActionProcessor[AdminUnblockUserAction, AdminUnblockUserActionResult]
+    resolve_user_id_by_access_key: LookupActionProcessor[
+        ResolveUserIDByAccessKeyAction, LookupOpsResult[UserID]
+    ]
+    login_sessions: LookupFieldGroup[LoginSessionData]
+    login_history: LookupFieldGroup[LoginHistoryData]
+    search_login_sessions: ScopeActionProcessor[
+        SearchLoginSessionsAction, ScopedFieldsOpsResult[LoginSessionData]
+    ]
+    search_login_history: ScopeActionProcessor[
+        SearchLoginHistoryAction, ScopedFieldsOpsResult[LoginHistoryData]
+    ]
+    global_search_login_sessions: GlobalActionProcessor[
+        GlobalSearchLoginSessionsAction, BatchOpsResult[LoginSessionData]
+    ]
+    global_search_login_history: GlobalActionProcessor[
+        GlobalSearchLoginHistoryAction, BatchOpsResult[LoginHistoryData]
+    ]
 
     def __init__(
         self,
+        auth_group: ProcessorGroup[Any],
+        user_group: ProcessorGroup[Any],
         service: AuthService,
-        action_monitors: list[ActionMonitor],
-        validators: ActionValidators,
     ) -> None:
-        self.logout = ActionProcessor(service.logout, action_monitors)
-        self.signout = ActionProcessor(service.signout, action_monitors)
-        self.update_full_name = ActionProcessor(service.update_full_name, action_monitors)
-        self.get_ssh_keypair = SingleEntityActionProcessor(
-            service.get_ssh_keypair, action_monitors, validators=[validators.rbac.single_entity]
+        self.authorize = auth_group.anonymous_global(AuthorizeAction, service.authorize)
+        self.update_password_no_auth = auth_group.anonymous_global(
+            UpdatePasswordNoAuthAction, service.update_password_no_auth
         )
-        self.generate_ssh_keypair = ScopeActionProcessor(
-            service.generate_ssh_keypair, action_monitors, validators=[validators.rbac.scope]
+        self.public_get_role = auth_group.public(PublicGetRoleAction, service.get_role)
+        self.public_resolve_access_key_scope = auth_group.public(
+            PublicResolveAccessKeyScopeAction, service.resolve_access_key_scope
         )
-        self.upload_ssh_keypair = ScopeActionProcessor(
-            service.upload_ssh_keypair, action_monitors, validators=[validators.rbac.scope]
+        self.public_resolve_user_scope = auth_group.public(
+            PublicResolveUserScopeAction, service.resolve_user_scope
         )
-        self.get_role = ActionProcessor(service.get_role, action_monitors)
-        self.authorize = ActionProcessor(service.authorize, action_monitors)
-        self.signup = ActionProcessor(service.signup, action_monitors)
-        self.update_password = ActionProcessor(service.update_password, action_monitors)
-        self.update_password_no_auth = ActionProcessor(
-            service.update_password_no_auth, action_monitors
+        self.global_revoke_login_session = auth_group.global_scope(
+            GlobalRevokeLoginSessionAction, service.global_revoke_login_session
         )
-        self.resolve_access_key_scope = ActionProcessor(
-            service.resolve_access_key_scope, action_monitors
+        self.global_unblock_user = auth_group.global_scope(
+            GlobalUnblockUserAction, service.global_unblock_user
         )
-        self.resolve_user_scope = ActionProcessor(service.resolve_user_scope, action_monitors)
-        self.resolve_user_id_by_access_key = ActionProcessor(
-            service.resolve_user_id_by_access_key, action_monitors
+        self.signup = user_group.anonymous_global(SignupAction, service.signup)
+        self.logout = user_group.single_entity(LogoutAction, service.logout)
+        self.signout = user_group.single_entity(SignoutAction, service.signout)
+        self.update_full_name = user_group.single_entity(
+            UpdateFullNameAction, service.update_full_name
         )
-        self.admin_search_login_sessions = ActionProcessor(
-            service.admin_search_login_sessions, action_monitors
+        self.update_password = user_group.single_entity(
+            UpdatePasswordAction, service.update_password
         )
-        self.search_login_sessions = ActionProcessor(service.search_login_sessions, action_monitors)
-        self.admin_search_login_history = ActionProcessor(
-            service.admin_search_login_history, action_monitors
+        self.get_ssh_keypair = user_group.single_entity(
+            GetSSHKeypairAction, service.get_ssh_keypair
         )
-        self.search_login_history = ActionProcessor(service.search_login_history, action_monitors)
-        self.admin_revoke_login_session = ActionProcessor(
-            service.admin_revoke_login_session, action_monitors
+        self.generate_ssh_keypair = user_group.single_entity(
+            GenerateSSHKeypairAction, service.generate_ssh_keypair
         )
-        self.my_revoke_login_session = ActionProcessor(
-            service.my_revoke_login_session, action_monitors
+        self.upload_ssh_keypair = user_group.single_entity(
+            UploadSSHKeypairAction, service.upload_ssh_keypair
         )
-        self.admin_unblock_user = ActionProcessor(service.admin_unblock_user, action_monitors)
+        self.revoke_login_session = user_group.single_entity(
+            RevokeLoginSessionAction, service.revoke_login_session
+        )
+        self.resolve_user_id_by_access_key = user_group.lookup_ops(ResolveUserIDByAccessKeyAction)
+        self.login_sessions = user_group.field_group(
+            FieldGroupMeta(LOGIN_SESSION_FIELD_TYPE),
+            LoginSessionData,
+            LookupLoginSessionOwnerAction,
+            LookupBulkLoginSessionOwnerAction,
+        )
+        self.login_history = user_group.field_group(
+            FieldGroupMeta(LOGIN_HISTORY_FIELD_TYPE),
+            LoginHistoryData,
+            LookupLoginHistoryOwnerAction,
+            LookupBulkLoginHistoryOwnerAction,
+        )
+        self.search_login_sessions = self.login_sessions.search_ops(SearchLoginSessionsAction)
+        self.search_login_history = self.login_history.search_ops(SearchLoginHistoryAction)
+        self.global_search_login_sessions = self.login_sessions.global_search_ops(
+            GlobalSearchLoginSessionsAction
+        )
+        self.global_search_login_history = self.login_history.global_search_ops(
+            GlobalSearchLoginHistoryAction
+        )

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -69,44 +69,33 @@ from ai.backend.manager.services.auth.actions.generate_ssh_keypair import (
     GenerateSSHKeypairAction,
     GenerateSSHKeypairActionResult,
 )
-from ai.backend.manager.services.auth.actions.get_role import GetRoleAction, GetRoleActionResult
+from ai.backend.manager.services.auth.actions.get_role import (
+    PublicGetRoleAction,
+    PublicGetRoleActionResult,
+)
 from ai.backend.manager.services.auth.actions.get_ssh_keypair import (
     GetSSHKeypairAction,
     GetSSHKeypairActionResult,
 )
 from ai.backend.manager.services.auth.actions.logout import LogoutAction, LogoutActionResult
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeAction,
-    ResolveAccessKeyScopeResult,
-)
-from ai.backend.manager.services.auth.actions.resolve_user_id_by_access_key import (
-    ResolveUserIDByAccessKeyAction,
-    ResolveUserIDByAccessKeyResult,
+    PublicResolveAccessKeyScopeAction,
+    PublicResolveAccessKeyScopeResult,
 )
 from ai.backend.manager.services.auth.actions.resolve_user_scope import (
-    ResolveUserScopeAction,
-    ResolveUserScopeResult,
+    PublicResolveUserScopeAction,
+    PublicResolveUserScopeResult,
 )
 from ai.backend.manager.services.auth.actions.revoke_login_session import (
-    AdminRevokeLoginSessionAction,
-    MyRevokeLoginSessionAction,
+    GlobalRevokeLoginSessionAction,
+    RevokeLoginSessionAction,
     RevokeLoginSessionActionResult,
-)
-from ai.backend.manager.services.auth.actions.search_login_history import (
-    AdminSearchLoginHistoryAction,
-    SearchLoginHistoryAction,
-    SearchLoginHistoryActionResult,
-)
-from ai.backend.manager.services.auth.actions.search_login_sessions import (
-    AdminSearchLoginSessionsAction,
-    SearchLoginSessionsAction,
-    SearchLoginSessionsActionResult,
 )
 from ai.backend.manager.services.auth.actions.signout import SignoutAction, SignoutActionResult
 from ai.backend.manager.services.auth.actions.signup import SignupAction, SignupActionResult
 from ai.backend.manager.services.auth.actions.unblock_user import (
-    AdminUnblockUserAction,
-    AdminUnblockUserActionResult,
+    GlobalUnblockUserAction,
+    GlobalUnblockUserActionResult,
 )
 from ai.backend.manager.services.auth.actions.update_full_name import (
     UpdateFullNameAction,
@@ -170,7 +159,7 @@ class AuthService:
         self._group_repository = group_repository
         self._ssh_key_validator = ssh_key_validator
 
-    async def get_role(self, action: GetRoleAction) -> GetRoleActionResult:
+    async def get_role(self, action: PublicGetRoleAction) -> PublicGetRoleActionResult:
         group_role = None
         if action.group_id is not None:
             if action.is_superadmin:
@@ -189,7 +178,7 @@ class AuthService:
                         object_name="project (user group)",
                     ) from e
 
-        return GetRoleActionResult(
+        return PublicGetRoleActionResult(
             global_role="superadmin" if action.is_superadmin else "user",
             domain_role="admin" if action.is_admin else "user",
             group_role=group_role,
@@ -566,8 +555,8 @@ class AuthService:
         await self._valkey_session_client.delete_login_session(action.session_token)
         return LogoutActionResult(success=True)
 
-    async def admin_revoke_login_session(
-        self, action: AdminRevokeLoginSessionAction
+    async def global_revoke_login_session(
+        self, action: GlobalRevokeLoginSessionAction
     ) -> RevokeLoginSessionActionResult:
         session_token = await self._auth_repository.delete_login_session_by_id(
             action.session_id, LoginAttemptResult.REVOKED_BY_ADMIN
@@ -575,8 +564,8 @@ class AuthService:
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
 
-    async def my_revoke_login_session(
-        self, action: MyRevokeLoginSessionAction
+    async def revoke_login_session(
+        self, action: RevokeLoginSessionAction
     ) -> RevokeLoginSessionActionResult:
         session_data = await self._auth_repository.get_login_session_by_id(action.session_id)
         if session_data.user_id != action.user_id:
@@ -587,11 +576,11 @@ class AuthService:
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
 
-    async def admin_unblock_user(
-        self, action: AdminUnblockUserAction
-    ) -> AdminUnblockUserActionResult:
+    async def global_unblock_user(
+        self, action: GlobalUnblockUserAction
+    ) -> GlobalUnblockUserActionResult:
         await self._valkey_session_client.clear_login_block(action.username)
-        return AdminUnblockUserActionResult(success=True)
+        return GlobalUnblockUserActionResult(success=True)
 
     async def signout(self, action: SignoutAction) -> SignoutActionResult:
         if action.email != action.requester_email:
@@ -724,7 +713,6 @@ class AuthService:
                 ssh_public_key=pubkey,
                 ssh_private_key=privkey,
             ),
-            user_id=action.user_id,
         )
 
     async def upload_ssh_keypair(
@@ -741,18 +729,17 @@ class AuthService:
                 ssh_public_key=pubkey,
                 ssh_private_key=privkey,
             ),
-            user_id=action.user_id,
         )
 
     async def resolve_access_key_scope(
-        self, action: ResolveAccessKeyScopeAction
-    ) -> ResolveAccessKeyScopeResult:
+        self, action: PublicResolveAccessKeyScopeAction
+    ) -> PublicResolveAccessKeyScopeResult:
         requester_ak = AccessKey(action.requester_access_key)
         if (
             action.owner_access_key is None
             or action.owner_access_key == action.requester_access_key
         ):
-            return ResolveAccessKeyScopeResult(
+            return PublicResolveAccessKeyScopeResult(
                 requester_access_key=requester_ak,
                 owner_access_key=requester_ak,
             )
@@ -775,20 +762,16 @@ class AuthService:
             )
         except RuntimeError as e:
             raise GenericForbidden(str(e)) from e
-        return ResolveAccessKeyScopeResult(
+        return PublicResolveAccessKeyScopeResult(
             requester_access_key=requester_ak,
             owner_access_key=owner_ak,
         )
 
-    async def resolve_user_id_by_access_key(
-        self, action: ResolveUserIDByAccessKeyAction
-    ) -> ResolveUserIDByAccessKeyResult:
-        user_id = await self._auth_repository.get_user_id_by_access_key(action.access_key)
-        return ResolveUserIDByAccessKeyResult(user_id=user_id)
-
-    async def resolve_user_scope(self, action: ResolveUserScopeAction) -> ResolveUserScopeResult:
+    async def resolve_user_scope(
+        self, action: PublicResolveUserScopeAction
+    ) -> PublicResolveUserScopeResult:
         if action.owner_user_email is None:
-            return ResolveUserScopeResult(
+            return PublicResolveUserScopeResult(
                 owner_uuid=action.requester_uuid,
                 owner_role=action.requester_role,
             )
@@ -813,38 +796,10 @@ class AuthService:
             )
         except RuntimeError as e:
             raise GenericForbidden(str(e)) from e
-        return ResolveUserScopeResult(
+        return PublicResolveUserScopeResult(
             owner_uuid=owner_uuid,
             owner_role=owner_role,
         )
-
-    async def admin_search_login_sessions(
-        self, action: AdminSearchLoginSessionsAction
-    ) -> SearchLoginSessionsActionResult:
-        result = await self._auth_repository.admin_search_login_sessions(querier=action.querier)
-        return SearchLoginSessionsActionResult(result=result)
-
-    async def search_login_sessions(
-        self, action: SearchLoginSessionsAction
-    ) -> SearchLoginSessionsActionResult:
-        result = await self._auth_repository.search_login_sessions(
-            scope=action.scope, querier=action.querier
-        )
-        return SearchLoginSessionsActionResult(result=result)
-
-    async def admin_search_login_history(
-        self, action: AdminSearchLoginHistoryAction
-    ) -> SearchLoginHistoryActionResult:
-        result = await self._auth_repository.admin_search_login_history(querier=action.querier)
-        return SearchLoginHistoryActionResult(result=result)
-
-    async def search_login_history(
-        self, action: SearchLoginHistoryAction
-    ) -> SearchLoginHistoryActionResult:
-        result = await self._auth_repository.search_login_history(
-            scope=action.scope, querier=action.querier
-        )
-        return SearchLoginHistoryActionResult(result=result)
 
     async def _check_password_age(self, user: RowMapping, auth_config: AuthConfig | None) -> None:
         if (

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -11,6 +11,7 @@ from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
 from ai.backend.common.data.entity.artifact_registry import ARTIFACT_REGISTRY_ENTITY_TYPE
 from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
 from ai.backend.common.data.entity.audit_log import AUDIT_LOG_FIELD_TYPE
+from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
 from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
 from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
 from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
@@ -665,7 +666,11 @@ def create_processors(
             deployment_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
             services.model_serving_auto_scaling,
         ),
-        auth=AuthProcessors(services.auth, action_monitors, validators),
+        auth=AuthProcessors(
+            organization_groups.group(GroupMeta(AUTH_ENTITY_TYPE)),
+            organization_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+            services.auth,
+        ),
         login_client_type=LoginClientTypeProcessors(
             system_groups.group(GroupMeta(LOGIN_CLIENT_TYPE_ENTITY_TYPE))
         ),

--- a/src/ai/backend/manager/services/user/actions/keypair_ops.py
+++ b/src/ai/backend/manager/services/user/actions/keypair_ops.py
@@ -320,7 +320,7 @@ class AdminRegisterSSHKeypairAction(_KeypairOfUserAction):
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "register_ssh_keypair"
+        return "admin_register_ssh_keypair"
 
 
 @dataclass(frozen=True)
@@ -342,7 +342,7 @@ class AdminDeleteSSHKeypairAction(_KeypairOfUserAction):
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "delete_ssh_keypair"
+        return "admin_delete_ssh_keypair"
 
 
 @dataclass(frozen=True)
@@ -364,7 +364,7 @@ class AdminGetSSHKeypairAction(_KeypairOfUserAction):
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "get_ssh_keypair"
+        return "admin_get_ssh_keypair"
 
 
 @dataclass(frozen=True)

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -46,9 +46,10 @@ from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyS
 from ai.backend.common.configs.etcd import EtcdConfig
 from ai.backend.common.configs.pyroscope import PyroscopeConfig
 from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
 from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.defs import (
@@ -83,13 +84,8 @@ from ai.backend.logging.config import ConsoleConfig, LogDriver, LoggingConfig
 from ai.backend.logging.types import LogFormat
 from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
-from ai.backend.manager.actions.registry.types import ProcessorDependencies
+from ai.backend.manager.actions.registry.types import GroupMeta, ProcessorDependencies
 from ai.backend.manager.actions.v2.validators import ActionValidators as V2ActionValidators
-from ai.backend.manager.actions.validators import ActionValidators
-from ai.backend.manager.actions.validators.rbac import RBACValidators
-from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
-from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
-from ai.backend.manager.actions.validators.rbac.single_entity import SingleEntityActionRBACValidator
 from ai.backend.manager.agent_cache import AgentRPCCache
 from ai.backend.manager.api.rest.app import build_root_app, mount_registries
 from ai.backend.manager.api.rest.middleware import build_auth_middleware, build_exception_middleware
@@ -161,7 +157,6 @@ from ai.backend.manager.repositories.user_resource_policy.repository import (
 )
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.auth.service import AuthService
-from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
 from ai.backend.testutils.bootstrap import (  # noqa: F401
     etcd_container,
     postgres_container,
@@ -1429,6 +1424,7 @@ def appproxy_client_pool() -> AppProxyClientPool:
 @pytest.fixture()
 def auth_processors(
     database_engine: ExtendedAsyncSAEngine,
+    processor_registry: ProcessorRegistry[Any],
     config_provider: ManagerConfigProvider,
     hook_plugin_ctx: HookPluginContext,
     valkey_clients: ValkeyClients,
@@ -1456,16 +1452,9 @@ def auth_processors(
         ssh_key_validator=SSHKeyValidator(),
     )
     return AuthProcessors(
-        service=service,
-        action_monitors=[],
-        validators=ActionValidators(
-            virtual_scope_rbac=mock_virtual_scope_rbac_validators(),
-            rbac=RBACValidators(
-                scope=MagicMock(spec=ScopeActionRBACValidator),
-                single_entity=MagicMock(spec=SingleEntityActionRBACValidator),
-                bulk=MagicMock(spec=BulkActionRBACValidator),
-            ),
-        ),
+        processor_registry.group(GroupMeta(AUTH_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        service,
     )
 
 

--- a/tests/unit/manager/actions/test_action_types.py
+++ b/tests/unit/manager/actions/test_action_types.py
@@ -6,25 +6,29 @@ from ai.backend.manager.actions.types import ActionOperationType
 
 # Import representative concrete action classes across different entity types
 # and operation types to verify enum usage at runtime.
-from ai.backend.manager.services.auth.actions.authorize import AuthorizeAction
-from ai.backend.manager.services.auth.actions.get_role import GetRoleAction
-from ai.backend.manager.services.auth.actions.logout import LogoutAction
-from ai.backend.manager.services.auth.actions.search_login_history import (
-    SearchLoginHistoryAction,
+from ai.backend.manager.services.permission_contoller.actions.create_role import CreateRoleAction
+from ai.backend.manager.services.permission_contoller.actions.delete_role import DeleteRoleAction
+from ai.backend.manager.services.permission_contoller.actions.get_role_detail import (
+    GetRoleDetailAction,
 )
-from ai.backend.manager.services.auth.actions.update_password import UpdatePasswordAction
 from ai.backend.manager.services.permission_contoller.actions.purge_role import PurgeRoleAction
+from ai.backend.manager.services.permission_contoller.actions.replace_role_permissions import (
+    ReplaceRolePermissionsAction,
+)
+from ai.backend.manager.services.permission_contoller.actions.search_entities import (
+    SearchEntitiesAction,
+)
 
 # Legacy-family actions only. The v2 families answer with
 # ``ai.backend.common.data.entity.types.EntityType``, a distinct NewType, so mixing
 # them in would conflate two type systems rather than test either one.
 _REPRESENTATIVE_ACTION_CLASSES: list[type[BaseAction]] = [
-    AuthorizeAction,
-    GetRoleAction,
-    LogoutAction,
+    CreateRoleAction,
+    DeleteRoleAction,
+    GetRoleDetailAction,
     PurgeRoleAction,
-    SearchLoginHistoryAction,
-    UpdatePasswordAction,
+    ReplaceRolePermissionsAction,
+    SearchEntitiesAction,
 ]
 
 

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -30,6 +30,7 @@ from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
 from ai.backend.common.data.entity.artifact_registry import ARTIFACT_REGISTRY_ENTITY_TYPE
 from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
 from ai.backend.common.data.entity.audit_log import AUDIT_LOG_FIELD_TYPE
+from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
 from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
 from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
 from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
@@ -106,6 +107,7 @@ from ai.backend.manager.services.artifact.revision.actions.lookup_owner import (
 from ai.backend.manager.services.artifact.revision.processors import ArtifactRevisionProcessors
 from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
 from ai.backend.manager.services.audit_log.processors import AuditLogProcessors
+from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.container_registry.processors import ContainerRegistryProcessors
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment_revision_preset.processors import (
@@ -284,6 +286,11 @@ def test_every_defined_v2_action_is_wired() -> None:
     DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
     ProjectProcessors(registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), MagicMock())
     UserProcessors(
+        registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        MagicMock(),
+    )
+    AuthProcessors(
+        registry.group(GroupMeta(AUTH_ENTITY_TYPE)),
         registry.group(GroupMeta(USER_ENTITY_TYPE)),
         MagicMock(),
     )

--- a/tests/unit/manager/api/auth/test_handlers.py
+++ b/tests/unit/manager/api/auth/test_handlers.py
@@ -47,7 +47,7 @@ from ai.backend.manager.services.auth.actions.authorize import AuthorizeActionRe
 from ai.backend.manager.services.auth.actions.generate_ssh_keypair import (
     GenerateSSHKeypairActionResult,
 )
-from ai.backend.manager.services.auth.actions.get_role import GetRoleActionResult
+from ai.backend.manager.services.auth.actions.get_role import PublicGetRoleActionResult
 from ai.backend.manager.services.auth.actions.get_ssh_keypair import GetSSHKeypairActionResult
 from ai.backend.manager.services.auth.actions.signout import SignoutActionResult
 from ai.backend.manager.services.auth.actions.signup import SignupActionResult
@@ -268,11 +268,11 @@ class TestAuthorize:
             "password": "password123",
             "client_type_id": str(sample_client_type_id),
         })
-        mock_processors.auth.authorize.wait_for_complete = AsyncMock(return_value=authorize_result)
+        mock_processors.auth.authorize.run = AsyncMock(return_value=authorize_result)
 
         response = await handler.authorize(body, request_ctx)
 
-        mock_processors.auth.authorize.wait_for_complete.assert_called_once()
+        mock_processors.auth.authorize.run.assert_called_once()
         assert not isinstance(response, web.StreamResponse)
         assert response.status_code == HTTPStatus.OK
         assert authorize_result.authorization_result is not None
@@ -304,11 +304,11 @@ class TestAuthorize:
             "stoken": stoken,
             "client_type_id": str(sample_client_type_id),
         })
-        mock_processors.auth.authorize.wait_for_complete = AsyncMock(return_value=authorize_result)
+        mock_processors.auth.authorize.run = AsyncMock(return_value=authorize_result)
 
         await handler.authorize(body, request_ctx)
 
-        action = mock_processors.auth.authorize.wait_for_complete.call_args[0][0]
+        action = mock_processors.auth.authorize.run.call_args[0][0]
         assert action.domain_name == domain
         assert action.email == email
         assert action.password == password
@@ -336,7 +336,7 @@ class TestAuthorize:
             "password": "pass",
             "client_type_id": str(sample_client_type_id),
         })
-        mock_processors.auth.authorize.wait_for_complete = AsyncMock(return_value=result)
+        mock_processors.auth.authorize.run = AsyncMock(return_value=result)
 
         response = await handler.authorize(body, request_ctx)
 
@@ -368,11 +368,11 @@ class TestSignup:
             "email": "newuser@example.com",
             "password": "securepassword",
         })
-        mock_processors.auth.signup.wait_for_complete = AsyncMock(return_value=signup_result)
+        mock_processors.auth.signup.run = AsyncMock(return_value=signup_result)
 
         response = await handler.signup(body, request_ctx)
 
-        mock_processors.auth.signup.wait_for_complete.assert_called_once()
+        mock_processors.auth.signup.run.assert_called_once()
         assert response.status_code == HTTPStatus.CREATED
         data = response.to_json
         assert data is not None
@@ -401,11 +401,11 @@ class TestSignup:
             "full_name": full_name,
             "description": "Description",
         })
-        mock_processors.auth.signup.wait_for_complete = AsyncMock(return_value=signup_result)
+        mock_processors.auth.signup.run = AsyncMock(return_value=signup_result)
 
         await handler.signup(body, request_ctx)
 
-        action = mock_processors.auth.signup.wait_for_complete.call_args[0][0]
+        action = mock_processors.auth.signup.run.call_args[0][0]
         assert action.domain_name == domain
         assert action.email == email
         assert action.username == username
@@ -425,14 +425,12 @@ class TestSignout:
         email = "test@example.com"
         body: BodyParam[SignoutRequest] = BodyParam(SignoutRequest)
         body.from_body({"email": email, "password": "pass"})
-        mock_processors.auth.signout.wait_for_complete = AsyncMock(
-            return_value=SignoutActionResult(success=True)
-        )
+        mock_processors.auth.signout.run = AsyncMock(return_value=SignoutActionResult(success=True))
 
         response = await handler.signout(body, user_context)
 
-        mock_processors.auth.signout.wait_for_complete.assert_called_once()
-        action = mock_processors.auth.signout.wait_for_complete.call_args[0][0]
+        mock_processors.auth.signout.run.assert_called_once()
+        action = mock_processors.auth.signout.run.call_args[0][0]
         assert action.user_id == user_context.user_uuid
         assert action.email == email
         assert response.status_code == HTTPStatus.OK
@@ -452,8 +450,8 @@ class TestGetRole:
         domain_role = "user"
         query: QueryParam[GetRoleRequest] = QueryParam(GetRoleRequest)
         query.from_query({})
-        mock_processors.auth.get_role.wait_for_complete = AsyncMock(
-            return_value=GetRoleActionResult(
+        mock_processors.auth.public_get_role.run = AsyncMock(
+            return_value=PublicGetRoleActionResult(
                 global_role=global_role,
                 domain_role=domain_role,
                 group_role=None,
@@ -462,7 +460,7 @@ class TestGetRole:
 
         response = await handler.get_role(query, user_context)
 
-        mock_processors.auth.get_role.wait_for_complete.assert_called_once()
+        mock_processors.auth.public_get_role.run.assert_called_once()
         assert response.status_code == HTTPStatus.OK
         data = response.to_json
         assert data is not None
@@ -481,8 +479,8 @@ class TestGetRole:
         group_uuid = uuid.uuid4()
         query: QueryParam[GetRoleRequest] = QueryParam(GetRoleRequest)
         query.from_query({"group": str(group_uuid)})
-        mock_processors.auth.get_role.wait_for_complete = AsyncMock(
-            return_value=GetRoleActionResult(
+        mock_processors.auth.public_get_role.run = AsyncMock(
+            return_value=PublicGetRoleActionResult(
                 global_role="user",
                 domain_role="user",
                 group_role="member",
@@ -491,7 +489,7 @@ class TestGetRole:
 
         await handler.get_role(query, user_context)
 
-        action = mock_processors.auth.get_role.wait_for_complete.call_args[0][0]
+        action = mock_processors.auth.public_get_role.run.call_args[0][0]
         assert action.group_id == group_uuid
 
     async def test_uses_admin_flags_from_context(
@@ -511,8 +509,8 @@ class TestGetRole:
         )
         query: QueryParam[GetRoleRequest] = QueryParam(GetRoleRequest)
         query.from_query({})
-        mock_processors.auth.get_role.wait_for_complete = AsyncMock(
-            return_value=GetRoleActionResult(
+        mock_processors.auth.public_get_role.run = AsyncMock(
+            return_value=PublicGetRoleActionResult(
                 global_role="superadmin",
                 domain_role="admin",
                 group_role=None,
@@ -521,7 +519,7 @@ class TestGetRole:
 
         await handler.get_role(query, admin_ctx)
 
-        action = mock_processors.auth.get_role.wait_for_complete.call_args[0][0]
+        action = mock_processors.auth.public_get_role.run.call_args[0][0]
         assert action.is_admin is True
         assert action.is_superadmin is True
 
@@ -543,13 +541,13 @@ class TestUpdatePassword:
             "new_password": "newpass",
             "new_password2": "newpass",
         })
-        mock_processors.auth.update_password.wait_for_complete = AsyncMock(
+        mock_processors.auth.update_password.run = AsyncMock(
             return_value=UpdatePasswordActionResult(success=True, message="OK")
         )
 
         response = await handler.update_password(body, user_context, request_ctx)
 
-        mock_processors.auth.update_password.wait_for_complete.assert_called_once()
+        mock_processors.auth.update_password.run.assert_called_once()
         assert response.status_code == HTTPStatus.OK
 
     async def test_returns_bad_request_on_failure(
@@ -566,7 +564,7 @@ class TestUpdatePassword:
             "new_password": "newpass",
             "new_password2": "differentpass",
         })
-        mock_processors.auth.update_password.wait_for_complete = AsyncMock(
+        mock_processors.auth.update_password.run = AsyncMock(
             return_value=UpdatePasswordActionResult(success=False, message="mismatch")
         )
 
@@ -593,7 +591,7 @@ class TestUpdatePasswordNoAuth:
             "current_password": "current",
             "new_password": "newpass",
         })
-        mock_processors.auth.update_password_no_auth.wait_for_complete = AsyncMock(
+        mock_processors.auth.update_password_no_auth.run = AsyncMock(
             return_value=UpdatePasswordNoAuthActionResult(
                 user_id=uuid.uuid4(),
                 password_changed_at=password_changed_at,
@@ -602,7 +600,7 @@ class TestUpdatePasswordNoAuth:
 
         response = await handler.update_password_no_auth(body, request_ctx)
 
-        mock_processors.auth.update_password_no_auth.wait_for_complete.assert_called_once()
+        mock_processors.auth.update_password_no_auth.run.assert_called_once()
         assert response.status_code == HTTPStatus.CREATED
         data = response.to_json
         assert data is not None
@@ -622,14 +620,14 @@ class TestUpdateFullName:
         full_name = "New Name"
         body: BodyParam[UpdateFullNameRequest] = BodyParam(UpdateFullNameRequest)
         body.from_body({"email": "user@example.com", "full_name": full_name})
-        mock_processors.auth.update_full_name.wait_for_complete = AsyncMock(
+        mock_processors.auth.update_full_name.run = AsyncMock(
             return_value=UpdateFullNameActionResult(success=True)
         )
 
         response = await handler.update_full_name(body, user_context)
 
-        mock_processors.auth.update_full_name.wait_for_complete.assert_called_once()
-        action = mock_processors.auth.update_full_name.wait_for_complete.call_args[0][0]
+        mock_processors.auth.update_full_name.run.assert_called_once()
+        action = mock_processors.auth.update_full_name.run.call_args[0][0]
         assert action.full_name == full_name
         assert response.status_code == HTTPStatus.OK
 
@@ -646,7 +644,7 @@ class TestGetSSHKeypair:
         """Verify processor is called and public key is returned."""
         public_key = "ssh-rsa AAAAB3...\n"
         access_key = "AKIAIOSFODNN7EXAMPLE"
-        mock_processors.auth.get_ssh_keypair.wait_for_complete = AsyncMock(
+        mock_processors.auth.get_ssh_keypair.run = AsyncMock(
             return_value=GetSSHKeypairActionResult(
                 public_key=public_key,
                 access_key=access_key,
@@ -655,7 +653,7 @@ class TestGetSSHKeypair:
 
         response = await handler.get_ssh_keypair(user_context)
 
-        mock_processors.auth.get_ssh_keypair.wait_for_complete.assert_called_once()
+        mock_processors.auth.get_ssh_keypair.run.assert_called_once()
         assert response.status_code == HTTPStatus.OK
         data = response.to_json
         assert data is not None
@@ -675,20 +673,18 @@ class TestGenerateSSHKeypair:
         """Verify processor is called and keypair is returned."""
         ssh_public_key = "ssh-rsa NEWPUB...\n"
         ssh_private_key = "-----BEGIN RSA PRIVATE KEY-----\n...\n"
-        user_id = user_context.user_uuid
-        mock_processors.auth.generate_ssh_keypair.wait_for_complete = AsyncMock(
+        mock_processors.auth.generate_ssh_keypair.run = AsyncMock(
             return_value=GenerateSSHKeypairActionResult(
                 ssh_keypair=SSHKeypair(
                     ssh_public_key=ssh_public_key,
                     ssh_private_key=ssh_private_key,
                 ),
-                user_id=user_id,
             )
         )
 
         response = await handler.generate_ssh_keypair(user_context)
 
-        mock_processors.auth.generate_ssh_keypair.wait_for_complete.assert_called_once()
+        mock_processors.auth.generate_ssh_keypair.run.assert_called_once()
         assert response.status_code == HTTPStatus.OK
         data = response.to_json
         assert data is not None
@@ -712,20 +708,18 @@ class TestUploadSSHKeypair:
             "pubkey": "ssh-rsa AAAAB3...",
             "privkey": "-----BEGIN RSA PRIVATE KEY-----\n...",
         })
-        user_id = user_context.user_uuid
-        mock_processors.auth.upload_ssh_keypair.wait_for_complete = AsyncMock(
+        mock_processors.auth.upload_ssh_keypair.run = AsyncMock(
             return_value=UploadSSHKeypairActionResult(
                 ssh_keypair=SSHKeypair(
                     ssh_public_key="ssh-rsa AAAAB3...\n",
                     ssh_private_key="-----BEGIN RSA PRIVATE KEY-----\n...\n",
                 ),
-                user_id=user_id,
             )
         )
 
         response = await handler.upload_ssh_keypair(body, user_context)
 
-        mock_processors.auth.upload_ssh_keypair.wait_for_complete.assert_called_once()
+        mock_processors.auth.upload_ssh_keypair.run.assert_called_once()
         assert response.status_code == HTTPStatus.OK
         data = response.to_json
         assert data is not None

--- a/tests/unit/manager/api/service/test_handler.py
+++ b/tests/unit/manager/api/service/test_handler.py
@@ -21,7 +21,7 @@ from ai.backend.common.types import AccessKey
 from ai.backend.manager.api.rest.service.handler import ServiceHandler
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeResult,
+    PublicResolveAccessKeyScopeResult,
 )
 from ai.backend.manager.services.model_serving.actions.validate_model_service import (
     ValidateModelServiceAction,
@@ -81,13 +81,13 @@ class TestRunValidationUsesKeypairResourcePolicy:
 
     @pytest.fixture
     def mock_auth(self, keypair_resource_policy: dict[str, Any]) -> MagicMock:
-        scope_result = ResolveAccessKeyScopeResult(
+        scope_result = PublicResolveAccessKeyScopeResult(
             requester_access_key=AccessKey("TESTACCESSKEY01"),
             owner_access_key=AccessKey("TESTACCESSKEY01"),
         )
         mock = MagicMock()
-        mock.resolve_access_key_scope = MagicMock()
-        mock.resolve_access_key_scope.wait_for_complete = AsyncMock(return_value=scope_result)
+        mock.public_resolve_access_key_scope = MagicMock()
+        mock.public_resolve_access_key_scope.run = AsyncMock(return_value=scope_result)
         return mock
 
     @pytest.fixture

--- a/tests/unit/manager/repositories/auth/test_auth_repository.py
+++ b/tests/unit/manager/repositories/auth/test_auth_repository.py
@@ -16,12 +16,12 @@ import sqlalchemy as sa
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.exception import UserNotFound
-from ai.backend.common.types import AccessKey, ResourceSlot, VFolderHostPermissionMap
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.auth.types import UserData
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.data.project.types import ProjectData
-from ai.backend.manager.errors.auth import AccessKeyNotFound, GroupMembershipNotFoundError
+from ai.backend.manager.errors.auth import GroupMembershipNotFoundError
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow
@@ -582,23 +582,6 @@ class TestAuthRepository:
         now_utc = datetime.now(UTC)
         time_diff = abs((now_utc - result).total_seconds())
         assert time_diff < 1.0
-
-    async def test_get_user_id_by_access_key_success(
-        self,
-        auth_repository: AuthRepository,
-        sample_user_data: UserTestData,
-    ) -> None:
-        result = await auth_repository.get_user_id_by_access_key(
-            AccessKey(sample_user_data.access_key)
-        )
-
-        assert result == sample_user_data.uuid
-
-    async def test_get_user_id_by_access_key_not_found(
-        self, auth_repository: AuthRepository
-    ) -> None:
-        with pytest.raises(AccessKeyNotFound):
-            await auth_repository.get_user_id_by_access_key(AccessKey("AKIANONEXISTENT"))
 
     async def test_create_user_with_keypair_writes_the_domain_id_from_the_name(
         self,

--- a/tests/unit/manager/services/auth/test_get_role.py
+++ b/tests/unit/manager/services/auth/test_get_role.py
@@ -9,7 +9,7 @@ from ai.backend.manager.repositories.auth.repository import AuthRepository
 from ai.backend.manager.repositories.user_resource_policy.repository import (
     UserResourcePolicyRepository,
 )
-from ai.backend.manager.services.auth.actions.get_role import GetRoleAction
+from ai.backend.manager.services.auth.actions.get_role import PublicGetRoleAction
 from ai.backend.manager.services.auth.service import AuthService
 
 
@@ -55,7 +55,7 @@ async def test_get_role_simple_cases(
     expected_domain: str,
 ) -> None:
     """Test role retrieval for simple cases without group logic"""
-    action = GetRoleAction(
+    action = PublicGetRoleAction(
         user_id=UUID("12345678-1234-5678-1234-567812345678"),
         is_superadmin=is_superadmin,
         is_admin=is_admin,
@@ -83,7 +83,7 @@ async def test_get_role_with_valid_group_membership(
         "user_id": user_id,
     }
 
-    action = GetRoleAction(
+    action = PublicGetRoleAction(
         user_id=user_id,
         is_superadmin=False,
         is_admin=False,
@@ -110,7 +110,7 @@ async def test_get_role_without_group_membership_raises_error(
         "No such project or you are not the member of it."
     )
 
-    action = GetRoleAction(
+    action = PublicGetRoleAction(
         user_id=user_id,
         is_superadmin=False,
         is_admin=False,
@@ -129,7 +129,7 @@ async def test_get_role_verifies_correct_parameters(
     user_id = UUID("abcdef12-3456-7890-abcd-ef1234567890")
     group_id = UUID("fedcba98-7654-3210-fedc-ba9876543210")
 
-    action = GetRoleAction(
+    action = PublicGetRoleAction(
         user_id=user_id,
         is_superadmin=False,
         is_admin=True,

--- a/tests/unit/manager/services/auth/test_resolve_scope.py
+++ b/tests/unit/manager/services/auth/test_resolve_scope.py
@@ -12,10 +12,10 @@ from ai.backend.manager.repositories.user_resource_policy.repository import (
     UserResourcePolicyRepository,
 )
 from ai.backend.manager.services.auth.actions.resolve_access_key_scope import (
-    ResolveAccessKeyScopeAction,
+    PublicResolveAccessKeyScopeAction,
 )
 from ai.backend.manager.services.auth.actions.resolve_user_scope import (
-    ResolveUserScopeAction,
+    PublicResolveUserScopeAction,
 )
 from ai.backend.manager.services.auth.service import AuthService
 
@@ -56,7 +56,7 @@ class TestResolveAccessKeyScope:
         self,
         auth_service: AuthService,
     ) -> None:
-        action = ResolveAccessKeyScopeAction(
+        action = PublicResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
             requester_role=UserRole.USER,
             requester_domain="default",
@@ -70,7 +70,7 @@ class TestResolveAccessKeyScope:
         self,
         auth_service: AuthService,
     ) -> None:
-        action = ResolveAccessKeyScopeAction(
+        action = PublicResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
             requester_role=UserRole.ADMIN,
             requester_domain="default",
@@ -88,7 +88,7 @@ class TestResolveAccessKeyScope:
             "default",
             UserRole.ADMIN,
         )
-        action = ResolveAccessKeyScopeAction(
+        action = PublicResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
             requester_role=UserRole.USER,
             requester_domain="default",
@@ -105,7 +105,7 @@ class TestResolveAccessKeyScope:
         mock_auth_repository.get_delegation_target_by_access_key.side_effect = ValueError(
             "Unknown owner access key"
         )
-        action = ResolveAccessKeyScopeAction(
+        action = PublicResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
             requester_role=UserRole.SUPERADMIN,
             requester_domain="default",
@@ -123,7 +123,7 @@ class TestResolveAccessKeyScope:
             "other-domain",
             UserRole.USER,
         )
-        action = ResolveAccessKeyScopeAction(
+        action = PublicResolveAccessKeyScopeAction(
             requester_access_key=REQUESTER_AK,
             requester_role=UserRole.ADMIN,
             requester_domain="default",
@@ -138,7 +138,7 @@ class TestResolveUserScope:
         self,
         auth_service: AuthService,
     ) -> None:
-        action = ResolveUserScopeAction(
+        action = PublicResolveUserScopeAction(
             requester_uuid=REQUESTER_UUID,
             requester_role=UserRole.USER,
             requester_domain="default",
@@ -153,7 +153,7 @@ class TestResolveUserScope:
         self,
         auth_service: AuthService,
     ) -> None:
-        action = ResolveUserScopeAction(
+        action = PublicResolveUserScopeAction(
             requester_uuid=REQUESTER_UUID,
             requester_role=UserRole.ADMIN,
             requester_domain="default",
@@ -173,7 +173,7 @@ class TestResolveUserScope:
             UserRole.USER,
             "default",
         )
-        action = ResolveUserScopeAction(
+        action = PublicResolveUserScopeAction(
             requester_uuid=REQUESTER_UUID,
             requester_role=UserRole.SUPERADMIN,
             requester_domain="default",
@@ -192,7 +192,7 @@ class TestResolveUserScope:
         mock_auth_repository.get_delegation_target_by_email.side_effect = ValueError(
             "Unknown user email"
         )
-        action = ResolveUserScopeAction(
+        action = PublicResolveUserScopeAction(
             requester_uuid=REQUESTER_UUID,
             requester_role=UserRole.SUPERADMIN,
             requester_domain="default",

--- a/tests/unit/manager/services/auth/test_signout.py
+++ b/tests/unit/manager/services/auth/test_signout.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import pytest
 
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.errors.auth import AuthorizationFailed
 from ai.backend.manager.errors.common import GenericForbidden
 from ai.backend.manager.models.user import UserRole, UserStatus
@@ -45,7 +46,7 @@ async def test_signout_successful_with_valid_credentials(
 ) -> None:
     """Test successful signout with valid credentials"""
     action = SignoutAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         password="correct_password",
@@ -73,7 +74,7 @@ async def test_signout_fails_when_not_account_owner(
 ) -> None:
     """Test signout fails when requester is not the account owner"""
     action = SignoutAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         password="password",
@@ -90,7 +91,7 @@ async def test_signout_fails_with_invalid_credentials(
 ) -> None:
     """Test signout fails with invalid credentials"""
     action = SignoutAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         password="wrong_password",

--- a/tests/unit/manager/services/auth/test_ssh_keypair.py
+++ b/tests/unit/manager/services/auth/test_ssh_keypair.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import pytest
 
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.errors.keypair import InvalidSSHPrivateKey, SSHKeypairMismatch
 from ai.backend.manager.models.keypair.ssh_key_validator import SSHKeyValidator
 from ai.backend.manager.repositories.auth.repository import AuthRepository
@@ -59,7 +60,7 @@ async def test_get_ssh_keypair_existing_key(
 ) -> None:
     """Test getting existing SSH public key"""
     action = GetSSHKeypairAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         access_key="AKIA1234567890ABCDEF",
     )
 
@@ -79,7 +80,7 @@ async def test_get_ssh_keypair_nonexistent_key(
 ) -> None:
     """Test getting non-existing SSH public key returns empty string"""
     action = GetSSHKeypairAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         access_key="AKIANONEXISTENT",
     )
 
@@ -98,7 +99,7 @@ async def test_generate_ssh_keypair(
 ) -> None:
     """Test SSH keypair generation"""
     action = GenerateSSHKeypairAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         access_key="AKIA1234567890ABCDEF",
     )
 
@@ -131,7 +132,7 @@ async def test_upload_ssh_keypair_valid_keys(
 ) -> None:
     """Test uploading valid SSH keypair"""
     action = UploadSSHKeypairAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         access_key="AKIA1234567890ABCDEF",
         public_key="ssh-rsa AAAAB3NzaC1yc2EUPLOADED...",
         private_key="-----BEGIN RSA PRIVATE KEY-----\nUPLOADED...\n-----END RSA PRIVATE KEY-----",
@@ -164,7 +165,7 @@ async def test_upload_ssh_keypair_invalid_keys(
 ) -> None:
     """Test uploading invalid SSH keypair propagates the validator error"""
     action = UploadSSHKeypairAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         access_key="AKIA1234567890ABCDEF",
         public_key="invalid-public-key",
         private_key="invalid-private-key",
@@ -186,7 +187,7 @@ async def test_upload_ssh_keypair_mismatch(
 ) -> None:
     """Test that a keypair mismatch from the validator propagates and skips the write"""
     action = UploadSSHKeypairAction(
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         access_key="AKIATEST",
         public_key="bad-key",
         private_key="bad-key",

--- a/tests/unit/manager/services/auth/test_update_full_name.py
+++ b/tests/unit/manager/services/auth/test_update_full_name.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import pytest
 
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import UserNotFound
 from ai.backend.manager.repositories.auth.repository import AuthRepository
 from ai.backend.manager.repositories.user_resource_policy.repository import (
@@ -44,7 +46,7 @@ async def test_update_full_name_successful(
 ) -> None:
     """Test successfully updating full name for existing user"""
     action = UpdateFullNameAction(
-        user_id="12345678-1234-5678-1234-567812345678",
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         email="user@example.com",
         domain_name="default",
         full_name="New Full Name",
@@ -67,7 +69,7 @@ async def test_update_full_name_fails_for_nonexistent_user(
 ) -> None:
     """Test updating full name fails for non-existent user"""
     action = UpdateFullNameAction(
-        user_id="12345678-1234-5678-1234-567812345678",
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         email="nonexistent@example.com",
         domain_name="default",
         full_name="Some Name",
@@ -93,7 +95,7 @@ async def test_update_full_name_repository_call(
 ) -> None:
     """Test that update full name calls repository with correct parameters"""
     action = UpdateFullNameAction(
-        user_id="12345678-1234-5678-1234-567812345678",
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         email="test@example.com",
         domain_name="test-domain",
         full_name="Test User Full Name",

--- a/tests/unit/manager/services/auth/test_update_password.py
+++ b/tests/unit/manager/services/auth/test_update_password.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import pytest
 
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.plugin.hook import HookResult, HookResults
 from ai.backend.manager.errors.auth import AuthorizationFailed
 from ai.backend.manager.errors.common import RejectedByHook
@@ -50,7 +51,7 @@ async def test_update_password_successful(
     """Test successful password update"""
     action = UpdatePasswordAction(
         request=MagicMock(),
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         old_password="old_password",
@@ -92,7 +93,7 @@ async def test_update_password_fails_when_new_passwords_dont_match(
     """Test password update fails when new passwords don't match"""
     action = UpdatePasswordAction(
         request=MagicMock(),
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         old_password="old_password",
@@ -133,7 +134,7 @@ async def test_update_password_fails_with_incorrect_old_password(
     """Test password update fails with incorrect old password"""
     action = UpdatePasswordAction(
         request=MagicMock(),
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         old_password="wrong_old_password",
@@ -169,7 +170,7 @@ async def test_update_password_with_hook_rejection(
     """Test password update fails when hook rejects password format"""
     action = UpdatePasswordAction(
         request=MagicMock(),
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="default",
         email="user@example.com",
         old_password="correct_old_password",
@@ -206,7 +207,7 @@ async def test_update_password_repository_call(
     """Test that password update calls repository with correct parameters"""
     action = UpdatePasswordAction(
         request=MagicMock(),
-        user_id=UUID("12345678-1234-5678-1234-567812345678"),
+        user_id=UserID(UUID("12345678-1234-5678-1234-567812345678")),
         domain_name="test-domain",
         email="update@example.com",
         old_password="old_pass",


### PR DESCRIPTION
## Summary

- Every action in `services/auth` now inherits a v2 base and is wired through a `ProcessorGroup`, so each one declares the entity it is answered for, the operation it performs and the gate it runs behind. The domain splits across two groups: the credential and login-session state that names no user (a new `auth` entity type) and what one user's row and login rows answer for.
- The sign-in path keeps no gate — `authorize`, `signup` and the no-auth password reset authenticate their own caller inside the service. `POST /auth/logout` now runs behind `auth_required` and names the caller, so it is no longer one of them. **This changes the endpoint's contract: an unauthenticated logout call now gets 401.**
- The four login searches and the access-key lookup run against the generic ops services. The login rows are field rows of their user, so the searches come from a field group; five service methods and the repository pass-throughs beneath them are gone.

## Test plan

- [ ] `pants lint` / `pants check` / `pants test` in CI
- [ ] `backend.ai mgr ops list --concern organization` lists 25 wirings — gates: anonymous 3, public 3, permission 19
- [ ] Sign in, read `/auth/role` and `/auth/ssh-keypair`, rotate and upload an SSH keypair as a non-admin
- [ ] Sign out through `/auth/logout` with a valid session, and confirm an unauthenticated call is rejected
- [ ] Page through login sessions and login history as both the owner and a superadmin, and revoke a session from each side

Resolves BA-7422