### PR TITLE
refactor(BA-7411): read the kernel and session resource slots from resource_allocations

### DIFF
--- a/changes/13902.enhance.md
+++ b/changes/13902.enhance.md
@@ -1,0 +1,1 @@
+Report the session and kernel resource slot fields from the normalized `resource_allocations` table instead of the deprecated JSONB columns.

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -342,7 +342,7 @@ class SessionAdapter(BaseAdapter):
 
         result = await self._processors.session.enqueue_session.run(action)
         return EnqueueSessionPayload(
-            session=self._session_data_to_node(result.session_data),
+            session=(await self._session_data_to_nodes([result.session_data]))[0],
         )
 
     # -------------------------------------------------------------------------
@@ -438,7 +438,7 @@ class SessionAdapter(BaseAdapter):
         action_result = await self._processors.session.get_session.run(
             GetSessionAction(session_id=SessionID(session_id))
         )
-        return self._session_data_to_node(action_result.session_data)
+        return (await self._session_data_to_nodes([action_result.session_data]))[0]
 
     # -------------------------------------------------------------------------
     # Batch load (DataLoader)
@@ -458,8 +458,9 @@ class SessionAdapter(BaseAdapter):
         action_result = await self._processors.session.search_sessions.run(
             SearchSessionsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
+        nodes = await self._session_data_to_nodes(action_result.data)
         session_map: dict[SessionId, SessionNode] = {
-            SessionId(data.id): self._session_data_to_node(data) for data in action_result.data
+            SessionId(data.id): node for data, node in zip(action_result.data, nodes, strict=True)
         }
         return [session_map.get(session_id) for session_id in session_ids]
 
@@ -479,8 +480,9 @@ class SessionAdapter(BaseAdapter):
         action_result = await self._processors.session.search_kernels.run(
             SearchKernelsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
+        nodes = await self._kernel_infos_to_nodes(action_result.data)
         kernel_map: dict[KernelId, KernelNode] = {
-            info.id: self._kernel_info_to_node(info) for info in action_result.data
+            info.id: node for info, node in zip(action_result.data, nodes, strict=True)
         }
         return [kernel_map.get(kernel_id) for kernel_id in kernel_ids]
 
@@ -542,6 +544,26 @@ class SessionAdapter(BaseAdapter):
             self._aggregate_to_allocation_dto(action_result.data.get(kid)) for kid in kernel_ids
         ]
 
+    async def _session_data_to_nodes(self, data: Sequence[SessionData]) -> list[SessionNode]:
+        """Convert session data to nodes, batch-loading their slot allocations."""
+        allocations = await self.batch_resource_allocation_by_session([
+            SessionId(item.id) for item in data
+        ])
+        return [
+            self._session_data_to_node(item, allocation)
+            for item, allocation in zip(data, allocations, strict=True)
+        ]
+
+    async def _kernel_infos_to_nodes(self, data: Sequence[KernelInfo]) -> list[KernelNode]:
+        """Convert kernel infos to nodes, batch-loading their slot allocations."""
+        allocations = await self.batch_resource_allocation_by_kernel([
+            KernelId(item.id) for item in data
+        ])
+        return [
+            self._kernel_info_to_node(item, allocation)
+            for item, allocation in zip(data, allocations, strict=True)
+        ]
+
     # -------------------------------------------------------------------------
     # Session search
     # -------------------------------------------------------------------------
@@ -570,7 +592,7 @@ class SessionAdapter(BaseAdapter):
         )
 
         return AdminSearchSessionsPayload(
-            items=[self._session_data_to_node(item) for item in action_result.data],
+            items=await self._session_data_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -603,7 +625,7 @@ class SessionAdapter(BaseAdapter):
         )
 
         return AdminSearchSessionsPayload(
-            items=[self._session_data_to_node(item) for item in action_result.data],
+            items=await self._session_data_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -637,7 +659,7 @@ class SessionAdapter(BaseAdapter):
             SearchSessionsAction(querier=querier, user_id=UserID(user.user_id))
         )
         return AdminSearchSessionsPayload(
-            items=[self._session_data_to_node(item) for item in action_result.data],
+            items=await self._session_data_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -666,7 +688,7 @@ class SessionAdapter(BaseAdapter):
             SearchSessionsInProjectAction(scope=scope, querier=querier)
         )
         return AdminSearchSessionsPayload(
-            items=[self._session_data_to_node(item) for item in action_result.data],
+            items=await self._session_data_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -698,7 +720,7 @@ class SessionAdapter(BaseAdapter):
             SearchSessionsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
         return AdminSearchSessionsPayload(
-            items=[self._session_data_to_node(item) for item in action_result.data],
+            items=await self._session_data_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -830,7 +852,7 @@ class SessionAdapter(BaseAdapter):
         )
 
         return AdminSearchKernelsPayload(
-            items=[self._kernel_info_to_node(item) for item in action_result.data],
+            items=await self._kernel_infos_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -863,7 +885,7 @@ class SessionAdapter(BaseAdapter):
         )
 
         return AdminSearchKernelsPayload(
-            items=[self._kernel_info_to_node(item) for item in action_result.data],
+            items=await self._kernel_infos_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -896,7 +918,7 @@ class SessionAdapter(BaseAdapter):
         )
 
         return AdminSearchKernelsPayload(
-            items=[self._kernel_info_to_node(item) for item in action_result.data],
+            items=await self._kernel_infos_to_nodes(action_result.data),
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -1082,7 +1104,9 @@ class SessionAdapter(BaseAdapter):
                 owner_access_key=AccessKey(access_key),
             )
             result = await self._processors.session.rename_session.run(action)
-            return UpdateSessionPayload(session=self._session_data_to_node(result.session_data))
+            return UpdateSessionPayload(
+                session=(await self._session_data_to_nodes([result.session_data]))[0]
+            )
         # If no fields to update, just return the current session
         session_node = await self.get(SessionId(session_id))
         return UpdateSessionPayload(session=session_node)
@@ -1092,19 +1116,9 @@ class SessionAdapter(BaseAdapter):
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _session_data_to_node(data: SessionData) -> SessionNode:
-        requested = ResourceSlotInfo(
-            entries=[
-                ResourceSlotEntryInfo(resource_type=k, quantity=Decimal(str(v)))
-                for k, v in (data.requested_slots or {}).items()
-            ]
-        )
-        occupied = ResourceSlotInfo(
-            entries=[
-                ResourceSlotEntryInfo(resource_type=k, quantity=Decimal(str(v)))
-                for k, v in (data.occupying_slots or {}).items()
-            ]
-        )
+    def _session_data_to_node(
+        data: SessionData, allocation: ResourceAllocationGQLDTO
+    ) -> SessionNode:
         environ = (
             EnvironmentVariablesInfoDTO(
                 entries=[
@@ -1134,7 +1148,7 @@ class SessionAdapter(BaseAdapter):
                 tag=data.tag,
             ),
             resource=SessionResourceInfoGQLDTO(
-                allocation=ResourceAllocationGQLDTO(requested=requested, used=occupied),
+                allocation=allocation,
                 resource_group_name=data.resource_group_name,
             ),
             lifecycle=SessionLifecycleInfoGQLDTO(
@@ -1160,19 +1174,7 @@ class SessionAdapter(BaseAdapter):
         )
 
     @staticmethod
-    def _kernel_info_to_node(info: KernelInfo) -> KernelNode:
-        requested = ResourceSlotInfo(
-            entries=[
-                ResourceSlotEntryInfo(resource_type=k, quantity=Decimal(v))
-                for k, v in info.resource.requested_slots.to_json().items()
-            ]
-        )
-        occupied = ResourceSlotInfo(
-            entries=[
-                ResourceSlotEntryInfo(resource_type=k, quantity=Decimal(v))
-                for k, v in info.resource.occupied_slots.to_json().items()
-            ]
-        )
+    def _kernel_info_to_node(info: KernelInfo, allocation: ResourceAllocationGQLDTO) -> KernelNode:
         shares = ResourceSlotInfo(
             entries=[
                 ResourceSlotEntryInfo(resource_type=k, quantity=Decimal(str(v)))
@@ -1219,7 +1221,7 @@ class SessionAdapter(BaseAdapter):
                 agent_id=info.resource.agent,
                 resource_group_name=info.resource.resource_group,
                 container_id=info.resource.container_id,
-                allocation=ResourceAllocationGQLDTO(requested=requested, used=occupied),
+                allocation=allocation,
                 shares=shares,
                 resource_opts=resource_opts,
             ),

--- a/src/ai/backend/manager/api/gql_legacy/kernel.py
+++ b/src/ai/backend/manager/api/gql_legacy/kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping, Sequence
+from decimal import Decimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -23,10 +24,12 @@ from ai.backend.common.types import (
     AgentId,
     BinarySize,
     KernelId,
+    ResourceSlot,
     SessionId,
 )
 from ai.backend.manager.api.gql_legacy.stat_converter import LegacyLiveStatConverter
 from ai.backend.manager.data.kernel.types import KernelStatus
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import (
@@ -43,6 +46,9 @@ from ai.backend.manager.models.minilang.queryfilter import (
     QueryFilterParser,
 )
 from ai.backend.manager.models.project import groups
+from ai.backend.manager.models.resource_slot.aggregates import (
+    batch_load_kernel_allocations,
+)
 from ai.backend.manager.models.user import UserRole, users
 from ai.backend.manager.services.metric.actions.batch_get_kernel_live_stats import (
     BatchGetKernelLiveStatsAction,
@@ -83,6 +89,15 @@ async def _batch_load_kernel_live_stat(
     )
     converted = LegacyLiveStatConverter.convert(kernel_ids, action_result.stats)
     return [converted.get(kid) for kid in kernel_ids]
+
+
+async def _batch_load_kernel_allocations(
+    ctx: GraphQueryContext,
+    kernel_ids: Sequence[KernelId],
+) -> list[ResourceAllocationAggregate]:
+    async with ctx.db.begin_readonly_session() as db_session:
+        aggregates = await batch_load_kernel_allocations(db_session, kernel_ids)
+    return [aggregates.get(kid) or ResourceAllocationAggregate.empty() for kid in kernel_ids]
 
 
 class KernelNode(graphene.ObjectType):  # type: ignore[misc]
@@ -186,7 +201,6 @@ class KernelNode(graphene.ObjectType):  # type: ignore[misc]
             terminated_at=row.terminated_at,
             starts_at=row.starts_at,
             scheduled_at=status_history.get(KernelStatus.SCHEDULED.name),
-            occupied_slots=row.occupied_slots.to_json(),
             agent_id=row.agent if not hide_agents else None,
             agent_addr=row.agent_addr if not hide_agents else None,
             container_id=row.container_id if not hide_agents else None,
@@ -211,6 +225,14 @@ class KernelNode(graphene.ObjectType):  # type: ignore[misc]
             graph_ctx, _batch_load_kernel_live_stat
         )
         return cast(dict[str, Any] | None, await loader.load(self.row_id))
+
+    async def resolve_occupied_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        graph_ctx: GraphQueryContext = info.context
+        loader = graph_ctx.dataloader_manager.get_loader_by_func(
+            graph_ctx, _batch_load_kernel_allocations
+        )
+        aggregate = cast(ResourceAllocationAggregate, await loader.load(self.row_id))
+        return aggregate.used.to_json()
 
 
 class KernelConnection(Connection):
@@ -301,7 +323,6 @@ class ComputeContainer(graphene.ObjectType):  # type: ignore[misc]
             "terminated_at": row.terminated_at,
             "starts_at": row.starts_at,
             "scheduled_at": status_history.get(KernelStatus.SCHEDULED.name),
-            "occupied_slots": row.occupied_slots.to_json(),
             # resources
             "agent": row.agent if not hide_agents else None,
             "agent_addr": row.agent_addr if not hide_agents else None,
@@ -331,6 +352,14 @@ class ComputeContainer(graphene.ObjectType):  # type: ignore[misc]
 
     async def resolve_last_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
         return await self.resolve_live_stat(info)
+
+    async def resolve_occupied_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        graph_ctx: GraphQueryContext = info.context
+        loader = graph_ctx.dataloader_manager.get_loader_by_func(
+            graph_ctx, _batch_load_kernel_allocations
+        )
+        aggregate = cast(ResourceAllocationAggregate, await loader.load(self.id))
+        return aggregate.used.to_json()
 
     async def resolve_abusing_report(
         self,
@@ -627,6 +656,33 @@ class LegacyComputeSession(graphene.ObjectType):  # type: ignore[misc]
     async def resolve_last_stat(self, info: graphene.ResolveInfo) -> Mapping[str, Any] | None:
         return await self.resolve_live_stat(info)
 
+    async def _resolve_occupied_slots(self, info: graphene.ResolveInfo) -> ResourceSlot:
+        graph_ctx: GraphQueryContext = info.context
+        loader = graph_ctx.dataloader_manager.get_loader_by_func(
+            graph_ctx, _batch_load_kernel_allocations
+        )
+        aggregate = cast(ResourceAllocationAggregate, await loader.load(self.id))
+        return aggregate.used
+
+    async def resolve_occupied_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        return (await self._resolve_occupied_slots(info)).to_json()
+
+    async def resolve_mem_slot(self, info: graphene.ResolveInfo) -> int:
+        occupied = await self._resolve_occupied_slots(info)
+        return int(BinarySize.from_str(occupied.get("mem", Decimal(0)))) // (2**20)
+
+    async def resolve_cpu_slot(self, info: graphene.ResolveInfo) -> float:
+        occupied = await self._resolve_occupied_slots(info)
+        return float(occupied.get("cpu", 0))
+
+    async def resolve_gpu_slot(self, info: graphene.ResolveInfo) -> float:
+        occupied = await self._resolve_occupied_slots(info)
+        return float(occupied.get("cuda.device", 0))
+
+    async def resolve_tpu_slot(self, info: graphene.ResolveInfo) -> float:
+        occupied = await self._resolve_occupied_slots(info)
+        return float(occupied.get("tpu.device", 0))
+
     async def _resolve_legacy_metric(
         self,
         info: graphene.ResolveInfo,
@@ -699,7 +755,6 @@ class LegacyComputeSession(graphene.ObjectType):  # type: ignore[misc]
             raise DataTransformationFailed("Legacy compute session row is None")
         from ai.backend.manager.models.user import UserRole
 
-        mega = 2**20
         is_superadmin = ctx.user["role"] == UserRole.SUPERADMIN
         if is_superadmin:
             hide_agents = False
@@ -730,7 +785,6 @@ class LegacyComputeSession(graphene.ObjectType):  # type: ignore[misc]
             "startup_command": row.startup_command,
             "result": row.result.name,
             "service_ports": row.service_ports,
-            "occupied_slots": row.occupied_slots.to_json(),
             "resource_opts": row.resource_opts,
             "num_queries": row.num_queries,
             # optionally hidden
@@ -752,10 +806,6 @@ class LegacyComputeSession(graphene.ObjectType):  # type: ignore[misc]
             "io_cur_scratch_size": 0,
             "lang": row.image,
             "occupied_shares": row.occupied_shares,
-            "mem_slot": BinarySize.from_str(row.occupied_slots.get("mem", 0)) // mega,
-            "cpu_slot": float(row.occupied_slots.get("cpu", 0)),
-            "gpu_slot": float(row.occupied_slots.get("cuda.device", 0)),
-            "tpu_slot": float(row.occupied_slots.get("tpu.device", 0)),
         }
 
     @classmethod

--- a/src/ai/backend/manager/api/gql_legacy/session.py
+++ b/src/ai/backend/manager/api/gql_legacy/session.py
@@ -42,6 +42,7 @@ from ai.backend.manager.data.permission.permission_defs import ComputeSessionPer
 from ai.backend.manager.data.permission.permission_defs import (
     VFolderPermission as VFolderRBACPermission,
 )
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.api import NotImplementedAPI
@@ -54,12 +55,14 @@ from ai.backend.manager.models.minilang.queryfilter import FieldSpecType, QueryF
 from ai.backend.manager.models.project.row import ProjectRow
 from ai.backend.manager.models.rbac import ScopeType, SystemScope
 from ai.backend.manager.models.rbac.context import ClientContext
+from ai.backend.manager.models.resource_slot.aggregates import (
+    batch_load_session_allocations,
+)
 from ai.backend.manager.models.session import (
     DEFAULT_SESSION_ORDERING,
     SessionDependencyRow,
     SessionRow,
     SessionTypes,
-    batch_populate_session_occupied_slots,
     by_domain_name,
     by_raw_filter,
     by_resource_group_name,
@@ -212,6 +215,23 @@ def _dedup_folder_ids(mounts: Iterable[_HasVFID]) -> list[uuid.UUID]:
     return list(dict.fromkeys(vf.vfid.folder_id for vf in mounts))
 
 
+async def _batch_load_session_allocations(
+    ctx: GraphQueryContext,
+    session_ids: Sequence[SessionId],
+) -> list[ResourceAllocationAggregate]:
+    async with ctx.db.begin_readonly_session() as db_session:
+        aggregates = await batch_load_session_allocations(db_session, session_ids)
+    return [aggregates.get(sid) or ResourceAllocationAggregate.empty() for sid in session_ids]
+
+
+async def _load_session_allocation(
+    info: graphene.ResolveInfo, session_id: SessionId
+) -> ResourceAllocationAggregate:
+    ctx: GraphQueryContext = info.context
+    loader = ctx.dataloader_manager.get_loader_by_func(ctx, _batch_load_session_allocations)
+    return cast(ResourceAllocationAggregate, await loader.load(session_id))
+
+
 @graphene_federation.key("id")
 class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
     class Meta:
@@ -317,7 +337,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             query_result = await db_session.scalar(stmt)
             if query_result is None:
                 return None
-            await batch_populate_session_occupied_slots(db_session, [query_result])
             return cls.from_row(graphene_ctx, query_result)
 
     @classmethod
@@ -399,8 +418,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             scaling_group=row.scaling_group_name,
             # TODO: Deprecate 'vfolder_mounts' and replace it with a list of VirtualFolderNodes
             vfolder_mounts=_dedup_folder_ids(row.vfolders_sorted_by_id),
-            occupied_slots=row.occupying_slots.to_json(),
-            requested_slots=row.requested_slots.to_json(),
             image_references=row.images,
             service_ports=row.main_kernel.service_ports,
             # statistics
@@ -459,8 +476,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             agent_ids=session_data.agent_ids,
             scaling_group=session_data.resource_group_name,
             vfolder_mounts=vfolder_mounts,
-            occupied_slots=session_data.occupying_slots,
-            requested_slots=session_data.requested_slots,
             image_references=session_data.images,
             service_ports=session_data.service_ports,
             # statistics
@@ -478,6 +493,14 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
         return await ComputeSessionNode.get_accessible_node(
             info, resolved_id, SystemScope(), ComputeSessionPermission.READ_ATTRIBUTE
         )
+
+    async def resolve_occupied_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        aggregate = await _load_session_allocation(info, SessionId(self.row_id))
+        return aggregate.used.to_json()
+
+    async def resolve_requested_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        aggregate = await _load_session_allocation(info, SessionId(self.row_id))
+        return aggregate.requested.to_json()
 
     async def resolve_idle_checks(self, info: graphene.ResolveInfo) -> dict[str, Any] | None:
         graph_ctx: GraphQueryContext = info.context
@@ -602,7 +625,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                 )
             )
             session_rows = list((await db_sess.execute(query)).scalars().all())
-            await batch_populate_session_occupied_slots(db_sess, session_rows)
 
         # Convert into GraphQL node objects
         sessions = [type(self).from_row(ctx, r) for r in session_rows]
@@ -659,7 +681,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                 )
             )
             rows = list((await db_sess.execute(sess_query)).unique().scalars().all())
-            await batch_populate_session_occupied_slots(db_sess, rows)
 
             for row in rows:
                 for dependee_id in dep_map.get(row.id, []):
@@ -704,7 +725,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
                 )
             )
             rows = list((await db_sess.execute(sess_query)).unique().scalars().all())
-            await batch_populate_session_occupied_slots(db_sess, rows)
 
             for row in rows:
                 for dependent_id in dep_map.get(row.id, []):
@@ -732,8 +752,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             query = cls._add_basic_options_to_query(query)
             async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
                 session_row = await db_session.scalar(query)
-                if session_row is not None:
-                    await batch_populate_session_occupied_slots(db_session, [session_row])
         if session_row is None:
             return None
         return cls.from_row(
@@ -800,7 +818,6 @@ class ComputeSessionNode(graphene.ObjectType):  # type: ignore[misc]
             async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
                 session_rows = list((await db_session.scalars(query)).all())
                 total_cnt = await db_session.scalar(cnt_query)
-                await batch_populate_session_occupied_slots(db_session, session_rows)
         result: list[Self] = [
             cls.from_row(
                 graph_ctx,
@@ -857,17 +874,18 @@ class TotalResourceSlot(graphene.ObjectType):  # type: ignore[misc]
             query_conditions, query_options, db=ctx.db
         )
         async with ctx.db.begin_readonly_session() as db_sess:
-            await batch_populate_session_occupied_slots(db_sess, session_rows)
+            aggregates = await batch_load_session_allocations(
+                db_sess, [SessionId(row.id) for row in session_rows]
+            )
         occupied_slots = ResourceSlot()
         requested_slots = ResourceSlot()
-        for row in session_rows:
-            occupied_slots += row.occupying_slots
-            requested_slots += row.requested_slots
-        occupied, requested = occupied_slots.to_json(), requested_slots.to_json()
+        for aggregate in aggregates.values():
+            occupied_slots += aggregate.used
+            requested_slots += aggregate.requested
 
         return TotalResourceSlot(
-            occupied_slots=occupied,
-            requested_slots=requested,
+            occupied_slots=occupied_slots.to_json(),
+            requested_slots=requested_slots.to_json(),
         )
 
 
@@ -1121,9 +1139,6 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
             "mounts": [*{mount.name for mount in vfolder_mounts}],
             # TODO: Deprecate 'vfolder_mounts' and replace it with a list of VirtualFolderNodes
             "vfolder_mounts": [*{vf.vfid.folder_id for vf in vfolder_mounts}],
-            "occupying_slots": row.occupying_slots.to_json(),
-            "occupied_slots": row.occupying_slots.to_json(),
-            "requested_slots": row.requested_slots.to_json(),
             # statistics
             "num_queries": row.num_queries,
         }
@@ -1144,6 +1159,17 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
             KernelStatistics.batch_load_inference_metrics_by_kernel,
         )
         return cast(Mapping[str, Any] | None, await loader.load(self.id))
+
+    async def resolve_occupying_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        aggregate = await _load_session_allocation(info, SessionId(self.session_id))
+        return aggregate.used.to_json()
+
+    async def resolve_occupied_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        return await self.resolve_occupying_slots(info)
+
+    async def resolve_requested_slots(self, info: graphene.ResolveInfo) -> Mapping[str, str]:
+        aggregate = await _load_session_allocation(info, SessionId(self.session_id))
+        return aggregate.requested.to_json()
 
     async def resolve_containers(
         self,
@@ -1348,8 +1374,6 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
             query = query.order_by(*DEFAULT_SESSION_ORDERING)
         async with ctx.db.begin_readonly_session() as db_sess:
             rows = (await db_sess.execute(query)).all()
-            session_rows = [r.SessionRow for r in rows]
-            await batch_populate_session_occupied_slots(db_sess, session_rows)
             return [cls.from_row(ctx, r) for r in rows]
 
     @classmethod
@@ -1381,8 +1405,6 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
             query = query.where(SessionRow.access_key == access_key)
         async with ctx.db.begin_readonly_session() as db_sess:
             rows = (await db_sess.execute(query)).all()
-            sr_list = [r.SessionRow for r in rows]
-            await batch_populate_session_occupied_slots(db_sess, sr_list)
             objs_per_key: dict[SessionId, ComputeSession | None] = dict.fromkeys(session_ids)
             for row in rows:
                 objs_per_key[row.SessionRow.id] = cls.from_row(ctx, row)
@@ -1407,8 +1429,6 @@ class ComputeSession(graphene.ObjectType):  # type: ignore[misc]
         )
         async with ctx.db.begin_readonly_session() as db_sess:
             rows = (await db_sess.execute(query)).all()
-            sr_list = [r.SessionRow for r in rows]
-            await batch_populate_session_occupied_slots(db_sess, sr_list)
             objs_per_key: dict[SessionId, list[ComputeSession]] = {sid: [] for sid in session_ids}
             for row in rows:
                 obj = cls.from_row(ctx, row)

--- a/src/ai/backend/manager/api/rest/compute_sessions/adapter.py
+++ b/src/ai/backend/manager/api/rest/compute_sessions/adapter.py
@@ -21,6 +21,7 @@ from ai.backend.common.dto.manager.compute_session import (
 )
 from ai.backend.common.types import SessionId
 from ai.backend.manager.data.kernel.types import KernelInfo
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.kernel.conditions import KernelConditions
@@ -56,18 +57,20 @@ class ComputeSessionsAdapter(BaseFilterAdapter):
         return grouped
 
     def convert_session_to_dto(
-        self, session: SessionData, kernels: list[KernelInfo] | None = None
+        self,
+        session: SessionData,
+        allocation: ResourceAllocationAggregate | None,
+        kernels: list[KernelInfo] | None = None,
     ) -> ComputeSessionDTO:
         """Convert SessionData + kernels to ComputeSessionDTO."""
         containers = [self._convert_kernel_to_container(k) for k in kernels] if kernels else []
 
-        resource_slots: dict[str, Any] | None = None
-        if session.requested_slots is not None:
-            resource_slots = dict(session.requested_slots)
-
-        occupied_slots: dict[str, Any] | None = None
-        if session.occupying_slots is not None:
-            occupied_slots = dict(session.occupying_slots)
+        resource_slots: dict[str, Any] | None = (
+            dict(allocation.requested) if allocation is not None else None
+        )
+        occupied_slots: dict[str, Any] | None = (
+            dict(allocation.used) if allocation is not None else None
+        )
 
         return ComputeSessionDTO(
             id=session.id,

--- a/src/ai/backend/manager/api/rest/compute_sessions/handler.py
+++ b/src/ai/backend/manager/api/rest/compute_sessions/handler.py
@@ -16,8 +16,12 @@ from ai.backend.common.dto.manager.compute_session import (
 )
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.dto.context import UserContext
 from ai.backend.manager.errors.user import UserNotFound
+from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
+    BatchGetSessionResourceAllocationAction,
+)
 from ai.backend.manager.services.session.actions.search import SearchSessionsAction
 from ai.backend.manager.services.session.actions.search_kernel import SearchKernelsAction
 from ai.backend.manager.services.session.processors import SessionProcessors
@@ -62,9 +66,21 @@ class ComputeSessionsHandler:
             )
             kernels_by_session = self._adapter.group_kernels_by_session(kernel_result.data)
 
-        # Step 3: Convert to DTOs
+        # Step 3: Aggregate the slot amounts from resource_allocations
+        allocations: dict[SessionId, ResourceAllocationAggregate] = {}
+        if session_ids:
+            allocation_result = await self._session.batch_get_session_resource_allocation.run(
+                BatchGetSessionResourceAllocationAction(session_ids=session_ids)
+            )
+            allocations = allocation_result.data
+
+        # Step 4: Convert to DTOs
         items = [
-            self._adapter.convert_session_to_dto(session, kernels_by_session.get(session.id, []))
+            self._adapter.convert_session_to_dto(
+                session,
+                allocations.get(SessionId(session.id)),
+                kernels_by_session.get(session.id, []),
+            )
             for session in session_result.data
         ]
 

--- a/src/ai/backend/manager/api/rest/export/adapter.py
+++ b/src/ai/backend/manager/api/rest/export/adapter.py
@@ -42,6 +42,7 @@ from ai.backend.manager.repositories.base.filter_adapter import BaseFilterAdapte
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.attributes import InstrumentedAttribute
+    from sqlalchemy.sql import ColumnElement
 
 __all__ = ("ExportAdapter",)
 
@@ -749,7 +750,7 @@ class ExportAdapter(BaseFilterAdapter):
         column = field_def.column
 
         if field_def.field_type == ExportFieldType.ENUM:
-            enum_cls = column.type._enum_cls
+            enum_cls = column.type.python_type
             enum_values = [enum_cls(v) for v in values]
             return lambda: column.in_(enum_values)
 
@@ -764,7 +765,7 @@ class ExportAdapter(BaseFilterAdapter):
         column = field_def.column
 
         def make_contains_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[StringMatchSpec], QueryCondition]:
             def factory(spec: StringMatchSpec) -> QueryCondition:
                 pattern = f"%{spec.value}%"
@@ -779,7 +780,7 @@ class ExportAdapter(BaseFilterAdapter):
             return factory
 
         def make_equals_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[StringMatchSpec], QueryCondition]:
             def factory(spec: StringMatchSpec) -> QueryCondition:
                 if spec.case_insensitive:
@@ -793,7 +794,7 @@ class ExportAdapter(BaseFilterAdapter):
             return factory
 
         def make_starts_with_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[StringMatchSpec], QueryCondition]:
             def factory(spec: StringMatchSpec) -> QueryCondition:
                 pattern = f"{spec.value}%"
@@ -808,7 +809,7 @@ class ExportAdapter(BaseFilterAdapter):
             return factory
 
         def make_ends_with_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[StringMatchSpec], QueryCondition]:
             def factory(spec: StringMatchSpec) -> QueryCondition:
                 pattern = f"%{spec.value}"
@@ -823,7 +824,7 @@ class ExportAdapter(BaseFilterAdapter):
             return factory
 
         def make_in_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[StringInMatchSpec], QueryCondition]:
             def factory(spec: StringInMatchSpec) -> QueryCondition:
                 if spec.case_insensitive:
@@ -855,7 +856,7 @@ class ExportAdapter(BaseFilterAdapter):
         column = field_def.column
 
         def make_equals_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[UUIDEqualMatchSpec], QueryCondition]:
             def factory(spec: UUIDEqualMatchSpec) -> QueryCondition:
                 value = spec.value
@@ -866,7 +867,7 @@ class ExportAdapter(BaseFilterAdapter):
             return factory
 
         def make_in_factory(
-            col: InstrumentedAttribute[Any],
+            col: InstrumentedAttribute[Any] | ColumnElement[Any],
         ) -> Callable[[UUIDInMatchSpec], QueryCondition]:
             def factory(spec: UUIDInMatchSpec) -> QueryCondition:
                 values = spec.values

--- a/src/ai/backend/manager/data/kernel/types.py
+++ b/src/ai/backend/manager/data/kernel/types.py
@@ -13,7 +13,6 @@ from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.types import (
     CIStrEnum,
     KernelId,
-    ResourceSlot,
     SessionId,
     SessionResult,
     SessionTypes,
@@ -237,8 +236,6 @@ class ResourceInfo:
     agent: str | None
     agent_addr: str | None
     container_id: str | None
-    occupied_slots: ResourceSlot
-    requested_slots: ResourceSlot
     occupied_shares: dict[str, Any]
     attached_devices: dict[str, Any]
     resource_opts: dict[str, Any]

--- a/src/ai/backend/manager/data/resource_slot/types.py
+++ b/src/ai/backend/manager/data/resource_slot/types.py
@@ -25,6 +25,11 @@ class ResourceAllocationAggregate:
     used: ResourceSlot
     allocated: ResourceSlot
 
+    @classmethod
+    def empty(cls) -> ResourceAllocationAggregate:
+        """The aggregate an owner with no ``resource_allocations`` rows reports."""
+        return cls(requested=ResourceSlot(), used=ResourceSlot(), allocated=ResourceSlot())
+
 
 @dataclass(frozen=True)
 class NumberFormatData:

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -26,7 +26,6 @@ from ai.backend.common.types import (
     CIStrEnum,
     ClusterMode,
     KernelId,
-    ResourceSlot,
     SessionId,
     SessionResult,
     SessionTypes,
@@ -196,8 +195,6 @@ class SessionData(EntityData):
     domain_name: str
     group_id: UUID
     user_uuid: UUID
-    occupying_slots: Any  # TODO: ResourceSlot?
-    requested_slots: Any
     use_host_network: bool
     created_at: datetime = field(compare=False)
     status: SessionStatus
@@ -273,8 +270,6 @@ class SessionEntityData(EntityData):
     images: list[str] | None
     image_ids: list[UUID] | None
     tag: str | None
-    occupying_slots: ResourceSlot
-    requested_slots: ResourceSlot
     vfolder_mounts: list[VFolderMount] | None
     environ: dict[str, Any] | None
     bootstrap_script: str | None
@@ -344,8 +339,6 @@ class SessionMetadata:
 class ResourceSpec:
     cluster_mode: str
     cluster_size: int
-    occupying_slots: ResourceSlot
-    requested_slots: ResourceSlot
     resource_group_name: str | None
     target_sgroup_names: list[str] | None
     agent_ids: list[str] | None

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -73,6 +73,10 @@ from .errors.kernel import IdlePolicyNotFound
 from .models.kernel import LIVE_STATUS, kernels
 from .models.keypair import keypairs
 from .models.resource_policy import keypair_resource_policies
+from .models.resource_slot.aggregates import (
+    kernel_requested_slots_expr,
+    kernel_used_slots_expr,
+)
 from .models.user import users
 from .types import DistributedLockFactory
 
@@ -272,8 +276,8 @@ class IdleCheckerHost:
                     kernels.c.session_type,
                     kernels.c.created_at,
                     kernels.c.starts_at,
-                    kernels.c.occupied_slots,
-                    kernels.c.requested_slots,
+                    kernel_used_slots_expr(kernels.c.id).label("occupied_slots"),
+                    kernel_requested_slots_expr(kernels.c.id).label("requested_slots"),
                     kernels.c.cluster_size,
                     users.c.created_at.label("user_created_at"),
                     keypairs.c.access_key.label("default_access_key"),

--- a/src/ai/backend/manager/models/kernel/row.py
+++ b/src/ai/backend/manager/models/kernel/row.py
@@ -249,13 +249,11 @@ class KernelRow(CreatedAtMixin, Base):
     container_id: Mapped[str | None] = mapped_column(
         "container_id", sa.String(length=64), nullable=True
     )
-    # DEPRECATED (Phase 3, BA-4308): No longer the source of truth.
-    # Kernel resource allocations are now tracked by the normalized
-    # resource_allocations table.  Retained for historical audit.
+    # DEPRECATED: nothing reads these; the authority is resource_allocations.
+    # See models/resource_slot/aggregates.py.
     occupied_slots: Mapped[ResourceSlot] = mapped_column(
         "occupied_slots", ResourceSlotColumn(), nullable=False
     )
-    # DEPRECATED (Phase 3, BA-4308): See resource_allocations table.
     requested_slots: Mapped[ResourceSlot] = mapped_column(
         "requested_slots", ResourceSlotColumn(), nullable=False
     )
@@ -561,8 +559,6 @@ class KernelRow(CreatedAtMixin, Base):
                 agent=self.agent,
                 agent_addr=self.agent_addr,
                 container_id=self.container_id,
-                occupied_slots=self.occupied_slots,
-                requested_slots=self.requested_slots,
                 occupied_shares=self.occupied_shares,
                 attached_devices=self.attached_devices or {},
                 resource_opts=self.resource_opts or {},

--- a/src/ai/backend/manager/models/resource_slot/aggregates.py
+++ b/src/ai/backend/manager/models/resource_slot/aggregates.py
@@ -1,0 +1,206 @@
+"""Kernel and session slot values aggregated from ``resource_allocations``.
+
+``resource_allocations`` is the authority for the requested amounts, the current
+occupancy, and what was ever allocated. The deprecated ``kernels.occupied_slots`` /
+``kernels.requested_slots`` / ``sessions.occupying_slots`` /
+``sessions.requested_slots`` columns are never read here.
+
+Which of the three a reader wants: ``used`` for what an owner holds right now,
+``allocated`` for what it ever held (it survives termination, so statistics and
+billing read this one), ``requested`` for what was asked at enqueue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession as SASession
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql import ColumnElement
+
+from ai.backend.common.types import KernelId, ResourceSlot, SessionId
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
+from ai.backend.manager.models.base import ResourceSlotColumn
+from ai.backend.manager.models.kernel.row import KernelRow
+from ai.backend.manager.models.resource_slot.row import ResourceAllocationRow
+
+type _OwnerIdColumn = InstrumentedAttribute[Any] | ColumnElement[Any]
+
+__all__ = (
+    "kernel_allocated_slots_expr",
+    "kernel_requested_slots_expr",
+    "kernel_used_slots_expr",
+    "session_allocated_slots_expr",
+    "session_requested_slots_expr",
+    "session_used_slots_expr",
+    "batch_load_kernel_allocations",
+    "batch_load_session_allocations",
+)
+
+
+def _requested_value() -> ColumnElement[Any]:
+    return sa.func.sum(ResourceAllocationRow.requested)
+
+
+def _used_value() -> ColumnElement[Any]:
+    return sa.func.sum(
+        sa.func.coalesce(ResourceAllocationRow.used, ResourceAllocationRow.requested)
+    ).filter(ResourceAllocationRow.free_at.is_(None))
+
+
+def _allocated_value() -> ColumnElement[Any]:
+    return sa.func.sum(ResourceAllocationRow.used).filter(ResourceAllocationRow.used_at.isnot(None))
+
+
+def _kernel_join() -> Any:
+    return sa.join(
+        ResourceAllocationRow, KernelRow, ResourceAllocationRow.kernel_id == KernelRow.id
+    )
+
+
+def _as_slots(value_by_slot: Any) -> ColumnElement[ResourceSlot]:
+    """Fold a (slot_name, value) selectable into a ``ResourceSlot``-typed scalar subquery."""
+    return sa.type_coerce(
+        sa.select(
+            sa.func.coalesce(
+                sa.func.jsonb_object_agg(
+                    value_by_slot.c.slot_name, sa.cast(value_by_slot.c.value, sa.Text)
+                ).filter(value_by_slot.c.value.isnot(None)),
+                sa.text("'{}'::jsonb"),
+            )
+        )
+        .select_from(value_by_slot)
+        .scalar_subquery(),
+        ResourceSlotColumn(),
+    )
+
+
+def _kernel_slots_expr(
+    value_column: ColumnElement[Any], kernel_id: _OwnerIdColumn
+) -> ColumnElement[ResourceSlot]:
+    return _as_slots(
+        sa.select(
+            ResourceAllocationRow.slot_name.label("slot_name"),
+            value_column.label("value"),
+        )
+        .where(ResourceAllocationRow.kernel_id == kernel_id)
+        .group_by(ResourceAllocationRow.slot_name)
+        .correlate_except(ResourceAllocationRow)
+        .subquery()
+        .lateral()
+    )
+
+
+def _session_slots_expr(
+    value_column: ColumnElement[Any], session_id: _OwnerIdColumn
+) -> ColumnElement[ResourceSlot]:
+    return _as_slots(
+        sa.select(
+            ResourceAllocationRow.slot_name.label("slot_name"),
+            value_column.label("value"),
+        )
+        .select_from(_kernel_join())
+        .where(KernelRow.session_id == session_id)
+        .group_by(ResourceAllocationRow.slot_name)
+        .correlate_except(ResourceAllocationRow, KernelRow)
+        .subquery()
+        .lateral()
+    )
+
+
+def kernel_requested_slots_expr(kernel_id: _OwnerIdColumn) -> ColumnElement[ResourceSlot]:
+    """A ``ResourceSlot``-typed scalar subquery of one kernel's requested slots."""
+    return _kernel_slots_expr(_requested_value(), kernel_id)
+
+
+def kernel_used_slots_expr(kernel_id: _OwnerIdColumn) -> ColumnElement[ResourceSlot]:
+    """A ``ResourceSlot``-typed scalar subquery of what one kernel holds right now."""
+    return _kernel_slots_expr(_used_value(), kernel_id)
+
+
+def kernel_allocated_slots_expr(kernel_id: _OwnerIdColumn) -> ColumnElement[ResourceSlot]:
+    """A ``ResourceSlot``-typed scalar subquery of what one kernel ever held."""
+    return _kernel_slots_expr(_allocated_value(), kernel_id)
+
+
+def session_requested_slots_expr(session_id: _OwnerIdColumn) -> ColumnElement[ResourceSlot]:
+    """A ``ResourceSlot``-typed scalar subquery of one session's requested slots."""
+    return _session_slots_expr(_requested_value(), session_id)
+
+
+def session_used_slots_expr(session_id: _OwnerIdColumn) -> ColumnElement[ResourceSlot]:
+    """A ``ResourceSlot``-typed scalar subquery of what one session holds right now."""
+    return _session_slots_expr(_used_value(), session_id)
+
+
+def session_allocated_slots_expr(session_id: _OwnerIdColumn) -> ColumnElement[ResourceSlot]:
+    """A ``ResourceSlot``-typed scalar subquery of what one session ever held."""
+    return _session_slots_expr(_allocated_value(), session_id)
+
+
+def _rows_to_aggregates(
+    rows: Sequence[Any], key_attr: str
+) -> dict[Any, ResourceAllocationAggregate]:
+    slots: dict[Any, tuple[ResourceSlot, ResourceSlot, ResourceSlot]] = {}
+    for row in rows:
+        key = getattr(row, key_attr)
+        if key not in slots:
+            slots[key] = (ResourceSlot(), ResourceSlot(), ResourceSlot())
+        requested, used, allocated = slots[key]
+        if row.requested is not None:
+            requested[row.slot_name] = row.requested
+        if row.used is not None:
+            used[row.slot_name] = row.used
+        if row.allocated is not None:
+            allocated[row.slot_name] = row.allocated
+    return {
+        key: ResourceAllocationAggregate(requested=requested, used=used, allocated=allocated)
+        for key, (requested, used, allocated) in slots.items()
+    }
+
+
+async def batch_load_kernel_allocations(
+    db_session: SASession,
+    kernel_ids: Sequence[KernelId],
+) -> dict[KernelId, ResourceAllocationAggregate]:
+    """Aggregate ``resource_allocations`` per kernel."""
+    if not kernel_ids:
+        return {}
+    stmt = (
+        sa.select(
+            ResourceAllocationRow.kernel_id.label("kernel_id"),
+            ResourceAllocationRow.slot_name.label("slot_name"),
+            _requested_value().label("requested"),
+            _used_value().label("used"),
+            _allocated_value().label("allocated"),
+        )
+        .where(ResourceAllocationRow.kernel_id.in_(kernel_ids))
+        .group_by(ResourceAllocationRow.kernel_id, ResourceAllocationRow.slot_name)
+    )
+    rows = (await db_session.execute(stmt)).all()
+    return {KernelId(key): agg for key, agg in _rows_to_aggregates(rows, "kernel_id").items()}
+
+
+async def batch_load_session_allocations(
+    db_session: SASession,
+    session_ids: Sequence[SessionId],
+) -> dict[SessionId, ResourceAllocationAggregate]:
+    """Aggregate ``resource_allocations`` per session, summed over its kernels."""
+    if not session_ids:
+        return {}
+    stmt = (
+        sa.select(
+            KernelRow.session_id.label("session_id"),
+            ResourceAllocationRow.slot_name.label("slot_name"),
+            _requested_value().label("requested"),
+            _used_value().label("used"),
+            _allocated_value().label("allocated"),
+        )
+        .select_from(_kernel_join())
+        .where(KernelRow.session_id.in_(session_ids))
+        .group_by(KernelRow.session_id, ResourceAllocationRow.slot_name)
+    )
+    rows = (await db_session.execute(stmt)).all()
+    return {SessionId(key): agg for key, agg in _rows_to_aggregates(rows, "session_id").items()}

--- a/src/ai/backend/manager/models/resource_usage.py
+++ b/src/ai/backend/manager/models/resource_usage.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import joinedload, load_only
 from sqlalchemy.sql.elements import ColumnElement
 
-from ai.backend.common.types import SlotName
+from ai.backend.common.types import KernelId, ResourceSlot, SlotName
 from ai.backend.common.utils import nmget
 from ai.backend.manager.data.kernel.types import KernelStatus
 
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 from .kernel import LIVE_STATUS, RESOURCE_USAGE_KERNEL_STATUSES, KernelRow
 from .project import ProjectRow
+from .resource_slot.aggregates import batch_load_kernel_allocations
 from .session import SessionRow
 from .user import UserRow
 from .utils import ExtendedAsyncSAEngine
@@ -445,6 +446,7 @@ def parse_total_resource_group(
 
 def parse_resource_usage(
     kernel: KernelRow,
+    allocated_slots: ResourceSlot,
     last_stat: Mapping[str, Any] | None,
 ) -> ResourceUsage:
     if not last_stat:
@@ -469,16 +471,16 @@ def parse_resource_usage(
             smp += int(nmget(dev_info, "data.smp", 0))
             gpu_mem_allocated += int(nmget(dev_info, "data.mem", 0))
     gpu_allocated = Decimal(0)
-    for key, value in kernel.occupied_slots.items():
+    for key, value in allocated_slots.items():
         if SlotName(key).is_accelerator():
             gpu_allocated += value
 
     return ResourceUsage(
         agent_ids={kernel.agent} if kernel.agent else set(),
         nfs={*nfs},
-        cpu_allocated=float(kernel.occupied_slots.get("cpu", 0)),
+        cpu_allocated=float(allocated_slots.get("cpu", 0)),
         cpu_used=float(nmget(last_stat, "cpu_used.current", 0)),
-        mem_allocated=int(kernel.occupied_slots.get("mem", 0)),
+        mem_allocated=int(allocated_slots.get("mem", 0)),
         mem_used=int(nmget(last_stat, "mem.capacity", 0)),
         shared_memory=int(nmget(kernel.resource_opts or {}, "shmem", 0)),
         disk_allocated=0,
@@ -494,6 +496,7 @@ def parse_resource_usage(
 
 async def parse_resource_usage_groups(
     kernels: list[KernelRow],
+    allocated_slots: Mapping[UUID, ResourceSlot],
     valkey_stat_client: ValkeyStatClient,
     local_tz: tzinfo,
 ) -> list[BaseResourceUsageGroup]:
@@ -540,7 +543,9 @@ async def parse_resource_usage_groups(
             cluster_mode=kern.cluster_mode,
             status_info=kern.status_info,
             group_unit=ResourceGroupUnit.KERNEL,
-            total_usage=parse_resource_usage(kern, stat_map.get(kern.id)),
+            total_usage=parse_resource_usage(
+                kern, allocated_slots.get(kern.id, ResourceSlot()), stat_map.get(kern.id)
+            ),
         )
         for kern in kernels
     ]
@@ -579,7 +584,6 @@ KERNEL_RESOURCE_SELECT_COLS = (
     KernelRow.session_id,
     KernelRow.id,
     KernelRow.container_id,
-    KernelRow.occupied_slots,
     KernelRow.attached_devices,
     KernelRow.vfolder_mounts,
     KernelRow.mounts,
@@ -622,7 +626,8 @@ async def fetch_resource_usage(
     end_date: datetime,
     session_ids: Sequence[UUID] | None = None,
     project_ids: Sequence[UUID] | None = None,
-) -> list[KernelRow]:
+) -> tuple[list[KernelRow], dict[UUID, ResourceSlot]]:
+    """Fetch the kernels overlapping the period with the slots they were allocated."""
     project_cond = None
     if project_ids:
         project_cond = ProjectRow.id.in_(project_ids)
@@ -646,4 +651,11 @@ async def fetch_resource_usage(
     )
     async with db_engine.begin_readonly_session() as db_sess:
         result = await db_sess.execute(query)
-        return list(result.scalars().all())
+        kernels: list[KernelRow] = list(result.scalars().all())
+        aggregates = await batch_load_kernel_allocations(
+            db_sess, [KernelId(kernel.id) for kernel in kernels]
+        )
+    allocated_slots: dict[UUID, ResourceSlot] = {
+        kernel_id: aggregate.allocated for kernel_id, aggregate in aggregates.items()
+    }
+    return kernels, allocated_slots

--- a/src/ai/backend/manager/models/session/__init__.py
+++ b/src/ai/backend/manager/models/session/__init__.py
@@ -25,9 +25,6 @@ from .row import (
     _build_session_fetch_query as _build_session_fetch_query,
 )
 from .row import (
-    batch_populate_session_occupied_slots as batch_populate_session_occupied_slots,
-)
-from .row import (
     get_permission_ctx as get_permission_ctx,
 )
 

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -108,7 +108,6 @@ from ai.backend.manager.models.rbac import (
     UserScope as UserRBACScope,
 )
 from ai.backend.manager.models.rbac.context import ClientContext
-from ai.backend.manager.models.resource_slot import ResourceAllocationRow
 from ai.backend.manager.models.types import (
     QueryCondition,
     QueryOption,
@@ -498,10 +497,8 @@ class SessionRow(CreatedAtMixin, Base):
     tag: Mapped[str | None] = mapped_column("tag", sa.String(length=64), nullable=True)
 
     # Resource occupation
-    # DEPRECATED (Phase 3, BA-4308): No longer written to.
-    # Resource allocations are now tracked by the normalized
-    # resource_allocations / agent_resources tables.
-    # Retained for historical audit; will be dropped in a future major version.
+    # DEPRECATED: nothing reads these; the authority is resource_allocations.
+    # See models/resource_slot/aggregates.py.
     occupying_slots: Mapped[ResourceSlot] = mapped_column(
         "occupying_slots", ResourceSlotColumn(), nullable=False
     )
@@ -701,8 +698,8 @@ class SessionRow(CreatedAtMixin, Base):
             images=session_data.images,
             image_ids=session_data.image_ids,
             tag=session_data.tag,
-            occupying_slots=session_data.occupying_slots,
-            requested_slots=session_data.requested_slots,
+            occupying_slots=ResourceSlot(),
+            requested_slots=ResourceSlot(),
             vfolder_mounts=vfolder_mounts,
             environ=session_data.environ,
             bootstrap_script=session_data.bootstrap_script,
@@ -748,8 +745,6 @@ class SessionRow(CreatedAtMixin, Base):
             images=self.images,
             image_ids=self.image_ids,
             tag=self.tag,
-            occupying_slots=self.occupying_slots,
-            requested_slots=self.requested_slots,
             vfolder_mounts=[mount.to_dataclass() for mount in self.vfolder_mounts]
             if self.vfolder_mounts
             else None,
@@ -806,8 +801,6 @@ class SessionRow(CreatedAtMixin, Base):
             images=self.images,
             image_ids=self.image_ids,
             tag=self.tag,
-            occupying_slots=self.occupying_slots,
-            requested_slots=self.requested_slots,
             vfolder_mounts=self.vfolder_mounts,
             environ=self.environ,
             bootstrap_script=self.bootstrap_script,
@@ -854,8 +847,6 @@ class SessionRow(CreatedAtMixin, Base):
             resource=ResourceSpec(
                 cluster_mode=self.cluster_mode,
                 cluster_size=self.cluster_size,
-                occupying_slots=self.occupying_slots,
-                requested_slots=self.requested_slots,
                 resource_group_name=self.scaling_group_name,
                 target_sgroup_names=self.target_sgroup_names,
                 agent_ids=self.agent_ids,
@@ -1608,49 +1599,3 @@ async def get_permission_ctx(
     async with ctx.db.begin_readonly_session(db_conn) as db_session:
         builder = ComputeSessionPermissionContextBuilder(db_session)
         return await builder.build(ctx, target_scope, requested_permission)
-
-
-async def batch_populate_session_occupied_slots(
-    db_session: SASession,
-    session_rows: Sequence[SessionRow],
-) -> None:
-    """Batch-compute occupied slots from the normalized resource_allocations table
-    and populate each SessionRow's occupying_slots attribute in-place.
-
-    This replaces the deprecated JSONB column read with a live computation
-    from the resource_allocations table (Phase 3, BA-4308).
-    """
-    if not session_rows:
-        return
-    session_ids = [row.id for row in session_rows]
-    ra = ResourceAllocationRow.__table__
-    kernels = KernelRow.__table__
-    effective = sa.func.coalesce(ra.c.used, ra.c.requested)
-    stmt = (
-        sa.select(
-            kernels.c.session_id,
-            ra.c.slot_name,
-            sa.func.sum(effective).label("total"),
-        )
-        .select_from(ra.join(kernels, ra.c.kernel_id == kernels.c.id))
-        .where(
-            kernels.c.session_id.in_(session_ids),
-            ra.c.free_at.is_(None),
-        )
-        .group_by(kernels.c.session_id, ra.c.slot_name)
-    )
-    rows = (await db_session.execute(stmt)).all()
-    slots_map: dict[SessionId, ResourceSlot] = {}
-    for r in rows:
-        sid = SessionId(r.session_id)
-        if sid not in slots_map:
-            slots_map[sid] = ResourceSlot()
-        slots_map[sid][r.slot_name] = r.total
-    for session_row in session_rows:
-        # Use set_committed_value to avoid marking the attribute as dirty
-        # in readonly sessions.
-        sa.orm.attributes.set_committed_value(
-            session_row,
-            "occupying_slots",
-            slots_map.get(SessionId(session_row.id), ResourceSlot()),
-        )

--- a/src/ai/backend/manager/repositories/base/export.py
+++ b/src/ai/backend/manager/repositories/base/export.py
@@ -17,6 +17,7 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.attributes import InstrumentedAttribute
+    from sqlalchemy.sql import ColumnElement
 
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
@@ -72,7 +73,7 @@ class ExportFieldDef:
         name: Name displayed in CSV header
         description: Field description (displayed in client UI)
         field_type: Field type for client display
-        column: ORM column reference for SELECT query building
+        column: column expression for SELECT query building; filtering needs an ORM attribute
         formatter: Custom formatter (None uses default conversion)
         joins: Set of JoinDef required to access this field (None = no joins needed)
     """
@@ -81,7 +82,7 @@ class ExportFieldDef:
     name: str
     description: str
     field_type: ExportFieldType
-    column: InstrumentedAttribute[Any]
+    column: InstrumentedAttribute[Any] | ColumnElement[Any]
     formatter: ExportFormatter | None = None
     joins: tuple[JoinDef, ...] | frozenset[JoinDef] | None = None
 

--- a/src/ai/backend/manager/repositories/export/reports/keypair.py
+++ b/src/ai/backend/manager/repositories/export/reports/keypair.py
@@ -9,6 +9,7 @@ from typing import Any
 from ai.backend.manager.models.keypair import KeyPairRow
 from ai.backend.manager.models.resource_group import ResourceGroupForKeypairsRow, ResourceGroupRow
 from ai.backend.manager.models.resource_policy import KeyPairResourcePolicyRow
+from ai.backend.manager.models.resource_slot.aggregates import session_requested_slots_expr
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base.export import (
@@ -395,7 +396,7 @@ KEYPAIR_FIELDS: list[ExportFieldDef] = [
         name="Session Resource Requested",
         description="Requested resource slots for session",
         field_type=ExportFieldType.JSON,
-        column=SessionRow.requested_slots,
+        column=session_requested_slots_expr(SessionRow.id),
         formatter=_serialize_json,
         joins=frozenset({SESSION_JOIN}),
     ),

--- a/src/ai/backend/manager/repositories/export/reports/session.py
+++ b/src/ai/backend/manager/repositories/export/reports/session.py
@@ -9,6 +9,10 @@ from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.project import ProjectRow
 from ai.backend.manager.models.resource_group import ResourceGroupRow
 from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_slot.aggregates import (
+    session_allocated_slots_expr,
+    session_requested_slots_expr,
+)
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.repositories.base.export import (
@@ -140,7 +144,7 @@ SESSION_FIELDS: list[ExportFieldDef] = [
         name="Resources Used",
         description="Occupied resource slots",
         field_type=ExportFieldType.JSON,
-        column=SessionRow.occupying_slots,
+        column=session_allocated_slots_expr(SessionRow.id),
         formatter=lambda v: json.dumps(dict(v), default=str) if v else "",
     ),
     ExportFieldDef(
@@ -148,7 +152,7 @@ SESSION_FIELDS: list[ExportFieldDef] = [
         name="Resources Requested",
         description="Requested resource slots",
         field_type=ExportFieldType.JSON,
-        column=SessionRow.requested_slots,
+        column=session_requested_slots_expr(SessionRow.id),
         formatter=lambda v: json.dumps(dict(v), default=str) if v else "",
     ),
     ExportFieldDef(

--- a/src/ai/backend/manager/repositories/project/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/project/db_source/db_source.py
@@ -21,7 +21,7 @@ from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityRef, ScopeRef
 from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
 from ai.backend.common.exception import DomainNotFound, InvalidAPIParameters
-from ai.backend.common.types import SlotName, VFolderID
+from ai.backend.common.types import ResourceSlot, SlotName, VFolderID
 from ai.backend.common.utils import nmget
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
@@ -51,6 +51,7 @@ from ai.backend.manager.models.project.row import (
     ProjectRow,
 )
 from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.resource_slot.aggregates import kernel_allocated_slots_expr
 from ai.backend.manager.models.resource_usage import fetch_resource_usage
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.specs.pagination import NoPagination
@@ -219,7 +220,7 @@ class ProjectDBSource:
                     kernels.c.domain_name,
                     kernels.c.group_id,
                     kernels.c.attached_devices,
-                    kernels.c.occupied_slots,
+                    kernel_allocated_slots_expr(kernels.c.id).label("occupied_slots"),
                     kernels.c.resource_opts,
                     kernels.c.vfolder_mounts,
                     kernels.c.mounts,
@@ -382,8 +383,8 @@ class ProjectDBSource:
         start_date: datetime,
         end_date: datetime,
         project_ids: Sequence[UUID] | None = None,
-    ) -> list[KernelRow]:
-        """Fetch resource usage data for projects."""
+    ) -> tuple[list[KernelRow], dict[UUID, ResourceSlot]]:
+        """Fetch the project's kernels with the slots they were allocated."""
         return await fetch_resource_usage(self._db, start_date, end_date, project_ids=project_ids)
 
     async def purge_group(

--- a/src/ai/backend/manager/repositories/project/repository.py
+++ b/src/ai/backend/manager/repositories/project/repository.py
@@ -15,6 +15,7 @@ from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
+from ai.backend.common.types import ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
 from ai.backend.manager.config.provider import ManagerConfigProvider
@@ -115,8 +116,8 @@ class ProjectRepository:
         start_date: datetime,
         end_date: datetime,
         project_ids: Sequence[UUID] | None = None,
-    ) -> list[KernelRow]:
-        """Fetch resource usage data for projects."""
+    ) -> tuple[list[KernelRow], dict[UUID, ResourceSlot]]:
+        """Fetch the project's kernels with the slots they were allocated."""
         return await self._db_source.fetch_project_resource_usage(start_date, end_date, project_ids)
 
     @project_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/scheduler/db_source/db_source.py
@@ -90,6 +90,10 @@ from ai.backend.manager.models.resource_slot import (
     ResourceAllocationRow,
     ResourceSlotTypeRow,
 )
+from ai.backend.manager.models.resource_slot.aggregates import (
+    batch_load_kernel_allocations,
+    kernel_requested_slots_expr,
+)
 from ai.backend.manager.models.scheduling_history.row import SessionSchedulingHistoryRow
 from ai.backend.manager.models.session import (
     PRIVATE_SESSION_TYPES,
@@ -1711,13 +1715,16 @@ class ScheduleDBSource:
                             KernelRow.container_id,
                             KernelRow.agent,
                             KernelRow.agent_addr,
-                            KernelRow.occupied_slots,
                         )
                     )
                 )
             )
             result = await session.execute(query)
             session_rows = list(result.scalars().all())
+            allocations = await batch_load_kernel_allocations(
+                session,
+                [KernelId(kernel.id) for row in session_rows for kernel in row.kernels],
+            )
 
             terminating_sessions = []
             for session_row in session_rows:
@@ -1728,7 +1735,11 @@ class ScheduleDBSource:
                         container_id=kernel.container_id,
                         agent_id=AgentId(kernel.agent) if kernel.agent else None,
                         agent_addr=kernel.agent_addr,
-                        occupied_slots=kernel.occupied_slots,
+                        occupied_slots=(
+                            allocations[KernelId(kernel.id)].used
+                            if KernelId(kernel.id) in allocations
+                            else ResourceSlot()
+                        ),
                     )
                     for kernel in session_row.kernels
                 ]
@@ -3676,7 +3687,7 @@ class ScheduleDBSource:
                 KernelRow.uid,
                 KernelRow.main_gid,
                 KernelRow.gids,
-                KernelRow.requested_slots,
+                kernel_requested_slots_expr(KernelRow.id).label("requested_slots"),
                 KernelRow.resource_opts,
                 KernelRow.bootstrap_script,
                 KernelRow.startup_command,
@@ -3988,6 +3999,15 @@ class ScheduleDBSource:
 
             return handler_sessions
 
+    async def get_kernel_allocated_slots(
+        self,
+        kernel_ids: Sequence[KernelId],
+    ) -> dict[KernelId, ResourceSlot]:
+        """Read from ``resource_allocations`` what each kernel was ever allocated."""
+        async with self._db.begin_readonly_session_read_committed() as db_sess:
+            aggregates = await batch_load_kernel_allocations(db_sess, kernel_ids)
+        return {kernel_id: agg.allocated for kernel_id, agg in aggregates.items()}
+
     async def search_kernels_for_handler(
         self,
         querier: BatchQuerier,
@@ -4254,7 +4274,7 @@ class ScheduleDBSource:
                 KernelRow.uid,
                 KernelRow.main_gid,
                 KernelRow.gids,
-                KernelRow.requested_slots,
+                kernel_requested_slots_expr(KernelRow.id).label("requested_slots"),
                 KernelRow.resource_opts,
                 KernelRow.bootstrap_script,
                 KernelRow.startup_command,
@@ -4398,7 +4418,7 @@ class ScheduleDBSource:
                     KernelRow.uid,
                     KernelRow.main_gid,
                     KernelRow.gids,
-                    KernelRow.requested_slots,
+                    kernel_requested_slots_expr(KernelRow.id).label("requested_slots"),
                     KernelRow.resource_opts,
                     KernelRow.bootstrap_script,
                     KernelRow.startup_command,
@@ -4560,7 +4580,7 @@ class ScheduleDBSource:
                     KernelRow.uid,
                     KernelRow.main_gid,
                     KernelRow.gids,
-                    KernelRow.requested_slots,
+                    kernel_requested_slots_expr(KernelRow.id).label("requested_slots"),
                     KernelRow.resource_opts,
                     KernelRow.bootstrap_script,
                     KernelRow.startup_command,

--- a/src/ai/backend/manager/repositories/scheduler/repository.py
+++ b/src/ai/backend/manager/repositories/scheduler/repository.py
@@ -32,6 +32,7 @@ from ai.backend.common.types import (
     AgentId,
     KernelId,
     PreemptionMode,
+    ResourceSlot,
     SessionId,
     VFolderMount,
     VFolderMountOptions,
@@ -786,6 +787,14 @@ class SchedulerRepository:
         return await self._db_source.fetch_sessions_for_handler(
             resource_group_id, session_statuses, kernel_statuses
         )
+
+    @scheduler_repository_resilience.apply()
+    async def get_kernel_allocated_slots(
+        self,
+        kernel_ids: Sequence[KernelId],
+    ) -> dict[KernelId, ResourceSlot]:
+        """Read from ``resource_allocations`` what each kernel was ever allocated."""
+        return await self._db_source.get_kernel_allocated_slots(kernel_ids)
 
     @scheduler_repository_resilience.apply()
     async def search_kernels_for_handler(

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -51,7 +51,6 @@ from ai.backend.manager.models.session import (
     KernelLoadingStrategy,
     SessionDependencyRow,
     SessionRow,
-    batch_populate_session_occupied_slots,
 )
 from ai.backend.manager.models.session_template import SessionTemplateRow
 from ai.backend.manager.models.specs.pagination import NoPagination
@@ -624,7 +623,6 @@ class SessionDBSource:
             )
 
             session_rows = [row.SessionRow for row in result.rows]
-            await batch_populate_session_occupied_slots(db_sess, session_rows)
             items = [row.to_dataclass() for row in session_rows]
 
             return SessionListResult(
@@ -659,7 +657,6 @@ class SessionDBSource:
             )
 
             session_rows = [row.SessionRow for row in result.rows]
-            await batch_populate_session_occupied_slots(db_sess, session_rows)
             items = [row.to_dataclass() for row in session_rows]
 
             return SessionListResult(

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -68,6 +68,7 @@ from ai.backend.manager.models.project import (
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.resource_policy import UserResourcePolicyRow
 from ai.backend.manager.models.resource_policy.row import KeyPairResourcePolicyRow
+from ai.backend.manager.models.resource_slot.aggregates import kernel_allocated_slots_expr
 from ai.backend.manager.models.session import (
     AGENT_RESOURCE_OCCUPYING_SESSION_STATUSES,
     QueryCondition,
@@ -606,7 +607,7 @@ class UserDBSource:
                     kernels.c.id,
                     kernels.c.created_at,
                     kernels.c.terminated_at,
-                    kernels.c.occupied_slots,
+                    kernel_allocated_slots_expr(kernels.c.id).label("occupied_slots"),
                 )
                 .select_from(kernels)
                 .where(

--- a/src/ai/backend/manager/services/project/service.py
+++ b/src/ai/backend/manager/services/project/service.py
@@ -119,12 +119,12 @@ class ProjectService:
         end_date: datetime,
         project_ids: Sequence[UUID] | None = None,
     ) -> dict[UUID, ProjectResourceUsage]:
-        kernels = await self._group_repository.fetch_project_resource_usage(
+        kernels, allocated_slots = await self._group_repository.fetch_project_resource_usage(
             start_date, end_date, project_ids=project_ids
         )
         local_tz = self._config_provider.config.system.timezone
         usage_groups = await parse_resource_usage_groups(
-            kernels, self._valkey_stat_client, local_tz
+            kernels, allocated_slots, self._valkey_stat_client, local_tz
         )
         total_groups, _ = parse_total_resource_group(usage_groups)
         return total_groups

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -44,6 +44,7 @@ from ai.backend.common.types import (
     ContainerId,
     ImageAlias,
     KernelId,
+    ResourceSlot,
     ResourceSlotEntry,
     SessionId,
     SessionTypes,
@@ -1199,6 +1200,15 @@ class SessionService:
             kernel_loading_strategy=KernelLoadingStrategy.MAIN_KERNEL_ONLY,
         )
 
+        session_id = SessionId(sess.id)
+        main_kernel_id = KernelId(sess.main_kernel.id)
+        session_allocation = (
+            await self._session_repository.batch_get_resource_allocation_by_session([session_id])
+        ).get(session_id)
+        kernel_allocation = (
+            await self._session_repository.batch_get_resource_allocation_by_kernel([main_kernel_id])
+        ).get(main_kernel_id)
+
         age = datetime.now(tzutc()) - sess.created_at
         session_info = LegacySessionInfo(
             domain_name=sess.domain_name,
@@ -1212,9 +1222,11 @@ class SessionService:
             container_id=ContainerId(sess.main_kernel.container_id)
             if sess.main_kernel.container_id
             else None,
-            occupied_slots=str(sess.main_kernel.occupied_slots),  # legacy
-            occupying_slots=str(sess.occupying_slots),
-            requested_slots=str(sess.requested_slots),
+            occupied_slots=str(kernel_allocation.used if kernel_allocation else ResourceSlot()),
+            occupying_slots=str(session_allocation.used if session_allocation else ResourceSlot()),
+            requested_slots=str(
+                session_allocation.requested if session_allocation else ResourceSlot()
+            ),
             occupied_shares=str(sess.main_kernel.occupied_shares),  # legacy
             environ=str(sess.environ),
             resource_opts=str(sess.resource_opts),

--- a/src/ai/backend/manager/sokovan/scheduler/fair_share/aggregator.py
+++ b/src/ai/backend/manager/sokovan/scheduler/fair_share/aggregator.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from decimal import Decimal
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.types import ResourceSlot
+from ai.backend.common.types import KernelId, ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.fair_share import (
     DomainUsageBucketKey,
@@ -78,6 +78,7 @@ class FairShareAggregator:
     def prepare_kernel_usage_records(
         self,
         kernels: Sequence[KernelInfo],
+        allocated_slots: Mapping[KernelId, ResourceSlot],
         resource_group_id: ResourceGroupID,
         resource_group: str,
         now: datetime,
@@ -104,7 +105,11 @@ class FairShareAggregator:
 
         for kernel in kernels:
             kernel_specs, observation_end = self._prepare_kernel_usage_specs(
-                kernel, resource_group_id, resource_group, now
+                kernel,
+                allocated_slots.get(KernelId(kernel.id), ResourceSlot()),
+                resource_group_id,
+                resource_group,
+                now,
             )
             if kernel_specs:
                 result.specs.extend(kernel_specs)
@@ -271,6 +276,7 @@ class FairShareAggregator:
     def _prepare_kernel_usage_specs(
         self,
         kernel: KernelInfo,
+        allocated_slots: ResourceSlot,
         resource_group_id: ResourceGroupID,
         resource_group: str,
         now: datetime,
@@ -286,6 +292,7 @@ class FairShareAggregator:
 
         Args:
             kernel: Kernel to process
+            allocated_slots: The slots the kernel was allocated
             resource_group_id: The resource group ID
             resource_group: The resource group name retained for compatibility
             now: Current time from DB
@@ -345,6 +352,7 @@ class FairShareAggregator:
         # Generate 5-minute slices
         specs = self._generate_slice_specs(
             kernel=kernel,
+            allocated_slots=allocated_slots,
             resource_group_id=resource_group_id,
             resource_group=resource_group,
             start_time=start_time,
@@ -365,6 +373,7 @@ class FairShareAggregator:
     def _generate_slice_specs(
         self,
         kernel: KernelInfo,
+        allocated_slots: ResourceSlot,
         resource_group_id: ResourceGroupID,
         resource_group: str,
         start_time: datetime,
@@ -406,7 +415,7 @@ class FairShareAggregator:
 
             # Calculate resource-seconds for this slice
             resource_seconds = self._calculate_resource_seconds(
-                kernel.resource.occupied_slots,
+                allocated_slots,
                 slice_seconds,
             )
 
@@ -421,7 +430,7 @@ class FairShareAggregator:
                 period_start=current_start,
                 period_end=current_end,
                 resource_usage=resource_seconds,
-                occupied_slots=kernel.resource.occupied_slots,
+                occupied_slots=allocated_slots,
             )
             specs.append(spec)
 

--- a/src/ai/backend/manager/sokovan/scheduler/handlers/observer/fair_share.py
+++ b/src/ai/backend/manager/sokovan/scheduler/handlers/observer/fair_share.py
@@ -16,6 +16,7 @@ from datetime import date, timedelta
 from typing import TYPE_CHECKING, override
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.types import KernelId
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.kernel.types import KernelInfo
 from ai.backend.manager.models.clauses import QueryCondition
@@ -145,8 +146,11 @@ class FairShareObserver(KernelObserver):
 
         # ===== Phase 1: Record usage =====
         # TODO: Remove resource_group name from spec once DB schema is updated
+        allocated_slots = await self._scheduler_repository.get_kernel_allocated_slots([
+            KernelId(kernel.id) for kernel in kernels
+        ])
         preparation_result = self._aggregator.prepare_kernel_usage_records(
-            kernels, resource_group_id, resource_group_name, now
+            kernels, allocated_slots, resource_group_id, resource_group_name, now
         )
 
         log.debug(

--- a/tests/unit/manager/api/adapters/test_session_adapter.py
+++ b/tests/unit/manager/api/adapters/test_session_adapter.py
@@ -9,7 +9,12 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
+from ai.backend.common.dto.manager.v2.common import (
+    ResourceSlotEntryInfo,
+    ResourceSlotEntryInput,
+    ResourceSlotInfo,
+)
+from ai.backend.common.dto.manager.v2.kernel.response import ResourceAllocationGQLDTO
 from ai.backend.common.dto.manager.v2.session.request import (
     BatchConfigInput,
     EnqueueSessionInput,
@@ -43,8 +48,6 @@ def _create_session_data(
         domain_name="default",
         group_id=uuid4(),
         user_uuid=uuid4(),
-        occupying_slots={},
-        requested_slots={"cpu": Decimal("1"), "mem": Decimal("1073741824")},
         use_host_network=False,
         created_at=datetime.now(tz=UTC),
         status=status,
@@ -79,13 +82,33 @@ def _create_session_data(
     )
 
 
+def _create_allocation(
+    requested: dict[str, Decimal] | None = None,
+    used: dict[str, Decimal] | None = None,
+) -> ResourceAllocationGQLDTO:
+    """Build the slot allocation the adapter receives from resource_allocations."""
+
+    def _entries(slots: dict[str, Decimal] | None) -> ResourceSlotInfo:
+        return ResourceSlotInfo(
+            entries=[
+                ResourceSlotEntryInfo(resource_type=k, quantity=v) for k, v in (slots or {}).items()
+            ]
+        )
+
+    return ResourceAllocationGQLDTO(
+        requested=_entries(requested),
+        used=_entries(used),
+        allocated=_entries(used),
+    )
+
+
 class TestSessionDataToNode:
     """Tests for _session_data_to_node conversion."""
 
     def test_basic_conversion(self) -> None:
         """SessionData should convert to SessionNode with correct fields."""
         data = _create_session_data(name="my-session")
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
 
         assert node.metadata.name == "my-session"
         assert node.metadata.session_type == "interactive"
@@ -96,7 +119,12 @@ class TestSessionDataToNode:
     def test_resource_allocation_conversion(self) -> None:
         """Resource slots should be converted to ResourceSlotInfo entries."""
         data = _create_session_data()
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(
+            data,
+            _create_allocation(
+                requested={"cpu": Decimal("1"), "mem": Decimal("1073741824")},
+            ),
+        )
 
         requested = node.resource.allocation.requested
         assert len(requested.entries) == 2
@@ -107,25 +135,25 @@ class TestSessionDataToNode:
     def test_lifecycle_running_status(self) -> None:
         """RUNNING status should be preserved as RUNNING."""
         data = _create_session_data(status=SessionStatus.RUNNING)
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
         assert node.lifecycle.status == "RUNNING"
 
     def test_lifecycle_pending_status(self) -> None:
         """PENDING status should be preserved as PENDING."""
         data = _create_session_data(status=SessionStatus.PENDING)
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
         assert node.lifecycle.status == "PENDING"
 
     def test_lifecycle_result(self) -> None:
         """Result should be passed through as string value."""
         data = _create_session_data()
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
         assert node.lifecycle.result == "undefined"
 
     def test_domain_and_user_fields(self) -> None:
         """Domain name and user/project IDs should be mapped."""
         data = _create_session_data()
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
         assert node.domain_name == "default"
         assert node.user_id == data.user_uuid
         assert node.project_id == data.group_id
@@ -133,13 +161,13 @@ class TestSessionDataToNode:
     def test_network_host_network_false(self) -> None:
         """Network info should reflect use_host_network."""
         data = _create_session_data()
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
         assert node.network.use_host_network is False
 
     def test_empty_occupying_slots(self) -> None:
         """Empty occupying slots should produce empty entries list."""
         data = _create_session_data()
-        node = SessionAdapter._session_data_to_node(data)
+        node = SessionAdapter._session_data_to_node(data, _create_allocation())
         assert len(node.resource.allocation.used.entries) == 0
 
 
@@ -152,6 +180,11 @@ class TestEnqueueActionBuilding:
         result = MagicMock()
         result.session_data = _create_session_data()
         processors.session.enqueue_session.run = AsyncMock(return_value=result)
+        allocation_result = MagicMock()
+        allocation_result.data = {}
+        processors.session.batch_get_session_resource_allocation.run = AsyncMock(
+            return_value=allocation_result
+        )
         return processors
 
     @pytest.fixture

--- a/tests/unit/manager/api/compute_sessions/test_handler.py
+++ b/tests/unit/manager/api/compute_sessions/test_handler.py
@@ -47,12 +47,25 @@ from ai.backend.manager.data.kernel.types import (
     RuntimeConfig,
     UserPermission,
 )
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import SessionData, SessionStatus
 from ai.backend.manager.models.specs.pagination import NoPagination, OffsetPagination
 from ai.backend.manager.services.session.actions.search import SearchSessionsAction
 from ai.backend.manager.services.session.actions.search_kernel import SearchKernelsAction
 
 # ========== Test Data Factories ==========
+
+
+def create_allocation(
+    requested: dict[str, Decimal] | None = None,
+    used: dict[str, Decimal] | None = None,
+) -> ResourceAllocationAggregate:
+    """Create the slot aggregate the adapter receives from resource_allocations."""
+    return ResourceAllocationAggregate(
+        requested=ResourceSlot(requested or {"cpu": Decimal("1")}),
+        used=ResourceSlot(used or {"cpu": Decimal("1")}),
+        allocated=ResourceSlot(used or {"cpu": Decimal("1")}),
+    )
 
 
 def create_session_data(
@@ -74,8 +87,6 @@ def create_session_data(
         domain_name="default",
         group_id=uuid4(),
         user_uuid=uuid4(),
-        occupying_slots=ResourceSlot({"cpu": Decimal("2.0"), "mem": Decimal("4294967296")}),
-        requested_slots=ResourceSlot({"cpu": Decimal("4.0"), "mem": Decimal("8589934592")}),
         use_host_network=False,
         created_at=datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC),
         status=status,
@@ -166,8 +177,6 @@ def create_kernel_info(
             agent=agent,
             agent_addr=None,
             container_id=None,
-            occupied_slots=ResourceSlot({"cpu": Decimal("2.0")}),
-            requested_slots=ResourceSlot({"cpu": Decimal("4.0")}),
             occupied_shares={},
             attached_devices={},
             resource_opts={},
@@ -360,7 +369,7 @@ class TestComputeSessionsAdapter:
     def test_convert_session_to_dto_without_containers(self) -> None:
         """Convert session without containers should have empty containers list."""
         session = create_session_data()
-        dto = self.adapter.convert_session_to_dto(session, kernels=None)
+        dto = self.adapter.convert_session_to_dto(session, create_allocation(), kernels=None)
 
         assert dto.id == session.id
         assert dto.name == session.name
@@ -386,7 +395,7 @@ class TestComputeSessionsAdapter:
                 agent="agent-002",
             ),
         ]
-        dto = self.adapter.convert_session_to_dto(session, kernels=kernels)
+        dto = self.adapter.convert_session_to_dto(session, create_allocation(), kernels=kernels)
 
         assert len(dto.containers) == 2
         assert dto.containers[0].agent_id == "agent-001"
@@ -404,7 +413,7 @@ class TestComputeSessionsAdapter:
         session.terminated_at = datetime(2024, 6, 2, 12, 0, 0, tzinfo=UTC)
         session.starts_at = datetime(2024, 6, 1, 11, 0, 0, tzinfo=UTC)
 
-        dto = self.adapter.convert_session_to_dto(session)
+        dto = self.adapter.convert_session_to_dto(session, create_allocation())
 
         assert dto.name == "my-session"
         assert dto.status == "TERMINATED"
@@ -422,7 +431,7 @@ class TestComputeSessionsAdapter:
             SessionStatus.CANCELLED,
         ]:
             session = create_session_data(status=status)
-            dto = self.adapter.convert_session_to_dto(session)
+            dto = self.adapter.convert_session_to_dto(session, create_allocation())
             assert dto.status == status.value
 
 
@@ -551,7 +560,9 @@ class TestComputeSessionsHandler:
 
         # session-1 should have 2 kernels, session-2 should have 1
         items = [
-            adapter.convert_session_to_dto(session, kernels_by_session.get(session.id, []))
+            adapter.convert_session_to_dto(
+                session, create_allocation(), kernels_by_session.get(session.id, [])
+            )
             for session in session_result.data
         ]
 
@@ -579,7 +590,7 @@ class TestComputeSessionsHandler:
         ]
 
         adapter = ComputeSessionsAdapter()
-        dto = adapter.convert_session_to_dto(session, kernels=kernels)
+        dto = adapter.convert_session_to_dto(session, create_allocation(), kernels=kernels)
 
         assert len(dto.containers) == 5
         agents = {c.agent_id for c in dto.containers}
@@ -590,6 +601,6 @@ class TestComputeSessionsHandler:
         session = create_session_data()
 
         adapter = ComputeSessionsAdapter()
-        dto = adapter.convert_session_to_dto(session, kernels=[])
+        dto = adapter.convert_session_to_dto(session, create_allocation(), kernels=[])
 
         assert dto.containers == []

--- a/tests/unit/manager/repositories/scheduler/test_session_network_propagation.py
+++ b/tests/unit/manager/repositories/scheduler/test_session_network_propagation.py
@@ -41,6 +41,10 @@ from ai.backend.manager.models.resource_policy import (
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
+from ai.backend.manager.models.resource_slot import (
+    ResourceAllocationRow,
+    ResourceSlotTypeRow,
+)
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.session.conditions import SessionConditions
 from ai.backend.manager.models.specs.pagination import NoPagination
@@ -73,6 +77,8 @@ class TestPersistentNetworkNotRecreated:
                 AgentRow,
                 SessionRow,
                 KernelRow,
+                ResourceSlotTypeRow,
+                ResourceAllocationRow,
             ],
         ):
             yield database_connection

--- a/tests/unit/manager/repositories/session/test_session_repository.py
+++ b/tests/unit/manager/repositories/session/test_session_repository.py
@@ -14,7 +14,6 @@ from decimal import Decimal
 import pytest
 import sqlalchemy as sa
 from dateutil.tz import tzutc
-from sqlalchemy.orm import selectinload
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
@@ -47,7 +46,8 @@ from ai.backend.manager.models.resource_policy import (
     UserResourcePolicyRow,
 )
 from ai.backend.manager.models.resource_slot import ResourceAllocationRow, ResourceSlotTypeRow
-from ai.backend.manager.models.session import SessionRow, batch_populate_session_occupied_slots
+from ai.backend.manager.models.resource_slot.aggregates import batch_load_session_allocations
+from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.session_template import SessionTemplateRow, TemplateType
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
@@ -585,10 +585,9 @@ class TestSessionRepository:
             await repository.get_session_with_routing_minimal(SessionID(terminated_id))
 
 
-class TestBatchPopulateSessionOccupiedSlots:
-    """Test batch_populate_session_occupied_slots computes occupied_slots
-    from the normalized resource_allocations table instead of the deprecated
-    JSONB column."""
+class TestBatchLoadSessionAllocations:
+    """Test that the session slot values are aggregated from the normalized
+    resource_allocations table instead of the deprecated JSONB columns."""
 
     @pytest.fixture
     async def db_with_resource_tables(
@@ -853,64 +852,49 @@ class TestBatchPopulateSessionOccupiedSlots:
             access_key=access_key,
         )
 
-    async def test_batch_populate_computes_slots_from_resource_allocations(
+    async def test_used_slots_come_from_resource_allocations(
         self,
         db_with_resource_tables: ExtendedAsyncSAEngine,
         session_with_allocations: SessionTestData,
     ) -> None:
-        """Verify that batch_populate reads from resource_allocations
-        instead of the deprecated JSONB column."""
+        """Verify the aggregate reads resource_allocations, not the JSONB column."""
+        session_id = SessionId(session_with_allocations.session_id)
         async with db_with_resource_tables.begin_readonly_session() as db_sess:
-            stmt = (
-                sa.select(SessionRow)
-                .where(SessionRow.id == session_with_allocations.session_id)
-                .options(selectinload(SessionRow.kernels))
-            )
+            stmt = sa.select(SessionRow).where(SessionRow.id == session_id)
             session_row = await db_sess.scalar(stmt)
             assert session_row is not None
-
-            # Before: JSONB column is empty (post-Phase 3)
+            # The deprecated JSONB column is empty (post-Phase 3)
             assert session_row.occupying_slots == ResourceSlot()
 
-            # Act: batch_populate computes from resource_allocations
-            await batch_populate_session_occupied_slots(db_sess, [session_row])
+            aggregates = await batch_load_session_allocations(db_sess, [session_id])
 
-            # After: occupying_slots is populated from resource_allocations
-            slots = session_row.occupying_slots
-            assert slots is not None
-            assert len(slots) == 2
-            # cpu: used=1.5 takes precedence over requested=2.0
-            assert slots["cpu"] == Decimal("1.500000")
-            # mem: used=NULL -> requested=2147483648
-            assert slots["mem"] == Decimal("2147483648")
+        slots = aggregates[session_id].used
+        assert len(slots) == 2
+        # cpu: used=1.5 takes precedence over requested=2.0
+        assert slots["cpu"] == Decimal("1.500000")
+        # mem: used=NULL -> requested=2147483648
+        assert slots["mem"] == Decimal("2147483648")
 
-    async def test_batch_populate_empty_sessions(
+    async def test_empty_session_ids(
         self,
         db_with_resource_tables: ExtendedAsyncSAEngine,
     ) -> None:
-        """Verify that batch_populate handles empty list gracefully."""
+        """Verify that an empty id list is handled gracefully."""
         async with db_with_resource_tables.begin_readonly_session() as db_sess:
-            await batch_populate_session_occupied_slots(db_sess, [])
+            assert await batch_load_session_allocations(db_sess, []) == {}
 
-    async def test_search_returns_computed_occupied_slots(
+    async def test_repository_aggregate_returns_computed_slots(
         self,
         db_with_resource_tables: ExtendedAsyncSAEngine,
         session_with_allocations: SessionTestData,
     ) -> None:
-        """Verify the search() repository method returns computed occupied_slots
-        from resource_allocations, not the empty JSONB column."""
+        """Verify the repository aggregate returns values computed from
+        resource_allocations, not the empty JSONB column."""
         repository = SessionRepository(db_with_resource_tables)
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=10, offset=0),
-            conditions=[],
-            orders=[],
-        )
-        result = await repository.search(querier=querier)
+        session_id = SessionId(session_with_allocations.session_id)
+        aggregates = await repository.batch_get_resource_allocation_by_session([session_id])
 
-        assert result.total_count == 1
-        session_data = result.items[0]
-        slots = session_data.occupying_slots
-        assert slots is not None
+        slots = aggregates[session_id].used
         assert slots["cpu"] == Decimal("1.500000")
         assert slots["mem"] == Decimal("2147483648")
 

--- a/tests/unit/manager/sokovan/scheduler/fair_share/test_aggregator_slice_generation.py
+++ b/tests/unit/manager/sokovan/scheduler/fair_share/test_aggregator_slice_generation.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 import pytest
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.types import ResourceSlot
+from ai.backend.common.types import KernelId, ResourceSlot
 from ai.backend.manager.sokovan.scheduler.fair_share.aggregator import (
     SLICE_DURATION_SECONDS,
     FairShareAggregator,
@@ -44,11 +44,16 @@ def mock_kernel_info() -> MagicMock:
     kernel.user_permission.user_uuid = uuid4()
     kernel.user_permission.group_id = uuid4()
     kernel.user_permission.domain_name = "default"
-    kernel.resource.occupied_slots = ResourceSlot({"cpu": Decimal("2"), "mem": Decimal("4096")})
     kernel.lifecycle.starts_at = None
     kernel.lifecycle.last_observed_at = None
     kernel.lifecycle.terminated_at = None
     return kernel
+
+
+@pytest.fixture
+def mock_allocated_slots() -> ResourceSlot:
+    """The slots a mock kernel was allocated, as resource_allocations reports them."""
+    return ResourceSlot({"cpu": Decimal("2"), "mem": Decimal("4096")})
 
 
 @pytest.fixture
@@ -80,6 +85,7 @@ class TestPrepareKernelUsageSpecs:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """First observation allows partial start slice from starts_at."""
         mock_kernel_info.lifecycle.starts_at = make_datetime(7, 42, 30)
@@ -87,7 +93,11 @@ class TestPrepareKernelUsageSpecs:
         mock_kernel_info.lifecycle.terminated_at = None  # RUNNING
 
         specs, last_observed_at = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 47, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 47, 0),
         )
 
         # Only one slice: 07:42:30 -> 07:45:00 (partial start)
@@ -101,6 +111,7 @@ class TestPrepareKernelUsageSpecs:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """RUNNING kernel should only generate complete slices up to last boundary."""
         mock_kernel_info.lifecycle.starts_at = make_datetime(7, 40, 0)
@@ -109,7 +120,11 @@ class TestPrepareKernelUsageSpecs:
 
         # now = 07:52:30 -> floors to 07:50:00
         specs, last_observed_at = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 52, 30)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 52, 30),
         )
 
         # One complete slice: 07:45:00 -> 07:50:00
@@ -123,6 +138,7 @@ class TestPrepareKernelUsageSpecs:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """RUNNING kernel should generate no slices if next boundary not reached."""
         mock_kernel_info.lifecycle.starts_at = make_datetime(7, 40, 0)
@@ -131,7 +147,11 @@ class TestPrepareKernelUsageSpecs:
 
         # now = 07:48:00 -> floors to 07:45:00, same as last_observed_at
         specs, last_observed_at = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 48, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 48, 0),
         )
 
         # No slices: floored now (07:45:00) <= last_observed_at (07:45:00)
@@ -142,6 +162,7 @@ class TestPrepareKernelUsageSpecs:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """TERMINATED kernel allows partial end slice at terminated_at."""
         mock_kernel_info.lifecycle.starts_at = make_datetime(7, 40, 0)
@@ -149,7 +170,11 @@ class TestPrepareKernelUsageSpecs:
         mock_kernel_info.lifecycle.terminated_at = make_datetime(7, 53, 30)  # TERMINATED
 
         specs, last_observed_at = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 55, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 55, 0),
         )
 
         # One partial slice: 07:50:00 -> 07:53:30
@@ -174,7 +199,6 @@ class TestPrepareKernelUsageRecords:
         kernel1.user_permission.user_uuid = uuid4()
         kernel1.user_permission.group_id = uuid4()
         kernel1.user_permission.domain_name = "default"
-        kernel1.resource.occupied_slots = ResourceSlot({"cpu": Decimal("2")})
         kernel1.lifecycle.starts_at = make_datetime(7, 40, 0)
         kernel1.lifecycle.last_observed_at = make_datetime(7, 45, 0)
         kernel1.lifecycle.terminated_at = None
@@ -185,7 +209,6 @@ class TestPrepareKernelUsageRecords:
         kernel2.user_permission.user_uuid = uuid4()
         kernel2.user_permission.group_id = uuid4()
         kernel2.user_permission.domain_name = "default"
-        kernel2.resource.occupied_slots = ResourceSlot({"cpu": Decimal("4")})
         kernel2.lifecycle.starts_at = make_datetime(7, 42, 0)
         kernel2.lifecycle.last_observed_at = make_datetime(7, 45, 0)
         kernel2.lifecycle.terminated_at = None
@@ -193,6 +216,10 @@ class TestPrepareKernelUsageRecords:
         resource_group_id = ResourceGroupID(uuid4())
         result = aggregator.prepare_kernel_usage_records(
             kernels=[kernel1, kernel2],
+            allocated_slots={
+                KernelId(kernel1.id): ResourceSlot({"cpu": Decimal("2")}),
+                KernelId(kernel2.id): ResourceSlot({"cpu": Decimal("4")}),
+            },
             resource_group_id=resource_group_id,
             resource_group="default",
             now=make_datetime(7, 52, 0),
@@ -232,6 +259,7 @@ class TestScenarioConsecutiveObservations:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """Test full kernel lifecycle with consecutive observations."""
         all_specs: list[KernelUsageRecordCreatorSpec] = []
@@ -241,7 +269,11 @@ class TestScenarioConsecutiveObservations:
         mock_kernel_info.lifecycle.last_observed_at = None
         mock_kernel_info.lifecycle.terminated_at = None
         specs_1, last_obs_1 = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 47, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 47, 0),
         )
         all_specs.extend(specs_1)
 
@@ -253,7 +285,11 @@ class TestScenarioConsecutiveObservations:
         # 2nd observation: now = 07:48:00 (before next boundary)
         mock_kernel_info.lifecycle.last_observed_at = last_obs_1
         specs_2, last_obs_2 = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 48, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 48, 0),
         )
         all_specs.extend(specs_2)
 
@@ -263,7 +299,11 @@ class TestScenarioConsecutiveObservations:
         # 3rd observation: now = 07:52:00 (after next boundary)
         mock_kernel_info.lifecycle.last_observed_at = last_obs_2
         specs_3, last_obs_3 = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 52, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 52, 0),
         )
         all_specs.extend(specs_3)
 
@@ -276,7 +316,11 @@ class TestScenarioConsecutiveObservations:
         mock_kernel_info.lifecycle.last_observed_at = last_obs_3
         mock_kernel_info.lifecycle.terminated_at = make_datetime(7, 53, 30)
         specs_4, last_obs_4 = aggregator._prepare_kernel_usage_specs(
-            mock_kernel_info, ResourceGroupID(uuid4()), "default", now=make_datetime(7, 55, 0)
+            mock_kernel_info,
+            mock_allocated_slots,
+            ResourceGroupID(uuid4()),
+            "default",
+            now=make_datetime(7, 55, 0),
         )
         all_specs.extend(specs_4)
 
@@ -304,10 +348,12 @@ class TestSliceGeneration:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """Test generation of multiple complete 5-minute slices."""
         specs = aggregator._generate_slice_specs(
             mock_kernel_info,
+            mock_allocated_slots,
             ResourceGroupID(uuid4()),
             "default",
             start_time=make_datetime(7, 45, 0),
@@ -327,11 +373,13 @@ class TestSliceGeneration:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """Verify resource-seconds are calculated correctly."""
         # 2.5 minute slice with cpu=2, mem=4096
         specs = aggregator._generate_slice_specs(
             mock_kernel_info,
+            mock_allocated_slots,
             ResourceGroupID(uuid4()),
             "default",
             start_time=make_datetime(7, 42, 30),
@@ -348,11 +396,13 @@ class TestSliceGeneration:
         self,
         aggregator: FairShareAggregator,
         mock_kernel_info: MagicMock,
+        mock_allocated_slots: ResourceSlot,
     ) -> None:
         """Verify no slices when start_time >= end_time."""
         same_time = make_datetime(7, 45, 0)
         specs = aggregator._generate_slice_specs(
             mock_kernel_info,
+            mock_allocated_slots,
             ResourceGroupID(uuid4()),
             "default",
             same_time,

--- a/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/handlers/conftest.py
@@ -117,8 +117,6 @@ def _create_session(
         resource=ResourceSpec(
             cluster_mode=cluster_mode.value,
             cluster_size=kernel_count,
-            occupying_slots=ResourceSlot(),
-            requested_slots=ResourceSlot(),
             resource_group_name=resource_group,
             target_sgroup_names=None,
             agent_ids=None,
@@ -201,8 +199,6 @@ def _create_session(
                 agent=agent_id,
                 agent_addr=f"tcp://agent-{i}:5001",
                 container_id=f"container-{kernel_id}",
-                occupied_slots=ResourceSlot(),
-                requested_slots=ResourceSlot(),
                 occupied_shares={},
                 attached_devices={},
                 resource_opts={},
@@ -302,8 +298,6 @@ def _create_kernel(
             agent=aid,
             agent_addr=agent_addr or f"tcp://{aid}:5001",
             container_id=f"container-{kid}",
-            occupied_slots=ResourceSlot(),
-            requested_slots=ResourceSlot(),
             occupied_shares={},
             attached_devices={},
             resource_opts={},
@@ -586,8 +580,6 @@ def kernel_without_agent() -> KernelInfo:
             agent=None,  # No agent assigned
             agent_addr=None,
             container_id=None,
-            occupied_slots=ResourceSlot(),
-            requested_slots=ResourceSlot(),
             occupied_shares={},
             attached_devices={},
             resource_opts={},
@@ -742,7 +734,7 @@ def terminating_session_data_factory() -> Callable[..., list[TerminatingSessionD
                         container_id=k.resource.container_id,
                         agent_id=AgentId(k.resource.agent) if k.resource.agent else None,
                         agent_addr=k.resource.agent_addr,
-                        occupied_slots=k.resource.occupied_slots or ResourceSlot(),
+                        occupied_slots=ResourceSlot(),
                     )
                     for k in s.kernel_infos
                 ],

--- a/tests/unit/manager/sokovan/scheduler/terminator/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/terminator/conftest.py
@@ -253,8 +253,6 @@ def _create_kernel_info(
             agent=aid,
             agent_addr=f"tcp://{aid}:5001" if aid else None,
             container_id=f"container-{kid}",
-            occupied_slots=ResourceSlot({"cpu": Decimal("1"), "mem": Decimal("1024")}),
-            requested_slots=ResourceSlot(),
             occupied_shares={},
             attached_devices={},
             resource_opts={},

--- a/tests/unit/manager/test_idle_check_host.py
+++ b/tests/unit/manager/test_idle_check_host.py
@@ -72,6 +72,10 @@ from ai.backend.manager.models.resource_policy import (
     ProjectResourcePolicyRow,
     UserResourcePolicyRow,
 )
+from ai.backend.manager.models.resource_slot import (
+    ResourceAllocationRow,
+    ResourceSlotTypeRow,
+)
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.runtime_variant import RuntimeVariantRow
 from ai.backend.manager.models.session import SessionRow
@@ -107,6 +111,8 @@ _IDLE_ROWS: list[TableOrORM] = [
     SessionRow,
     AgentRow,
     KernelRow,
+    ResourceSlotTypeRow,
+    ResourceAllocationRow,
     ReplicaGroupRow,
     RoutingRow,
 ]


### PR DESCRIPTION
## Summary
- Add `models/resource_slot/aggregates.py`: batch loaders and correlated scalar subqueries that fold `resource_allocations` per kernel and per session into the existing `requested` / `used` / `allocated` values.
- Move every read of the four deprecated JSONB columns onto that module. API-surface fields read `used`; statistics and export readers read `allocated`, which survives termination. `gql_legacy` slot fields become DataLoader resolvers, so `batch_populate_session_occupied_slots` and its six call sites are gone.
- Drop the slot fields from `data/kernel/types.py` and `data/session/types.py`, so a column value can no longer leave an ORM row while the columns remain.

Enqueue-time writes and the column declarations stay; they go with the columns.

## Test plan
- [ ] `pants lint check test --changed-since=origin/main`
- [ ] GraphQL `ComputeSession` / `ComputeSessionNode` / `ComputeContainer` / `LegacyComputeSession` report non-empty slots for a running session
- [ ] REST `compute-sessions` search returns `resource_slots` / `occupied_slots`
- [ ] Project and user monthly usage stats, and the session/keypair export reports, still report the slots of terminated kernels

Resolves BA-7411

🤖 Generated with [Claude Code](https://claude.com/claude-code)