### PR TITLE
feat(BA-7042): add the storage format and key providers for secret columns

### DIFF
--- a/changes/13929.feature.md
+++ b/changes/13929.feature.md
@@ -1,0 +1,1 @@
+Add at-rest encryption for secret columns, with the stored format, key providers and column type it is built from; no column adopts it yet

--- a/proposals/BEP-1065-encrypted-secret-key-storage.md
+++ b/proposals/BEP-1065-encrypted-secret-key-storage.md
@@ -49,24 +49,28 @@ For each area, separate **✅ what already exists** from **➕ what to add**.
 
 | | Item |
 |---|---|
-| ✅ | The pydantic section pattern of `ManagerUnifiedConfig` (`AuthConfig` and friends), with the password hash algorithm/rounds settings as precedent |
+| ✅ | The pydantic section pattern of `ManagerUnifiedConfig` (`AuthConfig` and friends), with the password hash algorithm settings as precedent |
 | ✅ | Unified config is loaded at component startup and reached at runtime through `ManagerConfigProvider` |
-| ✅ | A `ManagerConfigProvider` assembly path for one-shot CLI commands - the CLI can read the full unified config too, so no separate key-injection path is needed (3.5) |
-| ➕ | New section `secret-encryption`: `mode = plain \| encrypt`, `algorithm`, **`active-key-version`**, and a **per-version key list** |
+| ✅ | A `ManagerConfigProvider` assembly path for one-shot CLI commands - the CLI reads the full unified config too, so no separate key-injection path is needed (3.5) |
+| ➕ | New section `secret-encryption`: **which provider type writes**, plus an optional subsection per provider type |
 
-- `mode` decides **the write policy only**. Reads are always decided by the value itself. The default is `plain` (opt-in).
-- **Multiple keys are injected at once, one per version.** Decryption uses the version the value names; new encryption uses `active-key-version` only. That is the whole of key rotation.
+- **There is no separate on/off switch.** Naming the provider type that writes is what turns encryption on, and naming `plain` again is what turns it off. The default is `plain`, so it is opt-in.
+- **Reads are decided by the stored value.** A value names the provider type that reads it, so returning writes to plaintext leaves already-encrypted rows readable.
+- A provider subsection that is absent leaves that provider unregistered. A subsection that is present must name its active key and carry the key list.
 
 ```toml
 [secret-encryption]
-mode = "encrypt"
-algorithm = "aes-256-gcm"
-active-key-version = "v2"
+write-provider-type = "config"        # defaults to "plain"
 
-[secret-encryption.keys]
-v1 = "<base64 32B>"   # kept for decryption only
-v2 = "<base64 32B>"   # used for new encryption
+[secret-encryption.config-provider]
+active-key-id = "v2"
+
+[secret-encryption.config-provider.keys]
+v1 = "Zn1QcOyzGX9OfSV9/XThDEPGTVFH2n0+PgZ7sDd1lDM="
+v2 = "hK8vN2pQrL4xW9cE1mYbT7uZ0aJ6dF3sG5nR8iO2kP4="
 ```
+
+A key is 32 random bytes in base64, produced by `openssl rand -base64 32`. Both the standard and url-safe alphabets are accepted. The unified config loader chain holds TOML and etcd only, so **a key cannot be supplied through an environment variable.**
 
 ### 2.2 DB (stored schema)
 
@@ -74,22 +78,26 @@ v2 = "<base64 32B>"   # used for new encryption
 |---|---|
 | ✅ | `keypairs.secret_key` = plaintext `String(40)`, nullable. `secrets.token_urlsafe(30)` fills exactly 40 characters |
 | ✅ | **No SQL query compares, filters, or sorts on `secret_key`** - every comparison happens in Python after fetching. The precondition for non-deterministic encryption is already satisfied |
-| ➕ | Widen the `secret_key` column - ciphertext necessarily exceeds 40 characters (about 120 expected; `String(255)` proposed) |
-| ➕ | **No extra metadata column.** The algorithm and key version live in the stored value's prefix (3.1) |
+| ✅ | `keypairs.ssh_private_key` in the same table is already `Text` |
+| ➕ | Change `secret_key` to `Text`. **No length limit** |
+| ➕ | **No extra metadata column.** One stored value carries everything needed to read it (3.1) |
 
-> A separate `secret_key_version` column was considered. It would let rotation progress be queried through an index, but it breaks the structure where one column type handles one value self-containedly (a type cannot see other columns). Progress queries are served well enough by a prefix `LIKE`, so the **single-column self-describing value** wins.
+> The limit is left off because it cannot be known. The size of a stored value follows two values a key provider decides: the key id it names (a GCP CryptoKey name alone runs 70-80 characters) and the size of a wrapped data encryption key. A limit on the column would turn changing providers into a migration. In PostgreSQL `varchar(n)` and `text` are stored the same way and perform the same, so a limit is pure cost. Measured against the config provider, a stored value is about 190 characters.
+
+> The existing column holds plaintext strings, so it becomes `text`.
 
 ### 2.3 Encryption layer
 
 | | Item |
 |---|---|
-| ✅ | The TypeDecorator convention in `models/base.py`, and the **`PasswordColumn` precedent** - it refuses raw string binding, demands a `PasswordInfo` value object, and performs the transformation at write time |
-| ✅ | Dependencies are already available (`cryptography` and `pycryptodome` are both in the lock file) |
-| ❌ | **There is no precedent for reversible at-rest encryption.** Zero uses of Fernet or an encrypted-string type |
-| ➕ | An `EncryptedSecretColumn` TypeDecorator - **encrypts on write, parses only on read** (3.3) |
-| ➕ | Two value objects - an encryption-request object and a stored-state object (3.3) |
-| ➕ | `SecretKeyCipher` - an injectable component that holds the per-version keys and performs decryption (3.2) |
-| ➕ | A branch for the new column type in `populate_fixture` (isomorphic to the `PasswordColumn` branch) |
+| ✅ | The TypeDecorator convention in `models/base.py`, and the **`PasswordColumn` precedent** - it refuses raw string binding and demands a value object |
+| ✅ | Dependencies are already available (`cryptography`) |
+| ❌ | **There is no precedent for reversible at-rest encryption.** |
+| ➕ | `SecretColumn` - converts between the stored string and its parsed form, and performs no cryptography (3.3) |
+| ➕ | Value types expressing the stored form (3.1) |
+| ➕ | `KeyProvider` - encrypts, decrypts, and rewraps one value (3.2) |
+| ➕ | `KeyProviderPool` - sends a read to the provider its value names, and a write to the provider designated for writes |
+| ➕ | A branch for the new column type in `populate_fixture` (fixtures carry plaintext, so they need no key) |
 
 ### 2.4 Creation and read paths
 
@@ -97,11 +105,10 @@ v2 = "<base64 32B>"   # used for new encryption
 |---|---|
 | ✅ | Creation: `generate_keypair()` from user creation, `issue_my_keypair`, admin creation, signup, the OpenID plugin, and the legacy GQL mutation |
 | ✅ | Read (hot path): the REST auth middleware core-selects the keypair row by access key, then recomputes the HMAC signature and validates JWTs |
-| ✅ | Read (rest): the keypair plugin's `/login` plaintext `compare_digest`, the keypair plugin hook's token signing, legacy GQL `KeyPair.secret_key` (consumed by the admin CLI), and the `/auth/authorize` and `/auth/signup` responses |
-| ➕ | Write paths bind an **encryption-request value object** instead of a plaintext string |
-| ➕ | Read paths get a **stored-state value object** instead of `str`, so every place that needs plaintext calls **explicit decryption** through `SecretKeyCipher` |
-| ➕ | A lazy re-encryption hook - at the decryption point, re-store in the background if the key version is not the active one (3.4) |
-| ➕ | Batch re-encryption exposed on **all three surfaces: REST API, GQL, and the admin CLI** (3.4) |
+| ✅ | Read (rest): the keypair plugin's `/login` plaintext `compare_digest`, the plugin hook's token signing, legacy GQL `KeyPair.secret_key`, and the `/auth/authorize` and `/auth/signup` responses |
+| ➕ | Write paths encrypt through a provider and bind the result. **Encryption is asynchronous, so it finishes before binding** |
+| ➕ | Read paths get a parsed value instead of `str`, and every place that needs plaintext decrypts explicitly through the pool |
+| ➕ | Batch rewrapping exposed on **all three surfaces: REST API, GQL, and the admin CLI** (3.4) |
 
 > **Every read path has to be touched.** In exchange, the column's static type is no longer `str`, so any place left unfixed fails type checking. Making it structurally impossible for a ciphertext string to flow downstream disguised as plaintext is the central benefit of this approach.
 
@@ -111,91 +118,104 @@ v2 = "<base64 32B>"   # used for new encryption
 |---|---|
 | ✅ | The alembic conventions, including the idempotency requirement for backports |
 | ✅ | A plaintext fixture (`example-keypairs.json`) and keypair generation inside alembic migrations |
-| ➕ | One column-widening migration. **No data conversion** (existing rows carry no prefix and are therefore read as plaintext) |
+| ➕ | One column type migration. **No data conversion** (existing rows carry no marker and are therefore read as plaintext) |
 | ➕ | Rollout and rollback procedure, with a warning (3.6) |
-| ➕ | A way to count rows per key version (rotation progress) |
+| ➕ | A way to count rows remaining per key id |
 
 ## 3. Implementation Design
 
-**Core flow:** on write, encrypt with the active key version and store a self-describing string. On read, the column type **parses only** and returns a value object. Where plaintext is needed, decrypt through `SecretKeyCipher`. If the key version is not the active one, lazy re-encryption converges it; batch re-encryption forces convergence.
+**Core flow:** on write, draw a fresh data encryption key per value, encrypt the value with it, wrap that key under the provider's active key, and store a self-describing string. On read the column **parses only**, and the value is decrypted through the provider it names. Rotating a key rewraps the data encryption key, so the ciphertext is never touched.
 
 ### 3.1 Stored format (self-describing)
 
 ```
-bai:enc:1:<algo>:<key_version>:<nonce_b64u>:<ciphertext_b64u>
+bai-enc:1:<provider type>:<key id>:<wrapped data key>:<nonce>:<ciphertext>
 ```
 
 | Field | Meaning |
 |---|---|
-| `bai:enc:1` | Magic plus **format version**. Without this prefix, the value is legacy plaintext |
-| `algo` | AEAD algorithm identifier (v1: `a256gcm`) |
-| `key_version` | Key of the configured key list (e.g. `v1`, `v2`) |
-| `nonce` | Freshly drawn per encryption |
-| `ciphertext` | Ciphertext plus authentication tag |
+| `bai-enc` | Marker. Without it, the value is legacy plaintext |
+| `1` | Format version |
+| provider type | The provider that reads this value. `plain` cannot appear, since plaintext is stored without the marker |
+| key id | Which key within that provider. **The provider defines it** |
+| wrapped data key | This value's own data encryption key, wrapped under the provider's key |
+| nonce | Freshly drawn per encryption |
+| ciphertext | Ciphertext plus authentication tag |
 
-- **Legacy detection**: an existing secret key is `token_urlsafe` output and cannot contain `:`, so it never collides with the prefix.
-- **AAD**: the column type instance uses its own context string (e.g. `keypairs.secret_key`) as AAD, which blocks transplanting a ciphertext from another column or table.
-- **Integrity**: no separate plaintext hash. **The AEAD authentication tag detects both a wrong key and tampering.**
-- **Rotation progress**: `WHERE secret_key LIKE 'bai:enc:1:a256gcm:v1:%'` counts the rows per key version. When it reaches zero, that key can be dropped from the config.
-- The format-version field means that if a KMS later requires a different structure, a v2 format can be added and coexist.
+- **Legacy detection**: an existing secret key is `token_urlsafe` output and cannot contain `:`, so it never collides with the marker.
+- **AAD**: the column's name is the associated data, which blocks transplanting a value from another column.
+- **Integrity**: no separate plaintext hash. The AEAD authentication tag detects both a wrong key and tampering.
+- **No algorithm field.** The format version implies the algorithm; changing the algorithm bumps that version.
+- **No length prefixes.** The three trailing fields are base64url and carry no delimiter, so splitting them off from the right is unambiguous. That is what lets a provider-defined key id contain delimiters.
+- **A data encryption key belongs to one row.** Two users' values are never encrypted under the same key.
+- The format version is a branch on read. A new version **adds** a branch rather than replacing one, so values written by older builds keep parsing.
 
-### 3.2 Key lookup and decryption (`SecretKeyCipher`)
+### 3.2 Key providers and the pool
 
-An **injectable component** holding the per-version keys. It depends on no global state.
+A `KeyProvider` works **on one value**. Which key id it writes under and how it wraps a data encryption key are its own business; a stored value names only which provider to hand it back to.
 
 | Method | Contract |
 |---|---|
-| `active_version()` | The key version to use for new encryption |
-| `encrypt_request(plaintext)` | Builds the **value object to bind** for encryption under the active key (3.3) |
-| `decrypt(stored)` | Turns a stored-state object into plaintext. Returns it as-is when the state is plaintext |
+| `provider_type()` | The type written into stored values |
+| `encrypt(plaintext, context)` | Encrypts a new value under this provider's current key |
+| `decrypt(value, context)` | Recovers the plaintext of a value this provider wrote |
+| `rewrap(value, context)` | Moves a value onto this provider's current key. **Only the wrapped data encryption key changes, so the plaintext is never produced** |
 
-- Key lookup sits behind a **`SecretKeyProvider` interface**. There is **exactly one implementation** for now (config); a KMS attaches to the same interface later.
-- An unknown key version raises rather than being silently passed through (a `BackendAIError` subclass).
-- Decryption is pure CPU work against an in-memory key, with no remote I/O, so it is safe on the authentication hot path.
+There is one implementation for now, backed by the config. It draws a data encryption key per value, encrypts the value with it, and wraps that key under the active key. A KMS attaches to the same interface later.
 
-**Injection points**: decryption is needed in the auth middleware, the keypair plugin (login comparison and token signing), the auth service (login response), and legacy GQL resolvers. The principle is to **decrypt at the repository boundary and pass data objects upward**; where a core select is used directly, as in the auth middleware, the cipher is injected there.
+`KeyProviderPool` holds the registered providers and the one designated for writes.
 
-### 3.3 Column type and value objects
+- A read goes to the provider its value names. Without a marker the value is plaintext and is returned as is.
+- A write goes to the designated provider. When that is `plain`, the value is stored unencrypted.
+- An unknown provider type, or one that is not configured, raises.
 
-The shape mirrors `PasswordColumn`: it **refuses raw `str` binding** and demands a value object.
+**Injection points**: decryption is needed in the auth middleware, the keypair plugin (login comparison and token signing), the auth service, and legacy GQL resolvers. The principle is to **decrypt at the repository boundary and pass data objects upward**; where a core select is used directly, as in the auth middleware, the pool is injected there.
+
+Decryption is pure CPU work against an in-memory key, with no remote I/O, so it is safe on the authentication hot path.
+
+### 3.3 Column type
+
+`SecretColumn` converts between the stored string and its parsed form and **performs no cryptography**. Encrypting needs a key provider and is asynchronous, which SQLAlchemy's synchronous bind hook cannot do, so a value is already encrypted when it reaches the column.
 
 | Direction | Input/output | What the column does |
 |---|---|---|
-| Write | Bind an encryption-request object (plaintext + target key version + key material) | **Performs encryption** and serializes to the 3.1 format. Stores plaintext as-is when `mode=plain` |
-| Read | Return a stored-state object | **Parses only.** With a prefix, splits into algorithm, key version, nonce, and ciphertext; without one, marks it plaintext |
+| Write | Bind a parsed value | Serializes it to the stored string. **Refuses anything but a parsed value** |
+| Read | Return a parsed value | Parses the stored string, marking a value without the marker as plaintext |
 
-- **Why reads do not decrypt**: decryption needs a key, and the column type's result-conversion point has no sensible way to receive one (it would require process-global state). Writes, by contrast, **carry the key material in the bound value object, so no global injection is needed.** This asymmetry is the rationale for the design.
-- The stored-state object holds the `key_version` (absent when plaintext) and the original string; `SecretKeyCipher` performs the decryption. Plaintext rows and ciphertext rows are **expressed by a single type**, so consumers do not branch.
-- The value objects default to frozen dataclasses (there is no serialization requirement). Exact names and fields are the implementer's discretion.
-- Both value objects carry a representation that does not expose plaintext, guarding against logging and `repr` accidents.
+- Refusing a raw `str` is what keeps a plaintext string from being stored by accident.
+- The column's `context` argument is its own name, and is what callers pass the provider as associated data. **It must be a plain attribute rather than a private one** - SQLAlchemy builds a type's statement cache key from the `__init__` arguments it finds as plain attributes, so hiding it would let two columns share a cache key and a compiled statement bind a value under another column's associated data.
+- Plaintext rows and encrypted rows are **expressed by a single type**, so consumers do not branch.
+- The value types are frozen dataclasses, and neither plaintext nor key material appears in `repr`.
 
-### 3.4 Key rotation and re-encryption
+### 3.4 Key rotation and rewrapping
 
-Rotating a key is **adding a new versioned key to the config and changing `active-key-version`** - nothing more. The old key stays for decryption only.
+Rotating a key is **adding a new key to the config and changing the active key id**. The old key stays for decryption only.
 
-**Definition of re-encryption**: read the stored value to obtain plaintext (as-is when plaintext, otherwise decrypted with the key version the value names), then encrypt that plaintext again under the **active key version with a freshly drawn nonce** and overwrite. Nonces are never reused - reusing a nonce under the same key destroys confidentiality in GCM, so a fresh nonce is drawn even when re-encrypting the same plaintext.
+**Definition of rewrapping**: unwrap the value's data encryption key under the old key and wrap it again under the active one. **The data encryption key, the ciphertext, and the nonce are all unchanged** - only about sixty bytes per value differ. The plaintext is never produced, so the work needs no permission to read the values.
 
-**The default is lazy re-encryption**, converging gradually by checking the key version at the decryption point.
+Because each row has its own data encryption key, that key never needs rotating: a new one is drawn on every write, leaving only the key that wraps it to rotate.
 
-| Condition | Action |
+An old key left in the config keeps its values readable. Convergence is needed when that key is to be dropped, and a batch pass is what does it.
+
+The batch takes no direction flag.
+
+| Write target | What the batch does |
 |---|---|
-| Plaintext state, `mode=encrypt` | Encrypt under the active key and re-store |
-| `key_version` != active version, `mode=encrypt` | Decrypt, then re-store under the active key |
-| `key_version` == active version | Nothing |
-| `mode=plain` | No re-store. **No automatic conversion to plaintext either** (ciphertext keeps being decrypted on read) |
+| A provider | Moves plaintext rows and rows on an old key onto the active key |
+| `plain` | Returns encrypted rows to plaintext |
 
-Re-encryption has exactly two constraints to honor.
+Turning ciphertext back into plaintext is not a separate feature but a consequence of the setting.
+
+Rewrapping has one constraint to honor.
 
 | Constraint | Reason |
 |---|---|
-| **Conditional UPDATE** - overwrite only if the stored value is still the exact string just read | If **the keypair is reissued between the read and the re-store, stale plaintext would overwrite the new value.** The condition prevents that. When multiple managers race on the same row, one succeeds and the rest are harmless no-ops |
-| **Performed outside the reading transaction** | The auth middleware queries the keypair in a read-only transaction and cannot write inside it, so this is split into a background task on a separate session |
+| **Conditional UPDATE** - overwrite only if the stored value is still the exact string just read | If **the keypair is reissued between the read and the write, a stale value would overwrite the new one.** The condition prevents that. When several managers race on one row, one succeeds and the rest are harmless no-ops |
 
-- Re-encryption **never blocks the authentication response path.** It is best-effort; failures leave a log and a metric while authentication still succeeds.
-- Total write volume is **one write per row**, a one-off load proportional to the number of keypairs. After convergence the condition is false, so no extra writes remain on the hot path.
-- Since the update does not change the value, a failure loses no consistency. The next read retries it.
+- Total write volume is **one write per row**, a one-off load proportional to the number of keypairs.
+- Since the value does not change, a failure loses no consistency. The next run retries it.
 
-**Batch re-encryption** is the way to force convergence: dropping a key requires zero rows on that version, and lazy convergence leaves rarely used keys behind. **All three surfaces are provided.**
+**The batch is provided on all three surfaces.**
 
 | Surface | Use |
 |---|---|
@@ -203,16 +223,7 @@ Re-encryption has exactly two constraints to honor.
 | GQL mutation (admin) | Management console integration |
 | `mgr` admin CLI | Run directly outside the server, for migration work |
 
-Common requirements: sweep the target column **in chunks, resumably**, report remaining counts per key version, and allow the run's status to be queried.
-
-**The batch is a single operation that normalizes storage to whatever the current config specifies.** There is no direction mode or flag.
-
-| `mode` | What the batch does |
-|---|---|
-| `encrypt` | Encrypts plaintext rows and old-version rows under the active key |
-| `plain` | Decrypts ciphertext rows back to plaintext |
-
-Going from ciphertext back to plaintext is not an actual operational requirement but **a generalization that falls out of the config**. No separate feature is built for it, so it costs nothing extra. The automatic path, lazy re-encryption, still does nothing under `mode=plain` - to avoid surprises, **conversion to plaintext happens only through an explicit batch run**.
+Common requirements: sweep the target column **in chunks, resumably**, report remaining counts per key id, and allow the run's status to be queried.
 
 ### 3.5 Where the key material lives
 
@@ -221,46 +232,54 @@ Going from ciphertext back to plaintext is not an actual operational requirement
 | Process | Needs the key | Basis |
 |---|---|---|
 | Manager server | Yes | Reaches unified config through `ManagerConfigProvider` |
-| `mgr` CLI (batch re-encryption) | Yes | A `ManagerConfigProvider` assembly path for one-shot CLI commands already exists (TOML plus etcd loader chain); `clear-history` and others use it |
-| alembic | **No** | Column widening only, no data conversion |
-| Fixture population | **No** | Written as plaintext and left to lazy re-encryption |
+| `mgr` CLI (batch rewrapping) | Yes | A `ManagerConfigProvider` assembly path for one-shot CLI commands already exists |
+| alembic | **No** | Column type change only, no data conversion |
+| Fixture population | **No** | Written as plaintext and moved later by a batch pass |
 
-Because reads do not decrypt, the bootstrap stages (alembic, fixtures) depend on the key not at all.
+Because reads only parse, the bootstrap stages (alembic, fixtures) depend on the key not at all.
+
+Holding the keys in etcd instead of the file takes no code change. etcd is already in the unified config loader chain, and a watcher that revalidates the whole unified config on change already runs. etcd is a separate store from PostgreSQL, so the threat model of "the DB leaking on its own" still holds.
 
 ### 3.6 Migration and rollout
 
-The migration is **one column widening** with no data conversion. It is written idempotently for backports.
+The migration is **one column type change** with no data conversion, written idempotently for backports. `varchar(40)` to `text` is binary coercible, so no table rewrite happens, and this column carries no index.
 
 Rollout order:
 
-1. Deploy the code (column type applied, `mode=plain`). Storage behavior does not change.
-2. Configure keys, then set `mode=encrypt`. New keypairs are stored encrypted; existing rows converge as they are read.
-3. Force convergence with batch re-encryption if needed.
+1. Deploy the code (column type applied, writes still `plain`). Storage behavior does not change.
+2. Configure keys, then name the write provider type. New keypairs are stored encrypted.
+3. Move existing rows with a batch pass if needed.
 
-**Rollback warning**: rolling back to step 1 is safe (all rows are plaintext). But **rolling back to an older build after step 2 breaks authentication, because ciphertext is mistaken for plaintext.** Reverting requires completing a batch decryption first. State this in the release notes.
+**Rollback warning**: rolling back to step 1 is safe (all rows are plaintext). But **rolling back to an older build after step 2 breaks authentication, because ciphertext is mistaken for plaintext.** Reverting requires setting the write target back to `plain` and completing a batch conversion first. State this in the release notes.
 
-**Performance**: AES-256-GCM decryption is microseconds per request against an in-memory key, so it has no meaningful effect on the authentication hot path.
+**Performance**: decryption is microseconds against an in-memory key, so it has no meaningful effect on the authentication hot path. Reading one value performs two AES operations - unwrapping the data encryption key and decrypting the value.
 
 ## Decision Summary
 
 | Decision | Content |
 |---|---|
-| Mode | Global config `plain \| encrypt`, default `plain` (opt-in). **Decides the write policy only; reads are decided by the value** |
-| Stored format | Single-column self-describing `bai:enc:<format version>:<algo>:<key_version>:<nonce>:<ct>`. No prefix means legacy plaintext |
-| Extra metadata column | None. Rotation progress is queried with a prefix `LIKE` |
-| Column type | Isomorphic to `PasswordColumn`. **Write = take a value object and encrypt; read = parse only, never decrypt** |
-| Decryption site | Explicit calls through an injected `SecretKeyCipher` where plaintext is needed. Every read path is modified, and anything missed fails type checking |
-| Algorithm | AEAD (AES-256-GCM). No separate plaintext hash; the authentication tag detects a wrong key and tampering. AAD binds the column context |
-| Key management | **Inject multiple per-version keys and name an `active-key-version`.** Decrypt with the version the value names, encrypt with the active one |
-| Key-lookup abstraction | A `SecretKeyProvider` interface with exactly one implementation (config). **KMS is out of scope here** |
-| Key rotation | Adding a new version to the config and changing `active-key-version` is the whole procedure. Re-encryption re-stores the read plaintext under the **active key with a fresh nonce** |
-| Re-encryption constraints | **Conditional UPDATE** (guards against a reissue race) plus **a background write outside the reading transaction**. Authentication succeeds even on failure |
+| Turning it on and off | No separate switch. **Naming the write provider type** turns it on, and naming `plain` turns it off. The default is `plain` |
+| Reads | **Decided by the stored value.** A value names the provider that reads it, so reads are independent of the write setting |
+| Stored format | Single-column self-describing `bai-enc:<format version>:<provider type>:<key id>:<wrapped data key>:<nonce>:<ciphertext>`. No marker means legacy plaintext |
+| Algorithm field | None. The format version implies it |
+| Length prefixes | None. The three trailing fields are base64url, so splitting from the right is unambiguous |
+| Extra metadata column | None |
+| Scope of a data encryption key | **One row.** Two users' values are never encrypted under the same key |
+| Column type | Converts between the stored string and its parsed form only. **It performs no cryptography** - encryption is asynchronous and finishes before binding. A raw string is refused |
+| Decryption site | Explicit calls through the pool where plaintext is needed. Every read path is modified, and anything missed fails type checking |
+| Algorithm | AEAD (AES-256-GCM). No separate plaintext hash. The column's name is bound as associated data |
+| Key management | Each provider holds keys by id and names an active id. Decrypt with the id the value names, wrap new values under the active one |
+| Key provider abstraction | `KeyProvider` encrypts, decrypts, and rewraps one value. There is one config-backed implementation, and a KMS attaches to the same interface later |
+| Key rotation | Adding a key to the config and changing the active id is the whole procedure. **Rewrapping touches neither the ciphertext nor the plaintext** |
+| Immediate convergence | Not performed. An old key left in the config keeps its values readable, and convergence happens in a batch when that key is dropped |
+| Rewrapping constraint | **Conditional UPDATE** (guards against a reissue race) |
 | Batch surfaces | **REST admin API, GQL mutation, and the `mgr` admin CLI - all three.** Chunked, resumable, progress-reporting |
-| Batch direction | No direction flag. It **normalizes to whatever the current `mode` specifies**, so `plain` yields conversion to plaintext as a consequence. Nothing converts automatically (lazy does nothing under `plain`) |
-| Backward compatibility | Plaintext and ciphertext rows coexist indefinitely. No bulk conversion, forced re-login, or key reissue |
-| Key material location | **The new unified-config section alone is enough.** The CLI reads it through the same provider assembly path, and alembic and fixtures need no key |
+| Batch direction | No direction flag. It **normalizes to whatever the current write target specifies**, so `plain` yields conversion to plaintext |
+| Column type change | `String(40)` to `Text`, **with no length limit** - the stored size follows the provider implementation, so no limit can be known. `varchar` to `text` needs no table rewrite |
+| Backward compatibility | Plaintext and encrypted rows coexist indefinitely. No bulk conversion, forced re-login, or key reissue |
+| Key material location | **The new unified-config section alone is enough.** The CLI reads it through the same assembly path, alembic and fixtures need no key, and etcd works without code changes |
 | First target | The single column `keypairs.secret_key` |
-| Out of scope | KMS, `ssh_private_key`, exposure-path reduction (BEP-1068), the Valkey and webserver session copies, secret columns in other tables and components |
+| Out of scope | KMS, `ssh_private_key`, exposure-path reduction (BEP-1068), the Valkey and webserver copies, secret columns in other tables and components |
 
 ## Open Questions
 

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -195,6 +195,7 @@ class ErrorDomain(enum.StrEnum):
     RUNTIME_VARIANT = "runtime-variant"
     ROLE_INVITATION = "role-invitation"
     RETENTION_POLICY = "retention-policy"
+    SECRET = "secret"
 
     EXTERNAL_SYSTEM = "external-system"  # Errors from external systems
 

--- a/src/ai/backend/manager/AGENTS.md
+++ b/src/ai/backend/manager/AGENTS.md
@@ -19,6 +19,7 @@ api/ → services/ → repositories/ → models/
 - `data/` — immutable value objects converted to DTOs
 - `dto/` — manager-only request/response DTOs
 - `views/` — internal-only value objects
+- `secret/` — at-rest encryption for secret columns
 - `sokovan/` — coordinator and scheduling
 
 ## Cross-layer rules

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -559,9 +559,11 @@ class ConfigKeyProviderConfig(BaseConfigSchema):
         Field(),
         BackendAIConfigMeta(
             description=(
-                "Key encryption keys by id, as base64-encoded 32-byte values. Each wraps "
-                "the per-value data encryption keys rather than the values themselves, so "
-                "an id may be retired only once no stored value still names it."
+                "Key encryption keys by id, each 32 random bytes in base64 as produced by "
+                "`openssl rand -base64 32`; the standard and url-safe alphabets are both "
+                "accepted. A key wraps the per-value data encryption keys rather than the "
+                "values themselves, so an id may be retired only once no stored value still "
+                "names it."
             ),
             added_version=NEXT_RELEASE_VERSION,
             secret=True,
@@ -574,7 +576,7 @@ class ConfigKeyProviderConfig(BaseConfigSchema):
             if not key_id:
                 raise ValueError("A key encryption key id must not be empty.")
             try:
-                decoded = base64.b64decode(material, validate=True)
+                decoded = base64.b64decode(material, altchars=b"-_", validate=True)
             except (binascii.Error, ValueError) as e:
                 raise ValueError(f"The key {key_id!r} is not valid base64.") from e
             if len(decoded) != 32:

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -172,6 +172,8 @@ Alias keys are also URL-quoted in the same way.
 
 from __future__ import annotations
 
+import base64
+import binascii
 import enum
 import logging
 import os
@@ -182,7 +184,7 @@ from datetime import UTC, datetime
 from ipaddress import IPv4Network
 from pathlib import Path
 from pprint import pformat
-from typing import Annotated, Any, Literal, override
+from typing import Annotated, Any, Literal, Self, override
 
 from pydantic import (
     AliasChoices,
@@ -192,6 +194,7 @@ from pydantic import (
     IPvAnyNetwork,
     field_serializer,
     field_validator,
+    model_validator,
 )
 
 from ai.backend.common.config import BaseConfigSchema
@@ -225,6 +228,11 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.logging.config import LoggingConfig
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.secret.types import (
+    KeyProviderType,
+    SecretKeyId,
+    SecretKeyMaterial,
+)
 from ai.backend.manager.defs import DEFAULT_METRIC_RANGE_VECTOR_TIMEWINDOW
 from ai.backend.manager.pglock import PgAdvisoryLock
 
@@ -525,6 +533,94 @@ class AuthConfig(BaseConfigSchema):
             ),
             added_version="26.4.2",
             example=ConfigExample(local="604800", prod="604800"),
+        ),
+    ]
+
+
+class ConfigKeyProviderConfig(BaseConfigSchema):
+    active_key_id: Annotated[
+        SecretKeyId,
+        Field(
+            validation_alias=AliasChoices("active-key-id", "active_key_id"),
+            serialization_alias="active-key-id",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "The key id new values are encrypted under. Rotating a key is adding a new "
+                "id to the key list and pointing this at it; the previous ids stay so their "
+                "values keep decrypting."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            example=ConfigExample(local="v1", prod="v1"),
+        ),
+    ]
+    keys: Annotated[
+        dict[SecretKeyId, SecretKeyMaterial],
+        Field(),
+        BackendAIConfigMeta(
+            description=(
+                "Key encryption keys by id, as base64-encoded 32-byte values. Each wraps "
+                "the per-value data encryption keys rather than the values themselves, so "
+                "an id may be retired only once no stored value still names it."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            secret=True,
+        ),
+    ]
+
+    @model_validator(mode="after")
+    def _validate_keys(self) -> Self:
+        for key_id, material in self.keys.items():
+            if not key_id:
+                raise ValueError("A key encryption key id must not be empty.")
+            try:
+                decoded = base64.b64decode(material, validate=True)
+            except (binascii.Error, ValueError) as e:
+                raise ValueError(f"The key {key_id!r} is not valid base64.") from e
+            if len(decoded) != 32:
+                raise ValueError(
+                    f"The key {key_id!r} must decode to 32 bytes but got {len(decoded)}."
+                )
+        if self.active_key_id not in self.keys:
+            raise ValueError(f"active-key-id {self.active_key_id!r} is not in the key list.")
+        return self
+
+
+class SecretEncryptionConfig(BaseConfigSchema):
+    write_provider_type: Annotated[
+        KeyProviderType,
+        Field(
+            default=KeyProviderType.PLAIN,
+            validation_alias=AliasChoices("write-provider-type", "write_provider_type"),
+            serialization_alias="write-provider-type",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "The key provider new secrets are written through, named by its type. "
+                "'plain' stores them unencrypted; every other type is configured by the "
+                "matching provider section below. Reads are decided by the stored value, so "
+                "secrets written earlier keep decrypting through the provider they name, and "
+                "a batch re-encryption normalizes stored secrets to whatever this names."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            example=ConfigExample(local="plain", prod="config"),
+        ),
+    ]
+    config_provider: Annotated[
+        ConfigKeyProviderConfig | None,
+        Field(
+            default=None,
+            validation_alias=AliasChoices("config-provider", "config_provider"),
+            serialization_alias="config-provider",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "The key provider that holds its key encryption keys in this file, under the "
+                "id 'config'. Omit this section to leave that provider unconfigured, in which "
+                "case no stored secret naming it can be read."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            composite=CompositeType.FIELD,
         ),
     ]
 
@@ -3686,6 +3782,23 @@ class ManagerUnifiedConfig(BaseConfigSchema):
                 "password requirements in production environments."
             ),
             added_version="25.8.0",
+            composite=CompositeType.FIELD,
+        ),
+    ]
+    secret_encryption: Annotated[
+        SecretEncryptionConfig,
+        Field(
+            default_factory=SecretEncryptionConfig,
+            validation_alias=AliasChoices("secret-encryption", "secret_encryption"),
+            serialization_alias="secret-encryption",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "At-rest encryption for secret columns such as the keypair secret key. "
+                "Names which key provider writes new secrets and configures the providers. "
+                "New secrets are stored as plaintext until a write provider is named."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
             composite=CompositeType.FIELD,
         ),
     ]

--- a/src/ai/backend/manager/data/secret/types.py
+++ b/src/ai/backend/manager/data/secret/types.py
@@ -1,0 +1,28 @@
+"""
+Secret encryption identifiers.
+
+The provider type says which provider reads a stored secret; the key id selects one
+key within that provider.
+"""
+
+import enum
+from typing import NewType
+
+# The id of one key encryption key within a provider. Provider-defined, so it may carry
+# whatever shape that provider names its keys with.
+SecretKeyId = NewType("SecretKeyId", str)
+
+# A key encryption key as configured: base64-encoded raw bytes.
+SecretKeyMaterial = NewType("SecretKeyMaterial", str)
+
+
+class KeyProviderType(enum.StrEnum):
+    """
+    The key providers this build knows.
+
+    ``PLAIN`` is a write target rather than a reader: it stores secrets unencrypted, and
+    a stored value never names it because plaintext carries no marker.
+    """
+
+    PLAIN = "plain"
+    CONFIG = "config"

--- a/src/ai/backend/manager/errors/secret.py
+++ b/src/ai/backend/manager/errors/secret.py
@@ -52,3 +52,55 @@ class UnknownSecretKeyProvider(BackendAIError, web.HTTPInternalServerError):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.NOT_FOUND,
         )
+
+
+class InvalidSecretKeyMaterial(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/invalid-secret-key-material"
+    error_title = "A configured secret encryption key is not of a usable size."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.SETUP,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )
+
+
+class UnknownSecretKeyId(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/unknown-secret-key-id"
+    error_title = "The stored secret names a key id that is not configured."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
+class SecretDecryptionFailed(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/secret-decryption-failed"
+    error_title = "The secret failed authentication during decryption."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
+        )
+
+
+class SecretEncryptionMisconfigured(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/secret-encryption-misconfigured"
+    error_title = "The secret encryption settings cannot be assembled."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.SETUP,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )

--- a/src/ai/backend/manager/errors/secret.py
+++ b/src/ai/backend/manager/errors/secret.py
@@ -1,0 +1,54 @@
+"""Secret encryption exceptions."""
+
+from __future__ import annotations
+
+from typing import override
+
+from aiohttp import web
+
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
+
+
+class InvalidEncryptedSecretFormat(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/invalid-encrypted-secret-format"
+    error_title = "The stored secret does not follow the encrypted secret format."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.PARSING,
+            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
+        )
+
+
+class UnsupportedSecretFormatVersion(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/unsupported-secret-format-version"
+    error_title = "The stored secret uses a format version this build cannot read."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.PARSING,
+            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
+        )
+
+
+class UnknownSecretKeyProvider(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/unknown-secret-key-provider"
+    error_title = "The stored secret names a key provider that is not configured."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.NOT_FOUND,
+        )

--- a/src/ai/backend/manager/errors/secret.py
+++ b/src/ai/backend/manager/errors/secret.py
@@ -104,3 +104,16 @@ class SecretEncryptionMisconfigured(BackendAIError, web.HTTPInternalServerError)
             operation=ErrorOperation.SETUP,
             error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
+
+
+class InvalidSecretBinding(BackendAIError, web.HTTPInternalServerError):
+    error_type = "https://api.backend.ai/probs/invalid-secret-binding"
+    error_title = "A secret column accepts only a parsed secret value."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SECRET,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
+        )

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -38,6 +38,8 @@ live in `models/specs/` — read `models/specs/AGENTS.md` before touching them.
 
 - Where possible, reuse the existing `TypeDecorator` wrappers in `models/base.py`.
 - Add new `TypeDecorator`s only to `models/base.py` — not in individual row files.
+- A `SecretColumn` takes a `SecretValue`. Encrypt through the key provider pool before
+  binding it — the column performs no cryptography and refuses a bare string.
 
 ## `__init__.py` rules
 

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -56,7 +56,9 @@ from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.resource import DataTransformationFailed
+from ai.backend.manager.errors.secret import InvalidSecretBinding
 from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.secret.types import SecretValue
 
 if TYPE_CHECKING:
     from sqlalchemy.engine.interfaces import Dialect
@@ -957,6 +959,44 @@ class GUID[TUUIDSubType: uuid.UUID](TypeDecorator[TUUIDSubType]):
         return type(self)(self._subtype_func)
 
 
+class SecretColumn(TypeDecorator[SecretValue]):
+    """
+    A column holding a secret, stored either as legacy plaintext or encrypted.
+
+    It only converts between the stored string and its parsed form: encrypting needs a
+    key provider and is asynchronous, so it happens before a value reaches here.
+    """
+
+    impl = UnicodeText
+    cache_ok = True
+
+    context: str
+
+    def __init__(self, context: str) -> None:
+        super().__init__()
+        # Names this column, and is what callers pass the key provider as the associated
+        # data. Public because SQLAlchemy keys a type's cache on the __init__ arguments it
+        # finds as plain attributes; sharing one key would bind a value under another
+        # column's associated data.
+        self.context = context
+
+    @override
+    def process_bind_param(self, value: Any, _dialect: Dialect) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, SecretValue):
+            raise InvalidSecretBinding(
+                f"A secret column takes a SecretValue but got {type(value).__name__}."
+            )
+        return value.serialize()
+
+    @override
+    def process_result_value(self, value: str | None, _dialect: Dialect) -> SecretValue | None:
+        if value is None:
+            return None
+        return SecretValue.parse(value)
+
+
 class SlugType(TypeDecorator[str]):
     """
     A type wrapper for slug type string
@@ -1133,6 +1173,11 @@ async def populate_fixture(
                                 rounds=600_000,
                                 salt_size=32,
                             )
+                elif isinstance(col.type, SecretColumn):
+                    for row in rows:
+                        if col.name in row and row[col.name] is not None:
+                            # Fixtures carry plaintext, which needs no key provider.
+                            row[col.name] = SecretValue(row[col.name])
                 elif isinstance(col.type, ResourceSlotColumn):
                     from ai.backend.common.types import ResourceSlot
 

--- a/src/ai/backend/manager/secret/config_provider.py
+++ b/src/ai/backend/manager/secret/config_provider.py
@@ -43,7 +43,7 @@ class ConfigKeyProvider(KeyProvider):
     @classmethod
     def _decode(cls, key_id: SecretKeyId, material: SecretKeyMaterial) -> bytes:
         try:
-            return base64.b64decode(material, validate=True)
+            return base64.b64decode(material, altchars=b"-_", validate=True)
         except (binascii.Error, ValueError) as e:
             raise InvalidSecretKeyMaterial(
                 f"The key encryption key {key_id!r} is not valid base64."

--- a/src/ai/backend/manager/secret/config_provider.py
+++ b/src/ai/backend/manager/secret/config_provider.py
@@ -1,0 +1,87 @@
+"""The key provider that reads its key encryption keys from the unified config."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import ClassVar, Self, override
+
+from ai.backend.manager.config.unified import ConfigKeyProviderConfig
+from ai.backend.manager.data.secret.types import (
+    KeyProviderType,
+    SecretKeyId,
+    SecretKeyMaterial,
+)
+from ai.backend.manager.errors.secret import InvalidSecretKeyMaterial, UnknownSecretKeyId
+from ai.backend.manager.secret.keys import DataEncryptionKey, EncryptedBytes, KeyEncryptionKey
+from ai.backend.manager.secret.provider import KeyProvider
+from ai.backend.manager.secret.types import EncryptedData
+
+
+class ConfigKeyProvider(KeyProvider):
+    PROVIDER_TYPE: ClassVar[KeyProviderType] = KeyProviderType.CONFIG
+
+    _keys: Mapping[SecretKeyId, KeyEncryptionKey]
+    _active_key_id: SecretKeyId
+
+    def __init__(
+        self, keys: Mapping[SecretKeyId, KeyEncryptionKey], active_key_id: SecretKeyId
+    ) -> None:
+        self._keys = keys
+        self._active_key_id = active_key_id
+
+    @classmethod
+    def from_config(cls, config: ConfigKeyProviderConfig) -> Self:
+        keys = {
+            key_id: KeyEncryptionKey(key_id=key_id, material=cls._decode(key_id, material))
+            for key_id, material in config.keys.items()
+        }
+        return cls(keys=keys, active_key_id=config.active_key_id)
+
+    @classmethod
+    def _decode(cls, key_id: SecretKeyId, material: SecretKeyMaterial) -> bytes:
+        try:
+            return base64.b64decode(material, validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise InvalidSecretKeyMaterial(
+                f"The key encryption key {key_id!r} is not valid base64."
+            ) from e
+
+    @override
+    def provider_type(self) -> KeyProviderType:
+        return self.PROVIDER_TYPE
+
+    @override
+    async def encrypt(self, plaintext: str, context: str) -> EncryptedData:
+        dek = DataEncryptionKey.generate()
+        data = dek.encrypt(plaintext, context)
+        return EncryptedData(
+            provider_type=self.PROVIDER_TYPE,
+            wrapped_key=self._active_key().wrap(dek, context),
+            nonce=data.nonce,
+            ciphertext=data.ciphertext,
+        )
+
+    @override
+    async def decrypt(self, data: EncryptedData, context: str) -> str:
+        dek = self._key_of(data.wrapped_key.key_id).unwrap(data.wrapped_key, context)
+        return dek.decrypt(EncryptedBytes(nonce=data.nonce, ciphertext=data.ciphertext), context)
+
+    @override
+    async def rewrap(self, data: EncryptedData, context: str) -> EncryptedData:
+        active = self._active_key()
+        if data.wrapped_key.key_id == active.key_id:
+            return data
+        dek = self._key_of(data.wrapped_key.key_id).unwrap(data.wrapped_key, context)
+        return replace(data, wrapped_key=active.wrap(dek, context))
+
+    def _active_key(self) -> KeyEncryptionKey:
+        return self._key_of(self._active_key_id)
+
+    def _key_of(self, key_id: SecretKeyId) -> KeyEncryptionKey:
+        key = self._keys.get(key_id)
+        if key is None:
+            raise UnknownSecretKeyId(f"No key encryption key is configured for {key_id!r}.")
+        return key

--- a/src/ai/backend/manager/secret/keys.py
+++ b/src/ai/backend/manager/secret/keys.py
@@ -1,0 +1,109 @@
+"""
+The two key kinds an envelope key provider works with.
+
+A data encryption key encrypts one stored value; a key encryption key wraps data
+encryption keys. Neither leaves the provider that holds it.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass, field
+from typing import Final, Self
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from ai.backend.manager.data.secret.types import SecretKeyId
+from ai.backend.manager.errors.secret import (
+    InvalidSecretKeyMaterial,
+    SecretDecryptionFailed,
+)
+from ai.backend.manager.secret.types import WrappedDataEncryptionKey
+
+KEY_SIZE: Final[int] = 32
+
+# The size a newly drawn nonce gets. Stored values carry their own nonce, so changing
+# this only affects values written afterwards.
+_NONCE_SIZE: Final[int] = 12
+
+
+@dataclass(frozen=True)
+class EncryptedBytes:
+    """What one encryption produced: the nonce it drew, and the ciphertext with its tag."""
+
+    nonce: bytes = field(repr=False)
+    ciphertext: bytes = field(repr=False)
+
+
+@dataclass(frozen=True)
+class DataEncryptionKey:
+    """The key one stored value is encrypted with. Lives in memory only."""
+
+    material: bytes = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if len(self.material) != KEY_SIZE:
+            raise InvalidSecretKeyMaterial(
+                f"A data encryption key must be {KEY_SIZE} bytes but got {len(self.material)}."
+            )
+
+    @classmethod
+    def generate(cls) -> Self:
+        return cls(material=secrets.token_bytes(KEY_SIZE))
+
+    def encrypt(self, plaintext: str, context: str) -> EncryptedBytes:
+        nonce = secrets.token_bytes(_NONCE_SIZE)
+        ciphertext = AESGCM(self.material).encrypt(
+            nonce, plaintext.encode("utf-8"), context.encode("utf-8")
+        )
+        return EncryptedBytes(nonce=nonce, ciphertext=ciphertext)
+
+    def decrypt(self, data: EncryptedBytes, context: str) -> str:
+        try:
+            plaintext = AESGCM(self.material).decrypt(
+                data.nonce, data.ciphertext, context.encode("utf-8")
+            )
+        except InvalidTag as e:
+            raise SecretDecryptionFailed(
+                "The authentication tag of the secret did not verify."
+            ) from e
+        return plaintext.decode("utf-8")
+
+
+@dataclass(frozen=True)
+class KeyEncryptionKey:
+    """A versioned key that wraps data encryption keys. Never encrypts a stored value."""
+
+    key_id: SecretKeyId
+    material: bytes = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.key_id:
+            raise InvalidSecretKeyMaterial("A key encryption key must have a key id.")
+        if len(self.material) != KEY_SIZE:
+            raise InvalidSecretKeyMaterial(
+                f"The key encryption key {self.key_id!r} must be {KEY_SIZE} bytes "
+                f"but got {len(self.material)}."
+            )
+
+    def wrap(self, dek: DataEncryptionKey, context: str) -> WrappedDataEncryptionKey:
+        nonce = secrets.token_bytes(_NONCE_SIZE)
+        wrapped = AESGCM(self.material).encrypt(nonce, dek.material, context.encode("utf-8"))
+        return WrappedDataEncryptionKey(key_id=self.key_id, blob=nonce + wrapped)
+
+    def unwrap(self, wrapped: WrappedDataEncryptionKey, context: str) -> DataEncryptionKey:
+        blob = wrapped.blob
+        if len(blob) <= _NONCE_SIZE:
+            raise SecretDecryptionFailed(
+                f"The wrapped data encryption key is {len(blob)} bytes, too short to unwrap."
+            )
+        try:
+            material = AESGCM(self.material).decrypt(
+                blob[:_NONCE_SIZE], blob[_NONCE_SIZE:], context.encode("utf-8")
+            )
+        except InvalidTag as e:
+            raise SecretDecryptionFailed(
+                f"The data encryption key wrapped by {self.key_id!r} did not verify."
+            ) from e
+        return DataEncryptionKey(material=material)

--- a/src/ai/backend/manager/secret/pool.py
+++ b/src/ai/backend/manager/secret/pool.py
@@ -1,0 +1,85 @@
+"""
+The set of configured key providers, plus which one writes.
+
+Reads route by the provider id the stored value names; writes go to the one provider
+designated for them. Without a write provider, new values are stored as plaintext.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from ai.backend.manager.config.unified import SecretEncryptionConfig
+from ai.backend.manager.data.secret.types import KeyProviderType
+from ai.backend.manager.errors.secret import (
+    SecretEncryptionMisconfigured,
+    UnknownSecretKeyProvider,
+)
+from ai.backend.manager.secret.config_provider import ConfigKeyProvider
+from ai.backend.manager.secret.provider import KeyProvider
+from ai.backend.manager.secret.types import EncryptedData, SecretValue
+
+
+class KeyProviderPool:
+    _providers: Mapping[KeyProviderType, KeyProvider]
+    _writer: KeyProvider | None
+
+    def __init__(
+        self, providers: Sequence[KeyProvider], write_provider_type: KeyProviderType
+    ) -> None:
+        self._providers = {provider.provider_type(): provider for provider in providers}
+        if len(self._providers) != len(providers):
+            raise SecretEncryptionMisconfigured("Two key providers share a provider type.")
+        if write_provider_type is KeyProviderType.PLAIN:
+            self._writer = None
+            return
+        writer = self._providers.get(write_provider_type)
+        if writer is None:
+            raise SecretEncryptionMisconfigured(
+                f"The write key provider {write_provider_type.value!r} is not configured."
+            )
+        self._writer = writer
+
+    @classmethod
+    def from_config(cls, config: SecretEncryptionConfig) -> KeyProviderPool:
+        providers: list[KeyProvider] = []
+        if config.config_provider is not None:
+            providers.append(ConfigKeyProvider.from_config(config.config_provider))
+        return cls(providers=providers, write_provider_type=config.write_provider_type)
+
+    async def encrypt(self, plaintext: str, context: str) -> SecretValue:
+        if self._writer is None:
+            return SecretValue(plaintext)
+        return SecretValue(await self._writer.encrypt(plaintext, context))
+
+    async def decrypt(self, value: SecretValue, context: str) -> str:
+        match value.content:
+            case EncryptedData() as data:
+                return await self._provider_of(data).decrypt(data, context)
+            case plaintext:
+                return plaintext
+
+    async def rewrap(self, value: SecretValue, context: str) -> SecretValue:
+        """
+        Move a value onto the write provider's current key.
+
+        Within one provider only the wrapped data encryption key changes. Moving between
+        providers, encrypting a plaintext value, or going back to plaintext needs the
+        plaintext.
+        """
+        if self._writer is None:
+            # The write target is plaintext, so encrypted values come back to plaintext.
+            return SecretValue(await self.decrypt(value, context))
+        match value.content:
+            case EncryptedData() as data if data.provider_type == self._writer.provider_type():
+                return SecretValue(await self._writer.rewrap(data, context))
+            case _:
+                return await self.encrypt(await self.decrypt(value, context), context)
+
+    def _provider_of(self, data: EncryptedData) -> KeyProvider:
+        provider = self._providers.get(data.provider_type)
+        if provider is None:
+            raise UnknownSecretKeyProvider(
+                f"No key provider of type {data.provider_type.value!r} is configured."
+            )
+        return provider

--- a/src/ai/backend/manager/secret/provider.py
+++ b/src/ai/backend/manager/secret/provider.py
@@ -1,0 +1,38 @@
+"""
+The contract every key provider implements.
+
+A provider decides which key id it writes under and how the data encryption key is
+wrapped. The stored value names only which provider to hand it back to.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ai.backend.manager.secret.types import EncryptedData
+
+
+class KeyProvider(ABC):
+    @abstractmethod
+    def provider_id(self) -> str:
+        """The id written into stored values, naming this provider as their reader."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def encrypt(self, plaintext: str, context: str) -> EncryptedData:
+        """Encrypt a new value under this provider's current key."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def decrypt(self, data: EncryptedData, context: str) -> str:
+        """Recover the plaintext of a value this provider wrote."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def rewrap(self, data: EncryptedData, context: str) -> EncryptedData:
+        """
+        Move a value onto this provider's current key.
+
+        Only the wrapped data encryption key changes, so the plaintext is never produced.
+        """
+        raise NotImplementedError

--- a/src/ai/backend/manager/secret/provider.py
+++ b/src/ai/backend/manager/secret/provider.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from ai.backend.manager.data.secret.types import KeyProviderType
 from ai.backend.manager.secret.types import EncryptedData
 
 
 class KeyProvider(ABC):
     @abstractmethod
-    def provider_id(self) -> str:
-        """The id written into stored values, naming this provider as their reader."""
+    def provider_type(self) -> KeyProviderType:
+        """The type written into stored values, naming this provider as their reader."""
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ai/backend/manager/secret/types.py
+++ b/src/ai/backend/manager/secret/types.py
@@ -17,8 +17,10 @@ import enum
 from dataclasses import dataclass, field
 from typing import Final, Self
 
+from ai.backend.manager.data.secret.types import KeyProviderType, SecretKeyId
 from ai.backend.manager.errors.secret import (
     InvalidEncryptedSecretFormat,
+    UnknownSecretKeyProvider,
     UnsupportedSecretFormatVersion,
 )
 
@@ -47,7 +49,7 @@ class SecretFormatVersion(enum.StrEnum):
 class WrappedDataEncryptionKey:
     """The data encryption key as stored. Both fields are set and read by its provider."""
 
-    key_id: str
+    key_id: SecretKeyId
     blob: bytes = field(repr=False)
 
     def __post_init__(self) -> None:
@@ -61,18 +63,15 @@ class WrappedDataEncryptionKey:
 class EncryptedData:
     """A secret in its encrypted form, addressed to the key provider that wrote it."""
 
-    provider_id: str
+    provider_type: KeyProviderType
     wrapped_key: WrappedDataEncryptionKey
     nonce: bytes = field(repr=False)
     ciphertext: bytes = field(repr=False)
 
     def __post_init__(self) -> None:
-        if not self.provider_id:
-            raise InvalidEncryptedSecretFormat("The key provider id of a secret is empty.")
-        if SECRET_FIELD_DELIMITER in self.provider_id:
+        if self.provider_type is KeyProviderType.PLAIN:
             raise InvalidEncryptedSecretFormat(
-                f"The key provider id {self.provider_id!r} must not contain "
-                f"{SECRET_FIELD_DELIMITER!r}."
+                "A plaintext secret is stored without a marker, so it cannot name a provider."
             )
         if not self.nonce:
             raise InvalidEncryptedSecretFormat("An encrypted secret carries an empty nonce.")
@@ -81,31 +80,42 @@ class EncryptedData:
 
     @classmethod
     def parse(cls, body: str) -> Self:
-        provider_id, _, tail = body.partition(SECRET_FIELD_DELIMITER)
+        provider_type, _, tail = body.partition(SECRET_FIELD_DELIMITER)
         # The key id is provider-defined and may contain the delimiter, so the three
         # base64url fields after it are split off from the right.
         fields = tail.rsplit(SECRET_FIELD_DELIMITER, _TRAILING_FIELD_COUNT)
         if len(fields) != _TRAILING_FIELD_COUNT + 1:
             raise InvalidEncryptedSecretFormat(
-                "An encrypted secret must hold a key provider id, a key id, "
+                "An encrypted secret must hold a key provider type, a key id, "
                 "a wrapped key, a nonce, and a ciphertext."
             )
         key_id, encoded_key, encoded_nonce, encoded_ciphertext = fields
         return cls(
-            provider_id=provider_id,
-            wrapped_key=WrappedDataEncryptionKey(key_id=key_id, blob=cls._decode(encoded_key)),
+            provider_type=cls._provider_type(provider_type),
+            wrapped_key=WrappedDataEncryptionKey(
+                key_id=SecretKeyId(key_id), blob=cls._decode(encoded_key)
+            ),
             nonce=cls._decode(encoded_nonce),
             ciphertext=cls._decode(encoded_ciphertext),
         )
 
     def serialize(self) -> str:
         return SECRET_FIELD_DELIMITER.join([
-            self.provider_id,
+            self.provider_type,
             self.wrapped_key.key_id,
             self._encode(self.wrapped_key.blob),
             self._encode(self.nonce),
             self._encode(self.ciphertext),
         ])
+
+    @classmethod
+    def _provider_type(cls, raw: str) -> KeyProviderType:
+        try:
+            return KeyProviderType(raw)
+        except ValueError as e:
+            raise UnknownSecretKeyProvider(
+                f"The stored secret names the key provider {raw!r}, which this build does not know."
+            ) from e
 
     @classmethod
     def _decode(cls, encoded: str) -> bytes:

--- a/src/ai/backend/manager/secret/types.py
+++ b/src/ai/backend/manager/secret/types.py
@@ -1,0 +1,165 @@
+"""
+The stored form of a secret column.
+
+Stored format version 1::
+
+    bai-enc:1:<provider id>:<key id>:<wrapped key>:<nonce>:<ciphertext>
+
+The three trailing fields are base64url. A value without the ``bai-enc:`` marker is
+legacy plaintext.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import enum
+from dataclasses import dataclass, field
+from typing import Final, Self
+
+from ai.backend.manager.errors.secret import (
+    InvalidEncryptedSecretFormat,
+    UnsupportedSecretFormatVersion,
+)
+
+SECRET_MAGIC: Final[str] = "bai-enc"
+SECRET_FIELD_DELIMITER: Final[str] = ":"
+
+# A legacy secret key is `secrets.token_urlsafe` output, whose alphabet excludes the
+# delimiter, so a legacy value can never begin with this marker.
+_MARKER: Final[str] = f"{SECRET_MAGIC}{SECRET_FIELD_DELIMITER}"
+_FRAME_FIELD_COUNT: Final[int] = 3
+_TRAILING_FIELD_COUNT: Final[int] = 3
+
+
+class SecretFormatVersion(enum.StrEnum):
+    """Stored format versions this build can read. A new version is added, not swapped in."""
+
+    V1 = "1"
+
+    @classmethod
+    def current(cls) -> SecretFormatVersion:
+        """The version new values are written in."""
+        return cls.V1
+
+
+@dataclass(frozen=True)
+class WrappedDataEncryptionKey:
+    """The data encryption key as stored. Both fields are set and read by its provider."""
+
+    key_id: str
+    blob: bytes = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.key_id:
+            raise InvalidEncryptedSecretFormat("The key id of a wrapped secret key is empty.")
+        if not self.blob:
+            raise InvalidEncryptedSecretFormat("The wrapped secret key is empty.")
+
+
+@dataclass(frozen=True)
+class EncryptedData:
+    """A secret in its encrypted form, addressed to the key provider that wrote it."""
+
+    provider_id: str
+    wrapped_key: WrappedDataEncryptionKey
+    nonce: bytes = field(repr=False)
+    ciphertext: bytes = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.provider_id:
+            raise InvalidEncryptedSecretFormat("The key provider id of a secret is empty.")
+        if SECRET_FIELD_DELIMITER in self.provider_id:
+            raise InvalidEncryptedSecretFormat(
+                f"The key provider id {self.provider_id!r} must not contain "
+                f"{SECRET_FIELD_DELIMITER!r}."
+            )
+        if not self.nonce:
+            raise InvalidEncryptedSecretFormat("An encrypted secret carries an empty nonce.")
+        if not self.ciphertext:
+            raise InvalidEncryptedSecretFormat("An encrypted secret carries an empty ciphertext.")
+
+    @classmethod
+    def parse(cls, body: str) -> Self:
+        provider_id, _, tail = body.partition(SECRET_FIELD_DELIMITER)
+        # The key id is provider-defined and may contain the delimiter, so the three
+        # base64url fields after it are split off from the right.
+        fields = tail.rsplit(SECRET_FIELD_DELIMITER, _TRAILING_FIELD_COUNT)
+        if len(fields) != _TRAILING_FIELD_COUNT + 1:
+            raise InvalidEncryptedSecretFormat(
+                "An encrypted secret must hold a key provider id, a key id, "
+                "a wrapped key, a nonce, and a ciphertext."
+            )
+        key_id, encoded_key, encoded_nonce, encoded_ciphertext = fields
+        return cls(
+            provider_id=provider_id,
+            wrapped_key=WrappedDataEncryptionKey(key_id=key_id, blob=cls._decode(encoded_key)),
+            nonce=cls._decode(encoded_nonce),
+            ciphertext=cls._decode(encoded_ciphertext),
+        )
+
+    def serialize(self) -> str:
+        return SECRET_FIELD_DELIMITER.join([
+            self.provider_id,
+            self.wrapped_key.key_id,
+            self._encode(self.wrapped_key.blob),
+            self._encode(self.nonce),
+            self._encode(self.ciphertext),
+        ])
+
+    @classmethod
+    def _decode(cls, encoded: str) -> bytes:
+        try:
+            return base64.b64decode(encoded, altchars=b"-_", validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise InvalidEncryptedSecretFormat(
+                "Failed to decode a base64 field of an encrypted secret."
+            ) from e
+
+    def _encode(self, raw: bytes) -> str:
+        return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+@dataclass(frozen=True)
+class SecretValue:
+    """What a secret column holds: legacy plaintext, or a value some provider encrypted."""
+
+    content: str | EncryptedData = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if isinstance(self.content, str) and self.content.startswith(_MARKER):
+            raise InvalidEncryptedSecretFormat(
+                "A plaintext secret must not begin with the encrypted secret marker."
+            )
+
+    @classmethod
+    def parse(cls, stored: str) -> Self:
+        if not stored.startswith(_MARKER):
+            return cls(stored)
+        fields = stored.split(SECRET_FIELD_DELIMITER, _FRAME_FIELD_COUNT - 1)
+        if len(fields) != _FRAME_FIELD_COUNT:
+            raise InvalidEncryptedSecretFormat(
+                "An encrypted secret must hold a marker, a format version, and a body."
+            )
+        _, version, body = fields
+        # One arm per readable format version: a new version adds an arm, it does not
+        # replace this one, so values written by older builds keep parsing.
+        match version:
+            case SecretFormatVersion.V1:
+                return cls(EncryptedData.parse(body))
+            case _:
+                raise UnsupportedSecretFormatVersion(
+                    f"The stored secret is in format version {version!r}, "
+                    "which this build cannot read."
+                )
+
+    def serialize(self) -> str:
+        match self.content:
+            case EncryptedData() as data:
+                return SECRET_FIELD_DELIMITER.join([
+                    SECRET_MAGIC,
+                    SecretFormatVersion.current(),
+                    data.serialize(),
+                ])
+            case _:
+                return self.content

--- a/tests/unit/common/configs/test_config_field_validation.py
+++ b/tests/unit/common/configs/test_config_field_validation.py
@@ -114,12 +114,18 @@ def get_secret_fields(
 
         # Check if it's marked as secret
         is_marked_secret = False
+        is_composite = False
         if get_origin(annotation) is Annotated:
             args = get_args(annotation)
             for arg in args[1:]:
-                if isinstance(arg, BackendAIConfigMeta) and arg.secret:
-                    is_marked_secret = True
+                if isinstance(arg, BackendAIConfigMeta):
+                    is_marked_secret = arg.secret
+                    is_composite = arg.composite is not None
                     break
+
+        # A composite section holds no value of its own to mask.
+        if is_composite:
+            continue
 
         yield (field_path, is_marked_secret)
 

--- a/tests/unit/manager/secret/BUILD
+++ b/tests/unit/manager/secret/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/secret/test_column.py
+++ b/tests/unit/manager/secret/test_column.py
@@ -1,0 +1,204 @@
+"""
+End-to-end checks for a secret column.
+
+Every case goes through the column's own hooks, so a value is encrypted, turned into
+the string a column stores, read back from that string, and only then decrypted.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.engine.interfaces import Dialect
+
+from ai.backend.manager.config.unified import SecretEncryptionConfig
+from ai.backend.manager.data.secret.types import KeyProviderType
+from ai.backend.manager.errors.secret import InvalidSecretBinding, SecretDecryptionFailed
+from ai.backend.manager.models.base import SecretColumn
+from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.secret.types import EncryptedData, SecretValue
+
+CONTEXT = "keypairs.secret_key"
+OTHER_CONTEXT = "object_storages.secret_key"
+PLAINTEXT = "AKIAIOSFODNN7EXAMPLEKEYSECRET0123456789ab"
+
+
+def _key(seed: int) -> str:
+    return base64.b64encode(bytes([seed]) * 32).decode()
+
+
+def _pool(write_provider_type: str, active_key_id: str = "v1") -> KeyProviderPool:
+    return KeyProviderPool.from_config(
+        SecretEncryptionConfig.model_validate({
+            "write-provider-type": write_provider_type,
+            "config-provider": {
+                "active-key-id": active_key_id,
+                "keys": {"v1": _key(1), "v2": _key(2)},
+            },
+        })
+    )
+
+
+@pytest.fixture
+def dialect() -> Dialect:
+    return DefaultDialect()
+
+
+@pytest.fixture
+def column() -> SecretColumn:
+    return SecretColumn(CONTEXT)
+
+
+def _store(column: SecretColumn, dialect: Dialect, value: SecretValue) -> str:
+    """Bind a value the way an INSERT would, and return what the column writes."""
+    stored = column.process_bind_param(value, dialect)
+    assert stored is not None
+    return stored
+
+
+def _load(column: SecretColumn, dialect: Dialect, stored: str) -> SecretValue:
+    """Read a stored string back the way a SELECT would."""
+    loaded = column.process_result_value(stored, dialect)
+    assert loaded is not None
+    return loaded
+
+
+class TestThroughTheColumn:
+    async def test_an_encrypted_value_survives_a_write_and_a_read(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        pool = _pool("config")
+        stored = _store(column, dialect, await pool.encrypt(PLAINTEXT, CONTEXT))
+        assert stored.startswith("bai-enc:1:config:v1:")
+        assert PLAINTEXT not in stored
+        assert await pool.decrypt(_load(column, dialect, stored), CONTEXT) == PLAINTEXT
+
+    async def test_a_plaintext_value_survives_a_write_and_a_read(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        pool = _pool("plain")
+        stored = _store(column, dialect, await pool.encrypt(PLAINTEXT, CONTEXT))
+        assert stored == PLAINTEXT
+        assert await pool.decrypt(_load(column, dialect, stored), CONTEXT) == PLAINTEXT
+
+    async def test_a_legacy_row_reads_back_as_its_plaintext(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        pool = _pool("config")
+        assert await pool.decrypt(_load(column, dialect, PLAINTEXT), CONTEXT) == PLAINTEXT
+
+    async def test_two_writes_of_one_plaintext_are_stored_differently(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        pool = _pool("config")
+        first = _store(column, dialect, await pool.encrypt(PLAINTEXT, CONTEXT))
+        second = _store(column, dialect, await pool.encrypt(PLAINTEXT, CONTEXT))
+        assert first != second
+        assert await pool.decrypt(_load(column, dialect, first), CONTEXT) == PLAINTEXT
+        assert await pool.decrypt(_load(column, dialect, second), CONTEXT) == PLAINTEXT
+
+    async def test_a_value_stored_before_a_key_rotation_still_reads(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        stored = _store(column, dialect, await _pool("config", "v1").encrypt(PLAINTEXT, CONTEXT))
+        rotated = _pool("config", "v2")
+        assert await rotated.decrypt(_load(column, dialect, stored), CONTEXT) == PLAINTEXT
+
+    async def test_a_value_read_under_another_column_fails_authentication(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        pool = _pool("config")
+        stored = _store(column, dialect, await pool.encrypt(PLAINTEXT, CONTEXT))
+        with pytest.raises(SecretDecryptionFailed):
+            await pool.decrypt(_load(column, dialect, stored), OTHER_CONTEXT)
+
+
+class TestRewrapThroughTheColumn:
+    async def test_a_rewrapped_value_survives_a_write_and_a_read(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        stored = _store(column, dialect, await _pool("config", "v1").encrypt(PLAINTEXT, CONTEXT))
+        rotated = _pool("config", "v2")
+
+        rewrapped = _store(
+            column, dialect, await rotated.rewrap(_load(column, dialect, stored), CONTEXT)
+        )
+
+        assert rewrapped.startswith("bai-enc:1:config:v2:")
+        assert await rotated.decrypt(_load(column, dialect, rewrapped), CONTEXT) == PLAINTEXT
+
+    async def test_rewrapping_leaves_the_ciphertext_alone(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        before = _load(
+            column,
+            dialect,
+            _store(column, dialect, await _pool("config", "v1").encrypt(PLAINTEXT, CONTEXT)),
+        )
+        after = _load(
+            column,
+            dialect,
+            _store(column, dialect, await _pool("config", "v2").rewrap(before, CONTEXT)),
+        )
+        assert isinstance(before.content, EncryptedData)
+        assert isinstance(after.content, EncryptedData)
+        assert after.content.nonce == before.content.nonce
+        assert after.content.ciphertext == before.content.ciphertext
+        assert after.content.wrapped_key.blob != before.content.wrapped_key.blob
+
+    async def test_a_plaintext_row_rewraps_into_an_encrypted_one(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        pool = _pool("config")
+        rewrapped = _store(
+            column, dialect, await pool.rewrap(_load(column, dialect, PLAINTEXT), CONTEXT)
+        )
+        assert rewrapped.startswith("bai-enc:1:config:v1:")
+        assert await pool.decrypt(_load(column, dialect, rewrapped), CONTEXT) == PLAINTEXT
+
+    async def test_an_encrypted_row_rewraps_back_to_plaintext(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        stored = _store(column, dialect, await _pool("config").encrypt(PLAINTEXT, CONTEXT))
+        plain_pool = _pool("plain")
+
+        rewrapped = _store(
+            column, dialect, await plain_pool.rewrap(_load(column, dialect, stored), CONTEXT)
+        )
+
+        assert rewrapped == PLAINTEXT
+        assert await plain_pool.decrypt(_load(column, dialect, rewrapped), CONTEXT) == PLAINTEXT
+
+
+class TestBinding:
+    def test_a_bare_string_is_refused(self, column: SecretColumn, dialect: Dialect) -> None:
+        with pytest.raises(InvalidSecretBinding):
+            column.process_bind_param(PLAINTEXT, dialect)
+
+    def test_a_bare_encrypted_value_is_refused(
+        self, column: SecretColumn, dialect: Dialect
+    ) -> None:
+        with pytest.raises(InvalidSecretBinding):
+            column.process_bind_param({"provider_type": KeyProviderType.CONFIG}, dialect)
+
+    def test_none_passes_through(self, column: SecretColumn, dialect: Dialect) -> None:
+        assert column.process_bind_param(None, dialect) is None
+        assert column.process_result_value(None, dialect) is None
+
+    def test_the_column_stores_text(self, column: SecretColumn) -> None:
+        assert isinstance(column.impl_instance, sa.UnicodeText)
+
+    def test_the_column_carries_the_context_callers_encrypt_under(
+        self, column: SecretColumn
+    ) -> None:
+        assert column.context == CONTEXT
+
+    def test_columns_of_different_contexts_do_not_share_a_cache_key(self) -> None:
+        # Sharing one would let a compiled statement bind a value under the wrong
+        # associated data.
+        assert (
+            SecretColumn(CONTEXT)._static_cache_key != SecretColumn(OTHER_CONTEXT)._static_cache_key
+        )

--- a/tests/unit/manager/secret/test_config.py
+++ b/tests/unit/manager/secret/test_config.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import pytest
+
+from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.manager.config.unified import ConfigKeyProviderConfig, SecretEncryptionConfig
+from ai.backend.manager.data.secret.types import KeyProviderType
+
+
+def _key(seed: int) -> str:
+    return base64.b64encode(bytes([seed]) * 32).decode()
+
+
+def _provider(**raw: Any) -> ConfigKeyProviderConfig:
+    return ConfigKeyProviderConfig.model_validate(raw)
+
+
+class TestConfigKeyProviderConfig:
+    def test_a_section_without_an_active_key_id_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            _provider(keys={"v1": _key(1)})
+
+    def test_a_section_without_keys_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            _provider(**{"active-key-id": "v1"})
+
+    def test_an_active_key_id_outside_the_key_list_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            _provider(**{"active-key-id": "v2", "keys": {"v1": _key(1)}})
+
+    def test_a_key_of_the_wrong_size_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            _provider(**{
+                "active-key-id": "v1",
+                "keys": {"v1": base64.b64encode(b"short").decode()},
+            })
+
+    def test_a_non_base64_key_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            _provider(**{"active-key-id": "v1", "keys": {"v1": "!!!!"}})
+
+    def test_an_empty_key_id_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            _provider(**{"active-key-id": "", "keys": {"": _key(1)}})
+
+
+class TestSecretEncryptionConfig:
+    def test_an_unknown_write_provider_type_is_rejected(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            SecretEncryptionConfig.model_validate({"write-provider-type": "kms"})
+
+    def test_the_default_writes_plaintext_and_configures_no_provider(self) -> None:
+        config = SecretEncryptionConfig.model_validate({})
+        assert config.write_provider_type is KeyProviderType.PLAIN
+        assert config.config_provider is None
+
+    def test_the_kebab_case_keys_are_accepted(self) -> None:
+        config = SecretEncryptionConfig.model_validate({
+            "write-provider-type": "config",
+            "config-provider": {"active-key-id": "v1", "keys": {"v1": _key(1)}},
+        })
+        assert config.write_provider_type is KeyProviderType.CONFIG
+        assert config.config_provider is not None
+        assert config.config_provider.active_key_id == "v1"
+        assert config.config_provider.keys == {"v1": _key(1)}

--- a/tests/unit/manager/secret/test_config.py
+++ b/tests/unit/manager/secret/test_config.py
@@ -38,6 +38,13 @@ class TestConfigKeyProviderConfig:
                 "keys": {"v1": base64.b64encode(b"short").decode()},
             })
 
+    def test_the_url_safe_alphabet_is_accepted(self) -> None:
+        material = base64.urlsafe_b64encode(bytes([0xFB, 0xEF] * 16)).decode()
+        assert "-" in material and "_" in material
+        assert _provider(**{"active-key-id": "v1", "keys": {"v1": material}}).keys == {
+            "v1": material
+        }
+
     def test_a_non_base64_key_is_rejected(self) -> None:
         with pytest.raises(BackendAISchemaValidationFailed):
             _provider(**{"active-key-id": "v1", "keys": {"v1": "!!!!"}})

--- a/tests/unit/manager/secret/test_provider.py
+++ b/tests/unit/manager/secret/test_provider.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import base64
+import dataclasses
+
+import pytest
+
+from ai.backend.manager.config.unified import ConfigKeyProviderConfig, SecretEncryptionConfig
+from ai.backend.manager.data.secret.types import KeyProviderType, SecretKeyId
+from ai.backend.manager.errors.secret import (
+    SecretDecryptionFailed,
+    SecretEncryptionMisconfigured,
+    UnknownSecretKeyId,
+    UnknownSecretKeyProvider,
+)
+from ai.backend.manager.secret.config_provider import ConfigKeyProvider
+from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.secret.types import EncryptedData, SecretValue, WrappedDataEncryptionKey
+
+CONTEXT = "keypairs.secret_key"
+OTHER_CONTEXT = "object_storages.secret_key"
+PLAINTEXT = "AKIAIOSFODNN7EXAMPLEKEYSECRET0123456789ab"
+
+
+def _key(seed: int) -> str:
+    return base64.b64encode(bytes([seed]) * 32).decode()
+
+
+def _provider_config(active_key_id: str = "v1", **keys: str) -> ConfigKeyProviderConfig:
+    return ConfigKeyProviderConfig.model_validate({
+        "active-key-id": active_key_id,
+        "keys": keys or {"v1": _key(1)},
+    })
+
+
+@pytest.fixture
+def provider() -> ConfigKeyProvider:
+    return ConfigKeyProvider.from_config(_provider_config(v1=_key(1), v2=_key(2)))
+
+
+@pytest.fixture
+def rotated() -> ConfigKeyProvider:
+    return ConfigKeyProvider.from_config(
+        _provider_config(active_key_id="v2", v1=_key(1), v2=_key(2))
+    )
+
+
+class TestConfigKeyProvider:
+    async def test_a_value_round_trips(self, provider: ConfigKeyProvider) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        assert await provider.decrypt(data, CONTEXT) == PLAINTEXT
+
+    async def test_the_value_names_the_provider_and_the_active_key(
+        self, provider: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        assert data.provider_type == ConfigKeyProvider.PROVIDER_TYPE
+        assert data.wrapped_key.key_id == "v1"
+
+    async def test_a_fresh_data_encryption_key_is_drawn_per_value(
+        self, provider: ConfigKeyProvider
+    ) -> None:
+        first = await provider.encrypt(PLAINTEXT, CONTEXT)
+        second = await provider.encrypt(PLAINTEXT, CONTEXT)
+        assert first.wrapped_key.blob != second.wrapped_key.blob
+        assert first.nonce != second.nonce
+        assert first.ciphertext != second.ciphertext
+
+    async def test_a_different_context_fails_authentication(
+        self, provider: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        with pytest.raises(SecretDecryptionFailed):
+            await provider.decrypt(data, OTHER_CONTEXT)
+
+    async def test_a_tampered_ciphertext_fails_authentication(
+        self, provider: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        tampered = dataclasses.replace(
+            data, ciphertext=bytes([data.ciphertext[0] ^ 0x01]) + data.ciphertext[1:]
+        )
+        with pytest.raises(SecretDecryptionFailed):
+            await provider.decrypt(tampered, CONTEXT)
+
+    async def test_a_tampered_wrapped_key_fails_authentication(
+        self, provider: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        blob = data.wrapped_key.blob
+        tampered = dataclasses.replace(
+            data,
+            wrapped_key=WrappedDataEncryptionKey(
+                key_id=data.wrapped_key.key_id,
+                blob=blob[:-1] + bytes([blob[-1] ^ 0x01]),
+            ),
+        )
+        with pytest.raises(SecretDecryptionFailed):
+            await provider.decrypt(tampered, CONTEXT)
+
+    async def test_an_unconfigured_key_id_raises(self, provider: ConfigKeyProvider) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        unknown = dataclasses.replace(
+            data,
+            wrapped_key=WrappedDataEncryptionKey(
+                key_id=SecretKeyId("gone"), blob=data.wrapped_key.blob
+            ),
+        )
+        with pytest.raises(UnknownSecretKeyId):
+            await provider.decrypt(unknown, CONTEXT)
+
+    async def test_a_value_written_under_an_old_key_still_decrypts(
+        self, provider: ConfigKeyProvider, rotated: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        assert await rotated.decrypt(data, CONTEXT) == PLAINTEXT
+
+
+class TestRewrap:
+    async def test_rewrap_moves_the_key_without_touching_the_ciphertext(
+        self, provider: ConfigKeyProvider, rotated: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        moved = await rotated.rewrap(data, CONTEXT)
+        assert moved.wrapped_key.key_id == "v2"
+        assert moved.wrapped_key.blob != data.wrapped_key.blob
+        assert moved.nonce == data.nonce
+        assert moved.ciphertext == data.ciphertext
+
+    async def test_a_rewrapped_value_still_decrypts(
+        self, provider: ConfigKeyProvider, rotated: ConfigKeyProvider
+    ) -> None:
+        data = await provider.encrypt(PLAINTEXT, CONTEXT)
+        moved = await rotated.rewrap(data, CONTEXT)
+        assert await rotated.decrypt(moved, CONTEXT) == PLAINTEXT
+
+    async def test_rewrapping_a_value_already_on_the_active_key_changes_nothing(
+        self, rotated: ConfigKeyProvider
+    ) -> None:
+        data = await rotated.encrypt(PLAINTEXT, CONTEXT)
+        assert await rotated.rewrap(data, CONTEXT) == data
+
+
+class TestKeyProviderPool:
+    def _pool(self, write_provider_type: str) -> KeyProviderPool:
+        return KeyProviderPool.from_config(
+            SecretEncryptionConfig.model_validate({
+                "write-provider-type": write_provider_type,
+                "config-provider": {"active-key-id": "v1", "keys": {"v1": _key(1)}},
+            })
+        )
+
+    async def test_without_a_write_provider_new_values_stay_plaintext(self) -> None:
+        value = await self._pool("plain").encrypt(PLAINTEXT, CONTEXT)
+        assert value.content == PLAINTEXT
+        assert value.serialize() == PLAINTEXT
+
+    async def test_with_a_write_provider_new_values_are_encrypted(self) -> None:
+        value = await self._pool("config").encrypt(PLAINTEXT, CONTEXT)
+        assert isinstance(value.content, EncryptedData)
+        assert value.content.provider_type is KeyProviderType.CONFIG
+
+    async def test_a_value_round_trips_through_the_pool(self) -> None:
+        pool = self._pool("config")
+        value = await pool.encrypt(PLAINTEXT, CONTEXT)
+        assert await pool.decrypt(value, CONTEXT) == PLAINTEXT
+
+    async def test_a_plaintext_value_reads_back_without_a_provider(self) -> None:
+        pool = self._pool("plain")
+        assert await pool.decrypt(SecretValue(PLAINTEXT), CONTEXT) == PLAINTEXT
+
+    async def test_an_encrypted_value_still_reads_after_writes_go_back_to_plaintext(self) -> None:
+        encrypted = await self._pool("config").encrypt(PLAINTEXT, CONTEXT)
+        assert await self._pool("plain").decrypt(encrypted, CONTEXT) == PLAINTEXT
+
+    async def test_an_unconfigured_provider_id_raises(self) -> None:
+        pool = self._pool("config")
+        value = await pool.encrypt(PLAINTEXT, CONTEXT)
+        assert isinstance(value.content, EncryptedData)
+        pool_without_provider = KeyProviderPool([], write_provider_type=KeyProviderType.PLAIN)
+        with pytest.raises(UnknownSecretKeyProvider):
+            await pool_without_provider.decrypt(value, CONTEXT)
+
+    async def test_a_stored_value_naming_an_unknown_provider_type_raises(self) -> None:
+        with pytest.raises(UnknownSecretKeyProvider):
+            SecretValue.parse("bai-enc:1:kms:v1:AAAA:BBBB:CCCC")
+
+    def test_omitting_a_provider_section_leaves_it_unregistered(self) -> None:
+        with pytest.raises(SecretEncryptionMisconfigured):
+            KeyProviderPool.from_config(
+                SecretEncryptionConfig.model_validate({"write-provider-type": "config"})
+            )
+
+    def test_two_providers_sharing_an_id_are_rejected(self) -> None:
+        provider = ConfigKeyProvider.from_config(_provider_config(v1=_key(1)))
+        with pytest.raises(SecretEncryptionMisconfigured):
+            KeyProviderPool([provider, provider], write_provider_type=KeyProviderType.PLAIN)
+
+    async def test_rewrapping_a_plaintext_value_encrypts_it(self) -> None:
+        pool = self._pool("config")
+        moved = await pool.rewrap(SecretValue(PLAINTEXT), CONTEXT)
+        assert isinstance(moved.content, EncryptedData)
+        assert await pool.decrypt(moved, CONTEXT) == PLAINTEXT
+
+    async def test_rewrapping_under_the_plain_write_target_returns_to_plaintext(self) -> None:
+        encrypted = await self._pool("config").encrypt(PLAINTEXT, CONTEXT)
+        assert await self._pool("plain").rewrap(encrypted, CONTEXT) == SecretValue(PLAINTEXT)

--- a/tests/unit/manager/secret/test_types.py
+++ b/tests/unit/manager/secret/test_types.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from ai.backend.manager.data.secret.types import KeyProviderType, SecretKeyId
 from ai.backend.manager.errors.secret import (
     InvalidEncryptedSecretFormat,
+    UnknownSecretKeyProvider,
     UnsupportedSecretFormatVersion,
 )
 from ai.backend.manager.secret.types import (
+    SECRET_FIELD_DELIMITER,
     SECRET_MAGIC,
     EncryptedData,
     SecretFormatVersion,
@@ -15,16 +18,18 @@ from ai.backend.manager.secret.types import (
 )
 
 LEGACY_PLAINTEXT = "AKIAIOSFODNN7EXAMPLEKEYSECRET0123456789ab"
-PROVIDER_ID = "config"
-KEY_ID = "v2"
+PROVIDER_TYPE = KeyProviderType.CONFIG
+KEY_ID = SecretKeyId("v2")
 WRAPPED_BLOB = bytes(range(60))
 NONCE = bytes(range(12))
 CIPHERTEXT = bytes(range(56))
 
 
-def _encrypted(provider_id: str = PROVIDER_ID, key_id: str = KEY_ID) -> EncryptedData:
+def _encrypted(
+    provider_type: KeyProviderType = PROVIDER_TYPE, key_id: SecretKeyId = KEY_ID
+) -> EncryptedData:
     return EncryptedData(
-        provider_id=provider_id,
+        provider_type=provider_type,
         wrapped_key=WrappedDataEncryptionKey(key_id=key_id, blob=WRAPPED_BLOB),
         nonce=NONCE,
         ciphertext=CIPHERTEXT,
@@ -34,24 +39,20 @@ def _encrypted(provider_id: str = PROVIDER_ID, key_id: str = KEY_ID) -> Encrypte
 class TestFieldValidation:
     def test_an_empty_key_id_is_rejected(self) -> None:
         with pytest.raises(InvalidEncryptedSecretFormat):
-            WrappedDataEncryptionKey(key_id="", blob=WRAPPED_BLOB)
+            WrappedDataEncryptionKey(key_id=SecretKeyId(""), blob=WRAPPED_BLOB)
 
     def test_an_empty_wrapped_key_is_rejected(self) -> None:
         with pytest.raises(InvalidEncryptedSecretFormat):
             WrappedDataEncryptionKey(key_id=KEY_ID, blob=b"")
 
-    def test_an_empty_provider_id_is_rejected(self) -> None:
-        with pytest.raises(InvalidEncryptedSecretFormat):
-            _encrypted(provider_id="")
-
-    def test_a_provider_id_containing_the_delimiter_is_rejected(self) -> None:
-        with pytest.raises(InvalidEncryptedSecretFormat):
-            _encrypted(provider_id="con:fig")
+    def test_no_provider_type_carries_the_delimiter(self) -> None:
+        for provider_type in KeyProviderType:
+            assert SECRET_FIELD_DELIMITER not in provider_type.value
 
     def test_an_empty_nonce_is_rejected(self) -> None:
         with pytest.raises(InvalidEncryptedSecretFormat):
             EncryptedData(
-                provider_id=PROVIDER_ID,
+                provider_type=PROVIDER_TYPE,
                 wrapped_key=WrappedDataEncryptionKey(key_id=KEY_ID, blob=WRAPPED_BLOB),
                 nonce=b"",
                 ciphertext=CIPHERTEXT,
@@ -60,7 +61,7 @@ class TestFieldValidation:
     def test_an_empty_ciphertext_is_rejected(self) -> None:
         with pytest.raises(InvalidEncryptedSecretFormat):
             EncryptedData(
-                provider_id=PROVIDER_ID,
+                provider_type=PROVIDER_TYPE,
                 wrapped_key=WrappedDataEncryptionKey(key_id=KEY_ID, blob=WRAPPED_BLOB),
                 nonce=NONCE,
                 ciphertext=b"",
@@ -97,11 +98,11 @@ class TestRoundTrip:
         assert (
             SecretValue(_encrypted())
             .serialize()
-            .startswith(f"{SECRET_MAGIC}:{SecretFormatVersion.current()}:{PROVIDER_ID}:{KEY_ID}:")
+            .startswith(f"{SECRET_MAGIC}:{SecretFormatVersion.current()}:{PROVIDER_TYPE}:{KEY_ID}:")
         )
 
     def test_a_key_id_containing_the_delimiter_round_trips(self) -> None:
-        key_id = "projects/p/locations/l:cryptoKeys/k"
+        key_id = SecretKeyId("projects/p/locations/l:cryptoKeys/k")
         parsed = SecretValue.parse(SecretValue(_encrypted(key_id=key_id)).serialize())
         assert isinstance(parsed.content, EncryptedData)
         assert parsed.content.wrapped_key.key_id == key_id
@@ -132,7 +133,6 @@ class TestMalformed:
             "config:v1",
             "config:v1:AAAA",
             "config:v1:AAAA:BBBB",
-            ":v1:AAAA:BBBB:CCCC",
             "config::AAAA:BBBB:CCCC",
             "config:v1:!!!!:BBBB:CCCC",
         ],
@@ -140,6 +140,14 @@ class TestMalformed:
     def test_a_malformed_body_raises(self, body: str) -> None:
         with pytest.raises(InvalidEncryptedSecretFormat):
             SecretValue.parse(f"{SECRET_MAGIC}:{SecretFormatVersion.current()}:{body}")
+
+    def test_a_stored_value_naming_an_unknown_provider_type_raises(self) -> None:
+        with pytest.raises(UnknownSecretKeyProvider):
+            SecretValue.parse(f"{SECRET_MAGIC}:1:kms:v1:AAAA:BBBB:CCCC")
+
+    def test_a_stored_value_naming_the_plain_provider_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            SecretValue.parse(f"{SECRET_MAGIC}:1:plain:v1:AAAA:BBBB:CCCC")
 
     @pytest.mark.parametrize("version", ["2", "0", "x", ""])
     def test_an_unreadable_format_version_raises(self, version: str) -> None:

--- a/tests/unit/manager/secret/test_types.py
+++ b/tests/unit/manager/secret/test_types.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.manager.errors.secret import (
+    InvalidEncryptedSecretFormat,
+    UnsupportedSecretFormatVersion,
+)
+from ai.backend.manager.secret.types import (
+    SECRET_MAGIC,
+    EncryptedData,
+    SecretFormatVersion,
+    SecretValue,
+    WrappedDataEncryptionKey,
+)
+
+LEGACY_PLAINTEXT = "AKIAIOSFODNN7EXAMPLEKEYSECRET0123456789ab"
+PROVIDER_ID = "config"
+KEY_ID = "v2"
+WRAPPED_BLOB = bytes(range(60))
+NONCE = bytes(range(12))
+CIPHERTEXT = bytes(range(56))
+
+
+def _encrypted(provider_id: str = PROVIDER_ID, key_id: str = KEY_ID) -> EncryptedData:
+    return EncryptedData(
+        provider_id=provider_id,
+        wrapped_key=WrappedDataEncryptionKey(key_id=key_id, blob=WRAPPED_BLOB),
+        nonce=NONCE,
+        ciphertext=CIPHERTEXT,
+    )
+
+
+class TestFieldValidation:
+    def test_an_empty_key_id_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            WrappedDataEncryptionKey(key_id="", blob=WRAPPED_BLOB)
+
+    def test_an_empty_wrapped_key_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            WrappedDataEncryptionKey(key_id=KEY_ID, blob=b"")
+
+    def test_an_empty_provider_id_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            _encrypted(provider_id="")
+
+    def test_a_provider_id_containing_the_delimiter_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            _encrypted(provider_id="con:fig")
+
+    def test_an_empty_nonce_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            EncryptedData(
+                provider_id=PROVIDER_ID,
+                wrapped_key=WrappedDataEncryptionKey(key_id=KEY_ID, blob=WRAPPED_BLOB),
+                nonce=b"",
+                ciphertext=CIPHERTEXT,
+            )
+
+    def test_an_empty_ciphertext_is_rejected(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            EncryptedData(
+                provider_id=PROVIDER_ID,
+                wrapped_key=WrappedDataEncryptionKey(key_id=KEY_ID, blob=WRAPPED_BLOB),
+                nonce=NONCE,
+                ciphertext=b"",
+            )
+
+    def test_the_secret_bytes_are_not_exposed_by_repr(self) -> None:
+        value = SecretValue(_encrypted())
+        rendered = f"{value!r} {value.content!r}"
+        assert WRAPPED_BLOB.hex() not in rendered
+        assert CIPHERTEXT.hex() not in rendered
+        assert LEGACY_PLAINTEXT not in repr(SecretValue(LEGACY_PLAINTEXT))
+
+
+class TestPlaintext:
+    def test_a_value_without_the_marker_is_read_as_plaintext(self) -> None:
+        parsed = SecretValue.parse(LEGACY_PLAINTEXT)
+        assert not isinstance(parsed.content, EncryptedData)
+        assert parsed.content == LEGACY_PLAINTEXT
+
+    def test_a_plaintext_value_serializes_as_is(self) -> None:
+        assert SecretValue(LEGACY_PLAINTEXT).serialize() == LEGACY_PLAINTEXT
+
+    def test_a_plaintext_value_may_not_impersonate_the_marker(self) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            SecretValue(f"{SECRET_MAGIC}:1:config:v1:AAAA:BBBB:CCCC")
+
+
+class TestRoundTrip:
+    def test_an_encrypted_value_round_trips(self) -> None:
+        value = SecretValue(_encrypted())
+        assert SecretValue.parse(value.serialize()) == value
+
+    def test_the_stored_value_names_the_marker_version_provider_and_key(self) -> None:
+        assert (
+            SecretValue(_encrypted())
+            .serialize()
+            .startswith(f"{SECRET_MAGIC}:{SecretFormatVersion.current()}:{PROVIDER_ID}:{KEY_ID}:")
+        )
+
+    def test_a_key_id_containing_the_delimiter_round_trips(self) -> None:
+        key_id = "projects/p/locations/l:cryptoKeys/k"
+        parsed = SecretValue.parse(SecretValue(_encrypted(key_id=key_id)).serialize())
+        assert isinstance(parsed.content, EncryptedData)
+        assert parsed.content.wrapped_key.key_id == key_id
+
+    def test_the_wrapped_key_and_data_survive_the_round_trip(self) -> None:
+        parsed = SecretValue.parse(SecretValue(_encrypted()).serialize())
+        assert isinstance(parsed.content, EncryptedData)
+        assert parsed.content.wrapped_key.blob == WRAPPED_BLOB
+        assert parsed.content.nonce == NONCE
+        assert parsed.content.ciphertext == CIPHERTEXT
+
+    def test_serializing_a_parsed_value_reproduces_the_stored_string(self) -> None:
+        stored = SecretValue(_encrypted()).serialize()
+        assert SecretValue.parse(stored).serialize() == stored
+        assert SecretValue.parse(LEGACY_PLAINTEXT).serialize() == LEGACY_PLAINTEXT
+
+
+class TestMalformed:
+    @pytest.mark.parametrize("stored", [f"{SECRET_MAGIC}:", f"{SECRET_MAGIC}:1"])
+    def test_a_frame_without_a_body_raises(self, stored: str) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            SecretValue.parse(stored)
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "config",
+            "config:v1",
+            "config:v1:AAAA",
+            "config:v1:AAAA:BBBB",
+            ":v1:AAAA:BBBB:CCCC",
+            "config::AAAA:BBBB:CCCC",
+            "config:v1:!!!!:BBBB:CCCC",
+        ],
+    )
+    def test_a_malformed_body_raises(self, body: str) -> None:
+        with pytest.raises(InvalidEncryptedSecretFormat):
+            SecretValue.parse(f"{SECRET_MAGIC}:{SecretFormatVersion.current()}:{body}")
+
+    @pytest.mark.parametrize("version", ["2", "0", "x", ""])
+    def test_an_unreadable_format_version_raises(self, version: str) -> None:
+        body = _encrypted().serialize()
+        with pytest.raises(UnsupportedSecretFormatVersion):
+            SecretValue.parse(f"{SECRET_MAGIC}:{version}:{body}")


### PR DESCRIPTION
## Summary

- Adds the pieces at-rest secret encryption is built from: the self-describing stored
  format, the `KeyProvider` contract with its config-backed implementation, the pool that
  routes a stored secret to the provider its value names, and `SecretColumn`.
- A data encryption key belongs to one row. The provider's key wraps it, so rotating a key
  rewraps sixty bytes per row and touches neither the ciphertext nor the plaintext, and a
  rotation pass never needs permission to read the values.
- Encryption is configured by naming the provider type that writes; there is no separate
  on/off switch, and `plain` is one of those types. Reads are decided by the stored value,
  so returning writes to plaintext leaves already-encrypted rows readable.
- **Nothing uses this yet.** Applying it to `keypairs.secret_key` is BA-7043, so the only
  behavior change here is a new config section that does nothing until a column adopts it.

## Test plan

- [x] a secret is encrypted, written as the string a column stores, read back from it, and
      decrypted — through the column's own hooks
- [x] a rewrap arrives on the new key with the nonce and ciphertext unchanged, and still
      decrypts
- [x] a rewrap under the `plain` write target returns a stored secret to plaintext
- [x] a legacy plaintext row reads back unchanged, and a bare string is refused on binding
- [x] a wrong column context, a tampered ciphertext, and a tampered wrapped key each fail
      authentication
- [x] `pants lint` and `pants check` clean; `pants test --changed-dependents=direct` green

Resolves BA-7042