### PR TITLE
refactor(BA-7414): read named ids through a partial bulk path

### DIFF
--- a/changes/13921.enhance.md
+++ b/changes/13921.enhance.md
@@ -1,0 +1,1 @@
+Check permission on each id a GraphQL DataLoader names, instead of on the scope its batch read looked in, and tell an id that matches no row apart from one the caller may not read.

--- a/src/ai/backend/manager/actions/AGENTS.md
+++ b/src/ai/backend/manager/actions/AGENTS.md
@@ -93,11 +93,45 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
   run is recorded as one failure, a `PartialBulk*` base answers per target and the run
   itself succeeds. No base is unmarked.
 - A read carries it on the factory instead, because the base names the operation rather
-  than the fate: `atomic_*` when every target shares the run's outcome. No factory
-  passing an atomic judge is unmarked.
+  than the fate: `atomic_bulk_*` when every target shares the run's outcome.
 - `Bulk` in a name means the bulk shape — the caller named the targets, so each is
   answered for. A many-row write whose target is a single scope, a single owner, or
   the system is not bulk-shaped.
+- A read of several named entities is partial for the same reason a write is: an entity
+  the caller may not read is one failed item, not a failed run. Wire it through
+  `partial_bulk_get_ops`, or `public_partial_bulk_get_ops` where the entity's single get
+  is public and nothing is denied.
+- Every bulk name carries its mark — `partial_bulk` / `atomic_bulk` on the factories,
+  the action bases and the validators alike. Nothing bulk-shaped is unmarked, so
+  neither has to be inferred from a default.
+- A partial shape inherits `BasePartialBulkAction` and re-states itself over the ids
+  that passed, so the operation keeps the one-argument signature every generic service
+  has. An atomic shape stays on `BaseBulkAction`: narrowing all-or-nothing is not it.
+- Reserve atomic for the runs that mean it — a permission definition, anything whose
+  targets must all go through or none. Partial is what a bulk run normally is.
+- `ActionValidators.partial_bulk` answers per entity; `atomic_bulk` refuses the run.
+  A partial shape takes the partial ones — an entity the caller may not reach is one
+  failed item. Only a shape that cannot narrow gates atomically, and it says so.
+- A field row is denied through its owner: the check is per owner, so a denied one
+  takes every row it owns out of the run. Which rows those are is known only after the
+  owner lookup, so that narrowing happens in the processor.
+- A partial run answers with `PartialBulkResult`, one item per entity the caller named
+  and in that order. Fixed rather than per domain: completing and ordering the answer
+  is the processor's job, and it cannot do that for a shape only the domain knows.
+- What a domain has to say per entity goes in the item's value — a session's four
+  termination states are that value, not four lists. A result keyed finer than the
+  entity (a pair, say) is not this shape.
+- The item carries the exception; `BulkEntityResult` carries the audit row's columns.
+  Two readers, two types — do NOT fold them together, and classify a failure only
+  where the run knows which step it came from.
+- The result tells a denial apart from an id matching no row, and an adapter keeps them
+  apart: a miss stays null and a denial is raised at the field that asked for it. The
+  no-leakage rule under Gates covers keys, which a caller can guess; these ids the
+  caller already holds.
+- An item answers in one of four ways, and the two axes are separate: whether the
+  operation ran for that entity (a denied one it never saw), and what came back if it
+  did — a value, nothing, or a failure. `nothing` is not a failure: only the domain
+  knows whether an absent value is the correct answer or a miss.
 
 ## Soft delete
 

--- a/src/ai/backend/manager/actions/registry/field.py
+++ b/src/ai/backend/manager/actions/registry/field.py
@@ -21,12 +21,14 @@ from ai.backend.manager.actions.v2.bulk.processor import (
     AtomicEntityResultJudge,
     BulkActionProcessor,
 )
-from ai.backend.manager.actions.v2.bulk.validator import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.validator import (
+    AtomicBulkActionValidator,
+    PartialBulkActionValidator,
+)
 from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
 from ai.backend.manager.actions.v2.field.bulk_processor import (
-    BulkFieldActionProcessor,
     OwnerBulkLookupProcessor,
-    PartialFieldResultJudge,
+    PartialBulkFieldActionProcessor,
 )
 from ai.backend.manager.actions.v2.field.ops import (
     DeleteFieldOpsAction,
@@ -56,7 +58,6 @@ from ai.backend.manager.actions.v2.ops.base import (
 )
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
-    BulkFieldOpsResult,
     CreatedFieldOpsResult,
     EntityOpsResult,
     FieldsOpsResult,
@@ -156,7 +157,7 @@ class FieldGroup[TFieldData: FieldData]:
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[AtomicBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
     ) -> BulkActionProcessor[TAction, ScopedFieldsOpsResult[TFieldData]]:
         """A page of the field rows owned by the entities the caller named.
@@ -169,14 +170,14 @@ class FieldGroup[TFieldData: FieldData]:
             SearchFieldsService(self._deps.repository).execute,
             AtomicEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            validators=(*self._deps.validators.atomic_bulk, *validators),
         )
 
     def atomic_bulk_get_ops[TAction: BulkGetOwnedFieldOpsAction[Any, Any, Any]](
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[AtomicBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
     ) -> BulkActionProcessor[TAction, OwnedFieldsOpsResult[Any, TFieldData]]:
         """The one row each entity the caller named designates.
@@ -189,7 +190,7 @@ class FieldGroup[TFieldData: FieldData]:
             BulkOwnedFieldGetService(self._deps.repository).execute,
             AtomicEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            validators=(*self._deps.validators.atomic_bulk, *validators),
         )
 
     def global_search_ops[TAction: SearchGlobalOpsAction[Any, Any]](
@@ -389,14 +390,18 @@ class LookupFieldGroup[TFieldData: FieldData](FieldGroup[TFieldData]):
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[PartialBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkFieldActionProcessor[TAction, BulkFieldOpsResult[TFieldData]]:
+    ) -> PartialBulkFieldActionProcessor[TAction, TFieldData]:
+        """Remove the rows the caller named, one permission check per owning entity.
+
+        An owner the caller may not write takes its rows out of the run and puts them
+        back into the answer as denied items.
+        """
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
-        return BulkFieldActionProcessor(
+        return PartialBulkFieldActionProcessor(
             FieldPartialBulkPurgeService(self._deps.repository).execute,
             self._bulk_owner_lookup,
-            PartialFieldResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )

--- a/src/ai/backend/manager/actions/registry/group.py
+++ b/src/ai/backend/manager/actions/registry/group.py
@@ -34,14 +34,24 @@ from ai.backend.manager.actions.types import (
     ActionKind,
     ActionOperationType,
 )
-from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction, BasePartialBulkAction
 from ai.backend.manager.actions.v2.bulk.monitor import BulkActionMonitor
+from ai.backend.manager.actions.v2.bulk.partial_processor import (
+    PartialBulkActionProcessor,
+    PublicPartialBulkActionProcessor,
+)
 from ai.backend.manager.actions.v2.bulk.processor import (
     BulkActionProcessor,
     PartialEntityResultJudge,
 )
-from ai.backend.manager.actions.v2.bulk.result import BasePartialBulkActionResult
-from ai.backend.manager.actions.v2.bulk.validator import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.result import (
+    BasePartialBulkActionResult,
+    PartialBulkResult,
+)
+from ai.backend.manager.actions.v2.bulk.validator import (
+    AtomicBulkActionValidator,
+    PartialBulkActionValidator,
+)
 from ai.backend.manager.actions.v2.field.bulk_base import BaseBulkFieldAction
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.bulk_processor import (
@@ -94,6 +104,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     GetSingleEntityOpsAction,
     LookupEntityOpsAction,
     OperationScopeOpsAction,
+    PartialBulkGetEntityOpsAction,
     PartialBulkPurgeEntityOpsAction,
     PartialBulkPurgeGlobalEntityOpsAction,
     PurgeEntityOpsAction,
@@ -108,7 +119,6 @@ from ai.backend.manager.actions.v2.ops.base import (
 )
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
-    BulkOpsResult,
     CreatedEntityOpsResult,
     CreatedEntityWithFieldsOpsResult,
     EntitiesOpsResult,
@@ -159,6 +169,7 @@ from ai.backend.manager.services.ops.service import (
     GlobalUpsertService,
     LookupService,
     PartialBulkDeleteService,
+    PartialBulkGetService,
     PartialBulkRestoreService,
     PartialBulkUpdateService,
     RestoreService,
@@ -291,20 +302,46 @@ class ProcessorGroup[TData: EntityData]:
             validators=(),
         )
 
-    def bulk[TAction: BaseBulkAction, TResult: BasePartialBulkActionResult](
+    def partial_bulk[TAction: BasePartialBulkAction, TValue](
+        self,
+        action_cls: type[TAction],
+        func: Callable[[TAction], Awaitable[PartialBulkResult[TValue]]],
+        *,
+        atomic_validators: Sequence[AtomicBulkActionValidator] = (),
+        monitors: Sequence[BulkActionMonitor] = (),
+    ) -> PartialBulkActionProcessor[TAction, TValue]:
+        """Several entities read or written by a service, answered for one by one.
+
+        The service answers with the standard result, so the processor is the one that
+        completes and orders it. Gated atomically for now: nothing narrows until the
+        permission check answers per entity.
+        """
+        self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.CUSTOM)
+        return PartialBulkActionProcessor(
+            func,
+            monitors=(*self._deps.monitors.bulk, *monitors),
+            atomic_validators=(*self._deps.validators.atomic_bulk, *atomic_validators),
+        )
+
+    def legacy_partial_bulk[TAction: BaseBulkAction, TResult: BasePartialBulkActionResult](
         self,
         action_cls: type[TAction],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[AtomicBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
     ) -> BulkActionProcessor[TAction, TResult]:
+        """The same, for a service whose answer is keyed finer than the entity.
+
+        Only the idle-check writes are left here: they answer per (session, checker)
+        pair, which the standard result cannot key. Wire nothing new through this.
+        """
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.CUSTOM)
         return BulkActionProcessor(
             func,
             PartialEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            validators=(*self._deps.validators.atomic_bulk, *validators),
         )
 
     def atomic_bulk_field[TAction: BaseBulkFieldAction[Any, Any], TResult](
@@ -313,7 +350,7 @@ class ProcessorGroup[TData: EntityData]:
         bulk_owner_lookup_action_cls: type[LookupBulkFieldOwnerOpsAction[Any, Any]],
         func: Callable[[TAction], Awaitable[TResult]],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[AtomicBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
     ) -> BulkFieldActionProcessor[TAction, TResult]:
         """Several field rows read by a service, answered for by the entities owning them.
@@ -336,14 +373,14 @@ class ProcessorGroup[TData: EntityData]:
         bulk_owner_lookup: OwnerBulkLookupProcessor = BulkLookupActionProcessor(
             BulkFieldOwnerLookupService(self._deps.repository).execute,
             monitors=self._deps.monitors.bulk_lookup,
-            post_validators=self._deps.validators.bulk,
+            post_validators=self._deps.validators.atomic_bulk,
         )
         return BulkFieldActionProcessor(
             func,
             bulk_owner_lookup,
             AtomicFieldResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            validators=(*self._deps.validators.atomic_bulk, *validators),
         )
 
     def public[TAction: BaseGlobalAction, TResult](
@@ -521,7 +558,7 @@ class ProcessorGroup[TData: EntityData]:
         bulk_owner_lookup: OwnerBulkLookupProcessor = BulkLookupActionProcessor(
             BulkFieldOwnerLookupService(self._deps.repository).execute,
             monitors=self._deps.monitors.bulk_lookup,
-            post_validators=self._deps.validators.bulk,
+            post_validators=self._deps.validators.atomic_bulk,
         )
         return LookupFieldGroup(
             self._deps,
@@ -547,6 +584,46 @@ class ProcessorGroup[TData: EntityData]:
             GetService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.single_entity, *monitors),
             validators=(*self._deps.validators.single_entity, *validators),
+        )
+
+    def partial_bulk_get_ops[TAction: PartialBulkGetEntityOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        partial_validators: Sequence[PartialBulkActionValidator] = (),
+        monitors: Sequence[BulkActionMonitor] = (),
+    ) -> PartialBulkActionProcessor[TAction, TData]:
+        """Read the entities the caller named, one permission check per entity.
+
+        Where a search narrowed to a list of ids checks the scope it looked in, this
+        checks each id, and answers for the ones it denied beside the ones that
+        matched no row.
+        """
+        self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
+        return PartialBulkActionProcessor(
+            PartialBulkGetService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.bulk, *monitors),
+            partial_validators=(*self._deps.validators.partial_bulk, *partial_validators),
+        )
+
+    def public_partial_bulk_get_ops[TAction: PartialBulkGetEntityOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        atomic_validators: Sequence[AtomicBulkActionValidator] = (),
+        monitors: Sequence[BulkActionMonitor] = (),
+    ) -> PartialBulkActionProcessor[TAction, TData]:
+        """The same read for entities every authenticated caller may see.
+
+        Wired where the entity's single get is ``public_get_ops``: naming the rows by
+        id costs no permission, so nothing is denied and only misses fail.
+        """
+        self._record(action_cls, ActionKind.BULK, ActionGate.PUBLIC, ActionBacking.GENERIC)
+        return PublicPartialBulkActionProcessor(
+            action_cls,
+            PartialBulkGetService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.bulk, *monitors),
+            atomic_validators=atomic_validators,
         )
 
     def scope_search_ops[TAction: OperationScopeOpsAction[Any, Any]](
@@ -767,30 +844,28 @@ class ProcessorGroup[TData: EntityData]:
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[PartialBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+    ) -> PartialBulkActionProcessor[TAction, TData]:
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
-        return BulkActionProcessor(
+        return PartialBulkActionProcessor(
             GlobalPartialBulkPurgeService(self._deps.repository).execute,
-            PartialEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )
 
     def entity_partial_bulk_purge_ops[TAction: PartialBulkPurgeEntityOpsAction[Any, Any]](
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[PartialBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+    ) -> PartialBulkActionProcessor[TAction, TData]:
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
-        return BulkActionProcessor(
+        return PartialBulkActionProcessor(
             EntityPartialBulkPurgeService(self._deps.repository).execute,
-            PartialEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )
 
     def global_upsert_ops[TAction: UpsertGlobalOpsAction[Any, Any]](
@@ -917,45 +992,42 @@ class ProcessorGroup[TData: EntityData]:
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[PartialBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+    ) -> PartialBulkActionProcessor[TAction, TData]:
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
-        return BulkActionProcessor(
+        return PartialBulkActionProcessor(
             PartialBulkUpdateService(self._deps.repository).execute,
-            PartialEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )
 
     def partial_bulk_delete_ops[TAction: DeletePartialBulkOpsAction[Any, Any]](
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[PartialBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+    ) -> PartialBulkActionProcessor[TAction, TData]:
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
-        return BulkActionProcessor(
+        return PartialBulkActionProcessor(
             PartialBulkDeleteService(self._deps.repository).execute,
-            PartialEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )
 
     def partial_bulk_restore_ops[TAction: RestorePartialBulkOpsAction[Any, Any]](
         self,
         action_cls: type[TAction],
         *,
-        validators: Sequence[BulkActionValidator] = (),
+        validators: Sequence[PartialBulkActionValidator] = (),
         monitors: Sequence[BulkActionMonitor] = (),
-    ) -> BulkActionProcessor[TAction, BulkOpsResult[TData]]:
+    ) -> PartialBulkActionProcessor[TAction, TData]:
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
-        return BulkActionProcessor(
+        return PartialBulkActionProcessor(
             PartialBulkRestoreService(self._deps.repository).execute,
-            PartialEntityResultJudge(),
             monitors=(*self._deps.monitors.bulk, *monitors),
-            validators=(*self._deps.validators.bulk, *validators),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )
 
     def scope_batch_update_ops[TAction: BatchUpdateScopeOpsAction[Any, Any]](

--- a/src/ai/backend/manager/actions/v2/bulk/__init__.py
+++ b/src/ai/backend/manager/actions/v2/bulk/__init__.py
@@ -9,7 +9,7 @@ from .result import (
     BulkActionResultMeta,
     BulkEntityResult,
 )
-from .validator import BulkActionValidator
+from .validator import AtomicBulkActionValidator
 
 __all__ = (
     "BaseBulkAction",
@@ -19,5 +19,5 @@ __all__ = (
     "BulkActionProcessor",
     "BulkActionProcessResult",
     "BulkActionResultMeta",
-    "BulkActionValidator",
+    "AtomicBulkActionValidator",
 )

--- a/src/ai/backend/manager/actions/v2/bulk/base.py
+++ b/src/ai/backend/manager/actions/v2/bulk/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import Self
 
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
@@ -28,4 +29,18 @@ class BaseBulkAction(ABC):
 
         Each names its own type, so one run may reach several kinds at once.
         """
+        raise NotImplementedError
+
+
+class BasePartialBulkAction(BaseBulkAction, ABC):
+    """A bulk action whose entities do not share one fate.
+
+    Re-states itself over a subset, which is what lets the run go ahead without the
+    entities the caller was denied. An atomic shape stays on :class:`BaseBulkAction`:
+    narrowing one would turn all-or-nothing into something else.
+    """
+
+    @abstractmethod
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        """Return the same action over ``entity_ids``, a subset of what it named."""
         raise NotImplementedError

--- a/src/ai/backend/manager/actions/v2/bulk/partial_processor.py
+++ b/src/ai/backend/manager/actions/v2/bulk/partial_processor.py
@@ -1,0 +1,233 @@
+import logging
+import uuid
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from typing import override
+
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.exception import UnreachableError
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.run_status import ActionRunStatus
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
+from ai.backend.manager.actions.v2.bulk.monitor import BulkActionMonitor
+from ai.backend.manager.actions.v2.bulk.result import (
+    BulkActionProcessResult,
+    BulkActionResultMeta,
+    BulkEntityResult,
+    PartialBulkEntityResult,
+    PartialBulkResult,
+)
+from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
+from ai.backend.manager.actions.v2.bulk.validator import (
+    AtomicBulkActionValidator,
+    AuthenticatedAtomicBulkActionValidator,
+    PartialBulkActionValidator,
+)
+from ai.backend.manager.errors.common import ServerMisconfiguredError
+
+__all__ = (
+    "PartialBulkActionProcessor",
+    "PublicPartialBulkActionProcessor",
+)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+type PartialBulkFunc[TAction, TData] = Callable[[TAction], Awaitable[PartialBulkResult[TData]]]
+
+
+class PartialBulkActionProcessor[TAction: BasePartialBulkAction, TData]:
+    """Run a bulk action over the entities the caller may reach, and fail the rest.
+
+    Unlike :class:`BulkActionProcessor`, a denied entity does not sink the run: the
+    validators say which entities are denied, the operation runs against the others,
+    and both kinds of failure reach the caller in one result. The atomic validators
+    beside them still refuse the run as a whole — the public path's gate is one.
+
+    The operation is run against the action narrowed to those others, so what the
+    caller was denied is never queried and the operation keeps the one-argument
+    signature every other generic service has.
+
+    Completing the answer is this class's job, not the operation's: it holds the ids
+    the caller named, so it is the only place that can put the denials back beside
+    what was read and hand the whole thing back in the order it was asked for.
+    """
+
+    _func: PartialBulkFunc[TAction, TData]
+    _monitors: Sequence[BulkActionMonitor]
+    _atomic_validators: Sequence[AtomicBulkActionValidator]
+    _partial_validators: Sequence[PartialBulkActionValidator]
+
+    def __init__(
+        self,
+        func: PartialBulkFunc[TAction, TData],
+        monitors: Sequence[BulkActionMonitor] | None = None,
+        atomic_validators: Sequence[AtomicBulkActionValidator] | None = None,
+        partial_validators: Sequence[PartialBulkActionValidator] | None = None,
+    ) -> None:
+        self._func = func
+        self._monitors = monitors or []
+        self._atomic_validators = atomic_validators or []
+        self._partial_validators = partial_validators or []
+
+    async def _prepare_monitors(self, trigger_meta: BulkActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(
+        self, trigger_meta: BulkActionTriggerMeta, meta: BulkActionResultMeta
+    ) -> None:
+        process_result = BulkActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(trigger_meta, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> PartialBulkResult[TData]:
+        started_at = datetime.now(UTC)
+        action_id = uuid.uuid4()
+        trigger_meta = BulkActionTriggerMeta(
+            action_id=action_id,
+            started_at=started_at,
+            entity_ids=action.entity_ids(),
+            operation_type=action.operation_type(),
+            action_name=action.action_name(),
+        )
+
+        entity_results: Sequence[BulkEntityResult] = []
+
+        # Validation runs inside the monitor lifecycle so a rejected action is
+        # recorded too; monitors that only wrapped execution missed every denial.
+        await self._prepare_monitors(trigger_meta)
+        try:
+            denied: dict[EntityIdentifier, Exception] = {}
+            try:
+                for atomic_validator in self._atomic_validators:
+                    await atomic_validator.validate(trigger_meta)
+                for partial_validator in self._partial_validators:
+                    denied.update(await partial_validator.validate(trigger_meta))
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=True)
+                entity_results = self._same_result_for_every_entity(trigger_meta, run_status)
+                raise
+            allowed = [
+                entity_id for entity_id in trigger_meta.entity_ids if entity_id not in denied
+            ]
+            try:
+                result = await self._func(action.narrowed_to(allowed))
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=False)
+                entity_results = self._same_result_for_every_entity(trigger_meta, run_status)
+                raise
+            else:
+                answer = self._complete(trigger_meta, result, denied)
+                entity_results = [self._recorded(item) for item in answer.items]
+                return answer
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = BulkActionResultMeta(
+                action_id=action_id,
+                entity_results=entity_results,
+                started_at=started_at,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+            )
+            await self._finalize_monitors(trigger_meta, meta)
+
+    def _complete(
+        self,
+        trigger_meta: BulkActionTriggerMeta,
+        result: PartialBulkResult[TData],
+        denied: Mapping[EntityIdentifier, Exception],
+    ) -> PartialBulkResult[TData]:
+        """Put the denials back beside what was read, in the order the caller asked.
+
+        An id the operation did not answer for and was not denied is a broken
+        contract, so it is reported as one rather than dropped.
+        """
+        answered = {item.entity_id: item for item in result.items}
+        items = []
+        for entity_id in trigger_meta.entity_ids:
+            denial = denied.get(entity_id)
+            if denial is not None:
+                items.append(PartialBulkEntityResult[TData].denied(entity_id, denial))
+                continue
+            item = answered.get(entity_id)
+            if item is None:
+                item = PartialBulkEntityResult[TData].failed(
+                    entity_id,
+                    UnreachableError(f"{trigger_meta.action_name} did not answer for {entity_id}"),
+                )
+            items.append(item)
+        return PartialBulkResult(items=items)
+
+    def _recorded(self, item: PartialBulkEntityResult[TData]) -> BulkEntityResult:
+        """Turn one answer into the audit row's columns.
+
+        The one place the classification runs: a denial is DENIED because it came
+        from a validator, and every other failure is an ordinary error.
+        """
+        if item.error is None:
+            run_status = ActionRunStatus.success()
+        else:
+            run_status = ActionRunStatus.of_failure(
+                item.error, during_validation=item.during_validation
+            )
+        return BulkEntityResult(
+            entity_id=item.entity_id,
+            status=run_status.status,
+            description=item.description or run_status.description,
+            error_code=run_status.error_code,
+        )
+
+    def _same_result_for_every_entity(
+        self, trigger_meta: BulkActionTriggerMeta, run_status: ActionRunStatus
+    ) -> Sequence[BulkEntityResult]:
+        """Attribute a whole-run failure to every entity the caller named."""
+        return [
+            BulkEntityResult(
+                entity_id=entity_id,
+                status=run_status.status,
+                description=run_status.description,
+                error_code=run_status.error_code,
+            )
+            for entity_id in trigger_meta.entity_ids
+        ]
+
+
+class PublicPartialBulkActionProcessor[TAction: BasePartialBulkAction, TData](
+    PartialBulkActionProcessor[TAction, TData]
+):
+    """Validate authentication only, then read every entity the caller named.
+
+    The shape stays bulk, so each entity still gets its own audit row; only the RBAC
+    validators are left off, which leaves nothing to deny. The constructor rejects
+    writes.
+    """
+
+    @override
+    def __init__(
+        self,
+        action_cls: type[TAction],
+        func: PartialBulkFunc[TAction, TData],
+        monitors: Sequence[BulkActionMonitor] | None = None,
+        atomic_validators: Sequence[AtomicBulkActionValidator] | None = None,
+    ) -> None:
+        operation_type = action_cls.operation_type()
+        if operation_type not in ActionOperationType.read_operations():
+            raise ServerMisconfiguredError(
+                f"{action_cls.__name__} declares operation_type()={operation_type}, "
+                "but the public path only accepts read actions."
+            )
+        super().__init__(
+            func,
+            monitors=monitors,
+            atomic_validators=[
+                AuthenticatedAtomicBulkActionValidator(),
+                *(atomic_validators or []),
+            ],
+        )

--- a/src/ai/backend/manager/actions/v2/bulk/processor.py
+++ b/src/ai/backend/manager/actions/v2/bulk/processor.py
@@ -17,7 +17,7 @@ from ai.backend.manager.actions.v2.bulk.result import (
     BulkEntityResult,
 )
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
-from ai.backend.manager.actions.v2.bulk.validator import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.validator import AtomicBulkActionValidator
 
 __all__ = ("BulkActionProcessor",)
 
@@ -79,14 +79,14 @@ class BulkActionProcessor[TAction: BaseBulkAction, TResult]:
     _func: Callable[[TAction], Awaitable[TResult]]
     _judge: EntityResultJudge[TResult]
     _monitors: Sequence[BulkActionMonitor]
-    _validators: Sequence[BulkActionValidator]
+    _validators: Sequence[AtomicBulkActionValidator]
 
     def __init__(
         self,
         func: Callable[[TAction], Awaitable[TResult]],
         judge: EntityResultJudge[TResult],
         monitors: Sequence[BulkActionMonitor] | None = None,
-        validators: Sequence[BulkActionValidator] | None = None,
+        validators: Sequence[AtomicBulkActionValidator] | None = None,
     ) -> None:
         self._func = func
         self._judge = judge

--- a/src/ai/backend/manager/actions/v2/bulk/result.py
+++ b/src/ai/backend/manager/actions/v2/bulk/result.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Self
 
 from ai.backend.common.data.entity.action import ActionID
 from ai.backend.common.data.entity.types import EntityIdentifier
@@ -13,6 +14,8 @@ __all__ = (
     "BasePartialBulkActionResult",
     "BulkActionResultMeta",
     "BulkActionProcessResult",
+    "PartialBulkEntityResult",
+    "PartialBulkResult",
 )
 
 
@@ -42,6 +45,82 @@ class BasePartialBulkActionResult(ABC):
         through and ERROR for the rest.
         """
         raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class PartialBulkEntityResult[TData]:
+    """What became of one entity of a partial bulk run, as the caller is told it.
+
+    Carries the exception, unlike :class:`BulkEntityResult`, which carries the audit
+    row's columns. The two readers want different things: the trail wants a status
+    and a code, the caller wants the error to raise or report.
+    """
+
+    entity_id: EntityIdentifier
+    value: TData | None
+    error: Exception | None
+    description: str = ""
+    during_validation: bool = False
+
+    @property
+    def is_denied(self) -> bool:
+        """Whether the caller was refused this entity rather than the operation failing.
+
+        Reads the step the error came from, which is the only thing that tells the two
+        apart: both carry an exception and neither carries a value.
+        """
+        return self.error is not None and self.during_validation
+
+    @classmethod
+    def succeeded(cls, entity_id: EntityIdentifier, value: TData, description: str = "") -> Self:
+        """``description`` says what the value was, for the audit row.
+
+        Carried rather than read off the value: what a domain's value means is the
+        domain's to say, and nothing above it can read one it does not know.
+        """
+        return cls(entity_id=entity_id, value=value, error=None, description=description)
+
+    @classmethod
+    def nothing(cls, entity_id: EntityIdentifier, description: str = "") -> Self:
+        """The operation answered for this entity and there was nothing to report.
+
+        Not a failure: a read whose subject legitimately holds no value says so this
+        way, while an id naming no row at all is a :meth:`failed` one.
+        """
+        return cls(entity_id=entity_id, value=None, error=None, description=description)
+
+    @classmethod
+    def failed(cls, entity_id: EntityIdentifier, error: Exception) -> Self:
+        """The operation answered for this entity and could not deliver it."""
+        return cls(entity_id=entity_id, value=None, error=error)
+
+    @classmethod
+    def denied(cls, entity_id: EntityIdentifier, error: Exception) -> Self:
+        """Validation removed this entity, so the operation never saw it.
+
+        Kept apart from :meth:`failed` because a denial is what the audit trail
+        records as DENIED, and only the step it happened in can say so.
+        """
+        return cls(entity_id=entity_id, value=None, error=error, during_validation=True)
+
+
+@dataclass(frozen=True)
+class PartialBulkResult[TData]:
+    """One answer per entity the caller named, in the order they named them.
+
+    Fixed rather than per domain: the processor completes and orders it, which it
+    could not do for a result whose shape only the domain knows.
+    """
+
+    items: Sequence[PartialBulkEntityResult[TData]]
+
+    def values(self) -> Mapping[EntityIdentifier, TData]:
+        """The entities that were delivered."""
+        return {item.entity_id: item.value for item in self.items if item.value is not None}
+
+    def errors(self) -> Mapping[EntityIdentifier, Exception]:
+        """The entities that were not, the denied ones among them."""
+        return {item.entity_id: item.error for item in self.items if item.error is not None}
 
 
 @dataclass

--- a/src/ai/backend/manager/actions/v2/bulk/validator/__init__.py
+++ b/src/ai/backend/manager/actions/v2/bulk/validator/__init__.py
@@ -1,3 +1,8 @@
-from .base import BulkActionValidator
+from .authenticated import AuthenticatedAtomicBulkActionValidator
+from .base import AtomicBulkActionValidator, PartialBulkActionValidator
 
-__all__ = ("BulkActionValidator",)
+__all__ = (
+    "AuthenticatedAtomicBulkActionValidator",
+    "AtomicBulkActionValidator",
+    "PartialBulkActionValidator",
+)

--- a/src/ai/backend/manager/actions/v2/bulk/validator/authenticated.py
+++ b/src/ai/backend/manager/actions/v2/bulk/validator/authenticated.py
@@ -1,0 +1,25 @@
+from typing import override
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
+from ai.backend.manager.actions.v2.bulk.validator.base import AtomicBulkActionValidator
+from ai.backend.manager.errors.common import GenericForbidden
+from ai.backend.manager.errors.user import UserNotFound
+
+__all__ = ("AuthenticatedAtomicBulkActionValidator",)
+
+
+class AuthenticatedAtomicBulkActionValidator(AtomicBulkActionValidator):
+    """The sole gate of the public bulk read path: the caller must be authenticated.
+
+    Mirrors the single-entity validator of the same name; the entities are ones every
+    authenticated user may read, so naming them by id costs no permission.
+    """
+
+    @override
+    async def validate(self, meta: BulkActionTriggerMeta) -> None:
+        user = current_user()
+        if user is None:
+            raise UserNotFound("User not found in context")
+        if not user.is_authorized:
+            raise GenericForbidden("Only authorized requests are allowed to perform this action")

--- a/src/ai/backend/manager/actions/v2/bulk/validator/base.py
+++ b/src/ai/backend/manager/actions/v2/bulk/validator/base.py
@@ -1,17 +1,32 @@
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
 
-__all__ = ("BulkActionValidator",)
+__all__ = ("AtomicBulkActionValidator", "PartialBulkActionValidator")
 
 
-class BulkActionValidator(ABC):
-    """Validates a bulk action before execution.
+class AtomicBulkActionValidator(ABC):
+    """Refuses a bulk action as a whole, by raising.
 
-    Bound to the self-contained :class:`BaseBulkAction` (pure ABC), so this
-    contract stays independent of the legacy ``BaseAction`` hierarchy.
+    Marked atomic because the run stands or falls as one; the unmarked
+    :class:`PartialBulkActionValidator` is the per-entity default. Bound to the
+    self-contained :class:`BaseBulkAction`, so neither leans on the legacy bases.
     """
 
     @abstractmethod
     async def validate(self, meta: BulkActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the validate method")
+
+
+class PartialBulkActionValidator(ABC):
+    """Says which of the named entities the caller may not reach, and why.
+
+    Answers with the denials rather than raising one: a bulk run answers for every
+    entity it was given, so a denial is one failed item, not a failed run.
+    """
+
+    @abstractmethod
+    async def validate(self, meta: BulkActionTriggerMeta) -> Mapping[EntityIdentifier, Exception]:
         raise NotImplementedError("Subclasses must implement the validate method")

--- a/src/ai/backend/manager/actions/v2/bulk/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/bulk/validator/rbac.py
@@ -1,10 +1,15 @@
+from collections.abc import Mapping, Sequence
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
-from ai.backend.manager.actions.v2.bulk.validator.base import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.validator.base import (
+    AtomicBulkActionValidator,
+    PartialBulkActionValidator,
+)
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.virtual_scope import EntityPermissionCheckKey
 from ai.backend.manager.errors.permission import NotEnoughPermission
@@ -13,11 +18,11 @@ from ai.backend.manager.repositories.permission_controller.repository import (
 )
 
 
-class VirtualScopeBulkActionRBACValidator(BulkActionValidator):
-    """Bulk RBAC validator resolving permissions via the virtual-scope chain.
+class VirtualScopeBulkPermissionCheck:
+    """Which of a run's named entities the caller lacks the run's permission on.
 
-    One bulk check across all target entities; the action is rejected as a
-    whole if any target lacks the required permission.
+    The check itself, kept apart from what a shape does with the answer: one shape
+    refuses the whole run, the other carries the denials into its result.
     """
 
     _repository: PermissionControllerRepository
@@ -31,16 +36,15 @@ class VirtualScopeBulkActionRBACValidator(BulkActionValidator):
         self._repository = repository
         self._config_provider = config_provider
 
-    @override
-    async def validate(self, meta: BulkActionTriggerMeta) -> None:
+    async def denied(self, meta: BulkActionTriggerMeta) -> Sequence[EntityIdentifier]:
         if not self._config_provider.config.manager.rbac.enforcement_enabled:
-            return
+            return ()
 
         user = current_user()
         if user is None:
             raise UnreachableError("User context is not available")
         if user.is_superadmin:
-            return
+            return ()
 
         keys = [
             EntityPermissionCheckKey(
@@ -53,8 +57,55 @@ class VirtualScopeBulkActionRBACValidator(BulkActionValidator):
         permission_map = await self._repository.check_bulk_permission_via_virtual_scope(
             keys, permission
         )
-        denied = [key.entity for key in keys if not permission_map.get(key, False)]
+        return [key.entity for key in keys if not permission_map.get(key, False)]
+
+
+class VirtualScopeAtomicBulkActionRBACValidator(AtomicBulkActionValidator):
+    """The check applied to the run: one target lacking the permission rejects it all.
+
+    For the per-entity answer see :class:`VirtualScopePartialBulkActionRBACValidator`; both
+    ask the same question of the virtual-scope chain.
+    """
+
+    _check: VirtualScopeBulkPermissionCheck
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
+    ) -> None:
+        self._check = VirtualScopeBulkPermissionCheck(repository, config_provider)
+
+    @override
+    async def validate(self, meta: BulkActionTriggerMeta) -> None:
+        denied = await self._check.denied(meta)
         if denied:
             raise NotEnoughPermission(
-                f"User {user.user_id} lacks permission {permission!r} on entities {denied}"
+                f"The caller lacks the permission this run asks for on entities {list(denied)}"
             )
+
+
+class VirtualScopePartialBulkActionRBACValidator(PartialBulkActionValidator):
+    """The check answered per entity, so the run keeps going without the denied ones.
+
+    A denied entity becomes one failed item of the result, told apart from an id that
+    matched no row by the error it carries.
+    """
+
+    _check: VirtualScopeBulkPermissionCheck
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
+    ) -> None:
+        self._check = VirtualScopeBulkPermissionCheck(repository, config_provider)
+
+    @override
+    async def validate(self, meta: BulkActionTriggerMeta) -> Mapping[EntityIdentifier, Exception]:
+        return {
+            entity_id: NotEnoughPermission(
+                f"The caller lacks the permission this run asks for on entity {entity_id}"
+            )
+            for entity_id in await self._check.denied(meta)
+        }

--- a/src/ai/backend/manager/actions/v2/field/bulk_base.py
+++ b/src/ai/backend/manager/actions/v2/field/bulk_base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from typing import Self
 
 from ai.backend.common.data.entity.types import EntityIdentifier, FieldIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
@@ -35,4 +36,19 @@ class BaseBulkFieldAction[TFieldID: FieldIdentifier, TOwnerID: EntityIdentifier]
     @abstractmethod
     def to_owner_lookup_action(self) -> LookupBulkFieldOwnerOpsAction[TFieldID, TOwnerID]:
         """Return the lookup that reads the entity owning each row."""
+        raise NotImplementedError
+
+
+class BasePartialBulkFieldAction[TFieldID: FieldIdentifier, TOwnerID: EntityIdentifier](
+    BaseBulkFieldAction[TFieldID, TOwnerID], ABC
+):
+    """A bulk field action whose rows do not share one fate.
+
+    Re-states itself over a subset, the way :class:`BasePartialBulkAction` does, so a
+    row whose owner the caller was denied can be left out of the run.
+    """
+
+    @abstractmethod
+    def narrowed_to(self, field_ids: Sequence[TFieldID]) -> Self:
+        """Return the same action over ``field_ids``, a subset of what it named."""
         raise NotImplementedError

--- a/src/ai/backend/manager/actions/v2/field/bulk_processor.py
+++ b/src/ai/backend/manager/actions/v2/field/bulk_processor.py
@@ -16,8 +16,14 @@ from ai.backend.manager.actions.v2.bulk.result import (
     BulkEntityResult,
 )
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
-from ai.backend.manager.actions.v2.bulk.validator import BulkActionValidator
-from ai.backend.manager.actions.v2.field.bulk_base import BaseBulkFieldAction
+from ai.backend.manager.actions.v2.bulk.validator import (
+    AtomicBulkActionValidator,
+    PartialBulkActionValidator,
+)
+from ai.backend.manager.actions.v2.field.bulk_base import (
+    BaseBulkFieldAction,
+    BasePartialBulkFieldAction,
+)
 from ai.backend.manager.actions.v2.field.bulk_lookup import (
     BulkFieldOwnerLookupOpsResult,
     LookupBulkFieldOwnerOpsAction,
@@ -30,6 +36,7 @@ __all__ = (
     "AtomicFieldResultJudge",
     "BulkFieldActionProcessor",
     "FieldResultJudge",
+    "PartialBulkFieldActionProcessor",
     "PartialFieldResultJudge",
 )
 
@@ -127,7 +134,7 @@ class BulkFieldActionProcessor[TAction: BaseBulkFieldAction[Any, Any], TResult]:
     _owner_lookup: OwnerBulkLookupProcessor
     _judge: FieldResultJudge[TResult]
     _monitors: Sequence[BulkActionMonitor]
-    _validators: Sequence[BulkActionValidator]
+    _validators: Sequence[AtomicBulkActionValidator]
 
     def __init__(
         self,
@@ -135,7 +142,7 @@ class BulkFieldActionProcessor[TAction: BaseBulkFieldAction[Any, Any], TResult]:
         owner_lookup: OwnerBulkLookupProcessor,
         judge: FieldResultJudge[TResult],
         monitors: Sequence[BulkActionMonitor] | None = None,
-        validators: Sequence[BulkActionValidator] | None = None,
+        validators: Sequence[AtomicBulkActionValidator] | None = None,
     ) -> None:
         self._func = func
         self._owner_lookup = owner_lookup
@@ -223,3 +230,147 @@ class BulkFieldActionProcessor[TAction: BaseBulkFieldAction[Any, Any], TResult]:
                 duration=ended_at - started_at,
             )
             await self._finalize_monitors(trigger_meta, meta)
+
+
+class PartialBulkFieldActionProcessor[TAction: BasePartialBulkFieldAction[Any, Any], TData]:
+    """Read the owners of every row named, then run over the ones the caller may reach.
+
+    The check is per owner and the answer is per row, so a denied owner takes every
+    row it owns out of the run and puts them back into the result as failed items.
+    Which rows those are is only knowable after the owner lookup, which is why the
+    narrowing happens here rather than before the run.
+    """
+
+    _func: Callable[[TAction], Awaitable[BulkFieldOpsResult[TData]]]
+    _owner_lookup: OwnerBulkLookupProcessor
+    _judge: FieldResultJudge[BulkFieldOpsResult[TData]]
+    _monitors: Sequence[BulkActionMonitor]
+    _atomic_validators: Sequence[AtomicBulkActionValidator]
+    _partial_validators: Sequence[PartialBulkActionValidator]
+
+    def __init__(
+        self,
+        func: Callable[[TAction], Awaitable[BulkFieldOpsResult[TData]]],
+        owner_lookup: OwnerBulkLookupProcessor,
+        monitors: Sequence[BulkActionMonitor] | None = None,
+        atomic_validators: Sequence[AtomicBulkActionValidator] | None = None,
+        partial_validators: Sequence[PartialBulkActionValidator] | None = None,
+    ) -> None:
+        self._func = func
+        self._owner_lookup = owner_lookup
+        self._judge = PartialFieldResultJudge()
+        self._monitors = monitors or []
+        self._atomic_validators = atomic_validators or []
+        self._partial_validators = partial_validators or []
+
+    async def _prepare_monitors(self, trigger_meta: BulkActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(
+        self, trigger_meta: BulkActionTriggerMeta, meta: BulkActionResultMeta
+    ) -> None:
+        process_result = BulkActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(trigger_meta, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> BulkFieldOpsResult[TData]:
+        lookup_result = await self._owner_lookup.run(action.to_owner_lookup_action())
+        owners = lookup_result.owners
+        if not owners:
+            raise EntityNotFoundError("No field row matches the given ids")
+
+        started_at = datetime.now(UTC)
+        action_id = uuid.uuid4()
+        distinct = list(dict.fromkeys(owners.values()))
+        trigger_meta = BulkActionTriggerMeta(
+            action_id=action_id,
+            started_at=started_at,
+            entity_ids=distinct,
+            operation_type=action.operation_type(),
+            action_name=action.action_name(),
+        )
+
+        entity_results: Sequence[BulkEntityResult] = []
+
+        await self._prepare_monitors(trigger_meta)
+        try:
+            denied_owners: dict[EntityIdentifier, Exception] = {}
+            try:
+                for atomic_validator in self._atomic_validators:
+                    await atomic_validator.validate(trigger_meta)
+                for partial_validator in self._partial_validators:
+                    denied_owners.update(await partial_validator.validate(trigger_meta))
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=True)
+                entity_results = self._same_result_for_every_owner(distinct, run_status)
+                raise
+            denied_rows = {
+                field_id: denied_owners[owner]
+                for field_id, owner in owners.items()
+                if owner in denied_owners
+            }
+            allowed = [field_id for field_id in action.field_ids() if field_id not in denied_rows]
+            try:
+                result = await self._func(action.narrowed_to(allowed))
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=False)
+                entity_results = self._same_result_for_every_owner(distinct, run_status)
+                raise
+            else:
+                entity_results = [
+                    *self._judge.judge(result, owners),
+                    *self._denied_row_results(denied_rows, owners),
+                ]
+                return BulkFieldOpsResult(
+                    successes=result.successes,
+                    errors={**result.errors, **denied_rows},
+                )
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = BulkActionResultMeta(
+                action_id=action_id,
+                entity_results=entity_results,
+                started_at=started_at,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+            )
+            await self._finalize_monitors(trigger_meta, meta)
+
+    def _denied_row_results(
+        self,
+        denied_rows: Mapping[FieldIdentifier, Exception],
+        owners: Mapping[FieldIdentifier, EntityIdentifier],
+    ) -> Sequence[BulkEntityResult]:
+        """Record a denial as DENIED, naming the owner that answered for the row."""
+        results = []
+        for field_id, exception in denied_rows.items():
+            run_status = ActionRunStatus.of_failure(exception, during_validation=True)
+            results.append(
+                BulkEntityResult(
+                    entity_id=owners[field_id],
+                    status=run_status.status,
+                    description=f"{run_status.description} ({field_id})",
+                    error_code=run_status.error_code,
+                )
+            )
+        return results
+
+    def _same_result_for_every_owner(
+        self, owners: Sequence[EntityIdentifier], run_status: ActionRunStatus
+    ) -> Sequence[BulkEntityResult]:
+        return [
+            BulkEntityResult(
+                entity_id=entity_id,
+                status=run_status.status,
+                description=run_status.description,
+                error_code=run_status.error_code,
+            )
+            for entity_id in owners
+        ]

--- a/src/ai/backend/manager/actions/v2/field/ops.py
+++ b/src/ai/backend/manager/actions/v2/field/ops.py
@@ -7,7 +7,7 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, FieldData, FieldIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
-from ai.backend.manager.actions.v2.field.bulk_base import BaseBulkFieldAction
+from ai.backend.manager.actions.v2.field.bulk_base import BasePartialBulkFieldAction
 from ai.backend.manager.actions.v2.ops.base import (
     FieldGetOpsAction,
     FieldPartialBulkPurgeOpsAction,
@@ -102,7 +102,7 @@ class PartialBulkPurgeFieldOpsAction[
     TRow: Base,
     TData: FieldData,
 ](
-    BaseBulkFieldAction[TFieldID, TOwnerID],
+    BasePartialBulkFieldAction[TFieldID, TOwnerID],
     FieldPartialBulkPurgeOpsAction[TFieldID, TRow, TData],
     ABC,
 ):

--- a/src/ai/backend/manager/actions/v2/lookup/bulk_processor.py
+++ b/src/ai/backend/manager/actions/v2/lookup/bulk_processor.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.run_status import ActionRunStatus
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
-from ai.backend.manager.actions.v2.bulk.validator import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.validator import AtomicBulkActionValidator
 from ai.backend.manager.actions.v2.lookup.bulk_base import (
     BaseBulkLookupAction,
     BaseBulkLookupActionResult,
@@ -43,14 +43,14 @@ class BulkLookupActionProcessor[TAction: BaseBulkLookupAction, TResult: BaseBulk
     _func: Callable[[TAction], Awaitable[TResult]]
     _monitors: Sequence[BulkLookupActionMonitor]
     _validators: Sequence[BulkLookupActionValidator]
-    _post_validators: Sequence[BulkActionValidator]
+    _post_validators: Sequence[AtomicBulkActionValidator]
 
     def __init__(
         self,
         func: Callable[[TAction], Awaitable[TResult]],
         monitors: Sequence[BulkLookupActionMonitor] | None = None,
         validators: Sequence[BulkLookupActionValidator] | None = None,
-        post_validators: Sequence[BulkActionValidator] | None = None,
+        post_validators: Sequence[AtomicBulkActionValidator] | None = None,
     ) -> None:
         self._func = func
         self._monitors = monitors or []

--- a/src/ai/backend/manager/actions/v2/ops/__init__.py
+++ b/src/ai/backend/manager/actions/v2/ops/__init__.py
@@ -64,7 +64,6 @@ from .base import (
 )
 from .result import (
     BatchOpsResult,
-    BulkOpsResult,
     CreatedEntityOpsResult,
     EntitiesOpsResult,
     EntityOpsResult,
@@ -133,7 +132,6 @@ __all__ = (
     "UpsertFieldOpsAction",
     "UpsertGlobalOpsAction",
     "BatchOpsResult",
-    "BulkOpsResult",
     "CreatedEntityOpsResult",
     "EntitiesOpsResult",
     "EntityOpsResult",

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -5,7 +5,7 @@ from typing import Any, override
 from ai.backend.common.data.entity.types import EntityIdentifier, FieldData, FieldIdentifier
 from ai.backend.common.data.entity.types import EntityIdentifier as OwnerEntityID
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction, BasePartialBulkAction
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction
 from ai.backend.manager.actions.v2.ops.backend import OpsBackendAction
@@ -26,6 +26,7 @@ from ai.backend.manager.models.specs.purger import (
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
+    BulkEntityQuerier,
     DataQuerier,
     FieldQuerier,
     OwnedFieldQuerier,
@@ -104,6 +105,8 @@ __all__ = (
     "GetGlobalOpsAction",
     "OwnedFieldGetOpsAction",
     "BulkGetOwnedFieldOpsAction",
+    "EntityPartialBulkGetOpsAction",
+    "PartialBulkGetEntityOpsAction",
 )
 
 
@@ -157,6 +160,20 @@ class OwnedFieldGetOpsAction[TOwnerID: EntityIdentifier, TRow: Base, TData: Fiel
         The same entities ``entity_ids()`` reports, narrowed to the type the querier
         keys on.
         """
+        raise NotImplementedError
+
+
+class EntityPartialBulkGetOpsAction[TRow: Base, TData](OpsBackendAction):
+    """A read of the entities the caller named, keyed by their own ids.
+
+    Carries a :class:`BulkEntityQuerier` for the reason :class:`GetOpsAction` carries a
+    ``DataQuerier``: the ids alone say neither which table to read nor how a row
+    becomes data.
+    """
+
+    @abstractmethod
+    def to_querier(self) -> BulkEntityQuerier[TRow, TData]:
+        """Return the read spec this action executes."""
         raise NotImplementedError
 
 
@@ -618,6 +635,21 @@ class BulkGetOwnedFieldOpsAction[TOwnerID: EntityIdentifier, TRow: Base, TData: 
         return ActionOperationType.GET
 
 
+class PartialBulkGetEntityOpsAction[TRow: Base, TData](
+    BasePartialBulkAction, EntityPartialBulkGetOpsAction[TRow, TData], ABC
+):
+    """A read over the entities the caller named, each answered for on its own.
+
+    Partial rather than atomic: an id the caller may not read and one that matches no
+    row are both a failed item, and the two are told apart by the error each carries.
+    """
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
 class SearchGlobalOpsAction[TRow: Base, TData](
     BaseGlobalAction, GlobalSearchOpsAction[TRow, TData], ABC
 ):
@@ -782,7 +814,7 @@ class PurgeEntityOpsAction[TRow: Base, TData](
 
 
 class PartialBulkPurgeGlobalEntityOpsAction[TRow: Base, TData](
-    BaseBulkAction, GlobalEntityPartialBulkPurgeOpsAction[TRow, TData], ABC
+    BasePartialBulkAction, GlobalEntityPartialBulkPurgeOpsAction[TRow, TData], ABC
 ):
     """A hard delete over the global entities the caller named."""
 
@@ -793,7 +825,7 @@ class PartialBulkPurgeGlobalEntityOpsAction[TRow: Base, TData](
 
 
 class PartialBulkPurgeEntityOpsAction[TRow: Base, TData](
-    BaseBulkAction, EntityPartialBulkPurgeOpsAction[TRow, TData], ABC
+    BasePartialBulkAction, EntityPartialBulkPurgeOpsAction[TRow, TData], ABC
 ):
     """A hard delete over the entities the caller named."""
 
@@ -926,7 +958,7 @@ class RestoreSingleEntityOpsAction[TRow: Base, TData](
 
 
 class UpdatePartialBulkOpsAction[TRow: Base, TData](
-    BaseBulkAction, PartialBulkUpdateOpsAction[TRow, TData], ABC
+    BasePartialBulkAction, PartialBulkUpdateOpsAction[TRow, TData], ABC
 ):
     """A write over the entities the caller named. A bulk soft delete carries this too."""
 
@@ -937,7 +969,7 @@ class UpdatePartialBulkOpsAction[TRow: Base, TData](
 
 
 class DeletePartialBulkOpsAction[TRow: Base, TData](
-    BaseBulkAction, PartialBulkUpdateOpsAction[TRow, TData], ABC
+    BasePartialBulkAction, PartialBulkUpdateOpsAction[TRow, TData], ABC
 ):
     """A soft delete over the entities the caller named."""
 
@@ -948,7 +980,7 @@ class DeletePartialBulkOpsAction[TRow: Base, TData](
 
 
 class RestorePartialBulkOpsAction[TRow: Base, TData](
-    BaseBulkAction, PartialBulkUpdateOpsAction[TRow, TData], ABC
+    BasePartialBulkAction, PartialBulkUpdateOpsAction[TRow, TData], ABC
 ):
     """A restore over the entities the caller named."""
 

--- a/src/ai/backend/manager/actions/v2/ops/result.py
+++ b/src/ai/backend/manager/actions/v2/ops/result.py
@@ -22,8 +22,6 @@ from ai.backend.common.data.entity.types import (
     FieldData,
     FieldIdentifier,
 )
-from ai.backend.manager.actions.run_status import ActionRunStatus
-from ai.backend.manager.actions.v2.bulk.result import BasePartialBulkActionResult, BulkEntityResult
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupActionResult
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
 
@@ -39,7 +37,6 @@ __all__ = (
     "FieldOwnerLookupOpsResult",
     "FieldKeyLookupOpsResult",
     "EntitiesOpsResult",
-    "BulkOpsResult",
     "BatchOpsResult",
     "ScopedBatchOpsResult",
 )
@@ -134,53 +131,6 @@ class FieldKeyLookupOpsResult(BaseLookupActionResult):
 
 
 @dataclass
-class BulkOpsResult[TData](BasePartialBulkActionResult):
-    """How each entity a bulk write named fared.
-
-    The bulk shape is the one that reports per entity: the caller named them, so each
-    one's fate is answered against that expectation rather than the run carrying a
-    single verdict. A partial success says SUCCESS for what went through and ERROR for
-    the rest.
-
-    Needs no :class:`EntityData`, unlike the scope and lookup results: the ids are the
-    ones the caller passed in, not something to recover from what came back.
-    """
-
-    successes: dict[EntityIdentifier, TData]
-    errors: dict[EntityIdentifier, Exception]
-
-    @override
-    def entity_results(self) -> Sequence[BulkEntityResult]:
-        """Successes first, then errors — not the caller's order.
-
-        Classification is :class:`ActionRunStatus`'s, the same one the processors use to
-        turn a raised exception into audit-visible fields, so a bulk entity's error
-        reads exactly like a single run's.
-        """
-        success_status = ActionRunStatus.success()
-        results = [
-            BulkEntityResult(
-                entity_id=entity_id,
-                status=success_status.status,
-                description=success_status.description,
-                error_code=success_status.error_code,
-            )
-            for entity_id in self.successes
-        ]
-        for entity_id, exception in self.errors.items():
-            failure = ActionRunStatus.of_failure(exception, during_validation=False)
-            results.append(
-                BulkEntityResult(
-                    entity_id=entity_id,
-                    status=failure.status,
-                    description=failure.description,
-                    error_code=failure.error_code,
-                )
-            )
-        return results
-
-
-@dataclass
 class EntitiesOpsResult[TData: EntityData](BaseScopeActionResult):
     """Every entity a scope-shaped write touched.
 
@@ -200,9 +150,9 @@ class EntitiesOpsResult[TData: EntityData](BaseScopeActionResult):
 class BulkFieldOpsResult[TData]:
     """How each field row a bulk write named fared.
 
-    Keyed by the field rows the caller named, unlike :class:`BulkOpsResult`: the answer
-    the caller expects is per row. What the run is recorded against is the entity owning
-    each row, which the processor resolves.
+    Keyed by the field rows the caller named, unlike :class:`PartialBulkResult`: the
+    answer the caller expects is per row. What the run is recorded against is the entity
+    owning each row, which the processor resolves.
     """
 
     successes: dict[FieldIdentifier, TData]

--- a/src/ai/backend/manager/actions/v2/validators.py
+++ b/src/ai/backend/manager/actions/v2/validators.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass, field
 
-from ai.backend.manager.actions.v2.bulk.validator.base import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.validator.base import (
+    AtomicBulkActionValidator,
+    PartialBulkActionValidator,
+)
 from ai.backend.manager.actions.v2.global_scope.validator.base import GlobalActionValidator
 from ai.backend.manager.actions.v2.lookup.validator.base import LookupActionValidator
 from ai.backend.manager.actions.v2.scope.validator.base import ScopeActionValidator
@@ -14,7 +17,8 @@ class ActionValidators:
     """Validators per target shape, mirroring :class:`ActionMonitors`."""
 
     single_entity: list[SingleEntityActionValidator] = field(default_factory=list)
-    bulk: list[BulkActionValidator] = field(default_factory=list)
+    partial_bulk: list[PartialBulkActionValidator] = field(default_factory=list)
+    atomic_bulk: list[AtomicBulkActionValidator] = field(default_factory=list)
     scope: list[ScopeActionValidator] = field(default_factory=list)
     global_scope: list[GlobalActionValidator] = field(default_factory=list)
     lookup: list[LookupActionValidator] = field(default_factory=list)

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 
 from ai.backend.manager.actions.v2.bulk.validator.rbac import (
-    VirtualScopeBulkActionRBACValidator,
+    VirtualScopeAtomicBulkActionRBACValidator,
+    VirtualScopePartialBulkActionRBACValidator,
 )
 from ai.backend.manager.actions.v2.scope.validator.rbac import (
     VirtualScopeScopeActionRBACValidator,
@@ -39,4 +40,5 @@ class VirtualScopeRBACValidators:
 
     scope: VirtualScopeScopeActionRBACValidator
     single_entity: VirtualScopeSingleEntityActionRBACValidator
-    bulk: VirtualScopeBulkActionRBACValidator
+    partial_bulk: VirtualScopePartialBulkActionRBACValidator
+    atomic_bulk: VirtualScopeAtomicBulkActionRBACValidator

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -57,6 +57,9 @@ from ai.backend.manager.models.condition_utils import combine_conditions_or, neg
 from ai.backend.manager.services.app_config.actions.allow_list.admin_search import (
     AdminSearchAppConfigAllowListAction,
 )
+from ai.backend.manager.services.app_config.actions.allow_list.bulk_get import (
+    BulkGetAppConfigAllowListsAction,
+)
 from ai.backend.manager.services.app_config.actions.allow_list.create import (
     CreateAppConfigAllowListAction,
 )
@@ -111,25 +114,24 @@ class AppConfigAllowListAdapter(BaseAdapter):
 
     async def batch_load_by_ids(
         self, ids: Sequence[AppConfigAllowListID]
-    ) -> list[AppConfigAllowListNode | None]:
-        """Batch load app config allow-list entries by id for DataLoader use.
+    ) -> list[AppConfigAllowListNode | Exception | None]:
+        """Batch load allow-list entries by id for DataLoader use.
 
-        Returns nodes in the same order as the input ids, with None for missing ones.
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
         """
         if not ids:
             return []
-        searcher = self._build_searcher(
-            AppConfigAllowListSearcher,
-            pagination_spec=_get_app_config_allow_list_pagination_spec(),
-            conditions=[AppConfigAllowListConditions.by_ids(list(ids))],
-            orders=[],
-            limit=len(ids),
+        entity_ids = [AppConfigAllowListID(value) for value in ids]
+        result = await self._processors.app_config.allow_list_bulk_get.run(
+            BulkGetAppConfigAllowListsAction(ids=entity_ids)
         )
-        action_result = await self._processors.app_config.allow_list_global_search.run(
-            AdminSearchAppConfigAllowListAction(searcher=searcher)
-        )
-        node_map = {node.id: node for node in map(self._data_to_node, action_result.items)}
-        return [node_map.get(allow_list_id) for allow_list_id in ids]
+        return [
+            self._data_to_node(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def admin_search(
         self, input: SearchAppConfigAllowListInput

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -41,6 +41,9 @@ from ai.backend.manager.models.condition_utils import combine_conditions_or, neg
 from ai.backend.manager.services.app_config.actions.definition.admin_search import (
     AdminSearchAppConfigDefinitionsAction,
 )
+from ai.backend.manager.services.app_config.actions.definition.bulk_get import (
+    BulkGetAppConfigDefinitionsAction,
+)
 from ai.backend.manager.services.app_config.actions.definition.create import (
     CreateAppConfigDefinitionAction,
 )
@@ -85,25 +88,24 @@ class AppConfigDefinitionAdapter(BaseAdapter):
 
     async def batch_load_by_ids(
         self, ids: Sequence[AppConfigDefinitionID]
-    ) -> list[AppConfigDefinitionNode | None]:
-        """Batch load app config definitions by id for DataLoader use.
+    ) -> list[AppConfigDefinitionNode | Exception | None]:
+        """Batch load registered config names by id for DataLoader use.
 
-        Returns nodes in the same order as the input ids, with None for missing ones.
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
         """
         if not ids:
             return []
-        searcher = self._build_searcher(
-            AppConfigDefinitionSearcher,
-            conditions=[AppConfigDefinitionConditions.by_ids(list(ids))],
-            orders=[],
-            pagination_spec=_get_app_config_definition_pagination_spec(),
-            limit=len(ids),
+        entity_ids = [AppConfigDefinitionID(value) for value in ids]
+        result = await self._processors.app_config.definition_bulk_get.run(
+            BulkGetAppConfigDefinitionsAction(ids=entity_ids)
         )
-        action_result = await self._processors.app_config.definition_global_search.run(
-            AdminSearchAppConfigDefinitionsAction(searcher=searcher)
-        )
-        node_map = {node.id: node for node in map(self._data_to_node, action_result.items)}
-        return [node_map.get(definition_id) for definition_id in ids]
+        return [
+            self._data_to_node(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def admin_search(
         self, input: SearchAppConfigDefinitionsInput

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -64,6 +64,9 @@ from ai.backend.manager.models.condition_utils import combine_conditions_or, neg
 from ai.backend.manager.services.app_config.actions.fragment.admin_search import (
     AdminSearchAppConfigFragmentAction,
 )
+from ai.backend.manager.services.app_config.actions.fragment.bulk_get import (
+    BulkGetAppConfigFragmentsAction,
+)
 from ai.backend.manager.services.app_config.actions.fragment.bulk_purge import (
     BulkPurgeAppConfigFragmentAction,
 )
@@ -176,43 +179,36 @@ class AppConfigFragmentAdapter(BaseAdapter):
             )
         )
         return BulkPurgeAppConfigFragmentPayload(
-            items=[fragment.id for fragment in action_result.successes.values()],
+            items=[item.value.id for item in action_result.items if item.value is not None],
             failed=[
                 AppConfigFragmentBulkErrorInfo(
-                    id=AppConfigFragmentID(entity_id), message=str(error)
+                    id=AppConfigFragmentID(item.entity_id), message=str(item.error)
                 )
-                for entity_id, error in action_result.errors.items()
+                for item in action_result.items
+                if item.error is not None
             ],
         )
 
     async def batch_load_by_ids(
         self, fragment_ids: Sequence[AppConfigFragmentID]
-    ) -> list[AppConfigFragmentNode | None]:
-        """Batch load fragments by id for the GraphQL DataLoader, scoped to the current user.
+    ) -> list[AppConfigFragmentNode | Exception | None]:
+        """Batch load config fragments by id for DataLoader use.
 
-        A scoped search at the caller's own ``user`` scope, narrowed to ``fragment_ids``.
-        Returns nodes in the order of ``fragment_ids``, with ``None`` for ids not visible in
-        that scope. Calls ``current_user()`` internally — the caller does not pass a scope.
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
         """
         if not fragment_ids:
             return []
-        me = current_user()
-        if me is None:
-            raise UnreachableError("User context is not available")
-        searcher = self._build_searcher(
-            AppConfigFragmentSearcher,
-            conditions=[AppConfigFragmentConditions.by_ids(list(fragment_ids))],
-            orders=[],
-            pagination_spec=_get_app_config_fragment_pagination_spec(),
-            limit=len(fragment_ids),
+        entity_ids = [AppConfigFragmentID(value) for value in fragment_ids]
+        result = await self._processors.app_config.fragment_bulk_get.run(
+            BulkGetAppConfigFragmentsAction(ids=entity_ids)
         )
-        action_result = await self._processors.app_config.fragment_scoped_search.run(
-            ScopedSearchAppConfigFragmentAction(owner=UserID(me.user_id), searcher=searcher)
-        )
-        node_map = {node.id: node for node in map(self._fragment_to_node, action_result.items)}
-        return [node_map.get(fragment_id) for fragment_id in fragment_ids]
-
-    # --- read fragments by config name (one scope, RBAC-authorized) ---
+        return [
+            self._fragment_to_node(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def scoped_app_config_fragments_by_names(
         self, input: ScopedAppConfigFragmentsByNamesInput

--- a/src/ai/backend/manager/api/adapters/base.py
+++ b/src/ai/backend/manager/api/adapters/base.py
@@ -10,6 +10,7 @@ from ai.backend.manager.api.adapter_options.pagination.pagination import (
     PaginationSpec,
     build_pagination,
 )
+from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.specs.searcher import Searcher
 from ai.backend.manager.repositories.base import BatchQuerier
@@ -34,6 +35,17 @@ class BaseAdapter(BaseFilterAdapter):
 
     def __init__(self, processors: Processors) -> None:
         self._processors = processors
+
+    def batch_load_failure(self, error: Exception | None) -> Exception | None:
+        """What a DataLoader is handed for an id a bulk read returned no data for.
+
+        An id matching no row stays ``None``; a denial is raised at the resolver
+        awaiting it, so a caller is never told a row is missing when it is one they may
+        not read.
+        """
+        if error is None or isinstance(error, EntityNotFoundError):
+            return None
+        return error
 
     def _build_querier(
         self,

--- a/src/ai/backend/manager/api/adapters/object_storage/adapter.py
+++ b/src/ai/backend/manager/api/adapters/object_storage/adapter.py
@@ -36,6 +36,9 @@ from ai.backend.manager.models.object_storage.orders import ObjectStorageOrders
 from ai.backend.manager.models.object_storage.searchers import ObjectStorageSearcher
 from ai.backend.manager.models.object_storage.updaters import ObjectStorageUpdater
 from ai.backend.manager.models.specs.pagination import OffsetPagination
+from ai.backend.manager.services.object_storage.actions.bulk_get import (
+    BulkGetObjectStoragesAction,
+)
 from ai.backend.manager.services.object_storage.actions.create import CreateObjectStorageAction
 from ai.backend.manager.services.object_storage.actions.get import GetObjectStorageAction
 from ai.backend.manager.services.object_storage.actions.get_download_presigned_url import (
@@ -137,22 +140,26 @@ class ObjectStorageAdapter(BaseAdapter):
             offset=input.offset if input.offset is not None else 0,
         )
 
-    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[ObjectStorageNode | None]:
-        """Batch load object storages by IDs for DataLoader use.
+    async def batch_load_by_ids(
+        self, ids: Sequence[UUID]
+    ) -> list[ObjectStorageNode | Exception | None]:
+        """Batch load object storages by id for DataLoader use.
 
-        Returns ObjectStorageNode DTOs in the same order as the input ids list.
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
         """
         if not ids:
             return []
-        searcher = ObjectStorageSearcher(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[ObjectStorageConditions.by_ids(ids)],
+        entity_ids = [ObjectStorageID(value) for value in ids]
+        result = await self._processors.object_storage.bulk_get.run(
+            BulkGetObjectStoragesAction(ids=entity_ids)
         )
-        action_result = await self._processors.object_storage.global_search_object_storages.run(
-            SearchObjectStoragesAction(searcher=searcher)
-        )
-        storage_map = {item.id: self._data_to_dto(item) for item in action_result.items}
-        return [storage_map.get(ObjectStorageID(storage_id)) for storage_id in ids]
+        return [
+            self._data_to_dto(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def get(self, storage_id: UUID) -> ObjectStorageNode:
         """Retrieve a single object storage by ID."""

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset_category/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset_category/adapter.py
@@ -47,33 +47,39 @@ from ai.backend.manager.models.prometheus_query_preset_category.orders import (
 from ai.backend.manager.models.prometheus_query_preset_category.searchers import (
     PrometheusQueryPresetCategorySearcher,
 )
-from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.services.prometheus_query_preset_category.actions import (
     CreateCategoryAction,
     GetCategoryAction,
     PurgeCategoryAction,
     SearchCategoriesAction,
 )
+from ai.backend.manager.services.prometheus_query_preset_category.actions.bulk_get import (
+    PublicBulkGetCategoriesAction,
+)
 
 
 class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
     """Adapter for prometheus query preset category domain operations."""
 
-    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[CategoryNode | None]:
+    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[CategoryNode | Exception | None]:
+        """Batch load categories by id for DataLoader use.
+
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
+        """
         if not ids:
             return []
-        searcher = PrometheusQueryPresetCategorySearcher(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[PrometheusQueryPresetCategoryConditions.by_ids(ids)],
-        )
-        action_result = (
-            await self._processors.prometheus_query_preset_category.public_search_categories.run(
-                SearchCategoriesAction(searcher=searcher)
+        entity_ids = [PrometheusQueryPresetCategoryID(value) for value in ids]
+        result = (
+            await self._processors.prometheus_query_preset_category.public_bulk_get_categories.run(
+                PublicBulkGetCategoriesAction(ids=entity_ids)
             )
         )
-        category_map = {item.id: self._data_to_dto(item) for item in action_result.items}
         return [
-            category_map.get(PrometheusQueryPresetCategoryID(category_id)) for category_id in ids
+            self._data_to_dto(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
         ]
 
     async def create(self, input: CreateCategoryInput) -> CreateCategoryPayload:

--- a/src/ai/backend/manager/api/adapters/role_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/role_preset/adapter.py
@@ -226,12 +226,15 @@ class RolePresetAdapter(BaseAdapter):
             BulkDeleteRolePresetsAction(ids=input.role_preset_ids)
         )
         return BulkDeleteRolePresetsPayload(
-            items=[self._data_to_node(d) for d in result.successes.values()],
+            items=[
+                self._data_to_node(item.value) for item in result.items if item.value is not None
+            ],
             failed=[
                 BulkRolePresetFailureInfo(
-                    role_preset_id=RolePresetID(preset_id), message=str(exception)
+                    role_preset_id=RolePresetID(item.entity_id), message=str(item.error)
                 )
-                for preset_id, exception in result.errors.items()
+                for item in result.items
+                if item.error is not None
             ],
         )
 
@@ -243,12 +246,15 @@ class RolePresetAdapter(BaseAdapter):
             BulkRestoreRolePresetsAction(ids=input.role_preset_ids)
         )
         return BulkRestoreRolePresetsPayload(
-            items=[self._data_to_node(d) for d in result.successes.values()],
+            items=[
+                self._data_to_node(item.value) for item in result.items if item.value is not None
+            ],
             failed=[
                 BulkRolePresetFailureInfo(
-                    role_preset_id=RolePresetID(preset_id), message=str(exception)
+                    role_preset_id=RolePresetID(item.entity_id), message=str(item.error)
                 )
-                for preset_id, exception in result.errors.items()
+                for item in result.items
+                if item.error is not None
             ],
         )
 
@@ -258,12 +264,15 @@ class RolePresetAdapter(BaseAdapter):
             BulkPurgeRolePresetsAction(ids=input.role_preset_ids)
         )
         return BulkPurgeRolePresetsPayload(
-            items=[self._data_to_node(d) for d in result.successes.values()],
+            items=[
+                self._data_to_node(item.value) for item in result.items if item.value is not None
+            ],
             failed=[
                 BulkRolePresetFailureInfo(
-                    role_preset_id=RolePresetID(preset_id), message=str(exception)
+                    role_preset_id=RolePresetID(item.entity_id), message=str(item.error)
                 )
-                for preset_id, exception in result.errors.items()
+                for item in result.items
+                if item.error is not None
             ],
         )
 

--- a/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
@@ -34,7 +34,9 @@ from ai.backend.manager.models.runtime_variant.orders import RuntimeVariantOrder
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
 from ai.backend.manager.models.runtime_variant.searchers import RuntimeVariantSearcher
 from ai.backend.manager.models.runtime_variant.updaters import RuntimeVariantUpdater
-from ai.backend.manager.models.specs.pagination import OffsetPagination
+from ai.backend.manager.services.runtime_variant.actions.bulk_get import (
+    PublicBulkGetRuntimeVariantsAction,
+)
 from ai.backend.manager.services.runtime_variant.actions.create import CreateRuntimeVariantAction
 from ai.backend.manager.services.runtime_variant.actions.get import GetRuntimeVariantAction
 from ai.backend.manager.services.runtime_variant.actions.lookup import (
@@ -57,18 +59,26 @@ def _runtime_variant_pagination_spec() -> PaginationSpec:
 
 
 class RuntimeVariantAdapter(BaseAdapter):
-    async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[RuntimeVariantNode | None]:
+    async def batch_load_by_ids(
+        self, ids: Sequence[UUID]
+    ) -> list[RuntimeVariantNode | Exception | None]:
+        """Batch load runtime variants by id for DataLoader use.
+
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
+        """
         if not ids:
             return []
-        searcher = RuntimeVariantSearcher(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[RuntimeVariantConditions.by_ids(ids)],
+        entity_ids = [RuntimeVariantID(value) for value in ids]
+        result = await self._processors.runtime_variant.public_bulk_get.run(
+            PublicBulkGetRuntimeVariantsAction(ids=entity_ids)
         )
-        result = await self._processors.runtime_variant.public_search.run(
-            SearchRuntimeVariantsAction(searcher=searcher)
-        )
-        variant_map = {item.id: self._data_to_node(item) for item in result.items}
-        return [variant_map.get(RuntimeVariantID(variant_id)) for variant_id in ids]
+        return [
+            self._data_to_node(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def search(
         self,

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -100,7 +101,11 @@ from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggreg
 from ai.backend.manager.data.session.compute_schedule import ComputeScheduleKernelResult
 from ai.backend.manager.data.session.draft import KernelResourceInput
 from ai.backend.manager.data.session.options import AgentSelectionPolicy
-from ai.backend.manager.data.session.types import SessionData, SessionStatus
+from ai.backend.manager.data.session.types import (
+    SessionData,
+    SessionStatus,
+    SessionTerminationStatus,
+)
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
 from ai.backend.manager.models.kernel.conditions import KernelConditions
@@ -519,9 +524,7 @@ class SessionAdapter(BaseAdapter):
         action_result = await self._processors.session.batch_get_session_resource_allocation.run(
             BatchGetSessionResourceAllocationAction(session_ids=list(session_ids))
         )
-        return [
-            self._aggregate_to_allocation_dto(action_result.data.get(sid)) for sid in session_ids
-        ]
+        return [self._aggregate_to_allocation_dto(item.value) for item in action_result.items]
 
     async def batch_resource_allocation_by_kernel(
         self, kernel_ids: Sequence[KernelId]
@@ -1004,11 +1007,15 @@ class SessionAdapter(BaseAdapter):
             forced=input.forced,
         )
         result = await self._processors.session.terminate_sessions.run(action)
+        by_state: dict[SessionTerminationStatus, list[SessionId]] = defaultdict(list)
+        for item in result.items:
+            if item.value is not None:
+                by_state[item.value].append(SessionId(item.entity_id))
         return TerminateSessionsPayload(
-            cancelled=result.cancelled,
-            terminating=result.terminating,
-            force_terminated=result.force_terminated,
-            skipped=result.skipped,
+            cancelled=by_state[SessionTerminationStatus.CANCELLED],
+            terminating=by_state[SessionTerminationStatus.TERMINATING],
+            force_terminated=by_state[SessionTerminationStatus.FORCE_TERMINATED],
+            skipped=by_state[SessionTerminationStatus.SKIPPED],
         )
 
     async def exclude_idle_checks(

--- a/src/ai/backend/manager/api/adapters/storage_namespace/adapter.py
+++ b/src/ai/backend/manager/api/adapters/storage_namespace/adapter.py
@@ -20,9 +20,11 @@ from ai.backend.common.dto.manager.v2.storage_namespace.response import (
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
 from ai.backend.manager.models.specs.pagination import OffsetPagination
-from ai.backend.manager.models.storage_namespace.conditions import StorageNamespaceConditions
 from ai.backend.manager.models.storage_namespace.creators import StorageNamespaceCreator
 from ai.backend.manager.models.storage_namespace.searchers import StorageNamespaceSearcher
+from ai.backend.manager.services.storage_namespace.actions.bulk_get import (
+    BulkGetStorageNamespacesAction,
+)
 from ai.backend.manager.services.storage_namespace.actions.get_multi import GetNamespacesAction
 from ai.backend.manager.services.storage_namespace.actions.lookup import (
     LookupStorageNamespaceAction,
@@ -83,24 +85,24 @@ class StorageNamespaceAdapter(BaseAdapter):
 
     async def batch_load_by_ids(
         self, ids: Sequence[uuid.UUID]
-    ) -> list[StorageNamespaceNode | None]:
-        """Batch load storage namespaces by IDs for DataLoader use.
+    ) -> list[StorageNamespaceNode | Exception | None]:
+        """Batch load storage namespaces by id for DataLoader use.
 
-        Returns StorageNamespaceNode DTOs in the same order as the input ids list.
+        One answer per id in the given order: the node, ``None`` for an id matching no
+        row, and the denial for one the caller may not read.
         """
         if not ids:
             return []
-        searcher = StorageNamespaceSearcher(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[StorageNamespaceConditions.by_ids(ids)],
+        entity_ids = [StorageNamespaceID(value) for value in ids]
+        result = await self._processors.storage_namespace.bulk_get.run(
+            BulkGetStorageNamespacesAction(ids=entity_ids)
         )
-        action_result = await self._processors.storage_namespace.global_search.run(
-            SearchStorageNamespacesAction(searcher=searcher)
-        )
-        namespace_map = {
-            item.id: self._storage_namespace_data_to_dto(item) for item in action_result.items
-        }
-        return [namespace_map.get(StorageNamespaceID(namespace_id)) for namespace_id in ids]
+        return [
+            self._storage_namespace_data_to_dto(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def search(
         self, input: AdminSearchStorageNamespacesInput

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -148,13 +148,16 @@ class DataLoaders:
 
         async def load_fn(
             ids: list[AppConfigAllowListID],
-        ) -> list[AppConfigAllowListGQL | None]:
+        ) -> list[AppConfigAllowListGQL | Exception | None]:
             from ai.backend.manager.api.gql.app_config_allow_list.types import (  # pants: no-infer-dep
                 AppConfigAllowListGQL as ACL,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [ACL.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else ACL.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -166,13 +169,16 @@ class DataLoaders:
 
         async def load_fn(
             ids: list[AppConfigDefinitionID],
-        ) -> list[AppConfigDefinitionGQL | None]:
+        ) -> list[AppConfigDefinitionGQL | Exception | None]:
             from ai.backend.manager.api.gql.app_config_definition.types import (  # pants: no-infer-dep
                 AppConfigDefinitionGQL as ACD,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [ACD.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else ACD.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -184,13 +190,16 @@ class DataLoaders:
 
         async def load_fn(
             ids: list[AppConfigFragmentID],
-        ) -> list[AppConfigFragmentGQL | None]:
+        ) -> list[AppConfigFragmentGQL | Exception | None]:
             from ai.backend.manager.api.gql.app_config_fragment.types import (  # pants: no-infer-dep
                 AppConfigFragmentGQL as ACF,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [ACF.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else ACF.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -388,13 +397,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, StorageNamespace | None]:
         adapter = self._adapters.storage_namespace
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[StorageNamespace | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[StorageNamespace | Exception | None]:
             from ai.backend.manager.api.gql.storage_namespace import (  # pants: no-infer-dep
                 StorageNamespace as SN,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [SN.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else SN.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -404,13 +416,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, ObjectStorage | None]:
         adapter = self._adapters.object_storage
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[ObjectStorage | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[ObjectStorage | Exception | None]:
             from ai.backend.manager.api.gql.object_storage import (  # pants: no-infer-dep
                 ObjectStorage as OS,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [OS.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else OS.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -995,13 +1010,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, RuntimeVariantGQL | None]:
         adapter = self._adapters.runtime_variant
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[RuntimeVariantGQL | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[RuntimeVariantGQL | Exception | None]:
             from ai.backend.manager.api.gql.runtime_variant.types import (  # pants: no-infer-dep
                 RuntimeVariantGQL as RV,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [RV.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else RV.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -1043,12 +1061,15 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, CategoryGQL | None]:
         adapter = self._adapters.prometheus_query_preset_category
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[CategoryGQL | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[CategoryGQL | Exception | None]:
             from ai.backend.manager.api.gql.prometheus_query_preset.types.category import (  # pants: no-infer-dep
                 CategoryGQL as CG,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [CG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else CG.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)

--- a/src/ai/backend/manager/api/rest/compute_sessions/handler.py
+++ b/src/ai/backend/manager/api/rest/compute_sessions/handler.py
@@ -72,7 +72,11 @@ class ComputeSessionsHandler:
             allocation_result = await self._session.batch_get_session_resource_allocation.run(
                 BatchGetSessionResourceAllocationAction(session_ids=session_ids)
             )
-            allocations = allocation_result.data
+            allocations = {
+                SessionId(item.entity_id): item.value
+                for item in allocation_result.items
+                if item.value is not None
+            }
 
         # Step 4: Convert to DTOs
         items = [

--- a/src/ai/backend/manager/data/session/types.py
+++ b/src/ai/backend/manager/data/session/types.py
@@ -237,6 +237,19 @@ class SessionData(EntityData):
         return SessionID(self.id)
 
 
+class SessionTerminationStatus(StrEnum):
+    """What a termination request did to one session.
+
+    Session-only, so it stays here rather than beside the bulk result: what a bulk
+    run's per-entity value means is the domain's to declare.
+    """
+
+    CANCELLED = "cancelled"
+    TERMINATING = "terminating"
+    FORCE_TERMINATED = "force-terminated"
+    SKIPPED = "skipped"
+
+
 @dataclass(frozen=True)
 class SessionEntityData(EntityData):
     """A session as its own row states it.

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -35,7 +35,8 @@ from ai.backend.manager.actions.v2.bulk.monitor.audit_log import BulkActionAudit
 from ai.backend.manager.actions.v2.bulk.monitor.prometheus import BulkActionPrometheusMonitor
 from ai.backend.manager.actions.v2.bulk.monitor.reporter import BulkActionReporterMonitor
 from ai.backend.manager.actions.v2.bulk.validator.rbac import (
-    VirtualScopeBulkActionRBACValidator,
+    VirtualScopeAtomicBulkActionRBACValidator,
+    VirtualScopePartialBulkActionRBACValidator,
 )
 from ai.backend.manager.actions.v2.global_scope.monitor.audit_log import (
     GlobalActionAuditLogMonitor,
@@ -362,7 +363,10 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             single_entity=VirtualScopeSingleEntityActionRBACValidator(
                 permission_controller_repository, config_provider
             ),
-            bulk=VirtualScopeBulkActionRBACValidator(
+            partial_bulk=VirtualScopePartialBulkActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
+            atomic_bulk=VirtualScopeAtomicBulkActionRBACValidator(
                 permission_controller_repository, config_provider
             ),
         )
@@ -381,7 +385,8 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 ),
                 v2_validators=v2_validators.ActionValidators(
                     single_entity=[virtual_scope_rbac_validators.single_entity],
-                    bulk=[virtual_scope_rbac_validators.bulk],
+                    partial_bulk=[virtual_scope_rbac_validators.partial_bulk],
+                    atomic_bulk=[virtual_scope_rbac_validators.atomic_bulk],
                     scope=[virtual_scope_rbac_validators.scope],
                 ),
             ),

--- a/src/ai/backend/manager/models/app_config_allow_list/queriers.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListID
 from ai.backend.manager.data.app_config.types import AppConfigAllowListData
 from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -29,6 +29,24 @@ class AppConfigAllowListQuerier(DataQuerier[AppConfigAllowListRow, AppConfigAllo
     @override
     def entity_id_value(self) -> AppConfigAllowListID:
         return self.allow_list_id
+
+    @override
+    def to_data(self, row: AppConfigAllowListRow) -> AppConfigAllowListData:
+        return row.to_data()
+
+
+class BulkAppConfigAllowListQuerier(
+    BulkEntityQuerier[AppConfigAllowListRow, AppConfigAllowListData]
+):
+    """The allow-list entries the caller named."""
+
+    @override
+    def row_class(self) -> type[AppConfigAllowListRow]:
+        return AppConfigAllowListRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return AppConfigAllowListRow.id
 
     @override
     def to_data(self, row: AppConfigAllowListRow) -> AppConfigAllowListData:

--- a/src/ai/backend/manager/models/app_config_definition/queriers.py
+++ b/src/ai/backend/manager/models/app_config_definition/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionID
 from ai.backend.manager.data.app_config.types import AppConfigDefinitionData
 from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -29,6 +29,24 @@ class AppConfigDefinitionQuerier(DataQuerier[AppConfigDefinitionRow, AppConfigDe
     @override
     def entity_id_value(self) -> AppConfigDefinitionID:
         return self.definition_id
+
+    @override
+    def to_data(self, row: AppConfigDefinitionRow) -> AppConfigDefinitionData:
+        return row.to_data()
+
+
+class BulkAppConfigDefinitionQuerier(
+    BulkEntityQuerier[AppConfigDefinitionRow, AppConfigDefinitionData]
+):
+    """The registered config names the caller named."""
+
+    @override
+    def row_class(self) -> type[AppConfigDefinitionRow]:
+        return AppConfigDefinitionRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return AppConfigDefinitionRow.id
 
     @override
     def to_data(self, row: AppConfigDefinitionRow) -> AppConfigDefinitionData:

--- a/src/ai/backend/manager/models/app_config_fragment/queriers.py
+++ b/src/ai/backend/manager/models/app_config_fragment/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentID
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -29,6 +29,22 @@ class AppConfigFragmentQuerier(DataQuerier[AppConfigFragmentRow, AppConfigFragme
     @override
     def entity_id_value(self) -> AppConfigFragmentID:
         return self.fragment_id
+
+    @override
+    def to_data(self, row: AppConfigFragmentRow) -> AppConfigFragmentData:
+        return row.to_data()
+
+
+class BulkAppConfigFragmentQuerier(BulkEntityQuerier[AppConfigFragmentRow, AppConfigFragmentData]):
+    """The config fragments the caller named."""
+
+    @override
+    def row_class(self) -> type[AppConfigFragmentRow]:
+        return AppConfigFragmentRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return AppConfigFragmentRow.id
 
     @override
     def to_data(self, row: AppConfigFragmentRow) -> AppConfigFragmentData:

--- a/src/ai/backend/manager/models/object_storage/queriers.py
+++ b/src/ai/backend/manager/models/object_storage/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.object_storage import ObjectStorageID
 from ai.backend.manager.data.object_storage.types import ObjectStorageData
 from ai.backend.manager.models.object_storage.row import ObjectStorageRow
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -29,6 +29,22 @@ class ObjectStorageQuerier(DataQuerier[ObjectStorageRow, ObjectStorageData]):
     @override
     def entity_id_value(self) -> ObjectStorageID:
         return self.storage_id
+
+    @override
+    def to_data(self, row: ObjectStorageRow) -> ObjectStorageData:
+        return row.to_dataclass()
+
+
+class BulkObjectStorageQuerier(BulkEntityQuerier[ObjectStorageRow, ObjectStorageData]):
+    """The object storages the caller named."""
+
+    @override
+    def row_class(self) -> type[ObjectStorageRow]:
+        return ObjectStorageRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return ObjectStorageRow.id
 
     @override
     def to_data(self, row: ObjectStorageRow) -> ObjectStorageData:

--- a/src/ai/backend/manager/models/prometheus_query_preset_category/queriers.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset_category/queriers.py
@@ -16,7 +16,7 @@ from ai.backend.manager.data.prometheus_query_preset_category.types import (
 from ai.backend.manager.models.prometheus_query_preset_category.row import (
     PrometheusQueryPresetCategoryRow,
 )
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -37,6 +37,24 @@ class PrometheusQueryPresetCategoryQuerier(
     @override
     def entity_id_value(self) -> PrometheusQueryPresetCategoryID:
         return self.category_id
+
+    @override
+    def to_data(self, row: PrometheusQueryPresetCategoryRow) -> PrometheusQueryPresetCategoryData:
+        return row.to_data()
+
+
+class BulkPrometheusQueryPresetCategoryQuerier(
+    BulkEntityQuerier[PrometheusQueryPresetCategoryRow, PrometheusQueryPresetCategoryData]
+):
+    """The categories the caller named."""
+
+    @override
+    def row_class(self) -> type[PrometheusQueryPresetCategoryRow]:
+        return PrometheusQueryPresetCategoryRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return PrometheusQueryPresetCategoryRow.id
 
     @override
     def to_data(self, row: PrometheusQueryPresetCategoryRow) -> PrometheusQueryPresetCategoryData:

--- a/src/ai/backend/manager/models/runtime_variant/queriers.py
+++ b/src/ai/backend/manager/models/runtime_variant/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -29,6 +29,22 @@ class RuntimeVariantQuerier(DataQuerier[RuntimeVariantRow, RuntimeVariantData]):
     @override
     def entity_id_value(self) -> RuntimeVariantID:
         return self.variant_id
+
+    @override
+    def to_data(self, row: RuntimeVariantRow) -> RuntimeVariantData:
+        return row.to_data()
+
+
+class BulkRuntimeVariantQuerier(BulkEntityQuerier[RuntimeVariantRow, RuntimeVariantData]):
+    """The runtime variants the caller named."""
+
+    @override
+    def row_class(self) -> type[RuntimeVariantRow]:
+        return RuntimeVariantRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return RuntimeVariantRow.id
 
     @override
     def to_data(self, row: RuntimeVariantRow) -> RuntimeVariantData:

--- a/src/ai/backend/manager/models/specs/querier.py
+++ b/src/ai/backend/manager/models/specs/querier.py
@@ -69,6 +69,29 @@ class DataQuerier[TRow: Base, TData](ABC):
         raise NotImplementedError
 
 
+class BulkEntityQuerier[TRow: Base, TData](ABC):
+    """Reads the entities the caller named, keyed by their own ids.
+
+    Plural :class:`DataQuerier`. The ids are the whole query — nothing to condition,
+    order or page — so the spec owns it and ops adds no clause of its own.
+    """
+
+    @abstractmethod
+    def row_class(self) -> type[TRow]:
+        """Return the ORM class the rows are read from."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        """Return the column that carries the entity id, which the read keys on."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_data(self, row: TRow) -> TData:
+        """Convert one fetched row into its ``data/`` type."""
+        raise NotImplementedError
+
+
 class OwnedFieldQuerier[TOwnerID: EntityIdentifier, TRow: Base, TData: FieldData](ABC):
     """The one field row each named entity designates.
 

--- a/src/ai/backend/manager/models/storage_namespace/queriers.py
+++ b/src/ai/backend/manager/models/storage_namespace/queriers.py
@@ -1,0 +1,27 @@
+"""Read specs for the storage namespace repository."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier
+from ai.backend.manager.models.storage_namespace.row import StorageNamespaceRow
+
+
+class BulkStorageNamespaceQuerier(BulkEntityQuerier[StorageNamespaceRow, StorageNamespaceData]):
+    """The storage namespaces the caller named."""
+
+    @override
+    def row_class(self) -> type[StorageNamespaceRow]:
+        return StorageNamespaceRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return StorageNamespaceRow.id
+
+    @override
+    def to_data(self, row: StorageNamespaceRow) -> StorageNamespaceData:
+        return row.to_dataclass()

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -40,6 +40,7 @@ from ai.backend.manager.models.specs.purger import (
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
+    BulkEntityQuerier,
     DataQuerier,
     FieldQuerier,
     OwnedFieldQuerier,
@@ -77,6 +78,17 @@ class OpsRepository[TData]:
                     f"{querier.row_class().__name__} {querier.entity_id_value()} not found"
                 )
             return data
+
+    async def bulk_get(
+        self, querier: BulkEntityQuerier[Any, TData], entity_ids: Sequence[EntityIdentifier]
+    ) -> Mapping[EntityIdentifier, TData]:
+        """Read the named entities; one that is gone is absent instead of raising.
+
+        Unlike :meth:`get`, the run answers for each id separately, so a missing row is
+        one failed item rather than a failed run.
+        """
+        async with self._ops.read_ops() as r:
+            return await r.query_bulk_data(querier, entity_ids)
 
     async def get_field[TFieldData: FieldData](
         self, querier: FieldQuerier[Any, TFieldData]

--- a/src/ai/backend/manager/repositories/ops/v2/read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/read.py
@@ -21,6 +21,7 @@ from ai.backend.manager.models.specs.lookup import (
     FieldOwnerLookup,
 )
 from ai.backend.manager.models.specs.querier import (
+    BulkEntityQuerier,
     DataQuerier,
     FieldQuerier,
     OwnedFieldQuerier,
@@ -44,6 +45,27 @@ class V2ReadOps(V2OpsBase):
         if row is None:
             return None
         return querier.to_data(row)
+
+    async def query_bulk_data[TRow: Base, TData](
+        self,
+        querier: BulkEntityQuerier[TRow, TData],
+        entity_ids: Sequence[EntityIdentifier],
+    ) -> Mapping[EntityIdentifier, TData]:
+        """Read the named entities, keyed by the ids the caller passed.
+
+        An id matching no row is absent rather than an error: the caller decides
+        whether that is a miss or one failed item among many.
+        """
+        if not entity_ids:
+            return {}
+        id_column = querier.entity_id_column()
+        rows = (
+            await self._sess.scalars(
+                sa.select(querier.row_class()).where(id_column.in_(entity_ids))
+            )
+        ).all()
+        found = {getattr(row, id_column.key): querier.to_data(row) for row in rows}
+        return {entity_id: found[entity_id] for entity_id in entity_ids if entity_id in found}
 
     async def lookup_entity_id[TRow: Base, TEntityID: EntityIdentifier](
         self, lookup: DataLookup[TRow, TEntityID]

--- a/src/ai/backend/manager/services/app_config/actions/allow_list/bulk_get.py
+++ b/src/ai/backend/manager/services/app_config/actions/allow_list/bulk_get.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.app_config.types import AppConfigAllowListData
+from ai.backend.manager.models.app_config_allow_list.queriers import (
+    BulkAppConfigAllowListQuerier,
+)
+from ai.backend.manager.models.app_config_allow_list.row import AppConfigAllowListRow
+
+
+@dataclass
+class BulkGetAppConfigAllowListsAction(
+    PartialBulkGetEntityOpsAction[AppConfigAllowListRow, AppConfigAllowListData]
+):
+    """Read the allow-list entries the caller named, answering for each id."""
+
+    ids: Sequence[AppConfigAllowListID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_app_config_allow_lists"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkAppConfigAllowListQuerier:
+        return BulkAppConfigAllowListQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/app_config/actions/definition/bulk_get.py
+++ b/src/ai/backend/manager/services/app_config/actions/definition/bulk_get.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.app_config.types import AppConfigDefinitionData
+from ai.backend.manager.models.app_config_definition.queriers import (
+    BulkAppConfigDefinitionQuerier,
+)
+from ai.backend.manager.models.app_config_definition.row import AppConfigDefinitionRow
+
+
+@dataclass
+class BulkGetAppConfigDefinitionsAction(
+    PartialBulkGetEntityOpsAction[AppConfigDefinitionRow, AppConfigDefinitionData]
+):
+    """Read the registered config names the caller named, answering for each id."""
+
+    ids: Sequence[AppConfigDefinitionID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_app_config_definitions"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkAppConfigDefinitionQuerier:
+        return BulkAppConfigDefinitionQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/app_config/actions/fragment/bulk_get.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/bulk_get.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.app_config.types import AppConfigFragmentData
+from ai.backend.manager.models.app_config_fragment.queriers import (
+    BulkAppConfigFragmentQuerier,
+)
+from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
+
+
+@dataclass
+class BulkGetAppConfigFragmentsAction(
+    PartialBulkGetEntityOpsAction[AppConfigFragmentRow, AppConfigFragmentData]
+):
+    """Read the config fragments the caller named, answering for each id."""
+
+    ids: Sequence[AppConfigFragmentID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_app_config_fragments"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkAppConfigFragmentQuerier:
+        return BulkAppConfigFragmentQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/app_config/actions/fragment/bulk_purge.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/bulk_purge.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.v2.ops.base import PartialBulkPurgeEntityOpsAction
@@ -31,3 +31,11 @@ class BulkPurgeAppConfigFragmentAction(
     @override
     def to_purgers(self) -> Mapping[EntityIdentifier, AppConfigFragmentPurger]:
         return {purger.entity_id(): purger for purger in self.purgers}
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(
+            self,
+            purgers=[purger for purger in self.purgers if purger.entity_id() in allowed],
+        )

--- a/src/ai/backend/manager/services/app_config/processors.py
+++ b/src/ai/backend/manager/services/app_config/processors.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from ai.backend.manager.actions.registry.group import ProcessorGroup
-from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
-    BulkOpsResult,
     CreatedEntityOpsResult,
     EntitiesOpsResult,
     EntityOpsResult,
@@ -22,6 +21,9 @@ from ai.backend.manager.data.app_config.types import (
 )
 from ai.backend.manager.services.app_config.actions.allow_list.admin_search import (
     AdminSearchAppConfigAllowListAction,
+)
+from ai.backend.manager.services.app_config.actions.allow_list.bulk_get import (
+    BulkGetAppConfigAllowListsAction,
 )
 from ai.backend.manager.services.app_config.actions.allow_list.create import (
     CreateAppConfigAllowListAction,
@@ -38,6 +40,9 @@ from ai.backend.manager.services.app_config.actions.allow_list.update import (
 from ai.backend.manager.services.app_config.actions.definition.admin_search import (
     AdminSearchAppConfigDefinitionsAction,
 )
+from ai.backend.manager.services.app_config.actions.definition.bulk_get import (
+    BulkGetAppConfigDefinitionsAction,
+)
 from ai.backend.manager.services.app_config.actions.definition.create import (
     CreateAppConfigDefinitionAction,
 )
@@ -49,6 +54,9 @@ from ai.backend.manager.services.app_config.actions.definition.purge import (
 )
 from ai.backend.manager.services.app_config.actions.fragment.admin_search import (
     AdminSearchAppConfigFragmentAction,
+)
+from ai.backend.manager.services.app_config.actions.fragment.bulk_get import (
+    BulkGetAppConfigFragmentsAction,
 )
 from ai.backend.manager.services.app_config.actions.fragment.bulk_purge import (
     BulkPurgeAppConfigFragmentAction,
@@ -99,6 +107,9 @@ class AppConfigProcessors:
     definition_get: SingleEntityActionProcessor[
         GetAppConfigDefinitionAction, EntityOpsResult[AppConfigDefinitionData]
     ]
+    definition_bulk_get: PartialBulkActionProcessor[
+        BulkGetAppConfigDefinitionsAction, AppConfigDefinitionData
+    ]
     definition_purge: SingleEntityActionProcessor[
         PurgeAppConfigDefinitionAction, EntityOpsResult[AppConfigDefinitionData]
     ]
@@ -111,6 +122,9 @@ class AppConfigProcessors:
     ]
     allow_list_get: SingleEntityActionProcessor[
         GetAppConfigAllowListAction, EntityOpsResult[AppConfigAllowListData]
+    ]
+    allow_list_bulk_get: PartialBulkActionProcessor[
+        BulkGetAppConfigAllowListsAction, AppConfigAllowListData
     ]
     allow_list_update: SingleEntityActionProcessor[
         UpdateAppConfigAllowListAction, EntityOpsResult[AppConfigAllowListData]
@@ -131,6 +145,9 @@ class AppConfigProcessors:
     fragment_get: SingleEntityActionProcessor[
         GetAppConfigFragmentAction, EntityOpsResult[AppConfigFragmentData]
     ]
+    fragment_bulk_get: PartialBulkActionProcessor[
+        BulkGetAppConfigFragmentsAction, AppConfigFragmentData
+    ]
     fragment_admin_search: GlobalActionProcessor[
         AdminSearchAppConfigFragmentAction, BatchOpsResult[AppConfigFragmentData]
     ]
@@ -140,8 +157,8 @@ class AppConfigProcessors:
     fragment_purge: SingleEntityActionProcessor[
         PurgeAppConfigFragmentAction, EntityOpsResult[AppConfigFragmentData]
     ]
-    fragment_bulk_purge: BulkActionProcessor[
-        BulkPurgeAppConfigFragmentAction, BulkOpsResult[AppConfigFragmentData]
+    fragment_bulk_purge: PartialBulkActionProcessor[
+        BulkPurgeAppConfigFragmentAction, AppConfigFragmentData
     ]
 
     def __init__(
@@ -164,6 +181,9 @@ class AppConfigProcessors:
             CreateAppConfigDefinitionAction
         )
         self.definition_get = definition_group.single_get_ops(GetAppConfigDefinitionAction)
+        self.definition_bulk_get = definition_group.partial_bulk_get_ops(
+            BulkGetAppConfigDefinitionsAction
+        )
         self.definition_purge = definition_group.entity_purge_ops(PurgeAppConfigDefinitionAction)
         self.definition_global_search = definition_group.global_search_ops(
             AdminSearchAppConfigDefinitionsAction
@@ -173,6 +193,9 @@ class AppConfigProcessors:
             CreateAppConfigAllowListAction
         )
         self.allow_list_get = allow_list_group.single_get_ops(GetAppConfigAllowListAction)
+        self.allow_list_bulk_get = allow_list_group.partial_bulk_get_ops(
+            BulkGetAppConfigAllowListsAction
+        )
         self.allow_list_update = allow_list_group.single_update_ops(UpdateAppConfigAllowListAction)
         self.allow_list_purge = allow_list_group.entity_purge_ops(PurgeAppConfigAllowListAction)
         self.allow_list_global_search = allow_list_group.global_search_ops(
@@ -186,6 +209,9 @@ class AppConfigProcessors:
             GlobalBulkUpsertAppConfigFragmentsAction
         )
         self.fragment_get = fragment_group.single_get_ops(GetAppConfigFragmentAction)
+        self.fragment_bulk_get = fragment_group.partial_bulk_get_ops(
+            BulkGetAppConfigFragmentsAction
+        )
         self.fragment_admin_search = fragment_group.global_search_ops(
             AdminSearchAppConfigFragmentAction
         )

--- a/src/ai/backend/manager/services/idle_checker/processors.py
+++ b/src/ai/backend/manager/services/idle_checker/processors.py
@@ -57,5 +57,9 @@ class IdleCheckerProcessors:
         self.create = GlobalActionProcessor(service.create, action_monitors)
         self.update = GlobalActionProcessor(service.update, action_monitors)
         self.purge = GlobalActionProcessor(service.purge, action_monitors)
-        self.exclude_sessions = group.bulk(ExcludeSessionIdleChecksAction, service.exclude_sessions)
-        self.include_sessions = group.bulk(IncludeSessionIdleChecksAction, service.include_sessions)
+        self.exclude_sessions = group.legacy_partial_bulk(
+            ExcludeSessionIdleChecksAction, service.exclude_sessions
+        )
+        self.include_sessions = group.legacy_partial_bulk(
+            IncludeSessionIdleChecksAction, service.include_sessions
+        )

--- a/src/ai/backend/manager/services/object_storage/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/object_storage/actions/bulk_get.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.object_storage import ObjectStorageID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.object_storage.types import ObjectStorageData
+from ai.backend.manager.models.object_storage.queriers import BulkObjectStorageQuerier
+from ai.backend.manager.models.object_storage.row import ObjectStorageRow
+
+
+@dataclass
+class BulkGetObjectStoragesAction(
+    PartialBulkGetEntityOpsAction[ObjectStorageRow, ObjectStorageData]
+):
+    """Read the object storages the caller named, answering for each id."""
+
+    ids: Sequence[ObjectStorageID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_object_storages"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkObjectStorageQuerier:
+        return BulkObjectStorageQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/object_storage/processors.py
+++ b/src/ai/backend/manager/services/object_storage/processors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.field.processor import SingleFieldActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
@@ -14,6 +15,9 @@ from ai.backend.manager.actions.v2.single_entity.processor import (
 )
 from ai.backend.manager.data.artifact.types import ArtifactRevisionData
 from ai.backend.manager.data.object_storage.types import ObjectStorageData
+from ai.backend.manager.services.object_storage.actions.bulk_get import (
+    BulkGetObjectStoragesAction,
+)
 from ai.backend.manager.services.object_storage.actions.create import (
     CreateObjectStorageAction,
 )
@@ -48,6 +52,7 @@ class ObjectStorageProcessors:
     ]
     purge: SingleEntityActionProcessor[PurgeObjectStorageAction, EntityOpsResult[ObjectStorageData]]
     get: SingleEntityActionProcessor[GetObjectStorageAction, EntityOpsResult[ObjectStorageData]]
+    bulk_get: PartialBulkActionProcessor[BulkGetObjectStoragesAction, ObjectStorageData]
     global_list_storages: GlobalActionProcessor[
         ListObjectStorageAction, BatchOpsResult[ObjectStorageData]
     ]
@@ -71,6 +76,7 @@ class ObjectStorageProcessors:
         self.update = group.single_update_ops(UpdateObjectStorageAction)
         self.purge = group.entity_purge_ops(PurgeObjectStorageAction)
         self.get = group.single_get_ops(GetObjectStorageAction)
+        self.bulk_get = group.partial_bulk_get_ops(BulkGetObjectStoragesAction)
         self.global_list_storages = group.global_search_ops(ListObjectStorageAction)
         self.global_search_object_storages = group.global_search_ops(SearchObjectStoragesAction)
         self.get_presigned_download_url = revision.single_field(

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -17,6 +17,10 @@ from typing import Any
 from ai.backend.common.data.entity.types import EntityData, FieldData
 from ai.backend.manager.actions.run_status import ActionRunStatus
 from ai.backend.manager.actions.types import OperationStatus
+from ai.backend.manager.actions.v2.bulk.result import (
+    PartialBulkEntityResult,
+    PartialBulkResult,
+)
 from ai.backend.manager.actions.v2.field.bulk_lookup import (
     BulkFieldOwnerLookupOpsResult,
     LookupBulkFieldOwnerOpsAction,
@@ -56,6 +60,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     GlobalRoleManagedEntityCreateOpsAction,
     GlobalSearchOpsAction,
     LookupOpsAction,
+    PartialBulkGetEntityOpsAction,
     PartialBulkUpdateOpsAction,
     RoleManagedEntityAtomicCreateOpsAction,
     RoleManagedEntityCreateOpsAction,
@@ -65,7 +70,6 @@ from ai.backend.manager.actions.v2.ops.base import (
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
     BulkFieldOpsResult,
-    BulkOpsResult,
     CreatedEntityOpsResult,
     CreatedEntityWithFieldsOpsResult,
     CreatedFieldOpsResult,
@@ -79,10 +83,13 @@ from ai.backend.manager.actions.v2.ops.result import (
     ScopedBatchOpsResult,
     ScopedFieldsOpsResult,
 )
+from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.models.specs.types import BulkResultWithFailures
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 __all__ = (
     "GetService",
+    "PartialBulkGetService",
     "BulkOwnedFieldGetService",
     "LookupService",
     "BulkFieldOwnerLookupService",
@@ -124,6 +131,26 @@ __all__ = (
 )
 
 
+def _partial_bulk_items[TData](
+    result: BulkResultWithFailures[TData],
+) -> list[PartialBulkEntityResult[TData]]:
+    """Turn a write's per-entity answer into the standard items.
+
+    Order is not settled here: the processor holds the ids the caller named and puts
+    these back in that order.
+    """
+    return [
+        *(
+            PartialBulkEntityResult[TData].succeeded(entity_id, data)
+            for entity_id, data in result.successes.items()
+        ),
+        *(
+            PartialBulkEntityResult[TData].failed(entity_id, error)
+            for entity_id, error in result.errors.items()
+        ),
+    ]
+
+
 class GetService[TData]:
     """Reads the entity the action's querier names."""
 
@@ -163,6 +190,37 @@ class BulkOwnedFieldGetService[TFieldData: FieldData]:
     ) -> OwnedFieldsOpsResult[Any, TFieldData]:
         designated = await self._repository.owned_fields(action.to_querier(), action.owner_ids())
         return OwnedFieldsOpsResult(designated=designated)
+
+
+class PartialBulkGetService[TData]:
+    """Reads the entities the action names, answering for each one.
+
+    Reads them off the action like every other generic service: the entities the
+    caller may not reach are gone from it by the time this runs.
+    """
+
+    _repository: OpsRepository[TData]
+
+    def __init__(self, repository: OpsRepository[TData]) -> None:
+        self._repository = repository
+
+    async def execute(
+        self, action: PartialBulkGetEntityOpsAction[Any, TData]
+    ) -> PartialBulkResult[TData]:
+        entity_ids = action.entity_ids()
+        querier = action.to_querier()
+        found = await self._repository.bulk_get(querier, entity_ids)
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[TData].succeeded(entity_id, found[entity_id])
+                if entity_id in found
+                else PartialBulkEntityResult[TData].failed(
+                    entity_id,
+                    EntityNotFoundError(f"{querier.row_class().__name__} {entity_id} not found"),
+                )
+                for entity_id in entity_ids
+            ]
+        )
 
 
 class LookupService[TData: EntityData]:
@@ -548,9 +606,9 @@ class GlobalPartialBulkPurgeService[TData]:
 
     async def execute(
         self, action: GlobalEntityPartialBulkPurgeOpsAction[Any, TData]
-    ) -> BulkOpsResult[TData]:
+    ) -> PartialBulkResult[TData]:
         result = await self._repository.partial_bulk_purge_entities(action.to_purgers())
-        return BulkOpsResult(successes=result.successes, errors=result.errors)
+        return PartialBulkResult(items=_partial_bulk_items(result))
 
 
 class EntityPartialBulkPurgeService[TData]:
@@ -563,9 +621,9 @@ class EntityPartialBulkPurgeService[TData]:
 
     async def execute(
         self, action: EntityPartialBulkPurgeOpsAction[Any, TData]
-    ) -> BulkOpsResult[TData]:
+    ) -> PartialBulkResult[TData]:
         result = await self._repository.partial_bulk_purge_entities(action.to_purgers())
-        return BulkOpsResult(successes=result.successes, errors=result.errors)
+        return PartialBulkResult(items=_partial_bulk_items(result))
 
 
 class FieldPartialBulkPurgeService[TData: FieldData]:
@@ -715,9 +773,11 @@ class PartialBulkUpdateService[TData]:
     def __init__(self, repository: OpsRepository[TData]) -> None:
         self._repository = repository
 
-    async def execute(self, action: PartialBulkUpdateOpsAction[Any, TData]) -> BulkOpsResult[TData]:
+    async def execute(
+        self, action: PartialBulkUpdateOpsAction[Any, TData]
+    ) -> PartialBulkResult[TData]:
         result = await self._repository.partial_bulk_update(action.to_updaters())
-        return BulkOpsResult(successes=result.successes, errors=result.errors)
+        return PartialBulkResult(items=_partial_bulk_items(result))
 
 
 class PartialBulkDeleteService[TData]:
@@ -732,9 +792,11 @@ class PartialBulkDeleteService[TData]:
     def __init__(self, repository: OpsRepository[TData]) -> None:
         self._repository = repository
 
-    async def execute(self, action: PartialBulkUpdateOpsAction[Any, TData]) -> BulkOpsResult[TData]:
+    async def execute(
+        self, action: PartialBulkUpdateOpsAction[Any, TData]
+    ) -> PartialBulkResult[TData]:
         result = await self._repository.partial_bulk_update(action.to_updaters())
-        return BulkOpsResult(successes=result.successes, errors=result.errors)
+        return PartialBulkResult(items=_partial_bulk_items(result))
 
 
 class PartialBulkRestoreService[TData]:
@@ -745,9 +807,11 @@ class PartialBulkRestoreService[TData]:
     def __init__(self, repository: OpsRepository[TData]) -> None:
         self._repository = repository
 
-    async def execute(self, action: PartialBulkUpdateOpsAction[Any, TData]) -> BulkOpsResult[TData]:
+    async def execute(
+        self, action: PartialBulkUpdateOpsAction[Any, TData]
+    ) -> PartialBulkResult[TData]:
         result = await self._repository.partial_bulk_update(action.to_updaters())
-        return BulkOpsResult(successes=result.successes, errors=result.errors)
+        return PartialBulkResult(items=_partial_bulk_items(result))
 
 
 class BatchUpdateService[TData: EntityData]:

--- a/src/ai/backend/manager/services/prometheus_query_preset_category/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset_category/actions/bulk_get.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.prometheus_query_preset_category import (
+    PrometheusQueryPresetCategoryID,
+)
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.prometheus_query_preset_category.types import (
+    PrometheusQueryPresetCategoryData,
+)
+from ai.backend.manager.models.prometheus_query_preset_category.queriers import (
+    BulkPrometheusQueryPresetCategoryQuerier,
+)
+from ai.backend.manager.models.prometheus_query_preset_category.row import (
+    PrometheusQueryPresetCategoryRow,
+)
+
+
+@dataclass
+class PublicBulkGetCategoriesAction(
+    PartialBulkGetEntityOpsAction[
+        PrometheusQueryPresetCategoryRow, PrometheusQueryPresetCategoryData
+    ]
+):
+    """Read the categories the caller named; every authenticated user may."""
+
+    ids: Sequence[PrometheusQueryPresetCategoryID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_bulk_get_prometheus_query_preset_categories"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkPrometheusQueryPresetCategoryQuerier:
+        return BulkPrometheusQueryPresetCategoryQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/prometheus_query_preset_category/processors.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset_category/processors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import (
     GlobalActionProcessor,
     PublicActionProcessor,
@@ -16,6 +17,9 @@ from ai.backend.manager.actions.v2.single_entity.processor import (
 )
 from ai.backend.manager.data.prometheus_query_preset_category.types import (
     PrometheusQueryPresetCategoryData,
+)
+from ai.backend.manager.services.prometheus_query_preset_category.actions.bulk_get import (
+    PublicBulkGetCategoriesAction,
 )
 from ai.backend.manager.services.prometheus_query_preset_category.actions.create import (
     CreateCategoryAction,
@@ -42,6 +46,10 @@ class PrometheusQueryPresetCategoryProcessors:
         GetCategoryAction,
         EntityOpsResult[PrometheusQueryPresetCategoryData],
     ]
+    public_bulk_get_categories: PartialBulkActionProcessor[
+        PublicBulkGetCategoriesAction,
+        PrometheusQueryPresetCategoryData,
+    ]
     public_search_categories: PublicActionProcessor[
         SearchCategoriesAction,
         BatchOpsResult[PrometheusQueryPresetCategoryData],
@@ -54,5 +62,8 @@ class PrometheusQueryPresetCategoryProcessors:
     def __init__(self, group: ProcessorGroup[PrometheusQueryPresetCategoryData]) -> None:
         self.global_create_category = group.global_create_ops(CreateCategoryAction)
         self.public_get_category = group.public_get_ops(GetCategoryAction)
+        self.public_bulk_get_categories = group.public_partial_bulk_get_ops(
+            PublicBulkGetCategoriesAction
+        )
         self.public_search_categories = group.public_search_ops(SearchCategoriesAction)
         self.purge_category = group.entity_purge_ops(PurgeCategoryAction)

--- a/src/ai/backend/manager/services/role_preset/actions/bulk_purge.py
+++ b/src/ai/backend/manager/services/role_preset/actions/bulk_purge.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import EntityIdentifier
@@ -34,3 +34,8 @@ class BulkPurgeRolePresetsAction(
     @override
     def to_purgers(self) -> Mapping[EntityIdentifier, RolePresetPurger]:
         return {preset_id: RolePresetPurger(preset_id=preset_id) for preset_id in self.ids}
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/role_preset/actions/bulk_remove_permissions.py
+++ b/src/ai/backend/manager/services/role_preset/actions/bulk_remove_permissions.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.role_permission_preset import RolePermissionPresetID
 from ai.backend.common.data.entity.role_preset import RolePresetID
@@ -57,3 +57,8 @@ class BulkRemoveRolePermissionPresetsAction(
             permission_id: RolePermissionPresetPurger(permission_preset_id=permission_id)
             for permission_id in self.ids
         }
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[RolePermissionPresetID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/role_preset/actions/delete.py
+++ b/src/ai/backend/manager/services/role_preset/actions/delete.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import EntityIdentifier
@@ -36,3 +36,8 @@ class BulkDeleteRolePresetsAction(DeletePartialBulkOpsAction[RolePresetRow, Role
         return {
             preset_id: RolePresetSoftDeleteUpdater(preset_id=preset_id) for preset_id in self.ids
         }
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/role_preset/actions/restore.py
+++ b/src/ai/backend/manager/services/role_preset/actions/restore.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import EntityIdentifier
@@ -34,3 +34,8 @@ class BulkRestoreRolePresetsAction(RestorePartialBulkOpsAction[RolePresetRow, Ro
     @override
     def to_updaters(self) -> Mapping[EntityIdentifier, RolePresetRestoreUpdater]:
         return {preset_id: RolePresetRestoreUpdater(preset_id=preset_id) for preset_id in self.ids}
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/role_preset/processors.py
+++ b/src/ai/backend/manager/services/role_preset/processors.py
@@ -6,13 +6,13 @@ from ai.backend.common.data.entity.role_permission_preset import (
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.registry.types import FieldGroupMeta
-from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
-from ai.backend.manager.actions.v2.field.bulk_processor import BulkFieldActionProcessor
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
+from ai.backend.manager.actions.v2.field.bulk_processor import (
+    PartialBulkFieldActionProcessor,
+)
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
-    BulkFieldOpsResult,
-    BulkOpsResult,
     CreatedEntityWithFieldsOpsResult,
     EntityOpsResult,
     FieldsOpsResult,
@@ -69,10 +69,10 @@ class RolePresetProcessors:
     get: SingleEntityActionProcessor[GetRolePresetAction, EntityOpsResult[RolePresetData]]
     search: GlobalActionProcessor[SearchRolePresetsAction, BatchOpsResult[RolePresetData]]
     update: SingleEntityActionProcessor[UpdateRolePresetAction, EntityOpsResult[RolePresetData]]
-    bulk_delete: BulkActionProcessor[BulkDeleteRolePresetsAction, BulkOpsResult[RolePresetData]]
-    bulk_restore: BulkActionProcessor[BulkRestoreRolePresetsAction, BulkOpsResult[RolePresetData]]
+    bulk_delete: PartialBulkActionProcessor[BulkDeleteRolePresetsAction, RolePresetData]
+    bulk_restore: PartialBulkActionProcessor[BulkRestoreRolePresetsAction, RolePresetData]
     purge: SingleEntityActionProcessor[PurgeRolePresetAction, EntityOpsResult[RolePresetData]]
-    bulk_purge: BulkActionProcessor[BulkPurgeRolePresetsAction, BulkOpsResult[RolePresetData]]
+    bulk_purge: PartialBulkActionProcessor[BulkPurgeRolePresetsAction, RolePresetData]
 
     # Permission entries: field rows of a preset, answered for by the preset owning them
     search_permission_presets: ScopeActionProcessor[
@@ -81,8 +81,8 @@ class RolePresetProcessors:
     bulk_add_permissions: SingleEntityActionProcessor[
         BulkAddRolePermissionPresetsAction, FieldsOpsResult[RolePermissionPresetData]
     ]
-    bulk_remove_permissions: BulkFieldActionProcessor[
-        BulkRemoveRolePermissionPresetsAction, BulkFieldOpsResult[RolePermissionPresetData]
+    bulk_remove_permissions: PartialBulkFieldActionProcessor[
+        BulkRemoveRolePermissionPresetsAction, RolePermissionPresetData
     ]
 
     def __init__(

--- a/src/ai/backend/manager/services/runtime_variant/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/runtime_variant/actions/bulk_get.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
+from ai.backend.manager.models.runtime_variant.queriers import BulkRuntimeVariantQuerier
+from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
+
+
+@dataclass
+class PublicBulkGetRuntimeVariantsAction(
+    PartialBulkGetEntityOpsAction[RuntimeVariantRow, RuntimeVariantData]
+):
+    """Read the runtime variants the caller named; every authenticated user may."""
+
+    ids: Sequence[RuntimeVariantID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_bulk_get_runtime_variants"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkRuntimeVariantQuerier:
+        return BulkRuntimeVariantQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/runtime_variant/processors.py
+++ b/src/ai/backend/manager/services/runtime_variant/processors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import (
     GlobalActionProcessor,
     PublicActionProcessor,
@@ -18,6 +19,9 @@ from ai.backend.manager.actions.v2.single_entity.processor import (
     SingleEntityActionProcessor,
 )
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
+from ai.backend.manager.services.runtime_variant.actions.bulk_get import (
+    PublicBulkGetRuntimeVariantsAction,
+)
 from ai.backend.manager.services.runtime_variant.actions.create import (
     CreateRuntimeVariantAction,
 )
@@ -42,6 +46,9 @@ class RuntimeVariantProcessors:
     public_get: PublicSingleEntityActionProcessor[
         GetRuntimeVariantAction, EntityOpsResult[RuntimeVariantData]
     ]
+    public_bulk_get: PartialBulkActionProcessor[
+        PublicBulkGetRuntimeVariantsAction, RuntimeVariantData
+    ]
     global_create: GlobalActionProcessor[
         CreateRuntimeVariantAction, CreatedEntityOpsResult[RuntimeVariantData]
     ]
@@ -60,6 +67,7 @@ class RuntimeVariantProcessors:
 
     def __init__(self, group: ProcessorGroup[RuntimeVariantData]) -> None:
         self.public_get = group.public_get_ops(GetRuntimeVariantAction)
+        self.public_bulk_get = group.public_partial_bulk_get_ops(PublicBulkGetRuntimeVariantsAction)
         self.global_create = group.global_create_ops(CreateRuntimeVariantAction)
         self.update = group.single_update_ops(UpdateRuntimeVariantAction)
         self.purge = group.entity_purge_ops(PurgeRuntimeVariantAction)

--- a/src/ai/backend/manager/services/session/actions/batch_get_session_resource_allocation.py
+++ b/src/ai/backend/manager/services/session/actions/batch_get_session_resource_allocation.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.session import SessionID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.types import SessionId
-from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
-from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
-from ai.backend.manager.actions.v2.bulk.result import BasePartialBulkActionResult, BulkEntityResult
-from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
 
 
 @dataclass
-class BatchGetSessionResourceAllocationAction(BaseBulkAction):
+class BatchGetSessionResourceAllocationAction(BasePartialBulkAction):
     """Aggregate the slot amounts recorded against the sessions the caller named.
 
     Answered for by each session the ids name.
@@ -36,19 +34,10 @@ class BatchGetSessionResourceAllocationAction(BaseBulkAction):
     def entity_ids(self) -> Sequence[EntityIdentifier]:
         return [SessionID(_id) for _id in self.session_ids]
 
-
-@dataclass
-class BatchGetSessionResourceAllocationActionResult(BasePartialBulkActionResult):
-    data: dict[SessionId, ResourceAllocationAggregate]
-
     @override
-    def entity_results(self) -> Sequence[BulkEntityResult]:
-        return [
-            BulkEntityResult(
-                entity_id=SessionID(_id),
-                status=OperationStatus.SUCCESS,
-                description="aggregated",
-                error_code=None,
-            )
-            for _id in self.data
-        ]
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(
+            self,
+            session_ids=[sid for sid in self.session_ids if SessionID(sid) in allowed],
+        )

--- a/src/ai/backend/manager/services/session/actions/terminate_sessions.py
+++ b/src/ai/backend/manager/services/session/actions/terminate_sessions.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import dataclass, field
-from typing import override
+from dataclasses import dataclass, replace
+from typing import Self, override
 
 from ai.backend.common.data.entity.session import SessionID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.types import SessionId
-from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
-from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
-from ai.backend.manager.actions.v2.bulk.result import BasePartialBulkActionResult, BulkEntityResult
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
 
 
 @dataclass
-class TerminateSessionsAction(BaseBulkAction):
+class TerminateSessionsAction(BasePartialBulkAction):
     """Terminate the sessions the caller named.
 
     Every named session is answered for on its own, which is what the bulk shape
-    says; a denial on one fails the run.
+    says, and the answer carries which of the four states it ended in.
     """
 
     session_ids: list[SessionId]
@@ -37,29 +36,10 @@ class TerminateSessionsAction(BaseBulkAction):
     def entity_ids(self) -> Sequence[EntityIdentifier]:
         return [SessionID(sid) for sid in self.session_ids]
 
-
-@dataclass
-class TerminateSessionsActionResult(BasePartialBulkActionResult):
-    """Result of bulk session termination."""
-
-    cancelled: list[SessionId] = field(default_factory=list)
-    terminating: list[SessionId] = field(default_factory=list)
-    force_terminated: list[SessionId] = field(default_factory=list)
-    skipped: list[SessionId] = field(default_factory=list)
-
     @override
-    def entity_results(self) -> Sequence[BulkEntityResult]:
-        def entry(sid: SessionId, description: str) -> BulkEntityResult:
-            return BulkEntityResult(
-                entity_id=SessionID(sid),
-                status=OperationStatus.SUCCESS,
-                description=description,
-                error_code=None,
-            )
-
-        return [
-            *(entry(sid, "cancelled") for sid in self.cancelled),
-            *(entry(sid, "terminating") for sid in self.terminating),
-            *(entry(sid, "force-terminated") for sid in self.force_terminated),
-            *(entry(sid, "skipped") for sid in self.skipped),
-        ]
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(
+            self,
+            session_ids=[sid for sid in self.session_ids if SessionID(sid) in allowed],
+        )

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -1,20 +1,20 @@
 from ai.backend.common.data.entity.session import SessionID
 from ai.backend.manager.actions.registry.group import ProcessorGroup
-from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.field.bulk_processor import BulkFieldActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import PublicActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import LookupOpsResult
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
-from ai.backend.manager.data.session.types import SessionEntityData
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
+from ai.backend.manager.data.session.types import SessionEntityData, SessionTerminationStatus
 from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
     BatchGetKernelResourceAllocationAction,
     BatchGetKernelResourceAllocationActionResult,
 )
 from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
     BatchGetSessionResourceAllocationAction,
-    BatchGetSessionResourceAllocationActionResult,
 )
 from ai.backend.manager.services.session.actions.commit_session import (
     CommitSessionAction,
@@ -142,7 +142,6 @@ from ai.backend.manager.services.session.actions.start_service import (
 )
 from ai.backend.manager.services.session.actions.terminate_sessions import (
     TerminateSessionsAction,
-    TerminateSessionsActionResult,
 )
 from ai.backend.manager.services.session.actions.update_session import (
     UpdateSessionAction,
@@ -206,8 +205,8 @@ class SessionProcessors:
         ResolveSessionNameAction, ResolveSessionNameActionResult
     ]
     search_kernels: ScopeActionProcessor[SearchKernelsAction, SearchKernelsActionResult]
-    batch_get_session_resource_allocation: BulkActionProcessor[
-        BatchGetSessionResourceAllocationAction, BatchGetSessionResourceAllocationActionResult
+    batch_get_session_resource_allocation: PartialBulkActionProcessor[
+        BatchGetSessionResourceAllocationAction, ResourceAllocationAggregate
     ]
     batch_get_kernel_resource_allocation: BulkFieldActionProcessor[
         BatchGetKernelResourceAllocationAction, BatchGetKernelResourceAllocationActionResult
@@ -220,7 +219,9 @@ class SessionProcessors:
         ShutdownServiceAction, ShutdownServiceActionResult
     ]
     start_service: SingleEntityActionProcessor[StartServiceAction, StartServiceActionResult]
-    terminate_sessions: BulkActionProcessor[TerminateSessionsAction, TerminateSessionsActionResult]
+    terminate_sessions: PartialBulkActionProcessor[
+        TerminateSessionsAction, SessionTerminationStatus
+    ]
     upload_files: SingleEntityActionProcessor[UploadFilesAction, UploadFilesActionResult]
     get_session: SingleEntityActionProcessor[GetSessionAction, GetSessionActionResult]
     update_session: SingleEntityActionProcessor[UpdateSessionAction, UpdateSessionActionResult]
@@ -283,7 +284,7 @@ class SessionProcessors:
         self.search_kernels = group.scope(SearchKernelsAction, service.search_kernels)
         # Bulk read for GraphQL DataLoaders; ids come from already-authorized
         # session/kernel nodes, so no per-target RBAC re-validation is applied.
-        self.batch_get_session_resource_allocation = group.bulk(
+        self.batch_get_session_resource_allocation = group.partial_bulk(
             BatchGetSessionResourceAllocationAction, service.batch_get_session_resource_allocation
         )
         self.batch_get_kernel_resource_allocation = group.atomic_bulk_field(
@@ -295,7 +296,9 @@ class SessionProcessors:
         self.search_sessions_in_project = group.scope(
             SearchSessionsInProjectAction, service.search_in_project
         )
-        self.terminate_sessions = group.bulk(TerminateSessionsAction, service.terminate_sessions)
+        self.terminate_sessions = group.partial_bulk(
+            TerminateSessionsAction, service.terminate_sessions
+        )
 
         # Actions without RBAC validation (name-based, no session_id at construction)
         self.destroy_session = group.single_entity(DestroySessionAction, service.destroy_session)

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -25,6 +25,7 @@ from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupName
 from ai.backend.common.data.entity.resource_slot import ResourceSlotName
 from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.session.types import CustomizedImageVisibilityScope
 from ai.backend.common.defs.session import JOB_PRIORITY_DEFAULT, SESSION_PRIORITY_DEFAULT
@@ -50,11 +51,16 @@ from ai.backend.common.types import (
     SessionTypes,
 )
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.v2.bulk.result import (
+    PartialBulkEntityResult,
+    PartialBulkResult,
+)
 from ai.backend.manager.bgtask.tasks.commit_session import CommitSessionManifest
 from ai.backend.manager.bgtask.types import ManagerBgtaskName
 from ai.backend.manager.clients.appproxy.client import AppProxyClientPool
 from ai.backend.manager.data.common.sentinel import undefined
 from ai.backend.manager.data.image.types import ImageIdentifier
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.draft import (
     KernelExecutionSpecDraft,
     KernelGroupDraft,
@@ -73,7 +79,7 @@ from ai.backend.manager.data.session.options import (
     InternalDataExtras,
     ResourceOpts,
 )
-from ai.backend.manager.data.session.types import SessionStatus
+from ai.backend.manager.data.session.types import SessionStatus, SessionTerminationStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
 from ai.backend.manager.errors.common import (
     InternalServerError,
@@ -112,7 +118,6 @@ from ai.backend.manager.services.session.actions.batch_get_kernel_resource_alloc
 )
 from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
     BatchGetSessionResourceAllocationAction,
-    BatchGetSessionResourceAllocationActionResult,
 )
 from ai.backend.manager.services.session.actions.commit_session import (
     CommitSessionAction,
@@ -236,7 +241,6 @@ from ai.backend.manager.services.session.actions.start_service import (
 )
 from ai.backend.manager.services.session.actions.terminate_sessions import (
     TerminateSessionsAction,
-    TerminateSessionsActionResult,
 )
 from ai.backend.manager.services.session.actions.update_session import (
     UpdateSessionAction,
@@ -881,7 +885,7 @@ class SessionService:
 
     async def terminate_sessions(
         self, action: TerminateSessionsAction
-    ) -> TerminateSessionsActionResult:
+    ) -> PartialBulkResult[SessionTerminationStatus]:
         """Terminate multiple sessions by their IDs."""
         reason = (
             KernelLifecycleEventReason.FORCE_TERMINATED
@@ -891,11 +895,26 @@ class SessionService:
         mark_result = await self._scheduling_controller.mark_sessions_for_termination(
             action.session_ids, reason=reason.value, forced=action.forced
         )
-        return TerminateSessionsActionResult(
-            cancelled=mark_result.cancelled_sessions,
-            terminating=mark_result.terminating_sessions,
-            force_terminated=mark_result.force_terminated_sessions,
-            skipped=mark_result.skipped_sessions,
+        # The controller answers in four buckets; the bulk shape answers per session,
+        # so the state each one ended in becomes that session's value.
+        states: dict[EntityIdentifier, SessionTerminationStatus] = {
+            SessionID(sid): state
+            for state, sids in (
+                (SessionTerminationStatus.CANCELLED, mark_result.cancelled_sessions),
+                (SessionTerminationStatus.TERMINATING, mark_result.terminating_sessions),
+                (SessionTerminationStatus.FORCE_TERMINATED, mark_result.force_terminated_sessions),
+                (SessionTerminationStatus.SKIPPED, mark_result.skipped_sessions),
+            )
+            for sid in sids
+        }
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[SessionTerminationStatus].succeeded(
+                    entity_id, state, description=state.value
+                )
+                for entity_id in action.entity_ids()
+                if (state := states.get(entity_id)) is not None
+            ]
         )
 
     async def download_file(self, action: DownloadFileAction) -> DownloadFileActionResult:
@@ -1556,12 +1575,25 @@ class SessionService:
 
     async def batch_get_session_resource_allocation(
         self, action: BatchGetSessionResourceAllocationAction
-    ) -> BatchGetSessionResourceAllocationActionResult:
+    ) -> PartialBulkResult[ResourceAllocationAggregate]:
         """Aggregate resource_allocations per session (requested/used/allocated)."""
         data = await self._session_repository.batch_get_resource_allocation_by_session(
             action.session_ids
         )
-        return BatchGetSessionResourceAllocationActionResult(data=data)
+        # Every named session is answered for: one with no allocations recorded holds
+        # nothing, which is not the same as an id naming no session.
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[ResourceAllocationAggregate].succeeded(
+                    SessionID(sid), aggregate, description="aggregated"
+                )
+                if (aggregate := data.get(sid)) is not None
+                else PartialBulkEntityResult[ResourceAllocationAggregate].nothing(
+                    SessionID(sid), description="no allocations"
+                )
+                for sid in action.session_ids
+            ]
+        )
 
     async def batch_get_kernel_resource_allocation(
         self, action: BatchGetKernelResourceAllocationAction

--- a/src/ai/backend/manager/services/storage_namespace/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/storage_namespace/actions/bulk_get.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
+from ai.backend.manager.models.storage_namespace.queriers import (
+    BulkStorageNamespaceQuerier,
+)
+from ai.backend.manager.models.storage_namespace.row import StorageNamespaceRow
+
+
+@dataclass
+class BulkGetStorageNamespacesAction(
+    PartialBulkGetEntityOpsAction[StorageNamespaceRow, StorageNamespaceData]
+):
+    """Read the storage namespaces the caller named, answering for each id."""
+
+    ids: Sequence[StorageNamespaceID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_storage_namespaces"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkStorageNamespaceQuerier:
+        return BulkStorageNamespaceQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/storage_namespace/processors.py
+++ b/src/ai/backend/manager/services/storage_namespace/processors.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from ai.backend.common.data.entity.storage_namespace import StorageNamespaceID
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
@@ -14,6 +15,9 @@ from ai.backend.manager.actions.v2.single_entity.processor import (
     SingleEntityActionProcessor,
 )
 from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
+from ai.backend.manager.services.storage_namespace.actions.bulk_get import (
+    BulkGetStorageNamespacesAction,
+)
 from ai.backend.manager.services.storage_namespace.actions.get_multi import GetNamespacesAction
 from ai.backend.manager.services.storage_namespace.actions.lookup import (
     LookupStorageNamespaceAction,
@@ -43,6 +47,7 @@ class StorageNamespaceProcessors:
     global_get_namespaces: GlobalActionProcessor[
         GetNamespacesAction, BatchOpsResult[StorageNamespaceData]
     ]
+    bulk_get: PartialBulkActionProcessor[BulkGetStorageNamespacesAction, StorageNamespaceData]
     lookup: LookupActionProcessor[LookupStorageNamespaceAction, LookupOpsResult[StorageNamespaceID]]
     unregister: SingleEntityActionProcessor[
         UnregisterNamespaceAction, EntityOpsResult[StorageNamespaceData]
@@ -52,5 +57,6 @@ class StorageNamespaceProcessors:
         self.global_register = group.global_create_ops(RegisterNamespaceAction)
         self.global_search = group.global_search_ops(SearchStorageNamespacesAction)
         self.global_get_namespaces = group.global_search_ops(GetNamespacesAction)
+        self.bulk_get = group.partial_bulk_get_ops(BulkGetStorageNamespacesAction)
         self.lookup = group.lookup_ops(LookupStorageNamespaceAction)
         self.unregister = group.entity_purge_ops(UnregisterNamespaceAction)

--- a/src/ai/backend/testutils/action_validators.py
+++ b/src/ai/backend/testutils/action_validators.py
@@ -3,7 +3,8 @@
 from unittest.mock import MagicMock
 
 from ai.backend.manager.actions.v2.bulk.validator.rbac import (
-    VirtualScopeBulkActionRBACValidator,
+    VirtualScopeAtomicBulkActionRBACValidator,
+    VirtualScopePartialBulkActionRBACValidator,
 )
 from ai.backend.manager.actions.v2.scope.validator.rbac import (
     VirtualScopeScopeActionRBACValidator,
@@ -23,5 +24,6 @@ def mock_virtual_scope_rbac_validators() -> VirtualScopeRBACValidators:
     return VirtualScopeRBACValidators(
         scope=MagicMock(spec=VirtualScopeScopeActionRBACValidator),
         single_entity=MagicMock(spec=VirtualScopeSingleEntityActionRBACValidator),
-        bulk=MagicMock(spec=VirtualScopeBulkActionRBACValidator),
+        partial_bulk=MagicMock(spec=VirtualScopePartialBulkActionRBACValidator),
+        atomic_bulk=MagicMock(spec=VirtualScopeAtomicBulkActionRBACValidator),
     )

--- a/tests/unit/manager/actions/test_bulk_v2_processor.py
+++ b/tests/unit/manager/actions/test_bulk_v2_processor.py
@@ -29,7 +29,7 @@ from ai.backend.manager.actions.v2.bulk.result import (
     BulkEntityResult,
 )
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
-from ai.backend.manager.actions.v2.bulk.validator.base import BulkActionValidator
+from ai.backend.manager.actions.v2.bulk.validator.base import AtomicBulkActionValidator
 
 _SESSION_ENTITY_TYPE = EntityType("session")
 
@@ -86,7 +86,7 @@ class _RecordingMonitor(BulkActionMonitor):
         self.done_results.append(result)
 
 
-class _DenyingValidator(BulkActionValidator):
+class _DenyingValidator(AtomicBulkActionValidator):
     @override
     async def validate(self, meta: BulkActionTriggerMeta) -> None:
         raise PermissionDeniedError("nope")

--- a/tests/unit/manager/actions/test_ops_action_results.py
+++ b/tests/unit/manager/actions/test_ops_action_results.py
@@ -14,10 +14,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityData, EntityIdentifier, EntityType
-from ai.backend.manager.actions.types import OperationStatus
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupActionResult
 from ai.backend.manager.actions.v2.ops.result import (
-    BulkOpsResult,
     CreatedEntityOpsResult,
     EntitiesOpsResult,
     EntityOpsResult,
@@ -25,7 +23,6 @@ from ai.backend.manager.actions.v2.ops.result import (
     ScopedBatchOpsResult,
 )
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
-from ai.backend.manager.errors.repository import EntityNotFoundError
 
 _ENTITY_TYPE = EntityType("preset")
 
@@ -98,29 +95,6 @@ def test_lookup_result_reports_the_id_its_key_resolved_to() -> None:
     result: BaseLookupActionResult = LookupOpsResult(resolved_entity_id=entity_id)
 
     assert result.entity_id() == entity_id
-
-
-def test_bulk_result_answers_for_every_entity_named() -> None:
-    ok, broken = _PresetID(uuid.uuid4()), _PresetID(uuid.uuid4())
-
-    result = BulkOpsResult(
-        successes={ok: _PresetData(id=ok, name="a")},
-        errors={broken: EntityNotFoundError("gone")},
-    )
-
-    by_id = {r.entity_id: r for r in result.entity_results()}
-    assert by_id[ok].status is OperationStatus.SUCCESS
-    assert by_id[broken].status is OperationStatus.ERROR
-    assert by_id[broken].error_code == EntityNotFoundError("gone").error_code()
-
-
-def test_bulk_result_needs_nothing_from_its_data_type() -> None:
-    # The ids are the ones the caller passed in, so `EntityData` is not required.
-    entity_id = _PresetID(uuid.uuid4())
-
-    result = BulkOpsResult(successes={entity_id: _PlainData(name="a")}, errors={})
-
-    assert [r.entity_id for r in result.entity_results()] == [entity_id]
 
 
 def test_entity_result_carries_only_its_data() -> None:

--- a/tests/unit/manager/actions/test_partial_bulk_get_processor.py
+++ b/tests/unit/manager/actions/test_partial_bulk_get_processor.py
@@ -1,0 +1,257 @@
+"""A bulk read answers for every id it was given, denials included.
+
+The point of the shape is that an id the caller may not read and an id matching no row
+are two different answers, so the processor is held to keeping them apart — in what it
+returns and in what the monitors record.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Self, override
+
+import pytest
+
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
+from ai.backend.manager.actions.v2.bulk.monitor.base import BulkActionMonitor
+from ai.backend.manager.actions.v2.bulk.partial_processor import (
+    PartialBulkActionProcessor,
+    PublicPartialBulkActionProcessor,
+)
+from ai.backend.manager.actions.v2.bulk.result import (
+    BulkActionProcessResult,
+    PartialBulkEntityResult,
+    PartialBulkResult,
+)
+from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
+from ai.backend.manager.actions.v2.bulk.validator.base import PartialBulkActionValidator
+from ai.backend.manager.errors.common import ServerMisconfiguredError
+from ai.backend.manager.errors.permission import NotEnoughPermission
+from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.user import UserNotFound
+
+_STORAGE_ENTITY_TYPE = EntityType("object_storage")
+
+
+class _StorageID(EntityIdentifier):
+    @override
+    def entity_type(self) -> EntityType:
+        return _STORAGE_ENTITY_TYPE
+
+
+def _eid(raw: str) -> _StorageID:
+    return _StorageID(uuid.uuid5(uuid.NAMESPACE_OID, raw))
+
+
+@dataclass
+class _Action(BasePartialBulkAction):
+    ids: list[_StorageID]
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return self.ids
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])
+
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "bulk_get_object_storages"
+
+
+@dataclass
+class _WriteAction(_Action):
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.PURGE
+
+
+class _RecordingMonitor(BulkActionMonitor):
+    def __init__(self) -> None:
+        self.done_results: list[BulkActionProcessResult] = []
+
+    @override
+    async def prepare(self, meta: BulkActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(self, meta: BulkActionTriggerMeta, result: BulkActionProcessResult) -> None:
+        self.done_results.append(result)
+
+
+@dataclass
+class _DenyingValidator(PartialBulkActionValidator):
+    """Denies the ids it was built with, leaving the rest to the operation."""
+
+    denied: list[_StorageID] = field(default_factory=list)
+
+    @override
+    async def validate(self, meta: BulkActionTriggerMeta) -> Mapping[EntityIdentifier, Exception]:
+        return {entity_id: NotEnoughPermission("nope") for entity_id in self.denied}
+
+
+class _Reader:
+    """Stands in for the ops read: it knows one row, and reads the narrowed action."""
+
+    def __init__(self, present: Sequence[_StorageID]) -> None:
+        self._present = set(present)
+        self.asked_for: list[EntityIdentifier] = []
+
+    async def run(self, action: _Action) -> PartialBulkResult[str]:
+        entity_ids = action.entity_ids()
+        self.asked_for = list(entity_ids)
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[str].succeeded(entity_id, f"data:{entity_id}")
+                if entity_id in self._present
+                else PartialBulkEntityResult[str].failed(entity_id, EntityNotFoundError("gone"))
+                for entity_id in entity_ids
+            ]
+        )
+
+
+def _user() -> UserData:
+    return UserData(
+        user_id=uuid.uuid4(),
+        is_authorized=True,
+        is_admin=False,
+        is_superadmin=False,
+        role=UserRole.USER,
+        domain_name="default",
+        domain_id=DomainID(uuid.uuid4()),
+    )
+
+
+@pytest.fixture
+def action() -> _Action:
+    return _Action(ids=[_eid("readable"), _eid("denied"), _eid("gone")])
+
+
+async def test_a_denied_id_is_never_read(action: _Action) -> None:
+    reader = _Reader(present=[_eid("readable"), _eid("denied")])
+    processor = PartialBulkActionProcessor[_Action, str](
+        reader.run,
+        partial_validators=[_DenyingValidator(denied=[_eid("denied")])],
+    )
+
+    await processor.run(action)
+
+    assert reader.asked_for == [_eid("readable"), _eid("gone")]
+
+
+async def test_a_denial_and_a_miss_carry_different_errors(action: _Action) -> None:
+    reader = _Reader(present=[_eid("readable"), _eid("denied")])
+    processor = PartialBulkActionProcessor[_Action, str](
+        reader.run,
+        partial_validators=[_DenyingValidator(denied=[_eid("denied")])],
+    )
+
+    result = await processor.run(action)
+
+    assert result.values() == {_eid("readable"): f"data:{_eid('readable')}"}
+    errors = result.errors()
+    assert isinstance(errors[_eid("denied")], NotEnoughPermission)
+    assert isinstance(errors[_eid("gone")], EntityNotFoundError)
+
+
+async def test_every_named_entity_is_recorded_with_its_own_status(action: _Action) -> None:
+    reader = _Reader(present=[_eid("readable"), _eid("denied")])
+    monitor = _RecordingMonitor()
+    processor = PartialBulkActionProcessor[_Action, str](
+        reader.run,
+        monitors=[monitor],
+        partial_validators=[_DenyingValidator(denied=[_eid("denied")])],
+    )
+
+    await processor.run(action)
+
+    meta = monitor.done_results[0].meta
+    assert {r.entity_id: r.status for r in meta.entity_results} == {
+        _eid("readable"): OperationStatus.SUCCESS,
+        _eid("gone"): OperationStatus.ERROR,
+        _eid("denied"): OperationStatus.DENIED,
+    }
+
+
+async def test_nothing_is_read_when_every_id_is_denied(action: _Action) -> None:
+    reader = _Reader(present=list(action.ids))
+    processor = PartialBulkActionProcessor[_Action, str](
+        reader.run,
+        partial_validators=[_DenyingValidator(denied=list(action.ids))],
+    )
+
+    result = await processor.run(action)
+
+    assert reader.asked_for == []
+    assert result.values() == {}
+    assert set(result.errors()) == set(action.ids)
+
+
+async def test_the_public_path_denies_nothing(action: _Action) -> None:
+    reader = _Reader(present=list(action.ids))
+    processor = PublicPartialBulkActionProcessor[_Action, str](_Action, reader.run)
+
+    with with_user(_user()):
+        result = await processor.run(action)
+
+    assert reader.asked_for == list(action.ids)
+    assert set(result.values()) == set(action.ids)
+
+
+async def test_the_public_path_still_needs_an_authenticated_caller(action: _Action) -> None:
+    reader = _Reader(present=list(action.ids))
+    processor = PublicPartialBulkActionProcessor[_Action, str](_Action, reader.run)
+
+    with pytest.raises(UserNotFound):
+        await processor.run(action)
+
+
+def test_the_public_path_rejects_a_write() -> None:
+    reader = _Reader(present=[])
+    with pytest.raises(ServerMisconfiguredError):
+        PublicPartialBulkActionProcessor[_WriteAction, str](_WriteAction, reader.run)
+
+
+async def test_the_answer_keeps_the_order_the_caller_asked_in(action: _Action) -> None:
+    """The denied id is put back where it was named, not appended after the rest."""
+    reader = _Reader(present=[_eid("readable"), _eid("denied")])
+    processor = PartialBulkActionProcessor[_Action, str](
+        reader.run,
+        partial_validators=[_DenyingValidator(denied=[_eid("denied")])],
+    )
+
+    result = await processor.run(action)
+
+    assert [item.entity_id for item in result.items] == list(action.entity_ids())
+
+
+async def test_a_denial_is_marked_apart_from_a_failure(action: _Action) -> None:
+    reader = _Reader(present=[_eid("readable"), _eid("denied")])
+    processor = PartialBulkActionProcessor[_Action, str](
+        reader.run,
+        partial_validators=[_DenyingValidator(denied=[_eid("denied")])],
+    )
+
+    result = await processor.run(action)
+
+    assert {item.entity_id: item.is_denied for item in result.items} == {
+        _eid("readable"): False,
+        _eid("denied"): True,
+        _eid("gone"): False,
+    }

--- a/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_scope_rbac_validators.py
@@ -48,7 +48,7 @@ from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
 from ai.backend.manager.actions.v2.bulk.validator.rbac import (
-    VirtualScopeBulkActionRBACValidator,
+    VirtualScopeAtomicBulkActionRBACValidator,
 )
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.validator.rbac import (
@@ -491,8 +491,8 @@ def single_entity_validator(
 @pytest.fixture
 def bulk_validator(
     repository: PermissionControllerRepository,
-) -> VirtualScopeBulkActionRBACValidator:
-    return VirtualScopeBulkActionRBACValidator(repository, _make_config_provider())
+) -> VirtualScopeAtomicBulkActionRBACValidator:
+    return VirtualScopeAtomicBulkActionRBACValidator(repository, _make_config_provider())
 
 
 @pytest.fixture
@@ -880,10 +880,10 @@ class TestUpsertRequiresBothCreateAndUpdate:
             )
 
 
-class TestVirtualScopeBulkActionRBACValidator:
+class TestVirtualScopeAtomicBulkActionRBACValidator:
     async def test_superadmin_bypasses_check(
         self,
-        bulk_validator: VirtualScopeBulkActionRBACValidator,
+        bulk_validator: VirtualScopeAtomicBulkActionRBACValidator,
         bulk_vfolder_action: _BulkVfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
         superadmin_user: UserData,
@@ -902,7 +902,7 @@ class TestVirtualScopeBulkActionRBACValidator:
 
     async def test_all_targets_granted_passes(
         self,
-        bulk_validator: VirtualScopeBulkActionRBACValidator,
+        bulk_validator: VirtualScopeAtomicBulkActionRBACValidator,
         bulk_vfolder_action: _BulkVfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
         user_with_all_bulk_vfolders_granted: UserData,
@@ -920,7 +920,7 @@ class TestVirtualScopeBulkActionRBACValidator:
 
     async def test_any_denied_target_rejects_whole_action(
         self,
-        bulk_validator: VirtualScopeBulkActionRBACValidator,
+        bulk_validator: VirtualScopeAtomicBulkActionRBACValidator,
         bulk_vfolder_action: _BulkVfolderUpdateAction,
         trigger_meta: BaseActionTriggerMeta,
         user_with_partial_bulk_membership: UserData,
@@ -940,7 +940,7 @@ class TestVirtualScopeBulkActionRBACValidator:
 
     async def test_entity_cap_clips_granted_permission(
         self,
-        bulk_validator: VirtualScopeBulkActionRBACValidator,
+        bulk_validator: VirtualScopeAtomicBulkActionRBACValidator,
         trigger_meta: BaseActionTriggerMeta,
         user_with_read_capped_bulk_vfolder: UserData,
     ) -> None:
@@ -952,7 +952,7 @@ class TestVirtualScopeBulkActionRBACValidator:
 
     async def test_empty_targets_passes(
         self,
-        bulk_validator: VirtualScopeBulkActionRBACValidator,
+        bulk_validator: VirtualScopeAtomicBulkActionRBACValidator,
         trigger_meta: BaseActionTriggerMeta,
         regular_user_without_permission: UserData,
     ) -> None:

--- a/tests/unit/manager/api/adapters/test_session_adapter.py
+++ b/tests/unit/manager/api/adapters/test_session_adapter.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from ai.backend.common.data.entity.session import SessionID
 from ai.backend.common.dto.manager.v2.common import (
     ResourceSlotEntryInfo,
     ResourceSlotEntryInput,
@@ -26,9 +27,21 @@ from ai.backend.common.dto.manager.v2.session.types import (
 )
 from ai.backend.common.dto.manager.v2.session_options.types import AgentSelectionPolicyEnum
 from ai.backend.common.types import ClusterMode, SessionResult, SessionTypes
+from ai.backend.manager.actions.v2.bulk.result import (
+    PartialBulkEntityResult,
+    PartialBulkResult,
+)
 from ai.backend.manager.api.adapters.session.adapter import SessionAdapter
+from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.options import AgentSelectionPolicy
-from ai.backend.manager.data.session.types import SessionData, SessionStatus
+from ai.backend.manager.data.session.types import (
+    SessionData,
+    SessionStatus,
+    SessionTerminationStatus,
+)
+from ai.backend.manager.services.session.actions.batch_get_session_resource_allocation import (
+    BatchGetSessionResourceAllocationAction,
+)
 
 
 def _create_session_data(
@@ -171,6 +184,18 @@ class TestSessionDataToNode:
         assert len(node.resource.allocation.used.entries) == 0
 
 
+async def _no_allocations(
+    action: BatchGetSessionResourceAllocationAction,
+) -> PartialBulkResult[ResourceAllocationAggregate]:
+    """The read answers for every session named, each holding nothing."""
+    return PartialBulkResult(
+        items=[
+            PartialBulkEntityResult[ResourceAllocationAggregate].nothing(SessionID(sid))
+            for sid in action.session_ids
+        ]
+    )
+
+
 class TestEnqueueActionBuilding:
     """Tests for adapter.enqueue() action construction."""
 
@@ -180,10 +205,8 @@ class TestEnqueueActionBuilding:
         result = MagicMock()
         result.session_data = _create_session_data()
         processors.session.enqueue_session.run = AsyncMock(return_value=result)
-        allocation_result = MagicMock()
-        allocation_result.data = {}
         processors.session.batch_get_session_resource_allocation.run = AsyncMock(
-            return_value=allocation_result
+            side_effect=_no_allocations
         )
         return processors
 
@@ -335,11 +358,13 @@ class TestTerminateActionBuilding:
     @pytest.fixture
     def mock_processors(self) -> MagicMock:
         processors = MagicMock()
-        result = MagicMock()
-        result.cancelled = []
-        result.terminating = [uuid4()]
-        result.force_terminated = []
-        result.skipped = []
+        result = PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[SessionTerminationStatus].succeeded(
+                    SessionID(uuid4()), SessionTerminationStatus.TERMINATING
+                )
+            ]
+        )
         processors.session.terminate_sessions.run = AsyncMock(return_value=result)
         return processors
 

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -56,7 +56,7 @@ from ai.backend.manager.models.specs.creator import GlobalEntityCreator
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.specs.purger import DataBatchPurger
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 from ai.backend.manager.models.specs.searcher import Searcher
 from ai.backend.manager.models.specs.types import ConflictCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataBatchUpdater
@@ -155,6 +155,22 @@ class _PresetQuerier(DataQuerier[RolePresetRow, RolePresetData]):
     @override
     def entity_id_value(self) -> RolePresetID:
         return RolePresetID(self.target)
+
+    @override
+    def to_data(self, row: RolePresetRow) -> RolePresetData:
+        return row.to_data()
+
+
+class _PresetBulkQuerier(BulkEntityQuerier[RolePresetRow, RolePresetData]):
+    """The plural read: the ids come with the call, so the spec carries none."""
+
+    @override
+    def row_class(self) -> type[RolePresetRow]:
+        return RolePresetRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return RolePresetRow.id
 
     @override
     def to_data(self, row: RolePresetRow) -> RolePresetData:
@@ -324,6 +340,36 @@ class TestGet:
     async def test_missing_row_raises(self, repository: OpsRepository[RolePresetData]) -> None:
         with pytest.raises(EntityNotFoundError):
             await repository.get(_PresetQuerier(target=uuid.uuid4()))
+
+
+class TestBulkGet:
+    async def test_every_named_row_comes_back_keyed_by_its_id(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        other = await repository.create_global_entity(
+            _PresetCreator(name="analysts", scope_type=RBACScopeType.PROJECT)
+        )
+
+        found = await repository.bulk_get(_PresetBulkQuerier(), [preset.id, other.id])
+
+        assert {key: value.name for key, value in found.items()} == {
+            preset.id: "default",
+            other.id: "analysts",
+        }
+
+    async def test_a_missing_id_is_absent_rather_than_raising(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        absent = RolePresetID(uuid.uuid4())
+
+        found = await repository.bulk_get(_PresetBulkQuerier(), [preset.id, absent])
+
+        assert list(found) == [preset.id]
+
+    async def test_no_ids_reads_nothing(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        assert await repository.bulk_get(_PresetBulkQuerier(), []) == {}
 
 
 class TestLookup:

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -1422,7 +1422,7 @@ async def test_partial_bulk_update_answers_for_every_named_entity(
 
     result = await service.execute(_BulkUpdateAction(updaters=updaters))
 
-    assert list(result.successes) == [stored.id]
+    assert list(result.values()) == [stored.id]
     repository.partial_bulk_update.assert_awaited_once_with(updaters)
 
 
@@ -1434,7 +1434,7 @@ async def test_partial_bulk_delete_writes_through_the_update_path(
 
     result = await service.execute(_BulkUpdateAction(updaters=updaters))
 
-    assert list(result.successes) == [stored.id]
+    assert list(result.values()) == [stored.id]
     repository.partial_bulk_update.assert_awaited_once_with(updaters)
 
 
@@ -1446,7 +1446,7 @@ async def test_partial_bulk_purge_answers_for_every_named_entity(
 
     result = await service.execute(_BulkPurgeAction(purgers=purgers))
 
-    assert list(result.successes) == [stored.id]
+    assert list(result.values()) == [stored.id]
     repository.partial_bulk_purge_entities.assert_awaited_once_with(purgers)
 
 
@@ -1524,7 +1524,7 @@ async def test_global_partial_bulk_purge_answers_for_every_named_entity(
 
     result = await service.execute(_BulkPurgeGlobalAction(purgers=purgers))
 
-    assert list(result.successes) == [stored.id]
+    assert list(result.values()) == [stored.id]
     repository.partial_bulk_purge_entities.assert_awaited_once_with(purgers)
 
 


### PR DESCRIPTION
## Summary

- A DataLoader adapter read the ids it was given through a scope-wide search, so the permission check landed on the scope — SUPERADMIN, where the search was global — instead of on each id, and a missing id was indistinguishable from one the caller may not read.
- Adds the path that names them: a `BulkEntityQuerier` keyed on the row's own id, a bulk validator that answers per entity instead of refusing the run, and the `PartialBulkResult` the processor completes and orders against the ids the caller passed. Seven adapters move onto it (object_storage, storage_namespace, runtime_variant, prometheus_query_preset_category, app_config allow-list / definition / fragment), and their DataLoaders now null a miss and raise a denial.
- Marks every bulk name partial or atomic — the factories, the action bases and the validators alike — and moves every partial-shaped write onto per-entity validation.

**Behavior change.** A denied entity is now one failed item rather than a failed run, so a bulk purge / update / delete / restore no longer rejects the whole request when the caller cannot reach one of its targets. The reads that were behind the SUPERADMIN gate only because their batch load ran a global search are now checked per entity instead.

## Test plan

- [x] `pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=origin/main --changed-dependents=transitive`
- [x] `pants test --changed-since=origin/main --changed-dependents=direct`
- [x] New: `tests/unit/manager/actions/test_partial_bulk_get_processor.py` — a denied id is never read, a denial and a miss carry different errors, every named entity is recorded with its own status, the answer keeps the caller's order, the public path denies nothing
- [x] New: `TestBulkGet` in `tests/unit/manager/repositories/ops/test_ops_repository.py` — real-DB reads keyed by the caller's ids, a missing id absent rather than raising
- [ ] Non-admin GraphQL read of the seven entity types against a live server

Resolves BA-7414