### PR TITLE
refactor(BA-7459): isolate the reconcile ops and settle the ops injection rules

### DIFF
--- a/changes/13933.enhance.md
+++ b/changes/13933.enhance.md
@@ -1,0 +1,1 @@
+Isolate the reconcile transition from the general v2 DB ops and take ops from a provider instead of opening a session

--- a/src/ai/backend/common/data/entity/vfolder_permission.py
+++ b/src/ai/backend/common/data/entity/vfolder_permission.py
@@ -1,0 +1,18 @@
+"""Field type and id of the vfolder_permissions table."""
+
+from typing import override
+
+from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+
+__all__ = ("VFOLDER_PERMISSION_FIELD_TYPE", "VFolderPermissionID")
+
+VFOLDER_PERMISSION_FIELD_TYPE = FieldType("vfolder_permission")
+
+
+class VFolderPermissionID(FieldIdentifier):
+    """A vfolder permission row's id."""
+
+    @override
+    @classmethod
+    def field_type(cls) -> FieldType:
+        return VFOLDER_PERMISSION_FIELD_TYPE

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -21,8 +21,8 @@ from ai.backend.manager.models.specs.creator import (
 )
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.purger import (
-    DataBatchPurger,
     EntityPurger,
+    FieldBatchPurger,
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
@@ -547,7 +547,7 @@ class BatchPurgeOpsAction[TRow: Base, TData](OpsBackendAction):
     """A hard delete of every row matching a condition within the scopes it names."""
 
     @abstractmethod
-    def to_batch_purger(self) -> DataBatchPurger[TRow, TData]:
+    def to_batch_purger(self) -> FieldBatchPurger[TRow, TData]:
         """Return the batch delete spec this action executes."""
         raise NotImplementedError
 
@@ -561,7 +561,7 @@ class GlobalBatchPurgeOpsAction[TRow: Base, TData](OpsBackendAction):
     """A hard delete of every matching row across the table, with no scope filter."""
 
     @abstractmethod
-    def to_batch_purger(self) -> DataBatchPurger[TRow, TData]:
+    def to_batch_purger(self) -> FieldBatchPurger[TRow, TData]:
         """Return the batch delete spec this action executes."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -21,8 +21,8 @@ from ai.backend.manager.models.specs.creator import (
 )
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.purger import (
+    EntityBatchPurger,
     EntityPurger,
-    FieldBatchPurger,
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
@@ -547,7 +547,7 @@ class BatchPurgeOpsAction[TRow: Base, TData](OpsBackendAction):
     """A hard delete of every row matching a condition within the scopes it names."""
 
     @abstractmethod
-    def to_batch_purger(self) -> FieldBatchPurger[TRow, TData]:
+    def to_batch_purger(self) -> EntityBatchPurger[TRow, TData]:
         """Return the batch delete spec this action executes."""
         raise NotImplementedError
 
@@ -561,7 +561,7 @@ class GlobalBatchPurgeOpsAction[TRow: Base, TData](OpsBackendAction):
     """A hard delete of every matching row across the table, with no scope filter."""
 
     @abstractmethod
-    def to_batch_purger(self) -> FieldBatchPurger[TRow, TData]:
+    def to_batch_purger(self) -> EntityBatchPurger[TRow, TData]:
         """Return the batch delete spec this action executes."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/api/gql_legacy/network.py
+++ b/src/ai/backend/manager/api/gql_legacy/network.py
@@ -29,8 +29,6 @@ from ai.backend.manager.models.network import NetworkRow
 from ai.backend.manager.models.network.creators import NetworkCreator
 from ai.backend.manager.models.project import AssocGroupUserRow, ProjectRow
 from ai.backend.manager.models.user import UserRole
-from ai.backend.manager.repositories.ops.repository import OpsRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 
 from .base import (
     FilterExprArg,
@@ -296,8 +294,7 @@ class CreateNetwork(graphene.Mutation):  # type: ignore[misc]
             raise
 
         async def _do_mutate() -> CreateNetwork:
-            ops: OpsRepository[NetworkData] = OpsRepository(V2DBOpsProvider(graph_ctx.db))
-            data = await ops.create_entity(
+            data = await graph_ctx.network_repository.create_entity(
                 NetworkCreator(
                     name=name,
                     ref_name=network_name,

--- a/src/ai/backend/manager/api/gql_legacy/schema.py
+++ b/src/ai/backend/manager/api/gql_legacy/schema.py
@@ -109,6 +109,7 @@ if TYPE_CHECKING:
 
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.manager.data.image.types import ImageStatus
+from ai.backend.manager.data.network.types import NetworkData
 from ai.backend.manager.data.permission.permission_defs import (
     AgentPermission,
     ComputeSessionPermission,
@@ -138,6 +139,7 @@ from ai.backend.manager.models.resource_group.row import (
     query_allowed_sgroups,
 )
 from ai.backend.manager.models.vfolder import ensure_quota_scope_accessible_by_user
+from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 from .acl import PredefinedAtomicPermission
 from .agent import (
@@ -337,6 +339,7 @@ class GraphQueryContext:
     scheduler_repository: SchedulerRepository
     user_repository: UserRepository
     agent_repository: AgentRepository
+    network_repository: OpsRepository[NetworkData]
 
 
 class Mutation(graphene.ObjectType):  # type: ignore[misc]

--- a/src/ai/backend/manager/api/rest/admin/handler.py
+++ b/src/ai/backend/manager/api/rest/admin/handler.py
@@ -134,6 +134,7 @@ class AdminHandler:
             scheduler_repository=gql_deps.scheduler_repository,
             user_repository=gql_deps.user_repository,
             agent_repository=gql_deps.agent_repository,
+            network_repository=gql_deps.network_repository,
         )
         result = cast(
             ExecutionResult,

--- a/src/ai/backend/manager/api/rest/setup.py
+++ b/src/ai/backend/manager/api/rest/setup.py
@@ -24,6 +24,7 @@ def setup_api(
     """
     from ai.backend.manager.api.adapters.registry import Adapters
     from ai.backend.manager.api.gql.adapter import BaseGQLAdapter
+    from ai.backend.manager.repositories.ops.repository import OpsRepository
 
     from .tree import build_api_routes
     from .types import GQLContextDeps
@@ -55,6 +56,7 @@ def setup_api(
         scheduler_repository=r.domain.repositories.scheduler.repository,
         user_repository=r.domain.repositories.user.repository,
         agent_repository=r.domain.repositories.agent.repository,
+        network_repository=OpsRepository(r.domain.repositories.v2_ops_provider),
         strawberry_gql_adapter=BaseGQLAdapter(),
         adapters=adapters,
     )

--- a/src/ai/backend/manager/api/rest/types.py
+++ b/src/ai/backend/manager/api/rest/types.py
@@ -9,6 +9,8 @@ from aiohttp import web
 from aiohttp.typedefs import Middleware
 
 from ai.backend.common.api_handlers import APIResponse, APIStreamResponse
+from ai.backend.manager.data.network.types import NetworkData
+from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 if TYPE_CHECKING:
     from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
@@ -79,6 +81,7 @@ class GQLContextDeps:
     scheduler_repository: SchedulerRepository
     user_repository: UserRepository
     agent_repository: AgentRepository
+    network_repository: OpsRepository[NetworkData]
     strawberry_gql_adapter: BaseGQLAdapter
     adapters: Adapters
 

--- a/src/ai/backend/manager/data/vfolder/types.py
+++ b/src/ai/backend/manager/data/vfolder/types.py
@@ -7,8 +7,9 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, override
 
-from ai.backend.common.data.entity.types import EntityData, EntityIdentifier
+from ai.backend.common.data.entity.types import EntityData, EntityIdentifier, FieldData
 from ai.backend.common.data.entity.vfolder import VFolderUUID
+from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.dto.manager.field import (
     VFolderOperationStatusField,
@@ -220,12 +221,12 @@ class VFolderUsageData:
 
 
 @dataclass
-class VFolderPermissionData:
+class VFolderPermissionData(FieldData):
     """
     VFolder permission data representing user-specific permissions on a VFolder.
     """
 
-    id: uuid.UUID
+    id: VFolderPermissionID
     vfolder: uuid.UUID
     user: uuid.UUID
     permission: VFolderMountPermission

--- a/src/ai/backend/manager/dependencies/domain/repositories.py
+++ b/src/ai/backend/manager/dependencies/domain/repositories.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, override
 
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.repositories.repositories import Repositories
 from ai.backend.manager.repositories.types import RepositoryArgs
 
@@ -69,6 +70,7 @@ class RepositoriesDependency(DomainDependency[RepositoriesInput, Repositories]):
                 db=setup_input.db,
                 ops_provider=DBOpsProvider(setup_input.db),
                 v2_ops_provider=V2DBOpsProvider(setup_input.db),
+                reconcile_ops_provider=ReconcileOpsProvider(setup_input.db),
                 storage_manager=setup_input.storage_manager,
                 config_provider=setup_input.config_provider,
                 valkey_stat_client=setup_input.valkey_stat,

--- a/src/ai/backend/manager/models/deployment_revision_preset/purgers.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/purgers.py
@@ -53,19 +53,16 @@ class DeploymentPresetPurger(
         return row.to_data()
 
 
-class PresetResourceSlotBatchPurger(FieldBatchPurger[PresetResourceSlotRow, ResourceSlotEntryData]):
+class PresetResourceSlotBatchPurger(
+    FieldBatchPurger[DeploymentPresetID, PresetResourceSlotRow, ResourceSlotEntryData]
+):
     """Clear every slot row of one preset, so an update can restate the whole set."""
 
-    _preset_id: DeploymentPresetID
-
-    def __init__(self, preset_id: DeploymentPresetID) -> None:
-        self._preset_id = preset_id
-
     @override
-    def build_subquery(self) -> sa.sql.Select[tuple[PresetResourceSlotRow]]:
-        return sa.select(PresetResourceSlotRow).where(
-            PresetResourceSlotRow.preset_id == self._preset_id
-        )
+    def build_subquery(
+        self, owner_id: DeploymentPresetID
+    ) -> sa.sql.Select[tuple[PresetResourceSlotRow]]:
+        return sa.select(PresetResourceSlotRow).where(PresetResourceSlotRow.preset_id == owner_id)
 
     @override
     def conflict_checks(self) -> Sequence[ConflictCheck]:

--- a/src/ai/backend/manager/models/deployment_revision_preset/purgers.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/purgers.py
@@ -13,7 +13,7 @@ from ai.backend.manager.data.deployment_revision_preset.types import (
 )
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
 from ai.backend.manager.models.resource_slot.row import PresetResourceSlotRow
-from ai.backend.manager.models.specs.purger import DataBatchPurger, EntityPurger
+from ai.backend.manager.models.specs.purger import EntityPurger, FieldBatchPurger
 from ai.backend.manager.models.specs.types import ConflictCheck
 
 __all__ = (
@@ -53,7 +53,7 @@ class DeploymentPresetPurger(
         return row.to_data()
 
 
-class PresetResourceSlotBatchPurger(DataBatchPurger[PresetResourceSlotRow, ResourceSlotEntryData]):
+class PresetResourceSlotBatchPurger(FieldBatchPurger[PresetResourceSlotRow, ResourceSlotEntryData]):
     """Clear every slot row of one preset, so an update can restate the whole set."""
 
     _preset_id: DeploymentPresetID

--- a/src/ai/backend/manager/models/domain/purgers.py
+++ b/src/ai/backend/manager/models/domain/purgers.py
@@ -24,7 +24,7 @@ from ai.backend.manager.models.kernel.row import (
     KernelRow,
 )
 from ai.backend.manager.models.project import ProjectRow
-from ai.backend.manager.models.specs.purger import DataBatchPurger, EntityPurger
+from ai.backend.manager.models.specs.purger import EntityPurger, FieldBatchPurger
 from ai.backend.manager.models.specs.types import ConflictCheck
 from ai.backend.manager.models.user import UserRow
 
@@ -67,7 +67,7 @@ class DomainPurger(EntityPurger[DomainRow, DomainData]):
 
 
 @dataclass
-class DomainKernelPurger(DataBatchPurger[KernelRow, KernelId]):
+class DomainKernelPurger(FieldBatchPurger[KernelRow, KernelId]):
     """Clears the kernel rows a domain leaves behind, before the domain itself goes.
 
     Kernels stand outside the RBAC graph, so nothing is torn down with them.

--- a/src/ai/backend/manager/models/domain/purgers.py
+++ b/src/ai/backend/manager/models/domain/purgers.py
@@ -67,17 +67,23 @@ class DomainPurger(EntityPurger[DomainRow, DomainData]):
 
 
 @dataclass
-class DomainKernelPurger(FieldBatchPurger[KernelRow, KernelId]):
+class DomainKernelPurger(FieldBatchPurger[DomainID, KernelRow, KernelId]):
     """Clears the kernel rows a domain leaves behind, before the domain itself goes.
 
-    Kernels stand outside the RBAC graph, so nothing is torn down with them.
+    Kernels stand outside the RBAC graph, so nothing is torn down with them. The owner
+    here is the domain the purge is authorized on, not the session each kernel belongs
+    to: the sweep is bounded by the domain going away.
     """
 
     name: str
 
     @override
-    def build_subquery(self) -> sa.sql.Select[Any]:
-        return sa.select(KernelRow).where(KernelRow.domain_name == self.name)
+    def build_subquery(self, owner_id: DomainID) -> sa.sql.Select[Any]:
+        return (
+            sa.select(KernelRow)
+            .join(DomainRow, DomainRow.name == KernelRow.domain_name)
+            .where(DomainRow.id == owner_id)
+        )
 
     @override
     def conflict_checks(self) -> Sequence[ConflictCheck]:

--- a/src/ai/backend/manager/models/mixins/history.py
+++ b/src/ai/backend/manager/models/mixins/history.py
@@ -1,8 +1,11 @@
-"""Shared mixin for reconcile history rows (session/deployment/route/replica group).
+"""Shared mixin for reconcile history rows.
 
 Holds the columns common to every history table and the single merge rule. Category
 and the entity FK stay on each row (not universal); the merge rule does not use them —
 category only scopes which row is read as the latest.
+
+``ReplicaGroupHistoryRow`` is the only row using it. The session, deployment and route
+history tables declare the same columns themselves, each with its own merge rule.
 """
 
 from __future__ import annotations

--- a/src/ai/backend/manager/models/model_card/purgers.py
+++ b/src/ai/backend/manager/models/model_card/purgers.py
@@ -4,12 +4,17 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
+import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.model_card import ModelCardID
+from ai.backend.common.data.entity.model_card_resource_requirement import (
+    ModelCardResourceRequirementID,
+)
 from ai.backend.manager.data.model_card.types import ModelCardData
 from ai.backend.manager.models.model_card.row import ModelCardRow
-from ai.backend.manager.models.specs.purger import EntityPurger
+from ai.backend.manager.models.resource_slot import ModelCardResourceRequirementRow
+from ai.backend.manager.models.specs.purger import EntityPurger, FieldBatchPurger
 from ai.backend.manager.models.specs.types import ConflictCheck
 
 
@@ -38,3 +43,26 @@ class ModelCardPurger(EntityPurger[ModelCardRow, ModelCardData]):
     @override
     def to_data(self, row: ModelCardRow) -> ModelCardData:
         return row.to_data()
+
+
+@dataclass
+class ModelCardResourceRequirementBatchPurger(
+    FieldBatchPurger[ModelCardID, ModelCardResourceRequirementRow, ModelCardResourceRequirementID]
+):
+    """Clears the minimum slot quantities of one card, for the replacement to insert."""
+
+    @override
+    def build_subquery(
+        self, owner_id: ModelCardID
+    ) -> sa.sql.Select[tuple[ModelCardResourceRequirementRow]]:
+        return sa.select(ModelCardResourceRequirementRow).where(
+            ModelCardResourceRequirementRow.model_card_id == owner_id
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+    @override
+    def to_data(self, row: ModelCardResourceRequirementRow) -> ModelCardResourceRequirementID:
+        return row.id

--- a/src/ai/backend/manager/models/specs/AGENTS.md
+++ b/src/ai/backend/manager/models/specs/AGENTS.md
@@ -76,14 +76,18 @@ joins nothing.
 - Enrollment writes graph edges only. Granting a joining user the target's auto_assign
   roles is an explicit ops primitive — never an implicit side effect keyed on the type.
 
-## A batch purge says which kind it removes
+## A batch purge says which kind it removes, and what bounds it
 
 - `EntityBatchPurger` tears down each deleted row's virtual scope, memberships and
   permissions, as `EntityPurger` does for one; `FieldBatchPurger` does not, because a
   field row holds nothing in the graph.
 - The two are unrelated roots, so an entity spec cannot flow through the field path and
   leave its graph rows behind. There is no unmarked batch purge.
-- `entity_id(row)` takes the row: a batch names a subquery, not an id.
+- What bounds the sweep follows the same axis every other write does: an entity batch is
+  bounded by the scopes the ops call names, a field batch by the owner it is given —
+  `build_subquery(owner_id)`, like `create_field(owner_id, ...)`. No field operation is
+  scoped, and this one is not either.
+- `EntityBatchPurger.entity_id(row)` takes the row: a batch names a subquery, not an id.
 
 ## Values left for the database to compute
 

--- a/src/ai/backend/manager/models/specs/AGENTS.md
+++ b/src/ai/backend/manager/models/specs/AGENTS.md
@@ -23,7 +23,7 @@ and is read through an entity's permission like a field, while belonging to neit
 | Operation | Roots | Why |
 |---|---|---|
 | creator | `GlobalEntityCreator` / `EntityCreator` / `RoleManagedEntityCreator` / `FieldCreator` / `SidecarCreator` | only a create settles what a row belongs to |
-| purger | `EntityPurger` / `FieldPurger` / `GuardedFieldPurger` | removing an entity removes what it left in the graph; a field row splits further on how it is picked: by id, or by id behind a precondition |
+| purger | `EntityPurger` / `EntityBatchPurger` / `FieldPurger` / `GuardedFieldPurger` / `FieldBatchPurger` | removing an entity removes what it left in the graph; a field row splits further on how it is picked: by id, or by id behind a precondition; the batch roots pick by subquery instead of by id |
 | updater | `DataUpdater` / `GuardedDataUpdater` | an update never changes what a row belongs to, so the roots split on how the row is picked: by id, or by id behind a precondition |
 
 The roots are deliberately unrelated. Do NOT extract a common base across them
@@ -71,6 +71,15 @@ joins nothing.
 - The plain entity paths never touch roles, even when matching presets exist.
 - Enrollment writes graph edges only. Granting a joining user the target's auto_assign
   roles is an explicit ops primitive — never an implicit side effect keyed on the type.
+
+## A batch purge says which kind it removes
+
+- `EntityBatchPurger` tears down each deleted row's virtual scope, memberships and
+  permissions, as `EntityPurger` does for one; `FieldBatchPurger` does not, because a
+  field row holds nothing in the graph.
+- The two are unrelated roots, so an entity spec cannot flow through the field path and
+  leave its graph rows behind. There is no unmarked batch purge.
+- `entity_id(row)` takes the row: a batch names a subquery, not an id.
 
 ## Values left for the database to compute
 

--- a/src/ai/backend/manager/models/specs/AGENTS.md
+++ b/src/ai/backend/manager/models/specs/AGENTS.md
@@ -54,6 +54,10 @@ joins nothing.
 - `member_of(row)` declares which existing entities the new one joins as a member; a
   target without a virtual scope node fails the write. It never carries a permission
   cap (membership vs sharing: `KNOWLEDGE.md`).
+- Sharing an entity afterwards is an `EntityGrant`, executed by `grant_entities` /
+  `revoke_entities`. Its `permission_cap` is the ceiling the grantee's permissions are
+  clipped to (`None` clips nothing); re-granting rewrites the cap. Do NOT reach for a
+  creator to share something that already exists.
 - Entity types are open strings: types outside the RBAC element enum are accepted, and
   permission-carrying paths convert lazily.
 - Do NOT keep module-level declaration instances (no `X_MEMBERSHIP = ...()`).

--- a/src/ai/backend/manager/models/specs/membership.py
+++ b/src/ai/backend/manager/models/specs/membership.py
@@ -1,10 +1,11 @@
-"""The membership record the entity writes carry to the ops layer."""
+"""The membership and grant records the entity writes carry to the ops layer."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.permission.types import Permission
 
 
 @dataclass(frozen=True)
@@ -13,3 +14,17 @@ class EntityMembershipEntry:
 
     member: EntityIdentifier
     parent: EntityIdentifier
+
+
+@dataclass(frozen=True)
+class EntityGrant:
+    """One existing entity shared into a grantee's scope, bounded by a cap.
+
+    Where :class:`EntityMembershipEntry` states belonging settled at creation, this
+    states access handed out afterwards and taken back later. ``permission_cap`` is
+    the ceiling the grantee's own permissions are clipped to; ``None`` clips nothing.
+    """
+
+    entity: EntityIdentifier
+    grantee: EntityIdentifier
+    permission_cap: Permission | None = None

--- a/src/ai/backend/manager/models/specs/purger.py
+++ b/src/ai/backend/manager/models/specs/purger.py
@@ -117,13 +117,47 @@ class GuardedFieldPurger[TRow: Base, TData: FieldData](ABC):
         raise NotImplementedError
 
 
-class DataBatchPurger[TRow: Base, TData](ABC):
-    """Delete spec for every row a subquery selects, converting each deleted row
+class FieldBatchPurger[TRow: Base, TData](ABC):
+    """Delete spec for every field row a subquery selects, converting each deleted row
     to data so the operation can report what it actually removed.
 
-    Carries no scope teardown: reserve it for rows that provision no scope
-    until a batch purge that tears scopes down exists.
+    A field row holds nothing in the RBAC graph, so the delete is the whole operation —
+    the batch counterpart of :class:`FieldPurger`.
     """
+
+    @abstractmethod
+    def build_subquery(self) -> sa.sql.Select[tuple[TRow]]:
+        """Build the subquery selecting the rows to delete."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        """Return rows that must not exist before deletion (empty if none)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_data(self, row: TRow) -> TData:
+        """Convert one deleted row into its ``data/`` type."""
+        raise NotImplementedError
+
+
+class EntityBatchPurger[TRow: Base, TData](ABC):
+    """Delete spec for every entity row a subquery selects; each row's RBAC graph goes
+    with it, as :class:`EntityPurger` does for one.
+
+    Deliberately NOT a :class:`FieldBatchPurger` subtype — the hooks are duplicated
+    instead — so an entity spec cannot flow through the field path and leave its virtual
+    scope, memberships and permissions behind.
+    """
+
+    @abstractmethod
+    def entity_id(self, row: TRow) -> EntityIdentifier:
+        """The id of the entity a deleted row was, read off that row.
+
+        Takes the row because the selection names no id; it answers its own type, so
+        nothing declares the type separately.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def build_subquery(self) -> sa.sql.Select[tuple[TRow]]:

--- a/src/ai/backend/manager/models/specs/purger.py
+++ b/src/ai/backend/manager/models/specs/purger.py
@@ -117,17 +117,18 @@ class GuardedFieldPurger[TRow: Base, TData: FieldData](ABC):
         raise NotImplementedError
 
 
-class FieldBatchPurger[TRow: Base, TData](ABC):
-    """Delete spec for every field row a subquery selects, converting each deleted row
-    to data so the operation can report what it actually removed.
+class FieldBatchPurger[TOwnerID: EntityIdentifier, TRow: Base, TData](ABC):
+    """Delete spec for the field rows of one owner that a subquery selects, converting
+    each deleted row to data so the operation can report what it actually removed.
 
     A field row holds nothing in the RBAC graph, so the delete is the whole operation —
-    the batch counterpart of :class:`FieldPurger`.
+    the batch counterpart of :class:`FieldPurger`. Bounded by the owner rather than by a
+    scope, as every field write is: what authorizes the rows is the entity owning them.
     """
 
     @abstractmethod
-    def build_subquery(self) -> sa.sql.Select[tuple[TRow]]:
-        """Build the subquery selecting the rows to delete."""
+    def build_subquery(self, owner_id: TOwnerID) -> sa.sql.Select[tuple[TRow]]:
+        """Build the subquery selecting the owner's rows to delete."""
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ai/backend/manager/models/vfolder/creators.py
+++ b/src/ai/backend/manager/models/vfolder/creators.py
@@ -11,16 +11,20 @@ from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
+from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
 from ai.backend.common.types import QuotaScopeID, VFolderUsageMode
 from ai.backend.manager.data.vfolder.types import (
     VFolderData,
     VFolderMountPermission,
     VFolderOperationStatus,
     VFolderOwnershipType,
+    VFolderPermissionData,
 )
-from ai.backend.manager.models.specs.creator import EntityCreator
+from ai.backend.manager.errors.repository import ForeignKeyViolationError
+from ai.backend.manager.errors.storage import VFolderNotFound
+from ai.backend.manager.models.specs.creator import EntityCreator, FieldCreator
 from ai.backend.manager.models.specs.types import IntegrityErrorCheck
-from ai.backend.manager.models.vfolder.row import VFolderRow
+from ai.backend.manager.models.vfolder.row import VFolderPermissionRow, VFolderRow
 
 
 @dataclass
@@ -90,3 +94,47 @@ class VFolderCreator(EntityCreator[VFolderRow, VFolderData]):
     @override
     def to_data(self, row: VFolderRow) -> VFolderData:
         return row.to_data()
+
+
+@dataclass
+class VFolderPermissionCreator(
+    FieldCreator[VFolderUUID, VFolderPermissionRow, VFolderPermissionData]
+):
+    """Records one user's mount permission on a vfolder.
+
+    The legacy row the mount path reads. Access itself is the grant recorded beside it;
+    this says nothing about the RBAC graph.
+    """
+
+    user_id: uuid.UUID
+    permission: VFolderMountPermission
+
+    @override
+    def field_id(self, row: VFolderPermissionRow) -> VFolderPermissionID:
+        return VFolderPermissionID(row.id)
+
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return (
+            IntegrityErrorCheck(
+                violation_type=ForeignKeyViolationError,
+                error=VFolderNotFound(),
+            ),
+        )
+
+    @override
+    def build_row(self, owner_id: VFolderUUID) -> VFolderPermissionRow:
+        return VFolderPermissionRow(
+            vfolder=owner_id,
+            user=self.user_id,
+            permission=self.permission,
+        )
+
+    @override
+    def to_data(self, row: VFolderPermissionRow) -> VFolderPermissionData:
+        return VFolderPermissionData(
+            id=VFolderPermissionID(row.id),
+            vfolder=row.vfolder,
+            user=row.user,
+            permission=row.permission or VFolderMountPermission.READ_WRITE,
+        )

--- a/src/ai/backend/manager/models/vfolder/purgers.py
+++ b/src/ai/backend/manager/models/vfolder/purgers.py
@@ -64,3 +64,26 @@ class VFolderPermissionBatchPurger(FieldBatchPurger[VFolderPermissionRow, VFolde
     @override
     def to_data(self, row: VFolderPermissionRow) -> VFolderUUID:
         return row.id
+
+
+@dataclass
+class VFolderUserPermissionBatchPurger(FieldBatchPurger[VFolderPermissionRow, VFolderUUID]):
+    """Clears one user's mount permission on one vfolder."""
+
+    vfolder_id: UUID
+    user_id: UUID
+
+    @override
+    def build_subquery(self) -> sa.sql.Select[tuple[VFolderPermissionRow]]:
+        return sa.select(VFolderPermissionRow).where(
+            (VFolderPermissionRow.vfolder == self.vfolder_id)
+            & (VFolderPermissionRow.user == self.user_id)
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+    @override
+    def to_data(self, row: VFolderPermissionRow) -> VFolderUUID:
+        return row.id

--- a/src/ai/backend/manager/models/vfolder/purgers.py
+++ b/src/ai/backend/manager/models/vfolder/purgers.py
@@ -10,7 +10,9 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.vfolder import VFolderUUID
-from ai.backend.manager.models.specs.purger import FieldBatchPurger
+from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationID
+from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
+from ai.backend.manager.models.specs.purger import EntityBatchPurger, FieldBatchPurger
 from ai.backend.manager.models.specs.types import ConflictCheck
 from ai.backend.manager.models.vfolder.row import (
     VFolderInvitationRow,
@@ -19,13 +21,18 @@ from ai.backend.manager.models.vfolder.row import (
 
 
 @dataclass
-class VFolderInvitationBatchPurger(FieldBatchPurger[VFolderInvitationRow, VFolderUUID]):
-    """Clears the invitations of the vfolders going away.
+class VFolderInvitationBatchPurger(EntityBatchPurger[VFolderInvitationRow, VFolderInvitationID]):
+    """Clears the invitations of the vfolders going away, each with its graph.
 
-    Invitations stand outside the RBAC graph, so nothing is torn down with them.
+    An invitation is an entity of its own — the invitee acts on it while holding no
+    permission on the folder — so what it left in the graph goes with it.
     """
 
     vfolder_ids: Sequence[UUID]
+
+    @override
+    def entity_id(self, row: VFolderInvitationRow) -> VFolderInvitationID:
+        return VFolderInvitationID(row.id)
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[VFolderInvitationRow]]:
@@ -38,46 +45,44 @@ class VFolderInvitationBatchPurger(FieldBatchPurger[VFolderInvitationRow, VFolde
         return ()
 
     @override
-    def to_data(self, row: VFolderInvitationRow) -> VFolderUUID:
-        return row.id
+    def to_data(self, row: VFolderInvitationRow) -> VFolderInvitationID:
+        return VFolderInvitationID(row.id)
 
 
 @dataclass
-class VFolderPermissionBatchPurger(FieldBatchPurger[VFolderPermissionRow, VFolderUUID]):
+class VFolderPermissionBatchPurger(
+    FieldBatchPurger[VFolderUUID, VFolderPermissionRow, VFolderPermissionID]
+):
     """Clears the per-user permission rows of the vfolders going away.
 
     Permission rows stand outside the RBAC graph, so nothing is torn down with them.
     """
 
-    vfolder_ids: Sequence[UUID]
-
     @override
-    def build_subquery(self) -> sa.sql.Select[tuple[VFolderPermissionRow]]:
-        return sa.select(VFolderPermissionRow).where(
-            VFolderPermissionRow.vfolder.in_(self.vfolder_ids)
-        )
+    def build_subquery(self, owner_id: VFolderUUID) -> sa.sql.Select[tuple[VFolderPermissionRow]]:
+        return sa.select(VFolderPermissionRow).where(VFolderPermissionRow.vfolder == owner_id)
 
     @override
     def conflict_checks(self) -> Sequence[ConflictCheck]:
         return ()
 
     @override
-    def to_data(self, row: VFolderPermissionRow) -> VFolderUUID:
-        return row.id
+    def to_data(self, row: VFolderPermissionRow) -> VFolderPermissionID:
+        return VFolderPermissionID(row.id)
 
 
 @dataclass
-class VFolderUserPermissionBatchPurger(FieldBatchPurger[VFolderPermissionRow, VFolderUUID]):
+class VFolderUserPermissionBatchPurger(
+    FieldBatchPurger[VFolderUUID, VFolderPermissionRow, VFolderPermissionID]
+):
     """Clears one user's mount permission on one vfolder."""
 
-    vfolder_id: UUID
     user_id: UUID
 
     @override
-    def build_subquery(self) -> sa.sql.Select[tuple[VFolderPermissionRow]]:
+    def build_subquery(self, owner_id: VFolderUUID) -> sa.sql.Select[tuple[VFolderPermissionRow]]:
         return sa.select(VFolderPermissionRow).where(
-            (VFolderPermissionRow.vfolder == self.vfolder_id)
-            & (VFolderPermissionRow.user == self.user_id)
+            (VFolderPermissionRow.vfolder == owner_id) & (VFolderPermissionRow.user == self.user_id)
         )
 
     @override
@@ -85,5 +90,5 @@ class VFolderUserPermissionBatchPurger(FieldBatchPurger[VFolderPermissionRow, VF
         return ()
 
     @override
-    def to_data(self, row: VFolderPermissionRow) -> VFolderUUID:
-        return row.id
+    def to_data(self, row: VFolderPermissionRow) -> VFolderPermissionID:
+        return VFolderPermissionID(row.id)

--- a/src/ai/backend/manager/models/vfolder/purgers.py
+++ b/src/ai/backend/manager/models/vfolder/purgers.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.vfolder import VFolderUUID
-from ai.backend.manager.models.specs.purger import DataBatchPurger
+from ai.backend.manager.models.specs.purger import FieldBatchPurger
 from ai.backend.manager.models.specs.types import ConflictCheck
 from ai.backend.manager.models.vfolder.row import (
     VFolderInvitationRow,
@@ -19,7 +19,7 @@ from ai.backend.manager.models.vfolder.row import (
 
 
 @dataclass
-class VFolderInvitationBatchPurger(DataBatchPurger[VFolderInvitationRow, VFolderUUID]):
+class VFolderInvitationBatchPurger(FieldBatchPurger[VFolderInvitationRow, VFolderUUID]):
     """Clears the invitations of the vfolders going away.
 
     Invitations stand outside the RBAC graph, so nothing is torn down with them.
@@ -43,7 +43,7 @@ class VFolderInvitationBatchPurger(DataBatchPurger[VFolderInvitationRow, VFolder
 
 
 @dataclass
-class VFolderPermissionBatchPurger(DataBatchPurger[VFolderPermissionRow, VFolderUUID]):
+class VFolderPermissionBatchPurger(FieldBatchPurger[VFolderPermissionRow, VFolderUUID]):
     """Clears the per-user permission rows of the vfolders going away.
 
     Permission rows stand outside the RBAC graph, so nothing is torn down with them.

--- a/src/ai/backend/manager/models/vfolder/updaters.py
+++ b/src/ai/backend/manager/models/vfolder/updaters.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
 
+import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.vfolder import VFolderUUID
@@ -14,8 +15,10 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderMountPermission,
     VFolderOperationStatus,
 )
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.session import DEAD_SESSION_STATUSES, SessionRow
 from ai.backend.manager.models.specs.types import IntegrityErrorCheck
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.models.vfolder.row import VFolderRow
 from ai.backend.manager.types import OptionalState
 
@@ -80,6 +83,61 @@ class VFolderSoftDeleteUpdater(DataUpdater[VFolderRow, VFolderData]):
     @override
     def target_id_value(self) -> VFolderUUID:
         return self.vfolder_id
+
+    @property
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return ()
+
+    @override
+    def build_values(self) -> dict[str, Any]:
+        return {"status": VFolderOperationStatus.DELETE_PENDING}
+
+    @override
+    def to_data(self, row: VFolderRow) -> VFolderData:
+        return row.to_data()
+
+
+@dataclass
+class VFolderTrashUpdater(GuardedDataUpdater[VFolderRow, VFolderData]):
+    """Moves a vfolder to the trash unless a live session still mounts it.
+
+    ``mount_key`` is the folder's mount identifier as sessions record it, which pairs
+    the quota scope with the folder id and so is read off the row rather than derived
+    from its id.
+    """
+
+    vfolder_id: VFolderUUID
+    mount_key: str
+
+    @property
+    @override
+    def row_class(self) -> type[VFolderRow]:
+        return VFolderRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return VFolderRow.id
+
+    @override
+    def target_id_value(self) -> VFolderUUID:
+        return self.vfolder_id
+
+    @override
+    def guard_conditions(self) -> list[QueryCondition]:
+        def not_mounted() -> sa.sql.expression.ColumnElement[bool]:
+            return sa.not_(
+                sa.exists(
+                    sa.select(sa.literal(1))
+                    .select_from(SessionRow)
+                    .where(
+                        SessionRow.status.not_in(DEAD_SESSION_STATUSES),
+                        SessionRow.vfolder_mounts.contains([{"vfid": self.mount_key}]),
+                    )
+                )
+            )
+
+        return [not_mounted]
 
     @property
     @override

--- a/src/ai/backend/manager/repositories/AGENTS.md
+++ b/src/ai/backend/manager/repositories/AGENTS.md
@@ -43,9 +43,18 @@
   The legacy `DBOpsProvider` path (including `create_dependent` and
   `create_with_next_value`) is for existing code only — when a new domain needs those
   capabilities, report it as a v2 gap (see the demotion mapping in `services/KNOWLEDGE.md`).
-- For general API paths, prefer using `DBOpsProvider` (`write_ops` / `read_ops`). Internal operations may use db directly,
-  but separating into a repository is the default.
-- ops use the default provider; keep a separate provider only for common operations in specific situations such as sokovan.
+- ❌ MUST NOT construct an ops object. `V2WriteOps(session)`, `V2ReadOps(session)` and
+  every form of it are forbidden, with no exception. ✅ Take ops from a provider's
+  `write_ops()` / `read_ops()`. The transaction boundary has to belong to the provider,
+  or nothing holds the work to the transaction the method opened.
+- ✅ MUST inject a provider into a repository — never a session, never an engine. A
+  repository holding an engine can open a session inside itself, which is the rule above
+  broken. The new path is `V2DBOpsProvider`.
+- A primitive only one domain uses does NOT go on the general ops. Write ops extending
+  `V2WriteOps` and a provider extending `V2DBOpsProvider` that overrides `write_ops()`,
+  and inject that provider only into the repositories needing the primitive
+  (`ops/v2/reconciler/`, `ops/rbac/`).
+- Separating into a repository is the default; internal operations may use db directly.
 - ops methods take only spec types (Querier/Creator/Updater/Upserter/Purger, `DependentCreatorSpec`).
   A single spec owns only a single table.
 - Do NOT do multi-table writes inside a spec. The repository creates the parent first, then composes the dependent values

--- a/src/ai/backend/manager/repositories/README.md
+++ b/src/ai/backend/manager/repositories/README.md
@@ -895,10 +895,10 @@ class SessionRepository:
 
     def __init__(
         self,
-        db: ExtendedAsyncSAEngine,
+        ops_provider: DBOpsProvider,
         redis: RedisConnectionInfo,
     ) -> None:
-        self._db_source = SessionDBSource(db)
+        self._db_source = SessionDBSource(ops_provider)
         self._cache_source = SessionCacheSource(redis)
 
     async def get_session(self, session_id: SessionId) -> Optional[SessionInfo]:
@@ -1048,7 +1048,7 @@ class TestSessionRepository:
         database_engine: ExtendedAsyncSAEngine,
     ) -> SessionDBSource:
         """Fixture dedicated to this test class"""
-        return SessionDBSource(database_engine)
+        return SessionDBSource(DBOpsProvider(database_engine))
 
     @pytest.fixture
     async def session_repository(

--- a/src/ai/backend/manager/repositories/base/purger.py
+++ b/src/ai/backend/manager/repositories/base/purger.py
@@ -225,7 +225,7 @@ async def execute_purger[TRow: Base](
 class BatchPurgerSpec[TRow: Base](ABC):
     """Abstract base class for defining batch purge targets.
 
-    Deprecated: use ``DataBatchPurger`` in ``models/specs/purger.py``.
+    Deprecated: use ``FieldBatchPurger`` in ``models/specs/purger.py``.
 
     Implementations specify what to delete by providing a subquery
     that selects rows to delete. The table and PK columns are inferred
@@ -253,7 +253,7 @@ class BatchPurgerSpec[TRow: Base](ABC):
 
 
 class DataBatchPurger[TRow: Base, TData](
-    BatchPurgerSpec[TRow], specs_purger.DataBatchPurger[TRow, TData], ABC
+    BatchPurgerSpec[TRow], specs_purger.FieldBatchPurger[TRow, TData], ABC
 ):
     """Legacy-compatible view of the v2 batch purge spec.
 

--- a/src/ai/backend/manager/repositories/base/purger.py
+++ b/src/ai/backend/manager/repositories/base/purger.py
@@ -16,7 +16,6 @@ from sqlalchemy.engine import CursorResult
 
 from ai.backend.manager.errors.repository import UnsupportedCompositePrimaryKeyError
 from ai.backend.manager.models.base import Base
-from ai.backend.manager.models.specs import purger as specs_purger
 from ai.backend.manager.repositories.base.types import ConflictCheck
 
 from .integrity import parse_integrity_error
@@ -252,15 +251,17 @@ class BatchPurgerSpec[TRow: Base](ABC):
         raise NotImplementedError
 
 
-class DataBatchPurger[TRow: Base, TData](
-    BatchPurgerSpec[TRow], specs_purger.FieldBatchPurger[TRow, TData], ABC
-):
-    """Legacy-compatible view of the v2 batch purge spec.
+class DataBatchPurger[TRow: Base, TData](BatchPurgerSpec[TRow], ABC):
+    """Legacy batch purge spec that converts each removed row.
 
-    The declaration lives in ``models/specs/purger.py``; this adds the legacy
-    ``BatchPurgerSpec`` contract on top, so existing executors and domain specs
-    keep working during the transition.
+    The v2 roots (``models/specs/purger.py``) bound a batch by its owner or its scope;
+    this one is bounded by whatever its subquery says, which is why it stays here.
     """
+
+    @abstractmethod
+    def to_data(self, row: TRow) -> TData:
+        """Convert one deleted row into its ``data/`` type."""
+        raise NotImplementedError
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -195,8 +195,8 @@ from ai.backend.manager.repositories.deployment.types import (
     RouteSessionInfo,
     RouteSessionKernelInfo,
 )
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
-from ai.backend.manager.repositories.ops.v2.reconcile_write import ReconcileTransition
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.write import ReconcileTransition
 from ai.backend.manager.types import OptionalState
 from ai.backend.manager.utils import query_userinfo_from_session
 
@@ -238,17 +238,17 @@ class DeploymentDBSource:
     """Database source for deployment-related operations."""
 
     _db: ExtendedAsyncSAEngine
-    _v2_ops: V2DBOpsProvider
+    _reconcile_ops: ReconcileOpsProvider
     _storage_manager: StorageSessionManager
 
     def __init__(
         self,
         db: ExtendedAsyncSAEngine,
-        v2_ops_provider: V2DBOpsProvider,
+        reconcile_ops_provider: ReconcileOpsProvider,
         storage_manager: StorageSessionManager,
     ) -> None:
         self._db = db
-        self._v2_ops = v2_ops_provider
+        self._reconcile_ops = reconcile_ops_provider
         self._storage_manager = storage_manager
 
     @actxmgr
@@ -330,7 +330,7 @@ class DeploymentDBSource:
             )
         else:
             policy_creator = DeploymentPolicyCreator.build_default()
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             deployment = await w.create_entity(creator)
             deployment_id = DeploymentID(deployment.id)
             await w.create_field(deployment_id, policy_creator)
@@ -721,7 +721,7 @@ class DeploymentDBSource:
         Raises:
             EndpointNotFound: If the endpoint does not exist
         """
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             result = await w.update_data(updater)
         if result is None:
             raise EndpointNotFound(f"Endpoint {updater.deployment_id} not found")
@@ -788,7 +788,7 @@ class DeploymentDBSource:
         if not batch_updaters:
             return 0
 
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             total_updated = 0
             # 1. Execute all status updates
             for batch_updater in batch_updaters:
@@ -1026,7 +1026,7 @@ class DeploymentDBSource:
         The creator is built at the upper layer (service/action) and injected here.
         This method only executes the creator.
         """
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             route = await w.create_field(deployment_id, creator)
             return route.id
 
@@ -1071,7 +1071,7 @@ class DeploymentDBSource:
         The spec is built at the upper layer (service/action) and injected here.
         This method only executes it.
         """
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             return await w.update_data(updater) is not None
 
     async def update_route_status(
@@ -1788,7 +1788,7 @@ class DeploymentDBSource:
         if not batch_updaters:
             return 0
 
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             total_updated = 0
             for batch_updater in batch_updaters:
                 updated = await w.batch_update_in_global(batch_updater)
@@ -2695,7 +2695,7 @@ class DeploymentDBSource:
         After creating a new revision, old revisions beyond the limit should be deleted.
         This requires adding a `revision_history_limit` column to EndpointRow.
         """
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             return await w.create_field(deployment_id, creator)
 
     async def create_revision_with_next_number(
@@ -2713,7 +2713,7 @@ class DeploymentDBSource:
         """
         for remaining_attempts in reversed(range(_REVISION_NUMBER_ATTEMPTS)):
             try:
-                async with self._v2_ops.write_ops() as w:
+                async with self._reconcile_ops.write_ops() as w:
                     return await w.create_field(endpoint_id, creator)
             except UniqueConstraintViolationError:
                 if remaining_attempts == 0:
@@ -2861,7 +2861,7 @@ class DeploymentDBSource:
         Raises:
             EndpointNotFound: If the endpoint does not exist.
         """
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             result = await w.update_data(updater)
         if result is None:
             raise EndpointNotFound(f"Endpoint {updater.deployment_id} not found")
@@ -3045,7 +3045,7 @@ class DeploymentDBSource:
         upserter: DeploymentPolicyUpserter,
     ) -> DeploymentPolicyUpsertResult:
         """Create or update a deployment policy using ON CONFLICT."""
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             data = await w.upsert_field_entity(deployment_id, upserter)
             return DeploymentPolicyUpsertResult(
                 data=data,
@@ -3246,7 +3246,7 @@ class DeploymentDBSource:
         Returns:
             Number of deployments whose revision was swapped.
         """
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             if rollout:
                 await w.atomic_create_fields(rollout)
             if drain is not None:

--- a/src/ai/backend/manager/repositories/deployment/repositories.py
+++ b/src/ai/backend/manager/repositories/deployment/repositories.py
@@ -19,7 +19,7 @@ class DeploymentRepositories:
         """Create deployment repositories."""
         repository = DeploymentRepository(
             args.db,
-            args.v2_ops_provider,
+            args.reconcile_ops_provider,
             args.storage_manager,
             args.valkey_stat_client,
             args.valkey_live_client,

--- a/src/ai/backend/manager/repositories/deployment/repository.py
+++ b/src/ai/backend/manager/repositories/deployment/repository.py
@@ -112,7 +112,7 @@ from ai.backend.manager.repositories.deployment.types import (
     RouteSessionInfo,
     RouteSessionKernelInfo,
 )
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 
 from .db_source import DeploymentDBSource
 from .storage_source import DeploymentStorageSource
@@ -157,7 +157,7 @@ class DeploymentRepository:
     """Repository for deployment-related operations."""
 
     _db_source: DeploymentDBSource
-    _v2_ops: V2DBOpsProvider
+    _reconcile_ops: ReconcileOpsProvider
     _storage_source: DeploymentStorageSource
     _valkey_stat: ValkeyStatClient
     _valkey_live: ValkeyLiveClient
@@ -166,14 +166,14 @@ class DeploymentRepository:
     def __init__(
         self,
         db: ExtendedAsyncSAEngine,
-        v2_ops_provider: V2DBOpsProvider,
+        reconcile_ops_provider: ReconcileOpsProvider,
         storage_manager: StorageSessionManager,
         valkey_stat: ValkeyStatClient,
         valkey_live: ValkeyLiveClient,
         valkey_schedule: ValkeyScheduleClient,
     ) -> None:
-        self._db_source = DeploymentDBSource(db, v2_ops_provider, storage_manager)
-        self._v2_ops = v2_ops_provider
+        self._db_source = DeploymentDBSource(db, reconcile_ops_provider, storage_manager)
+        self._reconcile_ops = reconcile_ops_provider
         self._storage_source = DeploymentStorageSource(storage_manager)
         self._valkey_stat = valkey_stat
         self._valkey_live = valkey_live
@@ -1550,7 +1550,7 @@ class DeploymentRepository:
         self, deployment_id: DeploymentID, creator: EndpointTokenCreator
     ) -> ModelDeploymentAccessTokenData:
         """Register an access token under the deployment it grants access to."""
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             return await w.create_field(deployment_id, creator)
 
     @deployment_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
@@ -47,7 +47,9 @@ class DeploymentPresetRepository:
                 )
             if slot_creators is not None:
                 preset_id = data.entity_id()
-                await w.batch_purge_in_global(PresetResourceSlotBatchPurger(preset_id))
+                await w.batch_purge_field_entities_in_global(
+                    PresetResourceSlotBatchPurger(preset_id)
+                )
                 await w.atomic_create_field_entities(preset_id, slot_creators)
             return data
 

--- a/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
+++ b/src/ai/backend/manager/repositories/deployment_revision_preset/repository.py
@@ -47,9 +47,7 @@ class DeploymentPresetRepository:
                 )
             if slot_creators is not None:
                 preset_id = data.entity_id()
-                await w.batch_purge_field_entities_in_global(
-                    PresetResourceSlotBatchPurger(preset_id)
-                )
+                await w.batch_purge_field_entities(preset_id, PresetResourceSlotBatchPurger())
                 await w.atomic_create_field_entities(preset_id, slot_creators)
             return data
 

--- a/src/ai/backend/manager/repositories/domain/repository.py
+++ b/src/ai/backend/manager/repositories/domain/repository.py
@@ -50,7 +50,7 @@ class DomainRepository:
     async def purge_domain(self, domain_id: DomainID, domain_name: str) -> DomainData:
         """Remove a domain and the kernel rows it left, in one transaction."""
         async with self._v2_ops.write_ops() as w:
-            await w.batch_purge_field_entities_in_global(DomainKernelPurger(name=domain_name))
+            await w.batch_purge_field_entities(domain_id, DomainKernelPurger(name=domain_name))
             data = await w.purge_entity(DomainPurger(domain_id=domain_id, name=domain_name))
             if data is None:
                 raise DomainDeletionFailed(f"Failed to delete domain: {domain_name}")

--- a/src/ai/backend/manager/repositories/domain/repository.py
+++ b/src/ai/backend/manager/repositories/domain/repository.py
@@ -50,7 +50,7 @@ class DomainRepository:
     async def purge_domain(self, domain_id: DomainID, domain_name: str) -> DomainData:
         """Remove a domain and the kernel rows it left, in one transaction."""
         async with self._v2_ops.write_ops() as w:
-            await w.batch_purge_in_global(DomainKernelPurger(name=domain_name))
+            await w.batch_purge_field_entities_in_global(DomainKernelPurger(name=domain_name))
             data = await w.purge_entity(DomainPurger(domain_id=domain_id, name=domain_name))
             if data is None:
                 raise DomainDeletionFailed(f"Failed to delete domain: {domain_name}")

--- a/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
@@ -15,6 +15,7 @@ from sqlalchemy.engine import CursorResult
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
+from ai.backend.common.data.entity.model_card import ModelCardID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.permission.types import RBACElementType, RelationType
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
@@ -27,6 +28,7 @@ from ai.backend.manager.data.model_card.types import (
     BulkModelCardDeleteFailure,
     BulkModelCardDeleteResultData,
     ModelCardData,
+    ModelCardResourceRequirementData,
     ResourceRequirementEntry,
     VFolderScanData,
 )
@@ -38,7 +40,11 @@ from ai.backend.manager.errors.resource import (
 )
 from ai.backend.manager.errors.storage import VFolderDeletionNotAllowed
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
-from ai.backend.manager.models.model_card.purgers import ModelCardPurger
+from ai.backend.manager.models.model_card.creators import ModelCardResourceRequirementCreator
+from ai.backend.manager.models.model_card.purgers import (
+    ModelCardPurger,
+    ModelCardResourceRequirementBatchPurger,
+)
 from ai.backend.manager.models.model_card.row import ModelCardRow
 from ai.backend.manager.models.model_card.updaters import ModelCardUpdater
 from ai.backend.manager.models.project.row import ProjectRow
@@ -49,6 +55,7 @@ from ai.backend.manager.models.resource_slot.row import (
     ModelCardResourceRequirementRow,
     PresetResourceSlotRow,
 )
+from ai.backend.manager.models.specs.creator import FieldToCreate
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder.row import (
     DEAD_VFOLDER_STATUSES,
@@ -61,6 +68,7 @@ from ai.backend.manager.repositories.model_card.types import (
     AvailablePresetsSearchResult,
 )
 from ai.backend.manager.repositories.model_card.upserters import ModelCardScanUpserterSpec
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
 from ai.backend.manager.types import TriState
 
@@ -69,43 +77,41 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 class ModelCardDBSource:
     _db: ExtendedAsyncSAEngine
+    _v2_ops: V2DBOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
         self._db = db
+        self._v2_ops = v2_ops_provider
 
     async def update(self, updater: ModelCardUpdater) -> ModelCardData:
-        async with self._db.begin_session() as session:
+        async with self._v2_ops.write_ops() as w:
             # The card comes back even when build_values() is empty (a child-only update
             # that syncs model_card_resource_requirements); None means it is missing.
-            data = await V2WriteOps(session).update_data(updater)
+            data = await w.update_data(updater)
             if data is None:
                 raise ModelCardNotFound(f"Model card with ID {updater.card_id} not found.")
 
             # Plain column UPDATE cannot touch the child table, so replace it explicitly.
-            await self._apply_min_resource_change(session, data.id, updater.min_resource)
+            await self._apply_min_resource_change(w, ModelCardID(data.id), updater.min_resource)
 
             return data
 
     async def _apply_min_resource_change(
         self,
-        session: SASession,
-        card_id: UUID,
+        w: V2WriteOps,
+        card_id: ModelCardID,
         min_resource: TriState[list[ResourceRequirementEntry]],
     ) -> None:
         """Replace normalized requirement rows for the card when requested.
 
-        NOP  → leave existing rows alone.
-        NULLIFY → delete every requirement for the card.
-        UPDATE → delete-then-insert with the provided list.
+        NOP  -> leave existing rows alone.
+        NULLIFY -> delete every requirement for the card.
+        UPDATE -> delete-then-insert with the provided list.
         """
         if min_resource.is_nop():
             return
 
-        await session.execute(
-            sa.delete(ModelCardResourceRequirementRow).where(
-                ModelCardResourceRequirementRow.model_card_id == card_id
-            )
-        )
+        await w.batch_purge_field_entities(card_id, ModelCardResourceRequirementBatchPurger())
 
         if min_resource.is_nullify():
             return
@@ -114,10 +120,14 @@ class ModelCardDBSource:
         if not entries:
             return
 
-        rows: list[dict[str, object]] = []
+        creations: list[
+            FieldToCreate[
+                ModelCardID, ModelCardResourceRequirementRow, ModelCardResourceRequirementData
+            ]
+        ] = []
         for entry in entries:
             try:
-                quantity = Decimal(entry.min_quantity)
+                Decimal(entry.min_quantity)
             except (InvalidOperation, ValueError):
                 log.warning(
                     "model card update: skipping invalid min_quantity {!r} for card {} slot {}",
@@ -126,13 +136,14 @@ class ModelCardDBSource:
                     entry.slot_name,
                 )
                 continue
-            rows.append({
-                "model_card_id": card_id,
-                "slot_name": entry.slot_name,
-                "min_quantity": quantity,
-            })
-        if rows:
-            await session.execute(sa.insert(ModelCardResourceRequirementRow).values(rows))
+            creations.append(
+                FieldToCreate(
+                    owner_id=card_id,
+                    creator=ModelCardResourceRequirementCreator(entry=entry),
+                )
+            )
+        if creations:
+            await w.atomic_create_fields(creations)
 
     async def delete(
         self,

--- a/src/ai/backend/manager/repositories/model_card/repositories.py
+++ b/src/ai/backend/manager/repositories/model_card/repositories.py
@@ -12,5 +12,5 @@ class ModelCardRepositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         return cls(
-            repository=ModelCardRepository(args.db),
+            repository=ModelCardRepository(args.db, args.v2_ops_provider),
         )

--- a/src/ai/backend/manager/repositories/model_card/repository.py
+++ b/src/ai/backend/manager/repositories/model_card/repository.py
@@ -21,6 +21,7 @@ from ai.backend.manager.repositories.model_card.types import (
     AvailablePresetsSearchResult,
 )
 from ai.backend.manager.repositories.model_card.upserters import ModelCardScanUpserterSpec
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 
 from .db_source.db_source import ModelCardDBSource
 
@@ -30,8 +31,8 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class ModelCardRepository:
     _db_source: ModelCardDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._db_source = ModelCardDBSource(db)
+    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
+        self._db_source = ModelCardDBSource(db, v2_ops_provider)
 
     async def update(self, updater: ModelCardUpdater) -> ModelCardData:
         return await self._db_source.update(updater)

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -35,8 +35,8 @@ from ai.backend.manager.models.specs.lookup import (
     FieldOwnerLookup,
 )
 from ai.backend.manager.models.specs.purger import (
+    EntityBatchPurger,
     EntityPurger,
-    FieldBatchPurger,
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
@@ -426,16 +426,16 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             return await w.batch_update_in_global(updater)
 
-    async def batch_purge_field_entities_in_scopes(
-        self, scopes: Sequence[OperationScope], purger: FieldBatchPurger[Any, TData]
+    async def batch_purge_entities_in_scopes(
+        self, scopes: Sequence[OperationScope], purger: EntityBatchPurger[Any, TData]
     ) -> list[TData]:
         """Delete every selected row within ``scopes``, which must not be empty."""
         async with self._ops.write_ops() as w:
-            return await w.batch_purge_field_entities_in_scopes(scopes, purger)
+            return await w.batch_purge_entities_in_scopes(scopes, purger)
 
-    async def batch_purge_field_entities_in_global(
-        self, purger: FieldBatchPurger[Any, TData]
+    async def batch_purge_entities_in_global(
+        self, purger: EntityBatchPurger[Any, TData]
     ) -> list[TData]:
         """Delete every selected row across the table; caller holds the authority."""
         async with self._ops.write_ops() as w:
-            return await w.batch_purge_field_entities_in_global(purger)
+            return await w.batch_purge_entities_in_global(purger)

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -35,8 +35,8 @@ from ai.backend.manager.models.specs.lookup import (
     FieldOwnerLookup,
 )
 from ai.backend.manager.models.specs.purger import (
-    DataBatchPurger,
     EntityPurger,
+    FieldBatchPurger,
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
@@ -426,14 +426,16 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             return await w.batch_update_in_global(updater)
 
-    async def batch_purge_in_scopes(
-        self, scopes: Sequence[OperationScope], purger: DataBatchPurger[Any, TData]
+    async def batch_purge_field_entities_in_scopes(
+        self, scopes: Sequence[OperationScope], purger: FieldBatchPurger[Any, TData]
     ) -> list[TData]:
         """Delete every selected row within ``scopes``, which must not be empty."""
         async with self._ops.write_ops() as w:
-            return await w.batch_purge_in_scopes(scopes, purger)
+            return await w.batch_purge_field_entities_in_scopes(scopes, purger)
 
-    async def batch_purge_in_global(self, purger: DataBatchPurger[Any, TData]) -> list[TData]:
+    async def batch_purge_field_entities_in_global(
+        self, purger: FieldBatchPurger[Any, TData]
+    ) -> list[TData]:
         """Delete every selected row across the table; caller holds the authority."""
         async with self._ops.write_ops() as w:
-            return await w.batch_purge_in_global(purger)
+            return await w.batch_purge_field_entities_in_global(purger)

--- a/src/ai/backend/manager/repositories/ops/v2/batch_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/batch_write.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import cast
+from collections.abc import Callable, Sequence
+from typing import Any, cast
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.errors.repository import (
     EmptyOperationScopeError,
 )
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.scopes import OperationScope
-from ai.backend.manager.models.specs.purger import DataBatchPurger
+from ai.backend.manager.models.specs.purger import EntityBatchPurger, FieldBatchPurger
+from ai.backend.manager.models.specs.types import ConflictCheck
 from ai.backend.manager.models.specs.updater import DataBatchUpdater
 from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
 
@@ -48,32 +50,73 @@ class V2BatchWriteOps(V2WriteOpsBase):
         """
         return await self._batch_update_returning(None, updater)
 
-    async def batch_purge_in_scopes[TRow: Base, TData](
-        self, scopes: Sequence[OperationScope], purger: DataBatchPurger[TRow, TData]
+    async def batch_purge_field_entities_in_scopes[TRow: Base, TData](
+        self, scopes: Sequence[OperationScope], purger: FieldBatchPurger[TRow, TData]
     ) -> list[TData]:
-        """Delete every row the spec selects within ``scopes``; at least one is
-        required. Scope conditions are injected into the selecting subquery.
-
-        Carries no membership work: reserve it for rows that register none until a
-        batch purge that deregisters exists.
-        """
+        """Delete every field row the spec selects within ``scopes``; at least one is
+        required. Scope conditions are injected into the selecting subquery."""
         if not scopes:
             raise EmptyOperationScopeError(
-                "batch_purge_in_scopes requires at least one scope; "
-                "use batch_purge_in_global for an explicit unscoped batch purge."
+                "batch_purge_field_entities_in_scopes requires at least one scope; use "
+                "batch_purge_field_entities_in_global for an explicit unscoped batch purge."
             )
         await self._validate_scope_existence(scopes)
-        return await self._batch_purge_returning(self._scopes_condition(scopes), purger)
+        return await self._batch_purge_returning(
+            self._scopes_condition(scopes),
+            purger.build_subquery,
+            purger.conflict_checks(),
+            purger.to_data,
+        )
 
-    async def batch_purge_in_global[TRow: Base, TData](
-        self, purger: DataBatchPurger[TRow, TData]
+    async def batch_purge_field_entities_in_global[TRow: Base, TData](
+        self, purger: FieldBatchPurger[TRow, TData]
     ) -> list[TData]:
-        """Delete every row the spec selects across the table, with NO scope filter.
+        """Delete every field row the spec selects across the table, with NO scope
+        filter. Same authority requirement as the global search."""
+        return await self._batch_purge_returning(
+            None, purger.build_subquery, purger.conflict_checks(), purger.to_data
+        )
 
-        Same authority requirement as the global search; same membership caveat as
-        :meth:`batch_purge_in_scopes`.
-        """
-        return await self._batch_purge_returning(None, purger)
+    async def batch_purge_entities_in_scopes[TRow: Base, TData](
+        self, scopes: Sequence[OperationScope], purger: EntityBatchPurger[TRow, TData]
+    ) -> list[TData]:
+        """Delete every entity row the spec selects within ``scopes``, each with the
+        RBAC graph it left; at least one scope is required."""
+        if not scopes:
+            raise EmptyOperationScopeError(
+                "batch_purge_entities_in_scopes requires at least one scope; use "
+                "batch_purge_entities_in_global for an explicit unscoped batch purge."
+            )
+        await self._validate_scope_existence(scopes)
+        return await self._batch_purge_entities(self._scopes_condition(scopes), purger)
+
+    async def batch_purge_entities_in_global[TRow: Base, TData](
+        self, purger: EntityBatchPurger[TRow, TData]
+    ) -> list[TData]:
+        """Delete every entity row the spec selects across the table, each with the
+        RBAC graph it left, with NO scope filter. Same authority requirement as the
+        global search."""
+        return await self._batch_purge_entities(None, purger)
+
+    async def _batch_purge_entities[TRow: Base, TData](
+        self,
+        scope_condition: sa.ColumnElement[bool] | None,
+        purger: EntityBatchPurger[TRow, TData],
+    ) -> list[TData]:
+        """The rows go first, then what each left in the graph, so a torn-down entity
+        can never be one whose row survived."""
+        entity_ids: list[EntityIdentifier] = []
+
+        def collect(row: TRow) -> TData:
+            entity_ids.append(purger.entity_id(row))
+            return purger.to_data(row)
+
+        removed = await self._batch_purge_returning(
+            scope_condition, purger.build_subquery, purger.conflict_checks(), collect
+        )
+        for entity_id in entity_ids:
+            await self._teardown_entity(entity_id)
+        return removed
 
     async def _batch_update_returning[TRow: Base, TData](
         self,
@@ -99,20 +142,22 @@ class V2BatchWriteOps(V2WriteOpsBase):
     async def _batch_purge_returning[TRow: Base, TData](
         self,
         scope_condition: sa.ColumnElement[bool] | None,
-        purger: DataBatchPurger[TRow, TData],
+        build_subquery: Callable[[], sa.sql.Select[Any]],
+        conflict_checks: Sequence[ConflictCheck],
+        to_data: Callable[[TRow], TData],
         batch_size: int = 1000,
     ) -> list[TData]:
-        base_subquery = purger.build_subquery()
+        base_subquery = build_subquery()
         entity = base_subquery.column_descriptions[0]["entity"]
         table = sa.inspect(entity).local_table
         pk_columns = list(table.primary_key.columns)
         row_class = cast("type[TRow]", entity)
 
-        await self._validate_conflict_checks(purger.conflict_checks())
+        await self._validate_conflict_checks(conflict_checks)
 
         removed: list[TData] = []
         while True:
-            selecting = purger.build_subquery()
+            selecting = build_subquery()
             if scope_condition is not None:
                 selecting = selecting.where(scope_condition)
             sub = selecting.subquery()
@@ -127,7 +172,7 @@ class V2BatchWriteOps(V2WriteOpsBase):
             except sa.exc.IntegrityError as e:
                 raise self._parse_integrity_error(e) from e
             rows = result.fetchall()
-            removed.extend(purger.to_data(row_class(**dict(r._mapping))) for r in rows)
+            removed.extend(to_data(row_class(**dict(r._mapping))) for r in rows)
             if len(rows) < batch_size:
                 break
         return removed

--- a/src/ai/backend/manager/repositories/ops/v2/batch_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/batch_write.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
-from typing import Any, cast
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 
@@ -13,8 +12,7 @@ from ai.backend.manager.errors.repository import (
 )
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.scopes import OperationScope
-from ai.backend.manager.models.specs.purger import EntityBatchPurger, FieldBatchPurger
-from ai.backend.manager.models.specs.types import ConflictCheck
+from ai.backend.manager.models.specs.purger import EntityBatchPurger
 from ai.backend.manager.models.specs.updater import DataBatchUpdater
 from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
 
@@ -49,33 +47,6 @@ class V2BatchWriteOps(V2WriteOpsBase):
         endpoints or internal system operations only.
         """
         return await self._batch_update_returning(None, updater)
-
-    async def batch_purge_field_entities_in_scopes[TRow: Base, TData](
-        self, scopes: Sequence[OperationScope], purger: FieldBatchPurger[TRow, TData]
-    ) -> list[TData]:
-        """Delete every field row the spec selects within ``scopes``; at least one is
-        required. Scope conditions are injected into the selecting subquery."""
-        if not scopes:
-            raise EmptyOperationScopeError(
-                "batch_purge_field_entities_in_scopes requires at least one scope; use "
-                "batch_purge_field_entities_in_global for an explicit unscoped batch purge."
-            )
-        await self._validate_scope_existence(scopes)
-        return await self._batch_purge_returning(
-            self._scopes_condition(scopes),
-            purger.build_subquery,
-            purger.conflict_checks(),
-            purger.to_data,
-        )
-
-    async def batch_purge_field_entities_in_global[TRow: Base, TData](
-        self, purger: FieldBatchPurger[TRow, TData]
-    ) -> list[TData]:
-        """Delete every field row the spec selects across the table, with NO scope
-        filter. Same authority requirement as the global search."""
-        return await self._batch_purge_returning(
-            None, purger.build_subquery, purger.conflict_checks(), purger.to_data
-        )
 
     async def batch_purge_entities_in_scopes[TRow: Base, TData](
         self, scopes: Sequence[OperationScope], purger: EntityBatchPurger[TRow, TData]
@@ -138,41 +109,3 @@ class V2BatchWriteOps(V2WriteOpsBase):
                 self._parse_integrity_error(e), updater.integrity_error_checks
             )
         return [updater.to_data(row_class(**dict(r._mapping))) for r in result.fetchall()]
-
-    async def _batch_purge_returning[TRow: Base, TData](
-        self,
-        scope_condition: sa.ColumnElement[bool] | None,
-        build_subquery: Callable[[], sa.sql.Select[Any]],
-        conflict_checks: Sequence[ConflictCheck],
-        to_data: Callable[[TRow], TData],
-        batch_size: int = 1000,
-    ) -> list[TData]:
-        base_subquery = build_subquery()
-        entity = base_subquery.column_descriptions[0]["entity"]
-        table = sa.inspect(entity).local_table
-        pk_columns = list(table.primary_key.columns)
-        row_class = cast("type[TRow]", entity)
-
-        await self._validate_conflict_checks(conflict_checks)
-
-        removed: list[TData] = []
-        while True:
-            selecting = build_subquery()
-            if scope_condition is not None:
-                selecting = selecting.where(scope_condition)
-            sub = selecting.subquery()
-            pk_subquery = sa.select(*[sub.c[pk.key] for pk in pk_columns]).limit(batch_size)
-            stmt = (
-                sa.delete(table)
-                .where(sa.tuple_(*pk_columns).in_(pk_subquery))
-                .returning(*table.columns)
-            )
-            try:
-                result = await self._sess.execute(stmt)
-            except sa.exc.IntegrityError as e:
-                raise self._parse_integrity_error(e) from e
-            rows = result.fetchall()
-            removed.extend(to_data(row_class(**dict(r._mapping))) for r in rows)
-            if len(rows) < batch_size:
-                break
-        return removed

--- a/src/ai/backend/manager/repositories/ops/v2/field_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/field_write.py
@@ -14,7 +14,11 @@ from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
 from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.creator import FieldCreator, FieldToCreate, NestedFieldCreator
-from ai.backend.manager.models.specs.purger import FieldPurger, GuardedFieldPurger
+from ai.backend.manager.models.specs.purger import (
+    FieldBatchPurger,
+    FieldPurger,
+    GuardedFieldPurger,
+)
 from ai.backend.manager.models.specs.upserter import FieldUpserter
 from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
 
@@ -86,6 +90,18 @@ class V2FieldWriteOps(V2WriteOpsBase):
         # First creator's checks: all specs share the same creator subclass.
         await self._insert_rows(rows, creators[0].integrity_error_checks())
         return [creator.to_data(row) for creator, row in zip(creators, rows, strict=True)]
+
+    async def batch_purge_field_entities[TOwnerID: EntityIdentifier, TRow: Base, TData](
+        self, owner_id: TOwnerID, purger: FieldBatchPurger[TOwnerID, TRow, TData]
+    ) -> list[TData]:
+        """Delete the owner's field rows the spec selects, in chunks, returning what
+        was removed. Bounded by the owner, as every field write is."""
+        return await self._batch_purge_returning(
+            None,
+            lambda: purger.build_subquery(owner_id),
+            purger.conflict_checks(),
+            purger.to_data,
+        )
 
     async def purge_field_entity[TRow: Base, TData: FieldData](
         self, purger: FieldPurger[TRow, TData]

--- a/src/ai/backend/manager/repositories/ops/v2/grant_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/grant_write.py
@@ -1,0 +1,70 @@
+"""Grant writes of the v2 ops: access to an existing entity, handed out and taken back.
+
+A grant records the entity as a member of the grantee's virtual scope carrying a
+permission cap, which is what
+``PermissionControllerDBSource._resolve_permissions_for_virtual_scope_group`` clips the
+grantee's permissions to. Creation-time belonging is not this: see
+``models/specs/AGENTS.md``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.models.specs.membership import EntityGrant
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
+
+
+class V2GrantWriteOps(V2WriteOpsBase):
+    """Grants over existing entities, bound to a single session."""
+
+    async def grant_entities(self, grants: Sequence[EntityGrant]) -> None:
+        """Hand each entity to its grantee, bounded by the grant's cap.
+
+        Re-granting rewrites the cap rather than keeping the earlier one: a grant
+        states the ceiling that holds now, so a widened or narrowed one has to win.
+        A grantee with no virtual scope fails, as every membership write does.
+        """
+        if not grants:
+            return
+        scope_ids = await self._resolve_virtual_scope_ids([g.grantee for g in grants])
+        stmt = pg_insert(EntityMembershipRow).values([
+            {
+                "virtual_scope_id": scope_ids[(g.grantee.entity_type(), g.grantee)],
+                "entity_type": g.entity.entity_type(),
+                "entity_id": g.entity,
+                "permission_cap": g.permission_cap,
+            }
+            for g in grants
+        ])
+        await self._sess.execute(
+            stmt.on_conflict_do_update(
+                index_elements=["virtual_scope_id", "entity_type", "entity_id"],
+                set_={"permission_cap": stmt.excluded.permission_cap},
+            )
+        )
+
+    async def revoke_entities(
+        self, entities: Sequence[EntityIdentifier], grantee: EntityIdentifier
+    ) -> None:
+        """Take the entities back from the grantee's scope.
+
+        Silent on what was never granted — a revoke states the absence it leaves, not
+        that it found something to remove.
+        """
+        if not entities:
+            return
+        scope_ids = await self._resolve_virtual_scope_ids([grantee])
+        await self._sess.execute(
+            sa.delete(EntityMembershipRow).where(
+                EntityMembershipRow.virtual_scope_id == scope_ids[(grantee.entity_type(), grantee)],
+                sa.tuple_(EntityMembershipRow.entity_type, EntityMembershipRow.entity_id).in_([
+                    (e.entity_type(), e) for e in entities
+                ]),
+            )
+        )

--- a/src/ai/backend/manager/repositories/ops/v2/reconciler/provider.py
+++ b/src/ai/backend/manager/repositories/ops/v2/reconciler/provider.py
@@ -1,0 +1,26 @@
+"""Reconcile DB ops provider.
+
+Hands out :class:`ReconcileWriteOps` where :class:`V2DBOpsProvider` hands out the
+general write ops, so the transition primitive reaches a repository by injection
+rather than by every repository inheriting it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import override
+
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.write import ReconcileWriteOps
+
+
+class ReconcileOpsProvider(V2DBOpsProvider):
+    """Hands out :class:`ReconcileWriteOps` for the read-write surface."""
+
+    @asynccontextmanager
+    @override
+    async def write_ops(self) -> AsyncGenerator[ReconcileWriteOps]:
+        """Open a read-write transaction and yield the reconcile write ops."""
+        async with self._db.begin_session_read_committed() as sess:
+            yield ReconcileWriteOps(sess)

--- a/src/ai/backend/manager/repositories/ops/v2/reconciler/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/reconciler/write.py
@@ -1,9 +1,13 @@
-"""Reconcile writes of the v2 ops: a status transition and the history it leaves.
+"""Reconcile writes: a status transition and the history it leaves.
 
 Every reconciled row (deployment, replica, replica group) advances the same way — the
 status is written and the transition is recorded — so the pair is one primitive rather
 than two calls a caller could get out of step. A repeated transition merges onto the
 latest history row within the same scope instead of inserting another.
+
+The primitive sits here rather than in the general write ops because reconciliation is
+the only thing that has it: :class:`ReconcileWriteOps` extends the general ops, so a
+repository handed the general ones never sees it.
 """
 
 from __future__ import annotations
@@ -20,7 +24,7 @@ from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.mixins.history import ReconcileHistoryMixin
 from ai.backend.manager.models.specs.creator import FieldCreator
 from ai.backend.manager.models.specs.updater import DataUpdater
-from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
+from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
 
 
 @dataclass
@@ -43,8 +47,8 @@ class ReconcileTransition[
     status_updater: DataUpdater[TStatusRow, TStatusData] | None = None
 
 
-class V2ReconcileWriteOps(V2WriteOpsBase):
-    """Status-with-history writes, bound to a single session."""
+class ReconcileWriteOps(V2WriteOps):
+    """The general v2 write ops plus the status-with-history transition."""
 
     async def apply_transitions(
         self, transitions: Sequence[ReconcileTransition[Any, Any, Any, Any, Any]]

--- a/src/ai/backend/manager/repositories/ops/v2/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/write.py
@@ -7,6 +7,7 @@ from ai.backend.manager.repositories.ops.v2.dangling_field_write import V2Dangli
 from ai.backend.manager.repositories.ops.v2.entity_write import V2EntityWriteOps
 from ai.backend.manager.repositories.ops.v2.field_write import V2FieldWriteOps
 from ai.backend.manager.repositories.ops.v2.global_write import V2GlobalWriteOps
+from ai.backend.manager.repositories.ops.v2.grant_write import V2GrantWriteOps
 from ai.backend.manager.repositories.ops.v2.read import V2ReadOps
 from ai.backend.manager.repositories.ops.v2.update_write import V2UpdateWriteOps
 
@@ -14,6 +15,7 @@ from ai.backend.manager.repositories.ops.v2.update_write import V2UpdateWriteOps
 class V2WriteOps(
     V2EntityWriteOps,
     V2GlobalWriteOps,
+    V2GrantWriteOps,
     V2FieldWriteOps,
     V2DanglingFieldWriteOps,
     V2UpdateWriteOps,
@@ -24,8 +26,9 @@ class V2WriteOps(
 
     Composed by inheritance from the per-concern ops — entity writes (the
     role-managed variants included), global, field and sidecar writes, the
-    updates and batch writes — on top of the read ops; each concern lives in its
-    own module and shares the primitives of ``V2WriteOpsBase``.
+    updates, batch writes and the grants over existing entities — on top of the
+    read ops; each concern lives in its own module and shares the primitives of
+    ``V2WriteOpsBase``.
 
     The reconcile transition is not among them: it belongs to
     ``repositories/ops/v2/reconciler/``, whose ops extend this class.

--- a/src/ai/backend/manager/repositories/ops/v2/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/write.py
@@ -8,7 +8,6 @@ from ai.backend.manager.repositories.ops.v2.entity_write import V2EntityWriteOps
 from ai.backend.manager.repositories.ops.v2.field_write import V2FieldWriteOps
 from ai.backend.manager.repositories.ops.v2.global_write import V2GlobalWriteOps
 from ai.backend.manager.repositories.ops.v2.read import V2ReadOps
-from ai.backend.manager.repositories.ops.v2.reconcile_write import V2ReconcileWriteOps
 from ai.backend.manager.repositories.ops.v2.update_write import V2UpdateWriteOps
 
 
@@ -19,14 +18,15 @@ class V2WriteOps(
     V2DanglingFieldWriteOps,
     V2UpdateWriteOps,
     V2BatchWriteOps,
-    V2ReconcileWriteOps,
     V2ReadOps,
 ):
     """Read-write operations over the v2 write specs, bound to a single session.
 
     Composed by inheritance from the per-concern ops — entity writes (the
     role-managed variants included), global, field and sidecar writes, the
-    updates, batch writes and the reconcile transitions — on top of the read
-    ops; each concern lives in its own module and shares the primitives of
-    ``V2WriteOpsBase``.
+    updates and batch writes — on top of the read ops; each concern lives in its
+    own module and shares the primitives of ``V2WriteOpsBase``.
+
+    The reconcile transition is not among them: it belongs to
+    ``repositories/ops/v2/reconciler/``, whose ops extend this class.
     """

--- a/src/ai/backend/manager/repositories/ops/v2/write_base.py
+++ b/src/ai/backend/manager/repositories/ops/v2/write_base.py
@@ -9,8 +9,8 @@ these on top of :class:`~.base.V2OpsBase`.
 from __future__ import annotations
 
 import uuid
-from collections.abc import Collection, Mapping, Sequence
-from typing import Any, ClassVar, NoReturn
+from collections.abc import Callable, Collection, Mapping, Sequence
+from typing import Any, ClassVar, NoReturn, cast
 
 import sqlalchemy as sa
 from asyncpg.exceptions import PostgresError
@@ -399,3 +399,41 @@ class V2WriteOpsBase(V2OpsBase):
                 + ", ".join(f"{e.entity_type()}:{e}" for e in missing)
             )
         return resolved
+
+    async def _batch_purge_returning[TRow: Base, TData](
+        self,
+        scope_condition: sa.ColumnElement[bool] | None,
+        build_subquery: Callable[[], sa.sql.Select[Any]],
+        conflict_checks: Sequence[ConflictCheck],
+        to_data: Callable[[TRow], TData],
+        batch_size: int = 1000,
+    ) -> list[TData]:
+        base_subquery = build_subquery()
+        entity = base_subquery.column_descriptions[0]["entity"]
+        table = sa.inspect(entity).local_table
+        pk_columns = list(table.primary_key.columns)
+        row_class = cast("type[TRow]", entity)
+
+        await self._validate_conflict_checks(conflict_checks)
+
+        removed: list[TData] = []
+        while True:
+            selecting = build_subquery()
+            if scope_condition is not None:
+                selecting = selecting.where(scope_condition)
+            sub = selecting.subquery()
+            pk_subquery = sa.select(*[sub.c[pk.key] for pk in pk_columns]).limit(batch_size)
+            stmt = (
+                sa.delete(table)
+                .where(sa.tuple_(*pk_columns).in_(pk_subquery))
+                .returning(*table.columns)
+            )
+            try:
+                result = await self._sess.execute(stmt)
+            except sa.exc.IntegrityError as e:
+                raise self._parse_integrity_error(e) from e
+            rows = result.fetchall()
+            removed.extend(to_data(row_class(**dict(r._mapping))) for r in rows)
+            if len(rows) < batch_size:
+                break
+        return removed

--- a/src/ai/backend/manager/repositories/project/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/project/db_source/db_source.py
@@ -85,6 +85,7 @@ from ai.backend.manager.repositories.ops.rbac.provider import (
     ScopeDeletion,
     ScopeUserMember,
 )
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.permission_controller.creators import UserRoleCreatorSpec
 from ai.backend.manager.repositories.project.purgers import (
     ProjectEndpointBatchPurgerSpec,
@@ -102,10 +103,12 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 class ProjectDBSource:
     _db: ExtendedAsyncSAEngine
+    _v2_ops: V2DBOpsProvider
     _rbac_ops_provider: RBACOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
         self._db = db
+        self._v2_ops = v2_ops_provider
         self._rbac_ops_provider = RBACOpsProvider(db)
 
     async def _get_domain_id(self, w: RBACWriteOps, domain_name: str) -> DomainID:
@@ -473,6 +476,7 @@ class ProjectDBSource:
         storage_ptask_group = aiotools.PersistentTaskGroup()
         await initiate_vfolder_deletion(
             self._db,
+            self._v2_ops,
             target_vfs,
             storage_manager,
             storage_ptask_group,

--- a/src/ai/backend/manager/repositories/project/repository.py
+++ b/src/ai/backend/manager/repositories/project/repository.py
@@ -61,7 +61,7 @@ class ProjectRepository:
         valkey_stat_client: ValkeyStatClient,
         storage_manager: StorageSessionManager,
     ) -> None:
-        self._db_source = ProjectDBSource(db)
+        self._db_source = ProjectDBSource(db, v2_ops_provider)
         self._v2_ops = v2_ops_provider
         self._config_provider = config_provider
         self._valkey_stat_client = valkey_stat_client

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -52,8 +52,8 @@ from ai.backend.manager.repositories.base import (
     execute_batch_querier,
 )
 from ai.backend.manager.repositories.ops import DBOpsProvider
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
-from ai.backend.manager.repositories.ops.v2.reconcile_write import ReconcileTransition
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.write import ReconcileTransition
 from ai.backend.manager.repositories.replica_group.types import (
     ApplyWritesResult,
     AutoscaleReconcileFetch,
@@ -111,12 +111,14 @@ def _scale_in_termination_priority() -> sa.ColumnElement[int]:
 class ReplicaGroupDBSource:
     _db: ExtendedAsyncSAEngine
     _ops: DBOpsProvider
-    _v2_ops: V2DBOpsProvider
+    _reconcile_ops: ReconcileOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
+    def __init__(
+        self, db: ExtendedAsyncSAEngine, reconcile_ops_provider: ReconcileOpsProvider
+    ) -> None:
         self._db = db
         self._ops = DBOpsProvider(db)
-        self._v2_ops = v2_ops_provider
+        self._reconcile_ops = reconcile_ops_provider
 
     async def search_deploy_scheduling_views(
         self,
@@ -378,7 +380,7 @@ class ReplicaGroupDBSource:
         updated_endpoint_ids: set[DeploymentID] = set()
         if not group_updaters and not endpoint_updaters:
             return ApplyWritesResult(updated_group_ids, updated_endpoint_ids)
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             for group_updater in group_updaters:
                 group_data = await w.update_data(group_updater)
                 if group_data is not None:
@@ -413,7 +415,7 @@ class ReplicaGroupDBSource:
             )
         primary_by_deployment = {row.id: row.primary_replica_group_id for row in endpoint_rows}
         endpoint_by_deployment = {row.id: row for row in endpoint_rows}
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             reuse_updaters: list[ReplicaGroupDeployUpdater] = []
             endpoint_updaters: list[EndpointReplicaGroupUpdater] = []
             for setup in setups:
@@ -474,7 +476,7 @@ class ReplicaGroupDBSource:
         async with self._db.begin_readonly_session_read_committed() as read_sess:
             creators = await self._build_route_creators(read_sess, apply.create_instructions)
             drain_updater = await self._build_drain_updater(read_sess, apply.drain_instructions)
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             if creators:
                 await w.atomic_create_fields(creators)
             if drain_updater is not None:
@@ -487,7 +489,7 @@ class ReplicaGroupDBSource:
         self,
         apply: ReplicaGroupLifecycleReconcileApply,
     ) -> None:
-        async with self._v2_ops.write_ops() as w:
+        async with self._reconcile_ops.write_ops() as w:
             await w.apply_transitions([
                 self._to_ops_transition(transition) for transition in apply.transitions
             ])

--- a/src/ai/backend/manager/repositories/replica_group/repositories.py
+++ b/src/ai/backend/manager/repositories/replica_group/repositories.py
@@ -17,4 +17,4 @@ class ReplicaGroupRepositories:
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
         """Create replica group repositories."""
-        return cls(repository=ReplicaGroupRepository(args.db, args.v2_ops_provider))
+        return cls(repository=ReplicaGroupRepository(args.db, args.reconcile_ops_provider))

--- a/src/ai/backend/manager/repositories/replica_group/repository.py
+++ b/src/ai/backend/manager/repositories/replica_group/repository.py
@@ -23,7 +23,7 @@ from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.specs.updater import DataUpdater
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.repositories.replica_group.types import (
     ApplyWritesResult,
     AutoscaleReconcileFetch,
@@ -65,8 +65,10 @@ class ReplicaGroupRepository:
 
     _db_source: ReplicaGroupDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
-        self._db_source = ReplicaGroupDBSource(db, v2_ops_provider)
+    def __init__(
+        self, db: ExtendedAsyncSAEngine, reconcile_ops_provider: ReconcileOpsProvider
+    ) -> None:
+        self._db_source = ReplicaGroupDBSource(db, reconcile_ops_provider)
 
     @replica_group_repository_resilience.apply()
     async def search_deploy_scheduling_views(

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -72,9 +72,9 @@ class SessionDBSource:
     _db: ExtendedAsyncSAEngine
     _ops: DBOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
         self._db = db
-        self._ops = DBOpsProvider(db)
+        self._ops = ops_provider
 
     async def resolve_session_id(
         self,

--- a/src/ai/backend/manager/repositories/session/repositories.py
+++ b/src/ai/backend/manager/repositories/session/repositories.py
@@ -11,7 +11,7 @@ class SessionRepositories:
 
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
-        repository = SessionRepository(args.db)
+        repository = SessionRepository(args.db, args.ops_provider)
 
         return cls(
             repository=repository,

--- a/src/ai/backend/manager/repositories/session/repository.py
+++ b/src/ai/backend/manager/repositories/session/repository.py
@@ -32,6 +32,7 @@ from ai.backend.manager.models.session.updaters import SessionUpdater
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.db_source import SessionDBSource
 
 session_repository_resilience = Resilience(
@@ -52,8 +53,8 @@ session_repository_resilience = Resilience(
 class SessionRepository:
     _db_source: SessionDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
-        self._db_source = SessionDBSource(db)
+    def __init__(self, db: ExtendedAsyncSAEngine, ops_provider: DBOpsProvider) -> None:
+        self._db_source = SessionDBSource(db, ops_provider)
 
     @session_repository_resilience.apply()
     async def get_session_name(self, session_id: SessionId) -> str:

--- a/src/ai/backend/manager/repositories/types.py
+++ b/src/ai/backend/manager/repositories/types.py
@@ -12,6 +12,7 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 
 
 @dataclass
@@ -19,6 +20,7 @@ class RepositoryArgs:
     db: ExtendedAsyncSAEngine
     ops_provider: DBOpsProvider
     v2_ops_provider: V2DBOpsProvider
+    reconcile_ops_provider: ReconcileOpsProvider
     storage_manager: StorageSessionManager
     config_provider: ManagerConfigProvider
     valkey_stat_client: ValkeyStatClient

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -107,6 +107,7 @@ from ai.backend.manager.repositories.ops.rbac.provider import (
     ScopeBatchDeletion,
     ScopeUserMember,
 )
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.user.creators import (
     UserCreateSpec,
     UserScopeCreation,
@@ -129,10 +130,12 @@ class UserDBSource:
     """Database source for user-related operations."""
 
     _db: ExtendedAsyncSAEngine
+    _v2_ops: V2DBOpsProvider
     _rbac_ops_provider: RBACOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
         self._db = db
+        self._v2_ops = v2_ops_provider
         self._rbac_ops_provider = RBACOpsProvider(db)
 
     async def get_user_by_uuid(self, user_uuid: UUID) -> UserData:
@@ -504,6 +507,7 @@ class UserDBSource:
         storage_ptask_group = aiotools.PersistentTaskGroup()
         await initiate_vfolder_deletion(
             self._db,
+            self._v2_ops,
             target_vfs,
             storage_manager,
             storage_ptask_group,

--- a/src/ai/backend/manager/repositories/user/repository.py
+++ b/src/ai/backend/manager/repositories/user/repository.py
@@ -75,7 +75,7 @@ class UserRepository:
     _db_source: UserDBSource
 
     def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
-        self._db_source = UserDBSource(db)
+        self._db_source = UserDBSource(db, v2_ops_provider)
         self._v2_ops = v2_ops_provider
 
     @user_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/vfolder/deletion.py
+++ b/src/ai/backend/manager/repositories/vfolder/deletion.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 
 import aiotools
 
+from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
 from ai.backend.manager.data.vfolder.types import VFolderOperationStatus
@@ -51,12 +52,13 @@ async def initiate_vfolder_deletion(
         return 0
 
     async with v2_ops_provider.write_ops() as w:
-        await w.batch_purge_field_entities_in_global(
+        await w.batch_purge_entities_in_global(
             VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids)
         )
-        await w.batch_purge_field_entities_in_global(
-            VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids)
-        )
+        for vfolder_id in vfolder_ids:
+            await w.batch_purge_field_entities(
+                VFolderUUID(vfolder_id), VFolderPermissionBatchPurger()
+            )
     await update_vfolder_status(
         db_engine,
         vfolder_ids,

--- a/src/ai/backend/manager/repositories/vfolder/deletion.py
+++ b/src/ai/backend/manager/repositories/vfolder/deletion.py
@@ -26,13 +26,14 @@ from ai.backend.manager.models.vfolder.row import (
     is_unmanaged,
     update_vfolder_status,
 )
-from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 async def initiate_vfolder_deletion(
     db_engine: ExtendedAsyncSAEngine,
+    v2_ops_provider: V2DBOpsProvider,
     requested_vfolders: Sequence[VFolderDeletionInfo],
     storage_manager: StorageSessionManager,
     _storage_ptask_group: aiotools.PersistentTaskGroup | None = None,
@@ -49,10 +50,9 @@ async def initiate_vfolder_deletion(
     if vfolder_info_len == 0:
         return 0
 
-    async with db_engine.begin_session() as db_session:
-        ops = V2WriteOps(db_session)
-        await ops.batch_purge_in_global(VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids))
-        await ops.batch_purge_in_global(VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids))
+    async with v2_ops_provider.write_ops() as w:
+        await w.batch_purge_in_global(VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids))
+        await w.batch_purge_in_global(VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids))
     await update_vfolder_status(
         db_engine,
         vfolder_ids,

--- a/src/ai/backend/manager/repositories/vfolder/deletion.py
+++ b/src/ai/backend/manager/repositories/vfolder/deletion.py
@@ -51,8 +51,12 @@ async def initiate_vfolder_deletion(
         return 0
 
     async with v2_ops_provider.write_ops() as w:
-        await w.batch_purge_in_global(VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids))
-        await w.batch_purge_in_global(VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids))
+        await w.batch_purge_field_entities_in_global(
+            VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids)
+        )
+        await w.batch_purge_field_entities_in_global(
+            VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids)
+        )
     await update_vfolder_status(
         db_engine,
         vfolder_ids,

--- a/src/ai/backend/manager/repositories/vfolder/repositories.py
+++ b/src/ai/backend/manager/repositories/vfolder/repositories.py
@@ -13,7 +13,7 @@ class VfolderRepositories:
 
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
-        repository = VfolderRepository(args.db)
+        repository = VfolderRepository(args.db, args.v2_ops_provider)
         admin_repository = VFolderAdminRepository(args.db)
 
         return cls(

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -117,6 +117,7 @@ from ai.backend.manager.models.vfolder.scopes import (
 from ai.backend.manager.models.vfolder.updaters import (
     VFolderAttributeUpdater,
     VFolderSoftDeleteUpdater,
+    VFolderTrashUpdater,
 )
 from ai.backend.manager.models.virtual_scope.queries import user_scope_membership_exists
 from ai.backend.manager.repositories.base import (
@@ -129,7 +130,6 @@ from ai.backend.manager.repositories.base.rbac.entity_purger import (
     execute_rbac_entity_purger,
 )
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
-from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
 from ai.backend.manager.repositories.vfolder.purge_guards import find_active_vfolder_references
 from ai.backend.manager.repositories.vfolder.types import (
     BulkVFolderPurgeResult,
@@ -524,28 +524,32 @@ class VfolderRepository:
         Rejects the update while an active session mounts the vfolder; raises
         ``VFolderNotFound`` if no matching row exists.
         """
-        async with self._db.begin_session() as session:
-            # Pre-check: reject if any session is currently mounting this vfolder
+        # The mount key pairs the quota scope with the folder id, so it is read off the
+        # row; the row's identity does not change, and the guard rides on the UPDATE.
+        async with self._db.begin_readonly_session_read_committed() as session:
             vfolder_row = await self._get_vfolder_by_id(session, updater.vfolder_id)
             if vfolder_row is None:
                 raise VFolderNotFound()
-            mount_sessions = await get_sessions_by_mounted_folder(
-                session, VFolderID.from_row(vfolder_row)
+            mount_key = str(VFolderID.from_row(vfolder_row))
+
+        async with self._v2_ops.write_ops() as w:
+            data = await w.update_guarded_data(
+                VFolderTrashUpdater(vfolder_id=updater.vfolder_id, mount_key=mount_key)
             )
-            if mount_sessions:
-                session_ids = [str(sid) for sid in mount_sessions]
-                raise VFolderDeletionNotAllowed(
-                    "Cannot delete the vfolder. "
-                    f"The vfolder(id: {vfolder_row.id}) is mounted on sessions(ids: {session_ids})."
-                )
-            # Expire the pre-loaded ORM identity so the RETURNING clause produces
-            # a fresh row with updated status.
-            await session.refresh(vfolder_row)
-            session.expunge(vfolder_row)
-            data = await V2WriteOps(session).update_data(updater)
-            if data is None:
-                raise VFolderNotFound()
+        if data is not None:
             return data
+
+        async with self._db.begin_readonly_session_read_committed() as session:
+            if await self._get_vfolder_by_id(session, updater.vfolder_id) is None:
+                raise VFolderNotFound()
+            mount_sessions = await get_sessions_by_mounted_folder(
+                session, VFolderID.from_str(mount_key)
+            )
+        session_ids = [str(sid) for sid in mount_sessions]
+        raise VFolderDeletionNotAllowed(
+            "Cannot delete the vfolder. "
+            f"The vfolder(id: {updater.vfolder_id}) is mounted on sessions(ids: {session_ids})."
+        )
 
     @vfolder_repository_resilience.apply()
     async def update_vfolder_attribute(self, updater: VFolderAttributeUpdater) -> VFolderData:
@@ -877,8 +881,8 @@ class VfolderRepository:
         Delete a VFolder permission entry.
         """
         async with self._v2_ops.write_ops() as w:
-            await w.batch_purge_field_entities_in_global(
-                VFolderUserPermissionBatchPurger(vfolder_id=vfolder_id, user_id=user_id)
+            await w.batch_purge_field_entities(
+                VFolderUUID(vfolder_id), VFolderUserPermissionBatchPurger(user_id=user_id)
             )
             await w.revoke_entities([VFolderUUID(vfolder_id)], UserID(user_id))
 

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -145,6 +145,7 @@ from ai.backend.manager.repositories.base.rbac.revoker import (
     RBACRevoker,
     execute_rbac_revoker,
 )
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
 from ai.backend.manager.repositories.vfolder.purge_guards import find_active_vfolder_references
 from ai.backend.manager.repositories.vfolder.types import (
@@ -177,9 +178,11 @@ class _VFolderWithLinkedModelCards:
 
 class VfolderRepository:
     _db: ExtendedAsyncSAEngine
+    _v2_ops: V2DBOpsProvider
 
-    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+    def __init__(self, db: ExtendedAsyncSAEngine, v2_ops_provider: V2DBOpsProvider) -> None:
         self._db = db
+        self._v2_ops = v2_ops_provider
 
     @vfolder_repository_resilience.apply()
     async def get_by_id_validated(
@@ -571,8 +574,8 @@ class VfolderRepository:
         Update VFolder attributes.
         Returns updated VFolderData.
         """
-        async with self._db.begin_session() as session:
-            data = await V2WriteOps(session).update_data(updater)
+        async with self._v2_ops.write_ops() as w:
+            data = await w.update_data(updater)
             if data is None:
                 raise VFolderNotFound()
             return data

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -5,14 +5,15 @@ from typing import Any, cast
 
 import sqlalchemy as sa
 from sqlalchemy import exc as sa_exc
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import contains_eager, selectinload
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
+from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
@@ -27,14 +28,9 @@ from ai.backend.common.types import (
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
-from ai.backend.manager.data.permission.id import ObjectId, ScopeId
+from ai.backend.manager.data.permission.id import ScopeId
 from ai.backend.manager.data.permission.types import (
-    EntityType,
-    OperationType,
     Permission,
-    RBACElementType,
-    RelationType,
-    RoleSource,
     ScopeType,
 )
 from ai.backend.manager.data.project.types import ProjectResourceInfo
@@ -54,7 +50,6 @@ from ai.backend.manager.data.vfolder.types import (
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.auth import AuthorizationFailed
 from ai.backend.manager.errors.common import ObjectNotFound
-from ai.backend.manager.errors.permission import UserSystemRoleNotProvisioned
 from ai.backend.manager.errors.repository import (
     ForeignKeyViolationError,
     RepositoryIntegrityError,
@@ -75,13 +70,8 @@ from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.keypair import KeyPairRow, keypairs
 from ai.backend.manager.models.model_card.row import ModelCardRow
 from ai.backend.manager.models.project import ProjectRow
-from ai.backend.manager.models.rbac_models.association_scopes_entities import (
-    AssociationScopesEntitiesRow,
-)
-from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
-from ai.backend.manager.models.rbac_models.role import RoleRow
-from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.resource_policy import keypair_resource_policies
+from ai.backend.manager.models.specs.membership import EntityGrant
 from ai.backend.manager.models.specs.types import IntegrityErrorCheck
 from ai.backend.manager.models.user import (
     ACTIVE_USER_STATUSES,
@@ -118,7 +108,8 @@ from ai.backend.manager.models.vfolder import (
     vfolders,
 )
 from ai.backend.manager.models.vfolder.conditions import VFolderConditions
-from ai.backend.manager.models.vfolder.creators import VFolderCreator
+from ai.backend.manager.models.vfolder.creators import VFolderCreator, VFolderPermissionCreator
+from ai.backend.manager.models.vfolder.purgers import VFolderUserPermissionBatchPurger
 from ai.backend.manager.models.vfolder.scopes import (
     ProjectVFolderOperationScope,
     UserVFolderOperationScope,
@@ -136,14 +127,6 @@ from ai.backend.manager.repositories.base.integrity import match_integrity_error
 from ai.backend.manager.repositories.base.rbac.entity_purger import (
     RBACEntityPurger,
     execute_rbac_entity_purger,
-)
-from ai.backend.manager.repositories.base.rbac.granter import (
-    RBACGranter,
-    execute_rbac_granter,
-)
-from ai.backend.manager.repositories.base.rbac.revoker import (
-    RBACRevoker,
-    execute_rbac_revoker,
 )
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
@@ -174,6 +157,14 @@ class _VFolderWithLinkedModelCards:
 
     vfolder_row: VFolderRow
     model_card_rows: list[ModelCardRow]
+
+
+def _mount_permission_cap(permission: VFolderMountPermission) -> Permission:
+    """The ceiling a mount permission puts on the grantee's own permissions."""
+    cap = Permission.NONE
+    for operation in permission.to_rbac_operation():
+        cap |= Permission.from_operation(operation)
+    return cap
 
 
 class VfolderRepository:
@@ -486,7 +477,7 @@ class VfolderRepository:
         Create a new VFolder with the given parameters and optionally create owner permission.
         Returns the created VFolderData.
         """
-        async with self._db.begin_session() as session:
+        async with self._v2_ops.write_ops() as w:
             creator = VFolderCreator(
                 id=params.id,
                 name=params.name,
@@ -505,36 +496,24 @@ class VfolderRepository:
                 status=params.status,
             )
 
-            created = await V2WriteOps(session).create_entity(creator)
+            created = await w.create_entity(creator)
 
-            # Create owner permission if requested (legacy compatibility)
             if create_owner_permission and params.user:
-                # Get user's role_id
-                user_role_id = await self._get_user_role_id(session, params.user)
-
-                # Insert VFolderPermissionRow for legacy compatibility
-                permission_insert = sa.insert(VFolderPermissionRow).values({
-                    "user": params.user,
-                    "vfolder": params.id.hex,
-                    "permission": VFolderPermission.OWNER_PERM,
-                })
-                await session.execute(permission_insert)
-
-                # Add permission to user's role using RBACGranter (entity-as-scope)
-                granter = RBACGranter(
-                    granted_entity_id=ObjectId(
-                        entity_type=EntityType.VFOLDER,
-                        entity_id=str(params.id),
+                vfolder_id = VFolderUUID(params.id)
+                await w.create_field(
+                    vfolder_id,
+                    VFolderPermissionCreator(
+                        user_id=params.user,
+                        permission=VFolderMountPermission.OWNER_PERM,
                     ),
-                    granted_entity_scope_type=RBACElementType.VFOLDER,
-                    target_scope_id=ScopeId(
-                        scope_type=ScopeType.USER,
-                        scope_id=str(params.user),
-                    ),
-                    target_role_ids=[user_role_id],
-                    operations=[OperationType.READ],
                 )
-                await execute_rbac_granter(session, granter)
+                await w.grant_entities([
+                    EntityGrant(
+                        entity=vfolder_id,
+                        grantee=UserID(params.user),
+                        permission_cap=Permission.READ,
+                    )
+                ])
 
             return created
 
@@ -860,7 +839,7 @@ class VfolderRepository:
 
             return [
                 VFolderPermissionData(
-                    id=row.id,
+                    id=VFolderPermissionID(row.id),
                     vfolder=row.vfolder,
                     user=row.user,
                     permission=row.permission or VFolderMountPermission.READ_ONLY,
@@ -878,75 +857,30 @@ class VfolderRepository:
         """
         Create a VFolder permission entry.
         """
-        async with self._db.begin_session() as session:
-            # Verify vfolder exists
-            vfolder_row = await self._get_vfolder_by_id(session, vfolder_id)
-            if vfolder_row is None:
-                raise VFolderNotFound()
-            # Get user's role_id
-            user_role_id = await self._get_user_role_id(session, user_id)
-
-            # Insert VFolderPermissionRow (legacy compatibility)
-            permission_id = uuid.uuid4()
-            insert_values = {
-                "id": permission_id,
-                "vfolder": vfolder_id,
-                "user": user_id,
-                "permission": permission,
-            }
-            query = sa.insert(VFolderPermissionRow).values(insert_values)
-            await session.execute(query)
-
-            # Grant permission to user's role using RBACGranter (entity-as-scope)
-            granter = RBACGranter(
-                granted_entity_id=ObjectId(
-                    entity_type=EntityType.VFOLDER,
-                    entity_id=str(vfolder_id),
-                ),
-                granted_entity_scope_type=RBACElementType.VFOLDER,
-                target_scope_id=ScopeId(
-                    scope_type=ScopeType.USER,
-                    scope_id=str(user_id),
-                ),
-                target_role_ids=[user_role_id],
-                operations=list(permission.to_rbac_operation()),
+        async with self._v2_ops.write_ops() as w:
+            created = await w.create_field(
+                VFolderUUID(vfolder_id),
+                VFolderPermissionCreator(user_id=user_id, permission=permission),
             )
-            await execute_rbac_granter(session, granter)
-
-            return VFolderPermissionData(
-                id=permission_id,
-                vfolder=vfolder_id,
-                user=user_id,
-                permission=permission,
-            )
+            await w.grant_entities([
+                EntityGrant(
+                    entity=VFolderUUID(vfolder_id),
+                    grantee=UserID(user_id),
+                    permission_cap=_mount_permission_cap(permission),
+                )
+            ])
+            return created
 
     @vfolder_repository_resilience.apply()
     async def delete_vfolder_permission(self, vfolder_id: uuid.UUID, user_id: uuid.UUID) -> None:
         """
         Delete a VFolder permission entry.
         """
-        async with self._db.begin_session() as session:
-            # Get user's role_id
-            user_role_id = await self._get_user_role_id(session, user_id)
-
-            # Delete VFolderPermissionRow (legacy compatibility)
-            query = sa.delete(VFolderPermissionRow).where(
-                (VFolderPermissionRow.vfolder == vfolder_id)
-                & (VFolderPermissionRow.user == user_id)
+        async with self._v2_ops.write_ops() as w:
+            await w.batch_purge_field_entities_in_global(
+                VFolderUserPermissionBatchPurger(vfolder_id=vfolder_id, user_id=user_id)
             )
-            await session.execute(query)
-
-            # Revoke permission from user's role using RBACRevoker
-            revoker = RBACRevoker(
-                entity_id=ObjectId(
-                    entity_type=EntityType.VFOLDER,
-                    entity_id=str(vfolder_id),
-                ),
-                entity_scope_type=RBACElementType.VFOLDER,
-                target_role_ids=[user_role_id],
-                operations=None,  # Revoke all operations
-            )
-            await execute_rbac_revoker(session, revoker)
+            await w.revoke_entities([VFolderUUID(vfolder_id)], UserID(user_id))
 
     @vfolder_repository_resilience.apply()
     async def get_vfolder_invitations_by_vfolder(
@@ -1172,29 +1106,6 @@ class VfolderRepository:
         query = sa.select(VFolderRow).where(VFolderRow.id == vfolder_id)
         result = await session.execute(query)
         return result.scalar()
-
-    async def _get_user_role_id(self, session: SASession, user_id: uuid.UUID) -> uuid.UUID:
-        """
-        Get the system role_id associated with a user.
-
-        Looks up the UserRoleRow joined with RoleRow where the role source is SYSTEM.
-        Raises UserSystemRoleNotProvisioned (5xx) if the user's system role is not found,
-        as a missing SYSTEM role is a server-side data-integrity condition.
-        """
-        stmt = (
-            sa.select(UserRoleRow.role_id)
-            .join(RoleRow, UserRoleRow.role_id == RoleRow.id)
-            .where(
-                sa.and_(
-                    UserRoleRow.user_id == user_id,
-                    RoleRow.source == RoleSource.SYSTEM,
-                )
-            )
-        )
-        result = await session.scalar(stmt)
-        if result is None:
-            raise UserSystemRoleNotProvisioned(extra_msg=str(user_id))
-        return result
 
     def _get_vfolder_scope(self, vfolder: VFolderData) -> ScopeId:
         """Determine scope from vfolder ownership."""
@@ -2234,18 +2145,10 @@ class VfolderRepository:
                 )
                 await conn.execute(del_query)
 
-                # Also clean up new owner's RBAC records from when they were an invitee
-                new_owner_role_id = await self._get_user_role_id(session, user_info.uuid)
-                revoker = RBACRevoker(
-                    entity_id=ObjectId(
-                        entity_type=EntityType.VFOLDER,
-                        entity_id=str(vfolder_id),
-                    ),
-                    entity_scope_type=RBACElementType.VFOLDER,
-                    target_role_ids=[new_owner_role_id],
-                    operations=None,
-                )
-                await execute_rbac_revoker(session, revoker)
+            # Also clear what the new owner held from when they were an invitee; the
+            # ownership grant below replaces it uncapped.
+            async with self._v2_ops.write_ops() as w:
+                await w.revoke_entities([VFolderUUID(vfolder_id)], UserID(user_info.uuid))
 
         await execute_with_retry(_delete_related_rows)
 
@@ -2253,72 +2156,20 @@ class VfolderRepository:
         if old_owner_uuid is not None and old_owner_uuid != user_info.uuid:
 
             async def _cleanup_old_owner_rbac() -> None:
-                async with self._db.begin_session() as session:
-                    user_role_id = await self._get_user_role_id(session, old_owner_uuid)
-                    revoker = RBACRevoker(
-                        entity_id=ObjectId(
-                            entity_type=EntityType.VFOLDER,
-                            entity_id=str(vfolder_id),
-                        ),
-                        entity_scope_type=RBACElementType.VFOLDER,
-                        target_role_ids=[user_role_id],
-                        operations=None,
-                    )
-                    await execute_rbac_revoker(session, revoker)
-                    # Remove scope-entity mapping (visibility)
-                    await session.execute(
-                        sa.delete(AssociationScopesEntitiesRow).where(
-                            sa.and_(
-                                AssociationScopesEntitiesRow.scope_type == ScopeType.USER,
-                                AssociationScopesEntitiesRow.scope_id == str(old_owner_uuid),
-                                AssociationScopesEntitiesRow.entity_type == EntityType.VFOLDER,
-                                AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                            )
-                        )
-                    )
+                async with self._v2_ops.write_ops() as w:
+                    await w.revoke_entities([VFolderUUID(vfolder_id)], UserID(old_owner_uuid))
 
             await execute_with_retry(_cleanup_old_owner_rbac)
 
-        # Step 6: Create owner RBAC records for new owner
+        # Step 6: Hand the vfolder to the new owner, uncapped
         async def _grant_new_owner_rbac() -> None:
-            async with self._db.begin_session() as session:
-                user_role_id = await self._get_user_role_id(session, user_info.uuid)
-
-                # Upsert scope-entity mapping (AUTO relation for owner)
-                # If new owner was previously invitee, upgrade REF -> AUTO
-                upsert_stmt = (
-                    pg_insert(AssociationScopesEntitiesRow)
-                    .values(
-                        scope_type=ScopeType.USER,
-                        scope_id=str(user_info.uuid),
-                        entity_type=EntityType.VFOLDER,
-                        entity_id=str(vfolder_id),
-                        relation_type=RelationType.AUTO,
+            async with self._v2_ops.write_ops() as w:
+                await w.grant_entities([
+                    EntityGrant(
+                        entity=VFolderUUID(vfolder_id),
+                        grantee=UserID(user_info.uuid),
                     )
-                    .on_conflict_do_update(
-                        constraint="uq_scope_id_entity_id",
-                        set_={"relation_type": RelationType.AUTO},
-                    )
-                )
-                await session.execute(upsert_stmt)
-
-                # Grant owner permission (ON CONFLICT DO NOTHING in case
-                # new owner already had permission as invitee)
-                perm_stmt = (
-                    pg_insert(PermissionRow)
-                    .values(
-                        role_id=user_role_id,
-                        scope_type=ScopeType.VFOLDER,
-                        scope_id=str(vfolder_id),
-                        entity_type=EntityType.VFOLDER,
-                        operation=OperationType.READ,
-                        permission=Permission.READ,
-                    )
-                    .on_conflict_do_nothing(
-                        constraint="uq_permissions_role_scope_entity_op",
-                    )
-                )
-                await session.execute(perm_stmt)
+                ])
 
         await execute_with_retry(_grant_new_owner_rbac)
 

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -856,7 +856,7 @@ class BatchPurgeService[TData: EntityData]:
 
     async def execute(self, action: BatchPurgeOpsAction[Any, TData]) -> EntitiesOpsResult[TData]:
         return EntitiesOpsResult(
-            items=await self._repository.batch_purge_in_scopes(
+            items=await self._repository.batch_purge_field_entities_in_scopes(
                 action.operation_scopes(), action.to_batch_purger()
             )
         )
@@ -874,5 +874,7 @@ class GlobalBatchPurgeService[TData: EntityData]:
         self, action: GlobalBatchPurgeOpsAction[Any, TData]
     ) -> EntitiesOpsResult[TData]:
         return EntitiesOpsResult(
-            items=await self._repository.batch_purge_in_global(action.to_batch_purger())
+            items=await self._repository.batch_purge_field_entities_in_global(
+                action.to_batch_purger()
+            )
         )

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -856,7 +856,7 @@ class BatchPurgeService[TData: EntityData]:
 
     async def execute(self, action: BatchPurgeOpsAction[Any, TData]) -> EntitiesOpsResult[TData]:
         return EntitiesOpsResult(
-            items=await self._repository.batch_purge_field_entities_in_scopes(
+            items=await self._repository.batch_purge_entities_in_scopes(
                 action.operation_scopes(), action.to_batch_purger()
             )
         )
@@ -874,7 +874,5 @@ class GlobalBatchPurgeService[TData: EntityData]:
         self, action: GlobalBatchPurgeOpsAction[Any, TData]
     ) -> EntitiesOpsResult[TData]:
         return EntitiesOpsResult(
-            items=await self._repository.batch_purge_field_entities_in_global(
-                action.to_batch_purger()
-            )
+            items=await self._repository.batch_purge_entities_in_global(action.to_batch_purger())
         )

--- a/tests/component/artifact/conftest.py
+++ b/tests/component/artifact/conftest.py
@@ -120,7 +120,7 @@ def artifact_revision_processors(
     storage_namespace_repository = StorageNamespaceRepository(database_engine)
     huggingface_repository = HuggingFaceRepository(database_engine)
     reservoir_repository = ReservoirRegistryRepository(database_engine)
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ArtifactRevisionService(
         artifact_repository=artifact_repository,
         revision_ops=OpsRepository(V2DBOpsProvider(database_engine)),

--- a/tests/component/artifact_registry/conftest.py
+++ b/tests/component/artifact_registry/conftest.py
@@ -127,7 +127,7 @@ def artifact_revision_processors(
     storage_namespace_repository = StorageNamespaceRepository(database_engine)
     huggingface_repository = HuggingFaceRepository(database_engine)
     reservoir_repository = ReservoirRegistryRepository(database_engine)
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ArtifactRevisionService(
         artifact_repository=artifact_repository,
         revision_ops=OpsRepository(V2DBOpsProvider(database_engine)),

--- a/tests/component/artifact_revision/conftest.py
+++ b/tests/component/artifact_revision/conftest.py
@@ -125,7 +125,7 @@ def artifact_revision_processors(
     storage_namespace_repository = StorageNamespaceRepository(database_engine)
     huggingface_repository = HuggingFaceRepository(database_engine)
     reservoir_repository = ReservoirRegistryRepository(database_engine)
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ArtifactRevisionService(
         artifact_repository=artifact_repository,
         revision_ops=OpsRepository(V2DBOpsProvider(database_engine)),

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -30,7 +30,7 @@ from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import DeploymentService
 from ai.backend.testutils.fixtures import DomainFixtureData
@@ -66,7 +66,7 @@ def deployment_processors(
     """Real DeploymentProcessors for auto-scaling-rule tests."""
     repo = DeploymentRepository(
         database_engine,
-        V2DBOpsProvider(database_engine),
+        ReconcileOpsProvider(database_engine),
         storage_manager,
         valkey_clients.stat,
         valkey_clients.live,

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -45,7 +45,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import vfolders
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.repositories.scheduler import SchedulerRepository
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import DeploymentService
@@ -102,7 +102,7 @@ def deployment_processors(
     """Real DeploymentProcessors with real DeploymentService and DeploymentRepository."""
     repo = DeploymentRepository(
         database_engine,
-        V2DBOpsProvider(database_engine),
+        ReconcileOpsProvider(database_engine),
         storage_manager,
         valkey_clients.stat,
         valkey_clients.live,

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -107,7 +107,7 @@ def model_card_processors(
     processor_registry: ProcessorRegistry[Any],
 ) -> ModelCardProcessors:
     """Real ModelCardProcessors with real RBAC enforcement."""
-    repo = ModelCardRepository(database_engine)
+    repo = ModelCardRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ModelCardService(repo, storage_manager)
     return ModelCardProcessors(processor_registry.group(GroupMeta(MODEL_CARD_ENTITY_TYPE)), service)
 

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -21,6 +21,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
 from ai.backend.manager.repositories.model_serving.repository import ModelServingRepository
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.deployment.service import DeploymentService
@@ -47,7 +48,7 @@ def model_serving_processors(
     ms_repo = ModelServingRepository(database_engine, V2DBOpsProvider(database_engine))
     deployment_repo = DeploymentRepository(
         database_engine,
-        V2DBOpsProvider(database_engine),
+        ReconcileOpsProvider(database_engine),
         storage_manager,
         valkey_clients.stat,
         valkey_clients.live,
@@ -104,7 +105,7 @@ def deployment_processors(
     """Real DeploymentProcessors with real DeploymentService and DeploymentRepository."""
     repo = DeploymentRepository(
         database_engine,
-        V2DBOpsProvider(database_engine),
+        ReconcileOpsProvider(database_engine),
         storage_manager,
         valkey_clients.stat,
         valkey_clients.live,

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -49,6 +49,7 @@ from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.auth.processors import AuthProcessors
@@ -98,7 +99,7 @@ def session_repository(
     """Real ``SessionRepository`` exposed as a fixture so individual tests can
     override or stub specific methods (e.g., ``resolve_image``) without
     monkey-patching the class globally."""
-    return SessionRepository(database_engine)
+    return SessionRepository(database_engine, DBOpsProvider(database_engine))
 
 
 @pytest.fixture()

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -71,6 +71,7 @@ from ai.backend.manager.models.resource_slot.row import AgentResourceRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.plugin.network import NetworkPluginContext
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
@@ -124,7 +125,7 @@ def rbac_permission_repo(
 def session_repository(
     database_engine: ExtendedAsyncSAEngine,
 ) -> SessionRepository:
-    return SessionRepository(database_engine)
+    return SessionRepository(database_engine, DBOpsProvider(database_engine))
 
 
 @pytest.fixture()
@@ -697,7 +698,7 @@ async def compute_session_processors(
         event_hub=AsyncMock(),
         error_monitor=error_monitor,
         idle_checker_host=AsyncMock(),
-        session_repository=SessionRepository(database_engine),
+        session_repository=SessionRepository(database_engine, DBOpsProvider(database_engine)),
         scheduler_repository=scheduler_repository,
         scheduling_controller=scheduling_controller,
         appproxy_client_pool=AsyncMock(),

--- a/tests/component/stream/conftest.py
+++ b/tests/component/stream/conftest.py
@@ -32,6 +32,7 @@ from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.repositories.stream.repository import StreamRepository
 from ai.backend.manager.services.session.actions.lookup import LookupSessionAction
@@ -96,7 +97,7 @@ async def session_processors(
     ``SessionRepository``); that is all the stream handler uses to normalize a
     UUID-shaped path reference to its canonical session name.
     """
-    repo = SessionRepository(database_engine)
+    repo = SessionRepository(database_engine, DBOpsProvider(database_engine))
     service = SessionService(
         SessionServiceArgs(
             agent_registry=AsyncMock(),

--- a/tests/component/streaming/conftest.py
+++ b/tests/component/streaming/conftest.py
@@ -32,6 +32,7 @@ from ai.backend.manager.dependencies.infrastructure.redis import ValkeyClients
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.manager.repositories.stream.repository import StreamRepository
 from ai.backend.manager.services.session.actions.lookup import LookupSessionAction
@@ -103,7 +104,7 @@ async def session_processors(
             event_hub=AsyncMock(),
             error_monitor=AsyncMock(),
             idle_checker_host=AsyncMock(),
-            session_repository=SessionRepository(database_engine),
+            session_repository=SessionRepository(database_engine, DBOpsProvider(database_engine)),
             scheduler_repository=AsyncMock(),
             scheduling_controller=AsyncMock(),
             appproxy_client_pool=AsyncMock(),

--- a/tests/component/vfolder/conftest.py
+++ b/tests/component/vfolder/conftest.py
@@ -119,7 +119,7 @@ def vfolder_processors(
     valkey_clients: ValkeyClients,
     processor_registry: ProcessorRegistry[Any],
 ) -> VFolderProcessors:
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     user_repository = UserRepository(database_engine, V2DBOpsProvider(database_engine))
     service = VFolderService(
         config_provider=config_provider,
@@ -140,7 +140,7 @@ def vfolder_file_processors(
     storage_manager: StorageSessionManager,
     processor_registry: ProcessorRegistry[Any],
 ) -> VFolderFileProcessors:
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     user_repository = UserRepository(database_engine, V2DBOpsProvider(database_engine))
     service = VFolderFileService(
         config_provider=config_provider,
@@ -157,7 +157,7 @@ def vfolder_invite_processors(
     config_provider: ManagerConfigProvider,
     processor_registry: ProcessorRegistry[Any],
 ) -> VFolderInviteProcessors:
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     user_repository = UserRepository(database_engine, V2DBOpsProvider(database_engine))
     service = VFolderInviteService(
         config_provider=config_provider,
@@ -175,7 +175,7 @@ def vfolder_sharing_processors(
     config_provider: ManagerConfigProvider,
     processor_registry: ProcessorRegistry[Any],
 ) -> VFolderSharingProcessors:
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     user_repository = UserRepository(database_engine, V2DBOpsProvider(database_engine))
     service = VFolderSharingService(
         config_provider=config_provider,

--- a/tests/component/vfolder/test_vfolder_management.py
+++ b/tests/component/vfolder/test_vfolder_management.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.exceptions import BackendAPIError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
 from ai.backend.common.dto.manager.field import VFolderPermissionField
 from ai.backend.common.dto.manager.vfolder import (
     AcceptInvitationReq,
@@ -30,6 +31,7 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOperationStatus,
 )
 from ai.backend.manager.models.vfolder import vfolder_invitations, vfolders
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 
 VFolderFixtureData = dict[str, Any]
 VFolderFactory = Callable[..., Coroutine[Any, Any, VFolderFixtureData]]
@@ -383,16 +385,17 @@ class TestVFolderInviteAcceptReject:
             assert row is not None
             assert row.state == VFolderInvitationState.ACCEPTED
 
-    async def test_accept_fails_when_invitee_has_no_system_role(
+    async def test_accept_fails_when_invitee_has_no_virtual_scope(
         self,
         admin_registry: BackendAIClientRegistry,
         user_registry: BackendAIClientRegistry,
         vfolder_factory: VFolderFactory,
         regular_user_fixture: Any,
+        db_engine: SAEngine,
     ) -> None:
-        """Accepting an invitation fails with a 5xx UserSystemRoleNotProvisioned error
-        when the invitee is missing the RBAC SYSTEM role (a server-side data-integrity
-        condition). Note: the user_system_role fixture is intentionally omitted here."""
+        """Accepting an invitation fails with a 5xx VirtualScopeNotFound error when the
+        invitee has no virtual scope to hold the vfolder — a server-side data-integrity
+        condition, since every user is provisioned one."""
         vf = await vfolder_factory()
         await admin_registry.vfolder.invite(
             vf["name"],
@@ -403,6 +406,16 @@ class TestVFolderInviteAcceptReject:
         )
         invitations = await user_registry.vfolder.list_invitations()
         inv_id = invitations.invitations[0].id
+
+        async with db_engine.begin() as conn:
+            await conn.execute(
+                sa.delete(VirtualScopeRow).where(
+                    sa.and_(
+                        VirtualScopeRow.scope_type == USER_SCOPE_TYPE,
+                        VirtualScopeRow.scope_id == regular_user_fixture.user_uuid,
+                    )
+                )
+            )
 
         with pytest.raises(BackendAPIError) as exc_info:
             await user_registry.vfolder.accept_invitation(

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -93,7 +93,7 @@ def vfolder_processors(
     RBAC checks use check_permission_with_scope_chain() against the real DB.
     Without explicit RBAC permission grants, all access is denied (403).
     """
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     user_repository = UserRepository(database_engine, V2DBOpsProvider(database_engine))
     service = VFolderService(
         config_provider=MagicMock(),

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -99,7 +99,7 @@ def vfolder_processors(
     the etcd-backed allowed-vfolder-types lookup are stubbed so that
     service-layer create paths can complete without external dependencies.
     """
-    vfolder_repository = VfolderRepository(database_engine)
+    vfolder_repository = VfolderRepository(database_engine, V2DBOpsProvider(database_engine))
     user_repository = UserRepository(database_engine, V2DBOpsProvider(database_engine))
     config_provider = MagicMock()
     config_provider.legacy_etcd_config_loader.get_vfolder_types = AsyncMock(

--- a/tests/unit/manager/models/group/test_conditions.py
+++ b/tests/unit/manager/models/group/test_conditions.py
@@ -51,6 +51,7 @@ from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.project.db_source import ProjectDBSource
 from ai.backend.testutils.db import TableOrORM, with_tables
 
@@ -239,7 +240,7 @@ class TestGroupNestedSearchIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ProjectDBSource:
-        return ProjectDBSource(db=db_with_cleanup)
+        return ProjectDBSource(db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def two_domains_with_projects(
@@ -578,7 +579,7 @@ class TestGroupUserNestedSearchIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ProjectDBSource:
-        return ProjectDBSource(db=db_with_cleanup)
+        return ProjectDBSource(db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def projects_with_users(

--- a/tests/unit/manager/models/user/test_conditions.py
+++ b/tests/unit/manager/models/user/test_conditions.py
@@ -49,6 +49,7 @@ from ai.backend.manager.models.user.orders import UserOrders
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.user.db_source import UserDBSource
 from ai.backend.testutils.db import TableOrORM, with_tables
 
@@ -414,7 +415,7 @@ class TestUserNestedSearchIntegration:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> UserDBSource:
-        return UserDBSource(db=db_with_cleanup)
+        return UserDBSource(db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def search_fixture(

--- a/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
+++ b/tests/unit/manager/repositories/deployment/test_active_access_key_resolution.py
@@ -24,7 +24,7 @@ from ai.backend.manager.models.resource_policy import (
 from ai.backend.manager.models.user import UserRole, UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.deployment.db_source.db_source import DeploymentDBSource
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.testutils.db import with_tables
 
 
@@ -74,7 +74,7 @@ class TestResolveUserAndActiveAccessKey:
     def db_source(self, db: ExtendedAsyncSAEngine) -> DeploymentDBSource:
         return DeploymentDBSource(
             db=db,
-            v2_ops_provider=V2DBOpsProvider(db),
+            reconcile_ops_provider=ReconcileOpsProvider(db),
             storage_manager=MagicMock(spec=StorageSessionManager),
         )
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -125,7 +125,7 @@ from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRo
 from ai.backend.manager.repositories.base.purger import Purger, PurgerSpec
 from ai.backend.manager.repositories.base.querier import BatchQuerier
 from ai.backend.manager.repositories.deployment import DeploymentRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
@@ -793,7 +793,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -1160,7 +1160,7 @@ class TestGetDefaultArchitectureFromScalingGroup:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -1742,7 +1742,7 @@ class TestDeploymentRevisionOperations:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -2387,7 +2387,7 @@ class TestDeploymentPolicyOperations:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -2744,7 +2744,7 @@ class TestSearchDeploymentPolicies:
         valkey_schedule = MagicMock()
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -3112,7 +3112,7 @@ class TestRouteOperations:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -3524,7 +3524,7 @@ class TestDeploymentRepositoryDuplicateName:
         mock_valkey_schedule = MagicMock()
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=mock_storage_manager,
             valkey_stat=mock_valkey_stat,
             valkey_live=mock_valkey_live,

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository_history.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository_history.py
@@ -56,7 +56,7 @@ from ai.backend.manager.repositories.deployment.types import (
     DeploymentHistoryToCreate,
     RouteHistoryToCreate,
 )
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.types import OptionalState
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
@@ -414,7 +414,7 @@ class TestUpdateEndpointLifecycleBulkWithHistory:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -856,7 +856,7 @@ class TestUpdateRouteStatusBulkWithHistory:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -1152,7 +1152,7 @@ class TestDeploymentHistoryMergeLogic:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,
@@ -1491,7 +1491,7 @@ class TestRouteHistoryMergeLogic:
 
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=storage_manager,
             valkey_stat=valkey_stat,
             valkey_live=valkey_live,

--- a/tests/unit/manager/repositories/deployment/test_deployment_search_in_project.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_search_in_project.py
@@ -53,7 +53,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.deployment import DeploymentRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.testutils.db import with_tables
 
 
@@ -290,7 +290,7 @@ class TestEndpointSearchInProject:
         mock_valkey_schedule = AsyncMock()
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=mock_storage_manager,
             valkey_stat=mock_valkey_stat,
             valkey_live=mock_valkey_live,

--- a/tests/unit/manager/repositories/deployment/test_legacy_extra_mounts_hydration.py
+++ b/tests/unit/manager/repositories/deployment/test_legacy_extra_mounts_hydration.py
@@ -49,7 +49,7 @@ from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.deployment import DeploymentRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.testutils.db import TableOrORM, with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
 
@@ -329,7 +329,7 @@ class TestLegacyExtraMountsHydration:
     ) -> DeploymentRepository:
         return DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=AsyncMock(),
             valkey_stat=AsyncMock(),
             valkey_live=AsyncMock(),

--- a/tests/unit/manager/repositories/deployment/test_observer_route_scope.py
+++ b/tests/unit/manager/repositories/deployment/test_observer_route_scope.py
@@ -61,7 +61,7 @@ from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.deployment import DeploymentRepository
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.sokovan.deployment.route.coordinator import RouteCoordinator
 from ai.backend.manager.sokovan.deployment.route.handlers.observer import (
     RouteObservationResult,
@@ -388,7 +388,7 @@ class TestObserverCycleRouteScope:
     ) -> RouteCoordinator:
         repository = DeploymentRepository(
             db=db_with_cleanup,
-            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
+            reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup),
             storage_manager=AsyncMock(),
             valkey_stat=AsyncMock(),
             valkey_live=AsyncMock(),

--- a/tests/unit/manager/repositories/domain/test_domain_purgers.py
+++ b/tests/unit/manager/repositories/domain/test_domain_purgers.py
@@ -277,8 +277,8 @@ class TestDomainPurgersIntegration:
 
         # Purge kernels
         async with V2DBOpsProvider(db_with_cleanup).write_ops() as w:
-            purged = await w.batch_purge_field_entities_in_global(
-                DomainKernelPurger(name=domain_name)
+            purged = await w.batch_purge_field_entities(
+                sample_domain.domain_id, DomainKernelPurger(name=domain_name)
             )
             assert len(purged) == len(sample_kernels)
 

--- a/tests/unit/manager/repositories/domain/test_domain_purgers.py
+++ b/tests/unit/manager/repositories/domain/test_domain_purgers.py
@@ -277,7 +277,9 @@ class TestDomainPurgersIntegration:
 
         # Purge kernels
         async with V2DBOpsProvider(db_with_cleanup).write_ops() as w:
-            purged = await w.batch_purge_in_global(DomainKernelPurger(name=domain_name))
+            purged = await w.batch_purge_field_entities_in_global(
+                DomainKernelPurger(name=domain_name)
+            )
             assert len(purged) == len(sample_kernels)
 
         # Verify kernels are deleted

--- a/tests/unit/manager/repositories/group/test_assign_users_to_project.py
+++ b/tests/unit/manager/repositories/group/test_assign_users_to_project.py
@@ -44,6 +44,7 @@ from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.project.db_source import ProjectDBSource
 from ai.backend.manager.repositories.project.scope_binders import UserProjectEntityUnbinder
 from ai.backend.testutils.db import with_tables
@@ -297,7 +298,7 @@ class TestAssignUsersToProject:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ProjectDBSource:
-        return ProjectDBSource(db=db_with_cleanup)
+        return ProjectDBSource(db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup))
 
     # --- Test cases ---
 
@@ -736,7 +737,7 @@ class TestUnassignUsersFromProject:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ProjectDBSource:
-        return ProjectDBSource(db=db_with_cleanup)
+        return ProjectDBSource(db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup))
 
     # --- Test cases ---
 

--- a/tests/unit/manager/repositories/image/test_image_repository.py
+++ b/tests/unit/manager/repositories/image/test_image_repository.py
@@ -40,6 +40,7 @@ from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.image.repository import ImageRepository
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.testutils.db import with_tables
 
@@ -484,7 +485,7 @@ class TestImageRepositoryLastUsedAt:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> SessionRepository:
-        return SessionRepository(db=db_with_cleanup)
+        return SessionRepository(db=db_with_cleanup, ops_provider=DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def domain(

--- a/tests/unit/manager/repositories/model_card/test_model_card_creator.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_creator.py
@@ -255,7 +255,7 @@ class TestModelCardCreatorResourceRequirements:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ModelCardDBSource:
-        return ModelCardDBSource(db_with_cleanup)
+        return ModelCardDBSource(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     def ops(

--- a/tests/unit/manager/repositories/model_card/test_model_card_delete.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_delete.py
@@ -311,7 +311,7 @@ class TestModelCardDelete:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ModelCardDBSource:
-        return ModelCardDBSource(db_with_cleanup)
+        return ModelCardDBSource(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def mounted_vfolder(

--- a/tests/unit/manager/repositories/model_card/test_model_card_scan.py
+++ b/tests/unit/manager/repositories/model_card/test_model_card_scan.py
@@ -56,6 +56,7 @@ from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.model_card.db_source.db_source import ModelCardDBSource
 from ai.backend.manager.repositories.model_card.upserters import ModelCardScanUpserterSpec
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.testutils.db import with_tables
 
 if TYPE_CHECKING:
@@ -248,7 +249,7 @@ class TestModelCardScanResourceRequirements:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ModelCardDBSource:
-        return ModelCardDBSource(db_with_cleanup)
+        return ModelCardDBSource(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
 
     def _build_scan_spec(
         self,

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -55,7 +55,7 @@ from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
 from ai.backend.manager.models.specs.creator import GlobalEntityCreator
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
-from ai.backend.manager.models.specs.purger import FieldBatchPurger
+from ai.backend.manager.models.specs.purger import EntityBatchPurger
 from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 from ai.backend.manager.models.specs.searcher import Searcher
 from ai.backend.manager.models.specs.types import ConflictCheck, IntegrityErrorCheck
@@ -208,10 +208,14 @@ class _PresetBatchUpdater(DataBatchUpdater[RolePresetRow, RolePresetData]):
 
 
 @dataclass
-class _PresetBatchPurger(FieldBatchPurger[RolePresetRow, RolePresetData]):
+class _PresetBatchPurger(EntityBatchPurger[RolePresetRow, RolePresetData]):
     """Removes every preset whose name matches."""
 
     name: str
+
+    @override
+    def entity_id(self, row: RolePresetRow) -> RolePresetID:
+        return RolePresetID(row.id)
 
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[RolePresetRow]]:
@@ -499,7 +503,7 @@ class TestBatchPurge:
             _PresetCreator(name="default", scope_type=RBACScopeType.PROJECT)
         )
 
-        removed = await repository.batch_purge_field_entities_in_global(
+        removed = await repository.batch_purge_entities_in_global(
             _PresetBatchPurger(name="default")
         )
 
@@ -512,8 +516,7 @@ class TestBatchPurge:
         self, repository: OpsRepository[RolePresetData], preset: RolePresetData
     ) -> None:
         assert (
-            await repository.batch_purge_field_entities_in_global(_PresetBatchPurger(name="absent"))
-            == []
+            await repository.batch_purge_entities_in_global(_PresetBatchPurger(name="absent")) == []
         )
 
 

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -55,7 +55,7 @@ from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
 from ai.backend.manager.models.specs.creator import GlobalEntityCreator
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
-from ai.backend.manager.models.specs.purger import DataBatchPurger
+from ai.backend.manager.models.specs.purger import FieldBatchPurger
 from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 from ai.backend.manager.models.specs.searcher import Searcher
 from ai.backend.manager.models.specs.types import ConflictCheck, IntegrityErrorCheck
@@ -208,7 +208,7 @@ class _PresetBatchUpdater(DataBatchUpdater[RolePresetRow, RolePresetData]):
 
 
 @dataclass
-class _PresetBatchPurger(DataBatchPurger[RolePresetRow, RolePresetData]):
+class _PresetBatchPurger(FieldBatchPurger[RolePresetRow, RolePresetData]):
     """Removes every preset whose name matches."""
 
     name: str
@@ -499,7 +499,9 @@ class TestBatchPurge:
             _PresetCreator(name="default", scope_type=RBACScopeType.PROJECT)
         )
 
-        removed = await repository.batch_purge_in_global(_PresetBatchPurger(name="default"))
+        removed = await repository.batch_purge_field_entities_in_global(
+            _PresetBatchPurger(name="default")
+        )
 
         assert len(removed) == 2
         assert {r.name for r in removed} == {"default"}
@@ -509,7 +511,10 @@ class TestBatchPurge:
     async def test_no_match_returns_nothing(
         self, repository: OpsRepository[RolePresetData], preset: RolePresetData
     ) -> None:
-        assert await repository.batch_purge_in_global(_PresetBatchPurger(name="absent")) == []
+        assert (
+            await repository.batch_purge_field_entities_in_global(_PresetBatchPurger(name="absent"))
+            == []
+        )
 
 
 class TestUpsert:

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -50,6 +50,7 @@ from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.permission_controller.db_source.db_source import (
     PermissionDBSource,
 )
@@ -285,7 +286,7 @@ class TestRoleAssignment:
 
     @pytest.fixture
     def group_db_source(self, db_with_cleanup: ExtendedAsyncSAEngine) -> ProjectDBSource:
-        return ProjectDBSource(db=db_with_cleanup)
+        return ProjectDBSource(db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup))
 
     # --- revoke_role remaining count ---
 

--- a/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
+++ b/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
@@ -70,7 +70,7 @@ from ai.backend.manager.models.virtual_scope.entity_membership import EntityMemb
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base.querier import BatchQuerier
-from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
+from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.repositories.replica_group import ReplicaGroupRepository
 from ai.backend.manager.repositories.replica_group.types import (
     GroupRolloutSetup,
@@ -338,7 +338,7 @@ class TestReplicaGroupRepository:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> ReplicaGroupRepository:
         return ReplicaGroupRepository(
-            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+            db=db_with_cleanup, reconcile_ops_provider=ReconcileOpsProvider(db_with_cleanup)
         )
 
     async def test_setup_target_groups_gives_a_fresh_group_its_placement_group(

--- a/tests/unit/manager/repositories/session/test_session_repository.py
+++ b/tests/unit/manager/repositories/session/test_session_repository.py
@@ -53,6 +53,7 @@ from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.testutils.db import with_tables
 
@@ -111,7 +112,7 @@ class TestSessionRepository:
 
     @pytest.fixture
     def repository(self, db_with_cleanup: ExtendedAsyncSAEngine) -> SessionRepository:
-        return SessionRepository(db_with_cleanup)
+        return SessionRepository(db_with_cleanup, DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def session_with_kernel(
@@ -878,7 +879,9 @@ class TestBatchLoadSessionAllocations:
     ) -> None:
         """Verify the repository aggregate returns values computed from
         resource_allocations, not the empty JSONB column."""
-        repository = SessionRepository(db_with_resource_tables)
+        repository = SessionRepository(
+            db_with_resource_tables, DBOpsProvider(db_with_resource_tables)
+        )
         session_id = SessionId(session_with_allocations.session_id)
         aggregates = await repository.batch_get_resource_allocation_by_session([session_id])
 
@@ -923,7 +926,7 @@ class TestGetTemplateInfoById:
 
     @pytest.fixture
     def repository(self, db_with_cleanup: ExtendedAsyncSAEngine) -> SessionRepository:
-        return SessionRepository(db_with_cleanup)
+        return SessionRepository(db_with_cleanup, DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def active_template(

--- a/tests/unit/manager/repositories/session/test_session_search_in_project.py
+++ b/tests/unit/manager/repositories/session/test_session_search_in_project.py
@@ -46,6 +46,7 @@ from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops import DBOpsProvider
 from ai.backend.manager.repositories.session.repository import SessionRepository
 from ai.backend.testutils.db import with_tables
 
@@ -93,7 +94,7 @@ class TestSessionSearchInProject:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> SessionRepository:
-        return SessionRepository(db_with_cleanup)
+        return SessionRepository(db_with_cleanup, DBOpsProvider(db_with_cleanup))
 
     @pytest.fixture
     async def test_data(

--- a/tests/unit/manager/repositories/vfolder/test_share_vfolder_membership.py
+++ b/tests/unit/manager/repositories/vfolder/test_share_vfolder_membership.py
@@ -59,6 +59,7 @@ from ai.backend.manager.models.vfolder import (
 )
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder import repository as vfolder_repo_module
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
@@ -519,7 +520,7 @@ class TestShareVfolderWithUsersMembership:
         member_user_email: str,
     ) -> None:
         """A user that is a project member is returned in the share result."""
-        repo = VfolderRepository(db_with_cleanup)
+        repo = VfolderRepository(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
         result = await repo.share_vfolder_with_users(
             **self._share_kwargs(vfolder, project, requester, domain_fixture, [member_user_email])
         )
@@ -536,7 +537,7 @@ class TestShareVfolderWithUsersMembership:
         non_member_user_email: str,
     ) -> None:
         """A user without a virtual-scope membership triggers ObjectNotFound."""
-        repo = VfolderRepository(db_with_cleanup)
+        repo = VfolderRepository(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
         with pytest.raises(ObjectNotFound):
             await repo.share_vfolder_with_users(
                 **self._share_kwargs(
@@ -555,7 +556,7 @@ class TestShareVfolderWithUsersMembership:
         non_member_user_email: str,
     ) -> None:
         """When some emails are not project members, the call must reject the whole batch."""
-        repo = VfolderRepository(db_with_cleanup)
+        repo = VfolderRepository(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
         with pytest.raises(ObjectNotFound):
             await repo.share_vfolder_with_users(
                 **self._share_kwargs(
@@ -577,7 +578,7 @@ class TestShareVfolderWithUsersMembership:
         other_project_member_email: str,
     ) -> None:
         """Membership in a different project does not satisfy this folder's group filter."""
-        repo = VfolderRepository(db_with_cleanup)
+        repo = VfolderRepository(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
         with pytest.raises(ObjectNotFound):
             await repo.share_vfolder_with_users(
                 **self._share_kwargs(
@@ -599,7 +600,7 @@ class TestShareVfolderWithUsersMembership:
         inactive_member_user_email: str,
     ) -> None:
         """Membership alone is not enough — inactive users are excluded by status filter."""
-        repo = VfolderRepository(db_with_cleanup)
+        repo = VfolderRepository(db_with_cleanup, V2DBOpsProvider(db_with_cleanup))
         with pytest.raises(ObjectNotFound):
             await repo.share_vfolder_with_users(
                 **self._share_kwargs(

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_invitations.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_invitations.py
@@ -31,6 +31,7 @@ from ai.backend.manager.models.vfolder.row import (
     VFolderInvitationRow,
     VFolderRow,
 )
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
@@ -199,7 +200,9 @@ class TestInvitationGettersUsernameFallback:
 
     @pytest.fixture
     def repository(self, db_with_cleanup: ExtendedAsyncSAEngine) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     # ------------------------------------------------------------------
     # get_invitation_by_id

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
@@ -16,6 +16,9 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import (
     BinarySize,
     ResourceSlot,
@@ -25,9 +28,6 @@ from ai.backend.common.types import (
 )
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.types import (
-    EntityType,
-    OperationType,
-    RelationType,
     RoleSource,
 )
 from ai.backend.manager.data.project.types import ProjectType
@@ -72,6 +72,36 @@ VFOLDER_HOST = "local:volume1"
 class UserWithKeypair(NamedTuple):
     user_id: uuid.UUID
     email: str
+
+
+async def _membership_cap(
+    db: ExtendedAsyncSAEngine, vfolder_id: uuid.UUID, user_id: uuid.UUID
+) -> tuple[bool, Permission | None]:
+    """Whether the vfolder sits in the user's virtual scope, and under what cap.
+
+    The v2 shape of what the legacy tables split into an AUTO/REF mapping plus
+    permission rows: owning it is a membership with no cap, being shared it is the same
+    membership under one.
+    """
+    async with db.begin_readonly_session() as db_sess:
+        row = (
+            await db_sess.execute(
+                sa.select(EntityMembershipRow.permission_cap)
+                .join(
+                    VirtualScopeRow,
+                    VirtualScopeRow.id == EntityMembershipRow.virtual_scope_id,
+                )
+                .where(
+                    VirtualScopeRow.scope_type == USER_SCOPE_TYPE,
+                    VirtualScopeRow.scope_id == user_id,
+                    EntityMembershipRow.entity_type == VFOLDER_ENTITY_TYPE,
+                    EntityMembershipRow.entity_id == vfolder_id,
+                )
+            )
+        ).first()
+    if row is None:
+        return False, None
+    return True, row.permission_cap
 
 
 class TestVFolderOwnershipTransferRBACCleanup:
@@ -321,6 +351,16 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 rate_limit=30000,
             )
             db_sess.add(keypair)
+
+            # Sharing a vfolder enrolls it in the grantee's virtual scope, which the
+            # real user-create path provisions.
+            db_sess.add(
+                VirtualScopeRow(
+                    id=uuid.uuid4(),
+                    scope_type=USER_SCOPE_TYPE,
+                    scope_id=UserID(user_uuid),
+                )
+            )
             await db_sess.flush()
 
         return UserWithKeypair(user_id=user_uuid, email=email)
@@ -370,77 +410,20 @@ class TestVFolderOwnershipTransferRBACCleanup:
             vfolder_id, user_a_id, VFolderMountPermission.OWNER_PERM
         )
 
-        # Verify A's RBAC records exist before transfer
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            mapping_count = await db_sess.scalar(
-                sa.select(sa.func.count()).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_a_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert mapping_count == 1, "Old owner should have scope-entity mapping before transfer"
+        # Verify A holds the vfolder before transfer
+        granted, _ = await _membership_cap(db_with_cleanup, vfolder_id, user_a_id)
+        assert granted, "Old owner should hold the vfolder before transfer"
 
         # Step 2: Transfer ownership to B
         await repo.change_vfolder_ownership(vfolder_id, user_b_email)
 
-        # Step 3: Verify old owner A's RBAC records are cleaned up
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            mapping_count_after = await db_sess.scalar(
-                sa.select(sa.func.count()).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_a_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert mapping_count_after == 0, (
-                "Old owner's scope-entity mapping should be removed after transfer"
-            )
+        # Step 3: the old owner holds nothing, the new one holds it uncapped
+        granted_a, _ = await _membership_cap(db_with_cleanup, vfolder_id, user_a_id)
+        assert not granted_a, "Old owner should hold nothing after transfer"
 
-            perm_count_after = await db_sess.scalar(
-                sa.select(sa.func.count())
-                .select_from(PermissionRow)
-                .where(
-                    sa.and_(
-                        PermissionRow.scope_id == str(vfolder_id),
-                        PermissionRow.entity_type == EntityType.VFOLDER,
-                    )
-                )
-                .join(UserRoleRow, UserRoleRow.role_id == PermissionRow.role_id)
-                .where(UserRoleRow.user_id == user_a_id)
-            )
-            assert perm_count_after == 0, "Old owner's permissions should be removed after transfer"
-
-            # Verify new owner B's RBAC records are created
-            b_mapping_count = await db_sess.scalar(
-                sa.select(sa.func.count()).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_b_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                        AssociationScopesEntitiesRow.relation_type == RelationType.AUTO,
-                    )
-                )
-            )
-            assert b_mapping_count == 1, (
-                "New owner should have AUTO scope-entity mapping after transfer"
-            )
-
-            b_perm_count = await db_sess.scalar(
-                sa.select(sa.func.count())
-                .select_from(PermissionRow)
-                .where(
-                    sa.and_(
-                        PermissionRow.scope_id == str(vfolder_id),
-                        PermissionRow.entity_type == EntityType.VFOLDER,
-                        PermissionRow.operation == OperationType.READ,
-                    )
-                )
-                .join(UserRoleRow, UserRoleRow.role_id == PermissionRow.role_id)
-                .where(UserRoleRow.user_id == user_b_id)
-            )
-            assert b_perm_count == 1, "New owner should have READ permission after transfer"
+        granted_b, cap_b = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert granted_b, "New owner should hold the vfolder after transfer"
+        assert cap_b is None, "An owner's hold carries no cap"
 
     async def test_round_trip_ownership_transfer_cleans_up_rbac(
         self,
@@ -491,50 +474,20 @@ class TestVFolderOwnershipTransferRBACCleanup:
         # Transfer A -> B
         await repo.change_vfolder_ownership(vfolder_id, user_b_email)
 
-        # Verify A's RBAC records are cleaned up after first transfer
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            mapping_count_a = await db_sess.scalar(
-                sa.select(sa.func.count()).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_a_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert mapping_count_a == 0, (
-                "User A's scope-entity mapping should be removed after A -> B transfer"
-            )
+        # Verify A holds nothing after the first transfer
+        granted_a, _ = await _membership_cap(db_with_cleanup, vfolder_id, user_a_id)
+        assert not granted_a, "User A should hold nothing after the A -> B transfer"
 
         # Transfer B -> A (back to original owner)
         await repo.change_vfolder_ownership(vfolder_id, user_a_email)
 
-        # Verify B's RBAC records are cleaned up after second transfer
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            mapping_count_b = await db_sess.scalar(
-                sa.select(sa.func.count()).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_b_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert mapping_count_b == 0, (
-                "User B's scope-entity mapping should be removed after B -> A transfer"
-            )
+        # Verify B holds nothing after the second transfer, and A holds it again
+        granted_b, _ = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert not granted_b, "User B should hold nothing after the B -> A transfer"
 
-        # Verify A now has valid RBAC records as the new owner
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            mapping_count_a_after = await db_sess.scalar(
-                sa.select(sa.func.count()).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_a_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert mapping_count_a_after == 1, (
-                "User A should have scope-entity mapping after ownership returned"
-            )
+        granted_a_after, cap_a_after = await _membership_cap(db_with_cleanup, vfolder_id, user_a_id)
+        assert granted_a_after, "User A should hold the vfolder after ownership returned"
+        assert cap_a_after is None, "An owner's hold carries no cap"
 
     async def test_invitee_rbac_cleaned_up_on_ownership_transfer(
         self,
@@ -589,35 +542,18 @@ class TestVFolderOwnershipTransferRBACCleanup:
             vfolder_id, user_b_id, VFolderMountPermission.READ_ONLY
         )
 
-        # Verify B has RBAC permission before transfer
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            perm_count_b = await db_sess.scalar(
-                sa.select(sa.func.count())
-                .select_from(PermissionRow)
-                .where(PermissionRow.scope_id == str(vfolder_id))
-                .join(UserRoleRow, UserRoleRow.role_id == PermissionRow.role_id)
-                .where(UserRoleRow.user_id == user_b_id)
-            )
-            assert perm_count_b is not None and perm_count_b > 0, (
-                "User B should have RBAC permissions as invitee"
-            )
+        # Verify B holds the vfolder under a cap before transfer
+        granted_b, cap_b = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert granted_b, "User B should hold the vfolder as invitee"
+        assert cap_b is not None, "An invitee's hold is capped"
 
         # Transfer ownership A -> B (B gets owner RBAC via Step 6)
         await repo.change_vfolder_ownership(vfolder_id, user_b_email)
 
-        # Verify B has owner RBAC after becoming owner
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            b_mapping_after = await db_sess.scalar(
-                sa.select(AssociationScopesEntitiesRow.relation_type).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_b_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert b_mapping_after == RelationType.AUTO, (
-                "User B's mapping should be upgraded to AUTO after becoming owner"
-            )
+        # Verify B's hold loses its cap on becoming owner
+        granted_b_after, cap_b_after = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert granted_b_after, "User B should hold the vfolder as owner"
+        assert cap_b_after is None, "The invitee's cap should be gone once B owns it"
 
         # Transfer ownership B -> A
         await repo.change_vfolder_ownership(vfolder_id, user_a_email)
@@ -627,18 +563,10 @@ class TestVFolderOwnershipTransferRBACCleanup:
             vfolder_id, user_b_id, VFolderMountPermission.READ_ONLY
         )
 
-        # Verify B has new RBAC permission
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            perm_count_b_final = await db_sess.scalar(
-                sa.select(sa.func.count())
-                .select_from(PermissionRow)
-                .where(PermissionRow.scope_id == str(vfolder_id))
-                .join(UserRoleRow, UserRoleRow.role_id == PermissionRow.role_id)
-                .where(UserRoleRow.user_id == user_b_id)
-            )
-            assert perm_count_b_final is not None and perm_count_b_final > 0, (
-                "User B should have RBAC permissions after re-accepting invitation"
-            )
+        # Verify B holds it again, capped, after re-accepting
+        granted_b_final, cap_b_final = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert granted_b_final, "User B should hold the vfolder after re-accepting"
+        assert cap_b_final is not None, "An invitee's hold is capped"
 
     async def test_ownership_transfer_grants_new_owner_rbac(
         self,
@@ -690,50 +618,18 @@ class TestVFolderOwnershipTransferRBACCleanup:
             vfolder_id, user_b_id, VFolderMountPermission.READ_ONLY
         )
 
-        # Verify B has REF mapping before transfer
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            b_mapping = await db_sess.scalar(
-                sa.select(AssociationScopesEntitiesRow.relation_type).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_b_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert b_mapping == RelationType.REF, "Invitee should have REF mapping before transfer"
+        # Verify B's hold is capped before transfer
+        granted_b, cap_b = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert granted_b, "Invitee should hold the vfolder before transfer"
+        assert cap_b is not None, "An invitee's hold is capped"
 
         # Transfer ownership to B
         await repo.change_vfolder_ownership(vfolder_id, user_b_email)
 
-        # Verify B's mapping is upgraded to AUTO
-        async with db_with_cleanup.begin_readonly_session() as db_sess:
-            b_mapping_after = await db_sess.scalar(
-                sa.select(AssociationScopesEntitiesRow.relation_type).where(
-                    sa.and_(
-                        AssociationScopesEntitiesRow.scope_id == str(user_b_id),
-                        AssociationScopesEntitiesRow.entity_id == str(vfolder_id),
-                    )
-                )
-            )
-            assert b_mapping_after == RelationType.AUTO, (
-                "New owner's mapping should be upgraded from REF to AUTO"
-            )
-
-            # Verify B has owner-level READ permission
-            b_perm_count = await db_sess.scalar(
-                sa.select(sa.func.count())
-                .select_from(PermissionRow)
-                .where(
-                    sa.and_(
-                        PermissionRow.scope_id == str(vfolder_id),
-                        PermissionRow.entity_type == EntityType.VFOLDER,
-                        PermissionRow.operation == OperationType.READ,
-                    )
-                )
-                .join(UserRoleRow, UserRoleRow.role_id == PermissionRow.role_id)
-                .where(UserRoleRow.user_id == user_b_id)
-            )
-            assert (b_perm_count or 0) >= 1, "New owner should have READ permission after transfer"
+        # Verify B's hold loses its cap on becoming owner
+        granted_b_after, cap_b_after = await _membership_cap(db_with_cleanup, vfolder_id, user_b_id)
+        assert granted_b_after, "New owner should hold the vfolder after transfer"
+        assert cap_b_after is None, "An owner's hold carries no cap"
 
     async def test_ownership_transfer_preserves_invitee_legacy_permission(
         self,

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
@@ -61,6 +61,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderInvitationRow, VFolderPermissionRow, VFolderRow
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
@@ -111,7 +112,9 @@ class TestVFolderOwnershipTransferRBACCleanup:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     @pytest.fixture
     async def test_domain(

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_purgers.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_purgers.py
@@ -238,7 +238,7 @@ class TestVFolderPurgersIntegration:
         # Purge invitations
         async with db_with_cleanup.begin_session() as session:
             purger = VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids)
-            removed = await V2WriteOps(session).batch_purge_in_global(purger)
+            removed = await V2WriteOps(session).batch_purge_field_entities_in_global(purger)
             assert len(removed) == len(sample_invitations)
 
         # Verify invitations are deleted
@@ -262,7 +262,7 @@ class TestVFolderPurgersIntegration:
         # Purge permissions
         async with db_with_cleanup.begin_session() as session:
             purger = VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids)
-            removed = await V2WriteOps(session).batch_purge_in_global(purger)
+            removed = await V2WriteOps(session).batch_purge_field_entities_in_global(purger)
             assert len(removed) == len(sample_permissions)
 
         # Verify permissions are deleted

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_purgers.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_purgers.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.vfolder.types import VFolderMountPermission, VFolderOwnershipType
@@ -20,6 +21,8 @@ from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.image import ImageRow  # noqa: F401
 from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
 from ai.backend.manager.models.resource_group import ResourceGroupRow
 from ai.backend.manager.models.resource_policy import (
     KeyPairResourcePolicyRow,
@@ -35,7 +38,10 @@ from ai.backend.manager.models.vfolder.row import (
     VFolderPermissionRow,
     VFolderRow,
 )
-from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
+from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFactory, DomainFixtureData
 
@@ -63,6 +69,12 @@ class TestVFolderPurgersIntegration:
                 VFolderRow,
                 VFolderInvitationRow,
                 VFolderPermissionRow,
+                # An entity batch purge tears the graph down with each row.
+                VirtualScopeRow,
+                EntityMembershipRow,
+                ScopeBindingRow,
+                RoleRow,
+                PermissionRow,
             ],
         ):
             yield database_connection
@@ -236,9 +248,10 @@ class TestVFolderPurgersIntegration:
         vfolder_ids = [sample_vfolder.id]
 
         # Purge invitations
-        async with db_with_cleanup.begin_session() as session:
-            purger = VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids)
-            removed = await V2WriteOps(session).batch_purge_field_entities_in_global(purger)
+        async with V2DBOpsProvider(db_with_cleanup).write_ops() as w:
+            removed = await w.batch_purge_entities_in_global(
+                VFolderInvitationBatchPurger(vfolder_ids=vfolder_ids)
+            )
             assert len(removed) == len(sample_invitations)
 
         # Verify invitations are deleted
@@ -260,9 +273,10 @@ class TestVFolderPurgersIntegration:
         vfolder_ids = [sample_vfolder.id]
 
         # Purge permissions
-        async with db_with_cleanup.begin_session() as session:
-            purger = VFolderPermissionBatchPurger(vfolder_ids=vfolder_ids)
-            removed = await V2WriteOps(session).batch_purge_field_entities_in_global(purger)
+        async with V2DBOpsProvider(db_with_cleanup).write_ops() as w:
+            removed = await w.batch_purge_field_entities(
+                VFolderUUID(sample_vfolder.id), VFolderPermissionBatchPurger()
+            )
             assert len(removed) == len(sample_permissions)
 
         # Verify permissions are deleted

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -18,6 +18,7 @@ from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.entity.container_registry import ContainerRegistryID
 from ai.backend.common.data.entity.domain import DomainID, DomainName
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.types import (
     BinarySize,
@@ -302,6 +303,17 @@ class TestVfolderRepository:
                 role_id=role_id,
             )
             db_sess.add(user_role)
+            await db_sess.flush()
+
+            # Sharing a vfolder enrolls it in the grantee's virtual scope, which the
+            # real user-create path provisions.
+            db_sess.add(
+                VirtualScopeRow(
+                    id=uuid.uuid4(),
+                    scope_type=USER_SCOPE_TYPE,
+                    scope_id=UserID(user_uuid),
+                )
+            )
             await db_sess.flush()
 
         yield user_uuid

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -103,6 +103,7 @@ from ai.backend.manager.models.virtual_scope.entity_membership import EntityMemb
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base.rbac.entity_purger import RBACEntityPurger
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder.purgers import VFolderPurgerSpec
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
@@ -348,7 +349,9 @@ class TestVfolderRepository:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> AsyncGenerator[VfolderRepository, None]:
         """Create VfolderRepository instance with database"""
-        repo = VfolderRepository(db=db_with_cleanup)
+        repo = VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
         yield repo
 
     async def test_model_store_vfolder_permission_is_overridden_to_read_only(
@@ -547,7 +550,9 @@ class TestVfolderRepositoryAllowedVfolderHosts:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
         """Create VfolderRepository instance."""
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     async def test_get_allowed_vfolder_hosts_returns_vfolder_host_permission_map(
         self,
@@ -776,7 +781,9 @@ class TestVfolderRepositoryPurge:
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
         """Create VfolderRepository instance."""
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     async def _create_vfolder_in_db(
         self,
@@ -1192,7 +1199,9 @@ class TestVfolderRepositoryDeleteForever:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     async def _create_vfolder(
         self,
@@ -1956,7 +1965,9 @@ class TestVFolderRepositoryTrashAndRestore:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     @pytest.fixture
     async def ready_vfolder(

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_search_filter.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_search_filter.py
@@ -35,6 +35,7 @@ from ai.backend.manager.models.vfolder import VFolderPermissionRow, VFolderRow
 from ai.backend.manager.models.vfolder.conditions import VFolderConditions
 from ai.backend.manager.models.vfolder.scopes import UserVFolderOperationScope
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
 
@@ -70,7 +71,9 @@ class TestVfolderSearchFilter:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     @pytest.fixture
     async def cloneable_data(

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_search_in_project.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_search_in_project.py
@@ -34,6 +34,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.models.vfolder.scopes import ProjectVFolderOperationScope
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
 
@@ -68,7 +69,9 @@ class TestVfolderSearchInProject:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     @pytest.fixture
     async def test_data(

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_search_user_vfolders.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_search_user_vfolders.py
@@ -36,6 +36,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderPermissionRow, VFolderRow
 from ai.backend.manager.models.vfolder.scopes import UserVFolderOperationScope
 from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.testutils.db import with_tables
 
@@ -71,7 +72,9 @@ class TestVfolderSearchUserVfolders:
         self,
         db_with_cleanup: ExtendedAsyncSAEngine,
     ) -> VfolderRepository:
-        return VfolderRepository(db=db_with_cleanup)
+        return VfolderRepository(
+            db=db_with_cleanup, v2_ops_provider=V2DBOpsProvider(db_with_cleanup)
+        )
 
     @pytest.fixture
     async def test_data(

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -92,8 +92,8 @@ from ai.backend.manager.models.specs.creator import (
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.specs.purger import (
-    DataBatchPurger,
     EntityPurger,
+    FieldBatchPurger,
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import DataQuerier
@@ -365,7 +365,7 @@ class _PresetBatchUpdater(DataBatchUpdater[RolePresetRow, _PresetData]):
 
 
 @dataclass
-class _PresetBatchPurger(DataBatchPurger[RolePresetRow, _PresetData]):
+class _PresetBatchPurger(FieldBatchPurger[RolePresetRow, _PresetData]):
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[RolePresetRow]]:
         return sa.select(RolePresetRow)
@@ -1112,7 +1112,7 @@ class _BatchPurgeAction(BaseScopeAction, BatchPurgeOpsAction[RolePresetRow, _Pre
     scopes: list[OperationScope] = field(default_factory=list)
 
     @override
-    def to_batch_purger(self) -> DataBatchPurger[RolePresetRow, _PresetData]:
+    def to_batch_purger(self) -> FieldBatchPurger[RolePresetRow, _PresetData]:
         return self.purger
 
     @override
@@ -1237,8 +1237,8 @@ def repository(stored: _PresetData) -> MagicMock:
         "atomic_create_field_entities",
         "batch_update_in_scopes",
         "batch_update_in_global",
-        "batch_purge_in_scopes",
-        "batch_purge_in_global",
+        "batch_purge_field_entities_in_scopes",
+        "batch_purge_field_entities_in_global",
     ):
         setattr(mock, operation, AsyncMock(return_value=[stored]))
     for operation in (
@@ -1587,7 +1587,7 @@ async def test_batch_purge_names_what_it_removed(
     )
 
     assert result.entity_ids() == (stored.id,)
-    repository.batch_purge_in_scopes.assert_awaited_once_with([search_scope], purger)
+    repository.batch_purge_field_entities_in_scopes.assert_awaited_once_with([search_scope], purger)
 
 
 async def test_search_forwards_the_searcher_and_its_scopes(

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -25,9 +25,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.role_preset import (
-    RolePresetID,
-)
+from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import (
     EntityData,
     EntityIdentifier,
@@ -92,8 +90,8 @@ from ai.backend.manager.models.specs.creator import (
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.specs.purger import (
+    EntityBatchPurger,
     EntityPurger,
-    FieldBatchPurger,
     FieldPurger,
 )
 from ai.backend.manager.models.specs.querier import DataQuerier
@@ -365,7 +363,11 @@ class _PresetBatchUpdater(DataBatchUpdater[RolePresetRow, _PresetData]):
 
 
 @dataclass
-class _PresetBatchPurger(FieldBatchPurger[RolePresetRow, _PresetData]):
+class _PresetBatchPurger(EntityBatchPurger[RolePresetRow, _PresetData]):
+    @override
+    def entity_id(self, row: RolePresetRow) -> RolePresetID:
+        return RolePresetID(row.id)
+
     @override
     def build_subquery(self) -> sa.sql.Select[tuple[RolePresetRow]]:
         return sa.select(RolePresetRow)
@@ -1112,7 +1114,7 @@ class _BatchPurgeAction(BaseScopeAction, BatchPurgeOpsAction[RolePresetRow, _Pre
     scopes: list[OperationScope] = field(default_factory=list)
 
     @override
-    def to_batch_purger(self) -> FieldBatchPurger[RolePresetRow, _PresetData]:
+    def to_batch_purger(self) -> EntityBatchPurger[RolePresetRow, _PresetData]:
         return self.purger
 
     @override
@@ -1237,8 +1239,8 @@ def repository(stored: _PresetData) -> MagicMock:
         "atomic_create_field_entities",
         "batch_update_in_scopes",
         "batch_update_in_global",
-        "batch_purge_field_entities_in_scopes",
-        "batch_purge_field_entities_in_global",
+        "batch_purge_entities_in_scopes",
+        "batch_purge_entities_in_global",
     ):
         setattr(mock, operation, AsyncMock(return_value=[stored]))
     for operation in (
@@ -1587,7 +1589,7 @@ async def test_batch_purge_names_what_it_removed(
     )
 
     assert result.entity_ids() == (stored.id,)
-    repository.batch_purge_field_entities_in_scopes.assert_awaited_once_with([search_scope], purger)
+    repository.batch_purge_entities_in_scopes.assert_awaited_once_with([search_scope], purger)
 
 
 async def test_search_forwards_the_searcher_and_its_scopes(


### PR DESCRIPTION
## Summary

- The reconcile transition moves out of the general v2 write ops into
  `repositories/ops/v2/reconciler/`, whose ops extend them and reach their two
  repositories through a provider. A repository handed the general ops no longer
  sees `apply_transitions`.
- `repositories/AGENTS.md` states the ops injection rules and loses the line that
  contradicted them: ops is never constructed, a repository is injected with a
  provider rather than a session or an engine, and a primitive one domain uses gets
  its own ops and provider.
- The call sites follow: nine places built ops or a provider of their own; the ones
  that only ran a spec now take ops from a provider.

Two defects surfaced while applying the rules, and are fixed here:

- A batch purge did not say whether it removed entities or field rows, so an entity
  purged through it left its virtual scope, memberships and permissions behind.
  `EntityBatchPurger` and `FieldBatchPurger` are now unrelated roots, bounded the way
  their kind is bounded — by scope and by owner respectively.
- Sharing a vfolder wrote the legacy granter's tables, which the v2 entity check never
  reads. Every vfolder action is a v2 action, so a shared folder was reachable only
  while RBAC enforcement was off. Sharing, unsharing and ownership transfer now grant
  and revoke through the virtual scope, where the cap clips what the grantee holds.

## Test plan

- [ ] `pants lint` / `pants check` over the branch
- [ ] `pants test` — vfolder, model card, domain, ops and generic-service suites
- [ ] Share a vfolder with another user and confirm they can read it with RBAC
      enforcement enabled
- [ ] Transfer a vfolder's ownership and confirm the old owner loses access

Resolves BA-7459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
