### PR TITLE
refactor(BA-7450): create domains through the role-managed ops path

### DIFF
--- a/changes/13906.enhance.md
+++ b/changes/13906.enhance.md
@@ -1,0 +1,1 @@
+Domain creation now runs through the generic role-managed create path, and the model-store project is created as a separate project operation rather than a side effect of the domain insert.

--- a/src/ai/backend/manager/actions/registry/group.py
+++ b/src/ai/backend/manager/actions/registry/group.py
@@ -84,6 +84,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     CreateEntityOpsAction,
     CreateEntityWithFieldsOpsAction,
     CreateGlobalOpsAction,
+    CreateGlobalRoleManagedEntityOpsAction,
     CreateGlobalWithFieldsOpsAction,
     CreateRoleManagedEntityOpsAction,
     DeletePartialBulkOpsAction,
@@ -150,6 +151,7 @@ from ai.backend.manager.services.ops.service import (
     GlobalCreateService,
     GlobalCreateWithFieldsService,
     GlobalPartialBulkPurgeService,
+    GlobalRoleManagedEntityCreateService,
     GlobalSearchService,
     GlobalUpsertService,
     LookupService,
@@ -665,6 +667,20 @@ class ProcessorGroup[TData: EntityData]:
             RoleManagedEntityCreateService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.scope, *monitors),
             validators=(*self._deps.validators.scope, *validators),
+        )
+
+    def global_role_managed_create_ops[TAction: CreateGlobalRoleManagedEntityOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        validators: Sequence[GlobalActionValidator] = (),
+        monitors: Sequence[GlobalActionMonitor] = (),
+    ) -> GlobalActionProcessor[TAction, CreatedEntityOpsResult[TData]]:
+        self._record(action_cls, ActionKind.GLOBAL, ActionGate.PERMISSION, ActionBacking.GENERIC)
+        return GlobalActionProcessor(
+            GlobalRoleManagedEntityCreateService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.global_scope, *monitors),
+            validators=(*self._deps.validators.global_scope, *validators),
         )
 
     def global_atomic_create_ops[TAction: AtomicCreateGlobalEntityOpsAction[Any, Any]](

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -44,6 +44,7 @@ __all__ = (
     "GlobalEntityWithFieldsCreateOpsAction",
     "EntityCreateOpsAction",
     "RoleManagedEntityCreateOpsAction",
+    "GlobalRoleManagedEntityCreateOpsAction",
     "FieldCreateOpsAction",
     "GlobalEntityAtomicCreateOpsAction",
     "EntityAtomicCreateOpsAction",
@@ -72,6 +73,7 @@ __all__ = (
     "CreateGlobalWithFieldsOpsAction",
     "CreateEntityOpsAction",
     "CreateRoleManagedEntityOpsAction",
+    "CreateGlobalRoleManagedEntityOpsAction",
     "CreateFieldOpsAction",
     "AtomicCreateGlobalEntityOpsAction",
     "AtomicCreateEntityOpsAction",
@@ -259,6 +261,16 @@ class EntityWithFieldsCreateOpsAction[TRow: Base, TData, TFieldRow: Base, TField
 class RoleManagedEntityCreateOpsAction[TRow: Base, TData](OpsBackendAction):
     """Carries the role-managed entity insert spec: the entity create plus the
     preset-role provisioning the combined spec declares."""
+
+    @abstractmethod
+    def to_creator(self) -> RoleManagedEntityCreator[TRow, TData]:
+        """Return the insert spec this action executes."""
+        raise NotImplementedError
+
+
+class GlobalRoleManagedEntityCreateOpsAction[TRow: Base, TData](OpsBackendAction):
+    """Carries the role-managed entity insert spec of an entity that goes under no
+    other scope: the row, its preset roles, and no membership to join."""
 
     @abstractmethod
     def to_creator(self) -> RoleManagedEntityCreator[TRow, TData]:
@@ -658,6 +670,21 @@ class CreateRoleManagedEntityOpsAction[TRow: Base, TData](
     BaseScopeAction, RoleManagedEntityCreateOpsAction[TRow, TData], ABC
 ):
     """An insert of one role-managed entity row."""
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+
+class CreateGlobalRoleManagedEntityOpsAction[TRow: Base, TData](
+    BaseGlobalAction, GlobalRoleManagedEntityCreateOpsAction[TRow, TData], ABC
+):
+    """An insert of one role-managed entity row that belongs under no other scope.
+
+    Global-shaped rather than scope-shaped: a top-level entity has no parent scope to
+    target, and the SUPERADMIN gate is what answers for creating one.
+    """
 
     @override
     @classmethod

--- a/src/ai/backend/manager/api/gql_legacy/domain.py
+++ b/src/ai/backend/manager/api/gql_legacy/domain.py
@@ -38,6 +38,7 @@ from ai.backend.manager.models.domain.updaters import DomainSoftDeleteUpdater, D
 from ai.backend.manager.models.minilang import FieldSpecItem, OrderSpecItem
 from ai.backend.manager.models.minilang.ordering import QueryOrderParser
 from ai.backend.manager.models.minilang.queryfilter import QueryFilterParser
+from ai.backend.manager.models.project.creators import ProjectCreator
 from ai.backend.manager.models.rbac import (
     ScopeType,
     SystemScope,
@@ -58,6 +59,7 @@ from ai.backend.manager.services.domain.actions.update_domain_node import (
     UpdateDomainNodeAction,
     UpdateDomainNodeActionResult,
 )
+from ai.backend.manager.services.project.actions.create_project import CreateProjectAction
 from ai.backend.manager.services.resource_group.actions.lookup import LookupResourceGroupAction
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -690,7 +692,7 @@ class DomainInput(graphene.InputObjectType):  # type: ignore[misc]
     )
     integration_id = graphene.String(required=False, default_value=None)
 
-    def to_action(self, domain_name: str, user_info: UserInfo) -> CreateDomainAction:
+    def to_action(self, domain_name: str) -> CreateDomainAction:
         def value_or_none(value: Any) -> Any:
             return value if value is not Undefined else None
 
@@ -706,7 +708,6 @@ class DomainInput(graphene.InputObjectType):  # type: ignore[misc]
                     integration_name=value_or_none(self.integration_id),
                 )
             ),
-            user_info=user_info,
         )
 
 
@@ -775,18 +776,20 @@ class CreateDomain(graphene.Mutation):  # type: ignore[misc]
     ) -> CreateDomain:
         ctx: GraphQueryContext = info.context
 
-        user_info: UserInfo = UserInfo(
-            id=ctx.user["uuid"],
-            role=ctx.user["role"],
-            domain_name=ctx.user["domain_name"],
+        res = await ctx.processors.domain.create_domain.run(props.to_action(name))
+        domain_data = res.data
+        await ctx.processors.project.create_project.run(
+            CreateProjectAction(
+                domain_id=domain_data.id,
+                creator=ProjectCreator.model_store(
+                    domain_id=domain_data.id, domain_name=domain_data.name
+                ),
+            )
         )
-
-        action: CreateDomainAction = props.to_action(name, user_info)
-        res = await ctx.processors.domain.create_domain.run(action)
         return cls(
             ok=True,
             msg="domain creation succeed",
-            domain=Domain.from_data(res.domain_data),
+            domain=Domain.from_data(domain_data),
         )
 
 

--- a/src/ai/backend/manager/api/rest/domain/handler.py
+++ b/src/ai/backend/manager/api/rest/domain/handler.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Final
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.data.entity.domain import DomainName
-from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.domain import (
     CreateDomainRequest,
     CreateDomainResponse,
@@ -31,7 +30,6 @@ from ai.backend.common.dto.manager.domain import (
 )
 from ai.backend.common.types import ResourceSlot
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.domain.types import UserInfo
 from ai.backend.manager.dto.context import UserContext
 from ai.backend.manager.dto.domain_request import (
     GetDomainPathParam,
@@ -39,6 +37,7 @@ from ai.backend.manager.dto.domain_request import (
 )
 from ai.backend.manager.models.domain.creators import DomainCreator
 from ai.backend.manager.models.domain.updaters import DomainSoftDeleteUpdater
+from ai.backend.manager.models.project.creators import ProjectCreator
 from ai.backend.manager.services.domain.actions.create_domain import CreateDomainAction
 from ai.backend.manager.services.domain.actions.delete_domain import DeleteDomainAction
 from ai.backend.manager.services.domain.actions.get import GetDomainAction
@@ -46,11 +45,13 @@ from ai.backend.manager.services.domain.actions.lookup import LookupDomainAction
 from ai.backend.manager.services.domain.actions.purge_domain import PurgeDomainAction
 from ai.backend.manager.services.domain.actions.search_domains import GlobalSearchDomainsAction
 from ai.backend.manager.services.domain.actions.update_domain import UpdateDomainAction
+from ai.backend.manager.services.project.actions.create_project import CreateProjectAction
 
 from .adapter import DomainAdapter
 
 if TYPE_CHECKING:
     from ai.backend.manager.services.domain.processors import DomainProcessors
+    from ai.backend.manager.services.project.processors import ProjectProcessors
 
 log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -58,8 +59,9 @@ log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class DomainHandler:
     """Domain API handler with constructor-injected dependencies."""
 
-    def __init__(self, *, domain: DomainProcessors) -> None:
+    def __init__(self, *, domain: DomainProcessors, project: ProjectProcessors) -> None:
         self._domain = domain
+        self._project = project
         self._adapter = DomainAdapter()
 
     # ------------------------------------------------------------------
@@ -85,17 +87,18 @@ class DomainHandler:
             allowed_docker_registries=body.parsed.allowed_docker_registries,
             integration_name=body.parsed.integration_id,  # v1 DTO uses integration_id
         )
-        user_info = UserInfo(
-            id=ctx.user_uuid,
-            role=UserRole.SUPERADMIN,
-            domain_name=ctx.user_domain,
+        action_result = await self._domain.create_domain.run(CreateDomainAction(creator=creator))
+        domain_data = action_result.data
+        await self._project.create_project.run(
+            CreateProjectAction(
+                domain_id=domain_data.id,
+                creator=ProjectCreator.model_store(
+                    domain_id=domain_data.id, domain_name=domain_data.name
+                ),
+            )
         )
 
-        action_result = await self._domain.create_domain.run(
-            CreateDomainAction(creator=creator, user_info=user_info)
-        )
-
-        resp = CreateDomainResponse(domain=self._adapter.convert_to_dto(action_result.domain_data))
+        resp = CreateDomainResponse(domain=self._adapter.convert_to_dto(domain_data))
         return APIResponse.build(status_code=HTTPStatus.CREATED, response_model=resp)
 
     # ------------------------------------------------------------------

--- a/src/ai/backend/manager/api/rest/tree.py
+++ b/src/ai/backend/manager/api/rest/tree.py
@@ -236,7 +236,7 @@ def build_api_routes(
     vfs_storage_handler = VFSStorageHandler(vfs_storage=processors.vfs_storage)
 
     # Admin sub-registries
-    domain_handler = DomainHandler(domain=processors.domain)
+    domain_handler = DomainHandler(domain=processors.domain, project=processors.project)
     user_handler = UserHandler(
         user=processors.user, domain=processors.domain, config_provider=config_provider
     )

--- a/src/ai/backend/manager/models/domain/creators.py
+++ b/src/ai/backend/manager/models/domain/creators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import ClassVar, override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
 from ai.backend.common.data.entity.types import EntityIdentifier
@@ -30,6 +30,15 @@ class DomainCreator(RoleManagedEntityCreator[DomainRow, DomainData]):
     allowed_docker_registries: list[str] | None = None
     integration_name: str | None = None
     dotfiles: bytes | None = None
+
+    _MAX_NAME_LENGTH: ClassVar[int] = 64
+
+    def __post_init__(self) -> None:
+        candidate = self.name.strip()
+        if candidate == "" or len(candidate) > self._MAX_NAME_LENGTH:
+            raise InvalidAPIParameters(
+                f"Domain name cannot be empty or exceed {self._MAX_NAME_LENGTH} characters."
+            )
 
     @override
     def entity_id(self, row: DomainRow) -> EntityIdentifier:

--- a/src/ai/backend/manager/models/project/creators.py
+++ b/src/ai/backend/manager/models/project/creators.py
@@ -39,6 +39,18 @@ class ProjectCreator(RoleManagedEntityCreator[ProjectRow, ProjectData]):
     container_registry: dict[str, str] | None = None
     dotfiles: bytes | None = None
 
+    @classmethod
+    def model_store(cls, domain_id: DomainID, domain_name: str) -> ProjectCreator:
+        """The model-store project a domain is registered with."""
+        return cls(
+            name="model-store",
+            domain_id=domain_id,
+            domain_name=domain_name,
+            description="Model Store",
+            resource_policy="default",
+            type=ProjectType.MODEL_STORE,
+        )
+
     @override
     def entity_id(self, row: ProjectRow) -> EntityIdentifier:
         return ProjectID(row.id)

--- a/src/ai/backend/manager/repositories/domain/repository.py
+++ b/src/ai/backend/manager/repositories/domain/repository.py
@@ -16,8 +16,6 @@ from ai.backend.manager.errors.resource import DomainDeletionFailed
 from ai.backend.manager.models.domain.creators import DomainCreator
 from ai.backend.manager.models.domain.purgers import DomainKernelPurger, DomainPurger
 from ai.backend.manager.models.domain.updaters import DomainDotfilesUpdater, DomainUpdater
-from ai.backend.manager.models.project.creators import ProjectCreator
-from ai.backend.manager.models.project.row import ProjectType
 from ai.backend.manager.models.resource_group import ResourceGroupForDomainRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.domain.db_source import DomainDBSource
@@ -47,23 +45,6 @@ class DomainRepository:
         self._db = db
         self._db_source = DomainDBSource(db)
         self._v2_ops = v2_ops_provider
-
-    @domain_repository_resilience.apply()
-    async def create_domain(self, creator: DomainCreator) -> DomainData:
-        """Register a domain together with the model-store project every domain has."""
-        async with self._v2_ops.write_ops() as w:
-            data = await w.create_role_managed_entity(creator)
-            await w.create_role_managed_entity(
-                ProjectCreator(
-                    name="model-store",
-                    domain_id=data.id,
-                    domain_name=data.name,
-                    description="Model Store",
-                    resource_policy="default",
-                    type=ProjectType.MODEL_STORE,
-                )
-            )
-            return data
 
     @domain_repository_resilience.apply()
     async def purge_domain(self, domain_id: DomainID, domain_name: str) -> DomainData:

--- a/src/ai/backend/manager/services/domain/README.md
+++ b/src/ai/backend/manager/services/domain/README.md
@@ -70,20 +70,10 @@ Domain nodes provide extended functionality:
 ### Creating a Domain
 
 ```python
-from ai.backend.manager.services.domain.service import DomainService
 from ai.backend.manager.services.domain.actions.create_domain import CreateDomainAction
-from ai.backend.manager.services.domain.types import DomainCreator, UserInfo
-from ai.backend.manager.models.user import UserRole
+from ai.backend.manager.models.domain.creators import DomainCreator
 from ai.backend.common.types import ResourceSlot
 
-# Create user info
-user_info = UserInfo(
-    id=uuid.uuid4(),
-    role=UserRole.SUPERADMIN,
-    domain_name="default"
-)
-
-# Create domain action
 action = CreateDomainAction(
     creator=DomainCreator(
         name="development",
@@ -92,14 +82,16 @@ action = CreateDomainAction(
         total_resource_slots=ResourceSlot({"cpu": 100, "mem": "200g", "cuda.device": 4}),
         allowed_vfolder_hosts={"local": ["rw"], "shared": ["ro"]},
         allowed_docker_registries=["registry.example.com", "docker.io"],
-        integration_id="dev-integration"
+        integration_name="dev-integration",
     ),
-    user_info=user_info
 )
 
-# Execute
-result = await domain_service.create_domain(action)
+result = await processors.domain.create_domain.run(action)
 ```
+
+The action wires straight to the generic role-managed create, so the domain row and its
+preset roles are all it writes. The model-store project is created by the caller as a
+separate `CreateProjectAction`.
 
 ### Modifying a Domain
 
@@ -214,8 +206,8 @@ Uses `DomainRow` from the models layer with the following key fields:
 The service follows the action-based pattern with comprehensive operations:
 
 1. **CreateDomainAction** (src/ai/backend/manager/services/domain/actions/create_domain.py)
-   - Uses `DomainCreator` for input validation
-   - Returns `CreateDomainActionResult` with domain data and status
+   - Carries `DomainCreator`; wired to the generic role-managed create
+   - Returns `CreatedEntityOpsResult[DomainData]`
 
 2. **ModifyDomainAction** (src/ai/backend/manager/services/domain/actions/modify_domain.py)
    - Accepts `DomainModifier` for partial updates

--- a/src/ai/backend/manager/services/domain/actions/create_domain.py
+++ b/src/ai/backend/manager/services/domain/actions/create_domain.py
@@ -3,19 +3,17 @@ from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
-from ai.backend.manager.data.domain.types import DomainData, UserInfo
+from ai.backend.manager.actions.v2.ops.base import CreateGlobalRoleManagedEntityOpsAction
+from ai.backend.manager.data.domain.types import DomainData
 from ai.backend.manager.models.domain.creators import DomainCreator
+from ai.backend.manager.models.domain.row import DomainRow
 
 
 @dataclass(frozen=True)
-class CreateDomainAction(BaseGlobalAction):
-    """Register a domain. The model-store project is created along with it, which is
-    why this does not run straight against ops."""
+class CreateDomainAction(CreateGlobalRoleManagedEntityOpsAction[DomainRow, DomainData]):
+    """Register a domain, the top-level scope everything else is created under."""
 
     creator: DomainCreator
-    user_info: UserInfo
 
     @override
     @classmethod
@@ -24,15 +22,9 @@ class CreateDomainAction(BaseGlobalAction):
 
     @override
     @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.CREATE
-
-    @override
-    @classmethod
     def action_name(cls) -> str:
         return "global_create_domain"
 
-
-@dataclass(frozen=True)
-class CreateDomainActionResult:
-    domain_data: DomainData
+    @override
+    def to_creator(self) -> DomainCreator:
+        return self.creator

--- a/src/ai/backend/manager/services/domain/processors.py
+++ b/src/ai/backend/manager/services/domain/processors.py
@@ -8,6 +8,7 @@ from ai.backend.manager.actions.v2.global_scope.processor import (
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
+    CreatedEntityOpsResult,
     EntityOpsResult,
     LookupOpsResult,
 )
@@ -16,10 +17,7 @@ from ai.backend.manager.actions.v2.single_entity.processor import (
     SingleEntityActionProcessor,
 )
 from ai.backend.manager.data.domain.types import DomainData
-from ai.backend.manager.services.domain.actions.create_domain import (
-    CreateDomainAction,
-    CreateDomainActionResult,
-)
+from ai.backend.manager.services.domain.actions.create_domain import CreateDomainAction
 from ai.backend.manager.services.domain.actions.create_domain_dotfile import (
     CreateDomainDotfileAction,
     CreateDomainDotfileActionResult,
@@ -64,7 +62,7 @@ class DomainProcessors:
     update_domain: SingleEntityActionProcessor[UpdateDomainAction, EntityOpsResult[DomainData]]
     delete_domain: SingleEntityActionProcessor[DeleteDomainAction, EntityOpsResult[DomainData]]
     restore_domain: SingleEntityActionProcessor[RestoreDomainAction, EntityOpsResult[DomainData]]
-    create_domain: GlobalActionProcessor[CreateDomainAction, CreateDomainActionResult]
+    create_domain: GlobalActionProcessor[CreateDomainAction, CreatedEntityOpsResult[DomainData]]
     create_domain_node: GlobalActionProcessor[CreateDomainNodeAction, CreateDomainNodeActionResult]
     update_domain_node: SingleEntityActionProcessor[
         UpdateDomainNodeAction, UpdateDomainNodeActionResult
@@ -93,7 +91,7 @@ class DomainProcessors:
         self.update_domain = group.single_update_ops(UpdateDomainAction)
         self.delete_domain = group.single_delete_ops(DeleteDomainAction)
         self.restore_domain = group.single_restore_ops(RestoreDomainAction)
-        self.create_domain = group.global_scope(CreateDomainAction, service.create_domain)
+        self.create_domain = group.global_role_managed_create_ops(CreateDomainAction)
         self.create_domain_node = group.global_scope(
             CreateDomainNodeAction, service.create_domain_node
         )

--- a/src/ai/backend/manager/services/domain/service.py
+++ b/src/ai/backend/manager/services/domain/service.py
@@ -9,10 +9,6 @@ from ai.backend.manager.data.dotfile.types import DotfileEntries
 from ai.backend.manager.models.domain.row import verify_dotfile_name
 from ai.backend.manager.models.domain.updaters import DomainDotfilesUpdater
 from ai.backend.manager.repositories.domain.repository import DomainRepository
-from ai.backend.manager.services.domain.actions.create_domain import (
-    CreateDomainAction,
-    CreateDomainActionResult,
-)
 from ai.backend.manager.services.domain.actions.create_domain_dotfile import (
     CreateDomainDotfileAction,
     CreateDomainDotfileActionResult,
@@ -40,8 +36,6 @@ from ai.backend.manager.services.domain.actions.update_domain_node import (
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
-_MAXIMUM_DOMAIN_NAME_LENGTH = 64
-
 
 class DomainService:
     _repository: DomainRepository
@@ -49,15 +43,9 @@ class DomainService:
     def __init__(self, repository: DomainRepository) -> None:
         self._repository = repository
 
-    async def create_domain(self, action: CreateDomainAction) -> CreateDomainActionResult:
-        self._validate_name(action.creator.name)
-        domain_data = await self._repository.create_domain(action.creator)
-        return CreateDomainActionResult(domain_data=domain_data)
-
     async def create_domain_node(
         self, action: CreateDomainNodeAction
     ) -> CreateDomainNodeActionResult:
-        self._validate_name(action.creator.name)
         domain_data = await self._repository.create_domain_node(
             action.creator, action.resource_group_ids
         )
@@ -109,13 +97,6 @@ class DomainService:
         entries = current.removed(action.path)
         await self._write_dotfiles(domain_id, entries)
         return DeleteDomainDotfileActionResult(entries=entries.entries)
-
-    def _validate_name(self, name: str) -> None:
-        candidate = name.strip()
-        if candidate == "" or len(candidate) > _MAXIMUM_DOMAIN_NAME_LENGTH:
-            raise InvalidAPIParameters(
-                f"Domain name cannot be empty or exceed {_MAXIMUM_DOMAIN_NAME_LENGTH} characters."
-            )
 
     async def _read_dotfiles(self, name: str) -> tuple[DomainID, DotfileEntries]:
         """The domain's id alongside its entries, so the write keys on the id it read."""

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -51,6 +51,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     GlobalEntityPartialBulkPurgeOpsAction,
     GlobalEntityUpsertOpsAction,
     GlobalEntityWithFieldsCreateOpsAction,
+    GlobalRoleManagedEntityCreateOpsAction,
     GlobalSearchOpsAction,
     LookupOpsAction,
     PartialBulkUpdateOpsAction,
@@ -366,6 +367,22 @@ class RoleManagedEntityCreateService[TData: EntityData]:
 
     async def execute(
         self, action: RoleManagedEntityCreateOpsAction[Any, TData]
+    ) -> CreatedEntityOpsResult[TData]:
+        return CreatedEntityOpsResult(
+            data=await self._repository.create_role_managed_entity(action.to_creator())
+        )
+
+
+class GlobalRoleManagedEntityCreateService[TData: EntityData]:
+    """Inserts the top-level role-managed entity row, preset roles included."""
+
+    _repository: OpsRepository[TData]
+
+    def __init__(self, repository: OpsRepository[TData]) -> None:
+        self._repository = repository
+
+    async def execute(
+        self, action: GlobalRoleManagedEntityCreateOpsAction[Any, TData]
     ) -> CreatedEntityOpsResult[TData]:
         return CreatedEntityOpsResult(
             data=await self._repository.create_role_managed_entity(action.to_creator())

--- a/tests/component/domain/conftest.py
+++ b/tests/component/domain/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
 from ai.backend.common.dto.manager.domain import (
     CreateDomainRequest,
     CreateDomainResponse,
@@ -31,6 +32,7 @@ from ai.backend.manager.repositories.domain.repository import DomainRepository
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.services.domain.processors import DomainProcessors
 from ai.backend.manager.services.domain.service import DomainService
+from ai.backend.manager.services.project.processors import ProjectProcessors
 
 DomainFactory = Callable[..., Coroutine[Any, Any, CreateDomainResponse]]
 
@@ -45,12 +47,21 @@ def domain_processors(
 
 
 @pytest.fixture()
+def project_processors(processor_registry: ProcessorRegistry[Any]) -> ProjectProcessors:
+    """Only the ops-backed create is exercised here, so the service is a stub."""
+    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), MagicMock())
+
+
+@pytest.fixture()
 def server_module_registries(
     route_deps: RouteDeps,
     domain_processors: DomainProcessors,
+    project_processors: ProjectProcessors,
 ) -> list[RouteRegistry]:
     """Load only the modules required for domain-domain tests."""
-    domain_registry = register_domain_routes(DomainHandler(domain=domain_processors), route_deps)
+    domain_registry = register_domain_routes(
+        DomainHandler(domain=domain_processors, project=project_processors), route_deps
+    )
     return [
         register_admin_routes(
             AdminHandler(

--- a/tests/unit/manager/repositories/domain/test_domain_repository.py
+++ b/tests/unit/manager/repositories/domain/test_domain_repository.py
@@ -462,7 +462,7 @@ class TestDomainRepository:
             await session.commit()
         return DomainFixtureData(domain_name=DomainName(domain_name), domain_id=domain_id)
 
-    async def test_create_domain_success(
+    async def test_create_domain_node_success(
         self,
         db_with_default_resource_policies: ExtendedAsyncSAEngine,
         domain_repository: DomainRepository,
@@ -477,7 +477,7 @@ class TestDomainRepository:
             assert result.first() is None
 
         # Create domain
-        created_domain = await domain_repository.create_domain(sample_domain_creator)
+        created_domain = await domain_repository.create_domain_node(sample_domain_creator)
 
         assert created_domain.name == sample_domain_creator.name
         assert created_domain.description == sample_domain_creator.description
@@ -494,22 +494,14 @@ class TestDomainRepository:
             assert domain_row is not None
             assert domain_row.name == sample_domain_creator.name
 
-            # Verify model-store group was created
-            result = await conn.execute(
-                sa.select(groups).where(groups.c.domain_name == sample_domain_creator.name)
-            )
-            group_row = result.first()
-            assert group_row is not None
-            assert group_row.name == "model-store"
-
-    async def test_create_domain_duplicate_name(
+    async def test_create_domain_node_duplicate_name(
         self,
         domain_repository: DomainRepository,
         sample_domain_creator: DomainCreator,
     ) -> None:
         """Test domain creation with duplicate name"""
         # Create domain first
-        await domain_repository.create_domain(sample_domain_creator)
+        await domain_repository.create_domain_node(sample_domain_creator)
 
         # Try to create another domain with same name
         duplicate_creator = DomainCreator(
@@ -519,7 +511,7 @@ class TestDomainRepository:
         )
 
         with pytest.raises(InvalidAPIParameters):
-            await domain_repository.create_domain(duplicate_creator)
+            await domain_repository.create_domain_node(duplicate_creator)
 
     async def test_purge_domain_success(
         self,
@@ -559,7 +551,7 @@ class TestDomainRepository:
         with pytest.raises(DomainDeletionFailed):
             await domain_repository.purge_domain(DomainID(uuid.uuid4()), "nonexistent-domain")
 
-    async def test_create_domain_with_all_fields(
+    async def test_create_domain_node_with_all_fields(
         self,
         db_with_default_resource_policies: ExtendedAsyncSAEngine,
         domain_repository: DomainRepository,
@@ -586,7 +578,7 @@ class TestDomainRepository:
             dotfiles=b"comprehensive dotfiles configuration",
         )
 
-        created_domain = await domain_repository.create_domain(comprehensive_creator)
+        created_domain = await domain_repository.create_domain_node(comprehensive_creator)
 
         assert created_domain.name == "comprehensive-domain"
         assert created_domain.description == "Comprehensive domain with all features"


### PR DESCRIPTION
## Summary
- Wire domain creation to the generic role-managed create ops path, adding a
  global-shaped factory so the SUPERADMIN gate survives the move.
- Split the model-store project out of the domain insert; the REST handler and
  the legacy GraphQL mutation create it as a separate project action.
- Drop `DomainService.create_domain`, `DomainRepository.create_domain` and the
  unused `user_info` field on `CreateDomainAction`.

## Test plan
- [ ] `pants lint check test --changed-since=origin/main --changed-dependents=direct`
- [ ] Create a domain over REST (`POST /admin/domains`) and confirm the domain, its
      preset roles and its model-store project all exist
- [ ] Create a domain over the legacy `create_domain` mutation and confirm the same
- [ ] Confirm a non-superadmin is rejected on both

Resolves BA-7450

🤖 Generated with [Claude Code](https://claude.com/claude-code)