### PR TITLE
feat(BA-7451): add the lifecycle status to domain, project, user, and image

### DIFF
--- a/changes/13930.feature.md
+++ b/changes/13930.feature.md
@@ -1,0 +1,1 @@
+Add the lifecycle status column to domain and project, and the purge states to the domain, project, user, and image statuses.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -1117,6 +1117,8 @@ type Image {
 enum ImageStatus {
   ALIVE
   DELETED
+  PURGING
+  PURGE_ERROR
 }
 
 """Added in 25.3.0."""

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8681,6 +8681,8 @@ enum ImageStatus
 {
   ALIVE @join__enumValue(graph: GRAPHENE)
   DELETED @join__enumValue(graph: GRAPHENE)
+  PURGING @join__enumValue(graph: GRAPHENE)
+  PURGE_ERROR @join__enumValue(graph: GRAPHENE)
 }
 
 """Added in 25.12.0."""

--- a/src/ai/backend/manager/data/domain/types.py
+++ b/src/ai/backend/manager/data/domain/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import uuid
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
@@ -18,6 +19,15 @@ from ai.backend.manager.data.permission.types import (
     ScopeType,
 )
 from ai.backend.manager.types import OptionalState, PartialModifier, TriState
+
+
+class DomainStatus(enum.StrEnum):
+    """Lifecycle status of a domain."""
+
+    ACTIVE = "active"
+    DELETED = "deleted"
+    PURGING = "purging"
+    PURGE_ERROR = "purge-error"
 
 
 @dataclass

--- a/src/ai/backend/manager/data/image/types.py
+++ b/src/ai/backend/manager/data/image/types.py
@@ -16,6 +16,8 @@ type Resources = dict[SlotName, dict[str, Any]]
 class ImageStatus(enum.StrEnum):
     ALIVE = "ALIVE"
     DELETED = "DELETED"
+    PURGING = "PURGING"
+    PURGE_ERROR = "PURGE_ERROR"
 
 
 class ImageOrderField(enum.StrEnum):

--- a/src/ai/backend/manager/data/project/types.py
+++ b/src/ai/backend/manager/data/project/types.py
@@ -22,6 +22,15 @@ from ai.backend.manager.errors.resource import DataTransformationFailed
 from ai.backend.manager.types import OptionalState, PartialModifier, TriState
 
 
+class ProjectStatus(enum.StrEnum):
+    """Lifecycle status of a project."""
+
+    ACTIVE = "active"
+    DELETED = "deleted"
+    PURGING = "purging"
+    PURGE_ERROR = "purge-error"
+
+
 class ProjectType(enum.StrEnum):
     GENERAL = "general"
     MODEL_STORE = "model-store"

--- a/src/ai/backend/manager/data/user/types.py
+++ b/src/ai/backend/manager/data/user/types.py
@@ -32,6 +32,8 @@ class UserStatus(enum.StrEnum):
     INACTIVE = "inactive"
     DELETED = "deleted"
     BEFORE_VERIFICATION = "before-verification"
+    PURGING = "purging"
+    PURGE_ERROR = "purge-error"
 
     @override
     @classmethod
@@ -49,6 +51,10 @@ class UserStatus(enum.StrEnum):
                 return cls.DELETED
             case "BEFORE-VERIFICATION" | "BEFORE_VERIFICATION":
                 return cls.BEFORE_VERIFICATION
+            case "PURGING":
+                return cls.PURGING
+            case "PURGE-ERROR" | "PURGE_ERROR":
+                return cls.PURGE_ERROR
         return None
 
 

--- a/src/ai/backend/manager/models/alembic/versions/a3f1c7d92b04_add_lifecycle_status_to_domain_and_project.py
+++ b/src/ai/backend/manager/models/alembic/versions/a3f1c7d92b04_add_lifecycle_status_to_domain_and_project.py
@@ -1,0 +1,41 @@
+"""Add the lifecycle status column to domain and project, and the purge statuses to user and image
+
+Revision ID: a3f1c7d92b04
+Revises: a3d17c9b45e2
+Create Date: 2026-08-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3f1c7d92b04"
+down_revision = "a3d17c9b45e2"
+branch_labels = None
+depends_on = None
+
+STATUS_TABLES = ("domains", "groups")
+
+
+def upgrade() -> None:
+    for table in STATUS_TABLES:
+        op.add_column(
+            table,
+            sa.Column("status", sa.String(length=64), nullable=False, server_default="active"),
+        )
+        op.create_index(f"ix_{table}_status", table, ["status"])
+        op.execute(sa.text(f"UPDATE {table} SET status = 'deleted' WHERE is_active IS FALSE"))
+    op.execute(sa.text("ALTER TYPE userstatus ADD VALUE IF NOT EXISTS 'purging'"))
+    op.execute(sa.text("ALTER TYPE userstatus ADD VALUE IF NOT EXISTS 'purge-error'"))
+
+
+def downgrade() -> None:
+    # The 'purging' and 'purge-error' labels stay on the userstatus enum type.
+    # PostgreSQL cannot drop enum labels.
+    op.execute(
+        sa.text("UPDATE users SET status = 'deleted' WHERE status IN ('purging', 'purge-error')")
+    )
+    for table in STATUS_TABLES:
+        op.drop_index(f"ix_{table}_status", table)
+        op.drop_column(table, "status")

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -24,7 +24,7 @@ from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.types import ScopeID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.domain.types import DomainData
+from ai.backend.manager.data.domain.types import DomainData, DomainStatus
 from ai.backend.manager.data.permission.permission_defs import DomainPermission
 from ai.backend.manager.defs import RESERVED_DOTFILES
 from ai.backend.manager.models.base import (
@@ -32,6 +32,7 @@ from ai.backend.manager.models.base import (
     Base,
     ResourceSlotColumn,
     SlugType,
+    StrEnumType,
     VFolderHostPermissionColumn,
 )
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
@@ -90,6 +91,14 @@ class DomainRow(LifecycleTimestampsMixin, Base):
     )
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool] = mapped_column("is_active", sa.Boolean, default=True, nullable=False)
+    status: Mapped[DomainStatus] = mapped_column(
+        "status",
+        StrEnumType(DomainStatus),
+        default=DomainStatus.ACTIVE,
+        server_default=DomainStatus.ACTIVE,
+        nullable=False,
+        index=True,
+    )
     is_default: Mapped[bool] = mapped_column(
         "is_default", sa.Boolean, nullable=False, default=False, server_default=sa.false()
     )

--- a/src/ai/backend/manager/models/project/row.py
+++ b/src/ai/backend/manager/models/project/row.py
@@ -38,7 +38,7 @@ from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.permission.permission_defs import ProjectPermission
-from ai.backend.manager.data.project.types import ProjectData, ProjectType
+from ai.backend.manager.data.project.types import ProjectData, ProjectStatus, ProjectType
 from ai.backend.manager.defs import RESERVED_DOTFILES
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.models.association_container_registries_groups import (
@@ -50,6 +50,7 @@ from ai.backend.manager.models.base import (
     EnumValueType,
     ResourceSlotColumn,
     SlugType,
+    StrEnumType,
     StructuredJSONColumn,
     VFolderHostPermissionColumn,
 )
@@ -158,6 +159,14 @@ class ProjectRow(LifecycleTimestampsMixin, Base):
     )
     description: Mapped[str | None] = mapped_column("description", sa.String(length=512))
     is_active: Mapped[bool | None] = mapped_column("is_active", sa.Boolean, default=True)
+    status: Mapped[ProjectStatus] = mapped_column(
+        "status",
+        StrEnumType(ProjectStatus),
+        default=ProjectStatus.ACTIVE,
+        server_default=ProjectStatus.ACTIVE,
+        nullable=False,
+        index=True,
+    )
     #: Field for synchronization with external services.
     integration_id: Mapped[str | None] = mapped_column("integration_id", sa.String(length=512))
     domain_name: Mapped[str] = mapped_column(


### PR DESCRIPTION
## Summary

- Add a `status` column to `domains` and `groups`, non-null with `ACTIVE` as the default, backfilled from `is_active`. `is_active` stays as it is; deriving it from the new column is BA-7458.
- Add `PURGING` and `PURGE_ERROR` to the domain, project, user, and image status enums. `users.status` is a native PostgreSQL enum, so its labels are added by `ALTER TYPE`.
- `vfolder` is untouched — its existing `DELETE_ONGOING` and `DELETE_ERROR` already carry these states.

Nothing writes the purge states yet. The lifecycle controller does, and the API-facing enums (GraphQL, DTO, client SDK) gain the new values there.

## Test plan

- [ ] `pants lint` / `pants check` / `pants test` on the changed targets
- [ ] `alembic upgrade head` on a database holding inactive domains and projects, and confirm those rows land on `deleted` while the rest land on `active`
- [ ] `alembic downgrade` and confirm the columns and index are gone

Resolves BA-7451

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13930.org.readthedocs.build/en/13930/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13930.org.readthedocs.build/ko/13930/

<!-- readthedocs-preview sorna-ko end -->