### PR TITLE
feat(BA-5733): record the client IP of logins and audited runs under an admin-set masking policy

### DIFF
--- a/changes/13941.feature.md
+++ b/changes/13941.feature.md
@@ -1,0 +1,1 @@
+Record the client IP of login attempts, session terminations and audited runs, masked per an admin-set policy that can keep the address as observed, truncate it to an IPv4 /24 or IPv6 /48, or record none at all.

--- a/changes/13941.feature.md
+++ b/changes/13941.feature.md
@@ -1,1 +1,1 @@
-Record the client IP of login attempts, session terminations and audited runs, masked per an admin-set policy that can keep the address as observed, truncate it to an IPv4 /24 or IPv6 /48, or record none at all.
+Record the client IP of login attempts, session terminations and audited runs, masked per an admin-set policy that can keep the address as observed, truncate it to a configurable IPv4 and IPv6 prefix, or record none at all.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -3087,6 +3087,12 @@ type ClientIPMaskingPolicy implements Node
   """Masking applied before the address is stored."""
   mode: ClientIPMaskingMode!
 
+  """IPv4 bits 'truncate' keeps; null takes the built-in width of 24."""
+  ipv4Prefix: Int
+
+  """IPv6 bits 'truncate' keeps; null takes the built-in width of 48."""
+  ipv6Prefix: Int
+
   """Timestamp when the policy was first written."""
   createdAt: DateTime!
 
@@ -22578,6 +22584,12 @@ input UpsertClientIPMaskingPolicyInput
 
   """Masking applied before the address is stored."""
   mode: ClientIPMaskingMode!
+
+  """IPv4 bits 'truncate' keeps; null takes the built-in width of 24."""
+  ipv4Prefix: Int = null
+
+  """IPv6 bits 'truncate' keeps; null takes the built-in width of 48."""
+  ipv6Prefix: Int = null
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2017,6 +2017,11 @@ type AuditLogV2 implements Node
   status: AuditLogStatus!
 
   """
+  Added in 26.9.0. IP address of the request that produced this record, masked per the client IP masking policy. Null when the policy records none, or when the address was unavailable or unusable.
+  """
+  clientIp: String
+
+  """
   The user who triggered this audit log entry, resolved from triggered_by UUID.
   """
   user: UserV2
@@ -3053,6 +3058,116 @@ type ClearImages
 {
   ok: Boolean
   msg: String
+}
+
+"""
+Added in 26.9.0. Masking applied before a client IP is stored. 'none' keeps the address as observed, 'truncate' zeroes the host bits — keeping an IPv4 /24 and an IPv6 /48 — and 'drop' records no address at all.
+"""
+enum ClientIPMaskingMode
+  @join__type(graph: STRAWBERRY)
+{
+  NONE @join__enumValue(graph: STRAWBERRY)
+  TRUNCATE @join__enumValue(graph: STRAWBERRY)
+  DROP @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.9.0. The masking one target gets. A target with no policy falls back to the 'default' target, and no default means the address is recorded as observed.
+"""
+type ClientIPMaskingPolicy implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Which recorded client IP is governed."""
+  targetType: ClientIPMaskingTarget!
+
+  """Masking applied before the address is stored."""
+  mode: ClientIPMaskingMode!
+
+  """Timestamp when the policy was first written."""
+  createdAt: DateTime!
+
+  """Timestamp when the policy was last changed."""
+  updatedAt: DateTime!
+}
+
+"""Added in 26.9.0. Paginated list of client IP masking policies."""
+type ClientIPMaskingPolicyConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ClientIPMaskingPolicyEdge!]!
+
+  """Total number of policies matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type ClientIPMaskingPolicyEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ClientIPMaskingPolicy!
+}
+
+"""Added in 26.9.0. Filter for client IP masking policies."""
+input ClientIPMaskingPolicyFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Filter by the governed target."""
+  targetType: ClientIPMaskingTarget = null
+
+  """Filter by masking mode."""
+  mode: ClientIPMaskingMode = null
+}
+
+"""Added in 26.9.0. Order specification for client IP masking policies."""
+input ClientIPMaskingPolicyOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """Field to order by."""
+  field: ClientIPMaskingPolicyOrderField!
+
+  """ASC or DESC."""
+  direction: String! = "ASC"
+}
+
+"""Added in 26.9.0. Order fields for client IP masking policies."""
+enum ClientIPMaskingPolicyOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  TARGET_TYPE @join__enumValue(graph: STRAWBERRY)
+  MODE @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in 26.9.0. Payload carrying the settled client IP masking policy.
+"""
+type ClientIPMaskingPolicyPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The policy the operation left."""
+  policy: ClientIPMaskingPolicy!
+}
+
+"""Added in 26.9.0. Which recorded client IP a masking policy governs."""
+enum ClientIPMaskingTarget
+  @join__type(graph: STRAWBERRY)
+{
+  DEFAULT @join__enumValue(graph: STRAWBERRY)
+  LOGIN_HISTORY @join__enumValue(graph: STRAWBERRY)
+  AUDIT_LOGS @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 26.4.2. Input for cloning a virtual folder."""
@@ -10362,6 +10477,11 @@ type LoginHistoryV2 implements Node
   """Detailed reason for the login failure."""
   failReason: String
 
+  """
+  Added in 26.9.0. IP address of the request that produced this entry, masked per the client IP masking policy. Null when the policy records none, or when the address was unavailable or unusable.
+  """
+  clientIp: String
+
   """Timestamp when the login attempt occurred."""
   createdAt: DateTime!
 
@@ -13192,6 +13312,16 @@ type Mutation
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
   adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.9.0. Set the client IP masking one target gets (superadmin only).
+  """
+  adminUpsertClientIpMaskingPolicy(input: UpsertClientIPMaskingPolicyInput!): ClientIPMaskingPolicyPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.9.0. Drop one target's client IP masking policy so it falls back to the default (superadmin only).
+  """
+  adminPurgeClientIpMaskingPolicy(id: UUID!): ClientIPMaskingPolicyPayload @join__field(graph: STRAWBERRY)
 
   """Added in 26.8.0. Create a retention policy (superadmin only)."""
   adminCreateRetentionPolicy(input: CreateRetentionPolicyInput!): CreateRetentionPolicyPayload @join__field(graph: STRAWBERRY)
@@ -16536,6 +16666,11 @@ type Query
 
   """Added in 26.4.2. Get a single runtime variant by ID."""
   runtimeVariant(id: UUID!): RuntimeVariant @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.9.0. Read the client IP masking set for every target (superadmin only).
+  """
+  adminClientIpMaskingPolicies(filter: ClientIPMaskingPolicyFilter = null, orderBy: [ClientIPMaskingPolicyOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ClientIPMaskingPolicyConnection @join__field(graph: STRAWBERRY)
 
   """Added in 26.8.0. Search retention policies (superadmin only)."""
   adminRetentionPolicies(filter: RetentionPolicyFilter = null, orderBy: [RetentionPolicyOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RetentionPolicyConnection @join__field(graph: STRAWBERRY)
@@ -22430,6 +22565,19 @@ type UpsertAppConfigFragmentsPayload
 
   """Per-item failures, each naming the config name it targeted."""
   failed: [AppConfigFragmentUpsertError!]!
+}
+
+"""
+Added in 26.9.0. Set the masking one target gets, replacing the policy it already has.
+"""
+input UpsertClientIPMaskingPolicyInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Which recorded client IP to govern."""
+  targetType: ClientIPMaskingTarget!
+
+  """Masking applied before the address is stored."""
+  mode: ClientIPMaskingMode!
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -2269,6 +2269,12 @@ type ClientIPMaskingPolicy implements Node {
   """Masking applied before the address is stored."""
   mode: ClientIPMaskingMode!
 
+  """IPv4 bits 'truncate' keeps; null takes the built-in width of 24."""
+  ipv4Prefix: Int
+
+  """IPv6 bits 'truncate' keeps; null takes the built-in width of 48."""
+  ipv6Prefix: Int
+
   """Timestamp when the policy was first written."""
   createdAt: DateTime!
 
@@ -16357,6 +16363,12 @@ input UpsertClientIPMaskingPolicyInput {
 
   """Masking applied before the address is stored."""
   mode: ClientIPMaskingMode!
+
+  """IPv4 bits 'truncate' keeps; null takes the built-in width of 24."""
+  ipv4Prefix: Int = null
+
+  """IPv6 bits 'truncate' keeps; null takes the built-in width of 48."""
+  ipv6Prefix: Int = null
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1465,6 +1465,11 @@ type AuditLogV2 implements Node {
   status: AuditLogStatus!
 
   """
+  Added in 26.9.0. IP address of the request that produced this record, masked per the client IP masking policy. Null when the policy records none, or when the address was unavailable or unusable.
+  """
+  clientIp: String
+
+  """
   The user who triggered this audit log entry, resolved from triggered_by UUID.
   """
   user: UserV2
@@ -2240,6 +2245,97 @@ Added in 25.14.0. Response payload for artifact revision cleanup operations. Con
 type CleanupArtifactRevisionsPayload {
   """Cleaned up artifact revisions."""
   artifactRevisions: ArtifactRevisionConnection!
+}
+
+"""
+Added in 26.9.0. Masking applied before a client IP is stored. 'none' keeps the address as observed, 'truncate' zeroes the host bits — keeping an IPv4 /24 and an IPv6 /48 — and 'drop' records no address at all.
+"""
+enum ClientIPMaskingMode {
+  NONE
+  TRUNCATE
+  DROP
+}
+
+"""
+Added in 26.9.0. The masking one target gets. A target with no policy falls back to the 'default' target, and no default means the address is recorded as observed.
+"""
+type ClientIPMaskingPolicy implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Which recorded client IP is governed."""
+  targetType: ClientIPMaskingTarget!
+
+  """Masking applied before the address is stored."""
+  mode: ClientIPMaskingMode!
+
+  """Timestamp when the policy was first written."""
+  createdAt: DateTime!
+
+  """Timestamp when the policy was last changed."""
+  updatedAt: DateTime!
+}
+
+"""Added in 26.9.0. Paginated list of client IP masking policies."""
+type ClientIPMaskingPolicyConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ClientIPMaskingPolicyEdge!]!
+
+  """Total number of policies matching the query."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type ClientIPMaskingPolicyEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ClientIPMaskingPolicy!
+}
+
+"""Added in 26.9.0. Filter for client IP masking policies."""
+input ClientIPMaskingPolicyFilter {
+  """Filter by the governed target."""
+  targetType: ClientIPMaskingTarget = null
+
+  """Filter by masking mode."""
+  mode: ClientIPMaskingMode = null
+}
+
+"""Added in 26.9.0. Order specification for client IP masking policies."""
+input ClientIPMaskingPolicyOrderBy {
+  """Field to order by."""
+  field: ClientIPMaskingPolicyOrderField!
+
+  """ASC or DESC."""
+  direction: String! = "ASC"
+}
+
+"""Added in 26.9.0. Order fields for client IP masking policies."""
+enum ClientIPMaskingPolicyOrderField {
+  TARGET_TYPE
+  MODE
+  CREATED_AT
+  UPDATED_AT
+}
+
+"""
+Added in 26.9.0. Payload carrying the settled client IP masking policy.
+"""
+type ClientIPMaskingPolicyPayload {
+  """The policy the operation left."""
+  policy: ClientIPMaskingPolicy!
+}
+
+"""Added in 26.9.0. Which recorded client IP a masking policy governs."""
+enum ClientIPMaskingTarget {
+  DEFAULT
+  LOGIN_HISTORY
+  AUDIT_LOGS
 }
 
 """Added in 26.4.2. Input for cloning a virtual folder."""
@@ -7114,6 +7210,11 @@ type LoginHistoryV2 implements Node {
   """Detailed reason for the login failure."""
   failReason: String
 
+  """
+  Added in 26.9.0. IP address of the request that produced this entry, masked per the client IP masking policy. Null when the policy records none, or when the address was unavailable or unusable.
+  """
+  clientIp: String
+
   """Timestamp when the login attempt occurred."""
   createdAt: DateTime!
 
@@ -8921,6 +9022,16 @@ type Mutation {
 
   """Added in 26.4.2. Delete multiple runtime variants (superadmin only)."""
   adminDeleteRuntimeVariants(input: DeleteRuntimeVariantsInput!): DeleteRuntimeVariantsPayload
+
+  """
+  Added in 26.9.0. Set the client IP masking one target gets (superadmin only).
+  """
+  adminUpsertClientIpMaskingPolicy(input: UpsertClientIPMaskingPolicyInput!): ClientIPMaskingPolicyPayload
+
+  """
+  Added in 26.9.0. Drop one target's client IP masking policy so it falls back to the default (superadmin only).
+  """
+  adminPurgeClientIpMaskingPolicy(id: UUID!): ClientIPMaskingPolicyPayload
 
   """Added in 26.8.0. Create a retention policy (superadmin only)."""
   adminCreateRetentionPolicy(input: CreateRetentionPolicyInput!): CreateRetentionPolicyPayload
@@ -11422,6 +11533,11 @@ type Query {
 
   """Added in 26.4.2. Get a single runtime variant by ID."""
   runtimeVariant(id: UUID!): RuntimeVariant
+
+  """
+  Added in 26.9.0. Read the client IP masking set for every target (superadmin only).
+  """
+  adminClientIpMaskingPolicies(filter: ClientIPMaskingPolicyFilter = null, orderBy: [ClientIPMaskingPolicyOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ClientIPMaskingPolicyConnection
 
   """Added in 26.8.0. Search retention policies (superadmin only)."""
   adminRetentionPolicies(filter: RetentionPolicyFilter = null, orderBy: [RetentionPolicyOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RetentionPolicyConnection
@@ -16230,6 +16346,17 @@ type UpsertAppConfigFragmentsPayload {
 
   """Per-item failures, each naming the config name it targeted."""
   failed: [AppConfigFragmentUpsertError!]!
+}
+
+"""
+Added in 26.9.0. Set the masking one target gets, replacing the policy it already has.
+"""
+input UpsertClientIPMaskingPolicyInput {
+  """Which recorded client IP to govern."""
+  targetType: ClientIPMaskingTarget!
+
+  """Masking applied before the address is stored."""
+  mode: ClientIPMaskingMode!
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -12759,6 +12759,225 @@
         "title": "UpdateLoginClientTypeInput",
         "type": "object"
       },
+      "ClientIPMaskingMode": {
+        "enum": [
+          "none",
+          "truncate",
+          "drop"
+        ],
+        "title": "ClientIPMaskingMode",
+        "type": "string"
+      },
+      "ClientIPMaskingPolicyFilter": {
+        "properties": {
+          "target_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ClientIPMaskingTarget"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by the governed target."
+          },
+          "mode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ClientIPMaskingMode"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by masking mode."
+          }
+        },
+        "title": "ClientIPMaskingPolicyFilter",
+        "type": "object"
+      },
+      "ClientIPMaskingPolicyOrder": {
+        "properties": {
+          "field": {
+            "$ref": "#/components/schemas/ClientIPMaskingPolicyOrderField"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/OrderDirection",
+            "default": "ASC"
+          }
+        },
+        "required": [
+          "field"
+        ],
+        "title": "ClientIPMaskingPolicyOrder",
+        "type": "object"
+      },
+      "ClientIPMaskingPolicyOrderField": {
+        "enum": [
+          "target_type",
+          "mode",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "ClientIPMaskingPolicyOrderField",
+        "type": "string"
+      },
+      "ClientIPMaskingTarget": {
+        "description": "Which recorded client IP a policy row governs.\n\n``DEFAULT`` is the fallback the other targets inherit; it is a target value rather\nthan a column so a row exists for each and no row has to be singled out.",
+        "enum": [
+          "default",
+          "login_history",
+          "audit_logs"
+        ],
+        "title": "ClientIPMaskingTarget",
+        "type": "string"
+      },
+      "AdminSearchClientIPMaskingPoliciesInput": {
+        "description": "Read the masking set for every target.",
+        "properties": {
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ClientIPMaskingPolicyFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "order": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ClientIPMaskingPolicyOrder"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Order"
+          },
+          "first": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "First"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "After"
+          },
+          "last": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Last"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Before"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Offset"
+          }
+        },
+        "title": "AdminSearchClientIPMaskingPoliciesInput",
+        "type": "object"
+      },
+      "AdminUpsertClientIPMaskingPolicyInput": {
+        "description": "Set the masking one target gets.",
+        "properties": {
+          "target_type": {
+            "$ref": "#/components/schemas/ClientIPMaskingTarget",
+            "description": "Which recorded client IP to govern"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/ClientIPMaskingMode",
+            "description": "Masking applied before the address is stored"
+          }
+        },
+        "required": [
+          "target_type",
+          "mode"
+        ],
+        "title": "AdminUpsertClientIPMaskingPolicyInput",
+        "type": "object"
+      },
+      "AdminPurgeClientIPMaskingPolicyInput": {
+        "description": "Drop one target's policy so it falls back to the default.",
+        "properties": {
+          "id": {
+            "description": "Policy ID",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "AdminPurgeClientIPMaskingPolicyInput",
+        "type": "object"
+      },
       "LoginAttemptResult": {
         "description": "Result of a login attempt.",
         "enum": [
@@ -46033,6 +46252,93 @@
           }
         ],
         "description": "Delete a login client type (superadmin only).\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/client-ip-masking-policies/search": {
+      "post": {
+        "operationId": "v2/client-ip-masking-policies.admin_search",
+        "tags": [
+          "v2/client-ip-masking-policies"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSearchClientIPMaskingPoliciesInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Read the masking set for every target.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/client-ip-masking-policies/upsert": {
+      "post": {
+        "operationId": "v2/client-ip-masking-policies.admin_upsert",
+        "tags": [
+          "v2/client-ip-masking-policies"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUpsertClientIPMaskingPolicyInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Set the masking one target gets.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/client-ip-masking-policies/purge": {
+      "post": {
+        "operationId": "v2/client-ip-masking-policies.admin_purge",
+        "tags": [
+          "v2/client-ip-masking-policies"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminPurgeClientIPMaskingPolicyInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Drop one target's policy so it falls back to the default.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
       }
     },
     "/v2/login-history/search": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -12953,6 +12953,36 @@
           "mode": {
             "$ref": "#/components/schemas/ClientIPMaskingMode",
             "description": "Masking applied before the address is stored"
+          },
+          "ipv4_prefix": {
+            "anyOf": [
+              {
+                "maximum": 32,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "IPv4 bits 'truncate' keeps; the rest are zeroed. Null takes the built-in width of 24.",
+            "title": "Ipv4 Prefix"
+          },
+          "ipv6_prefix": {
+            "anyOf": [
+              {
+                "maximum": 128,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "IPv6 bits 'truncate' keeps; the rest are zeroed. Null takes the built-in width of 48.",
+            "title": "Ipv6 Prefix"
           }
         },
         "required": [

--- a/src/ai/backend/client/cli/v2/admin/__init__.py
+++ b/src/ai/backend/client/cli/v2/admin/__init__.py
@@ -111,6 +111,14 @@ def container_registry() -> None:
 
 @admin.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.admin.client_ip_masking:client_ip_masking_policy",
+)
+def client_ip_masking_policy() -> None:
+    """Admin client IP masking policy commands."""
+
+
+@admin.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.admin.login_history:login_history",
 )
 def login_history() -> None:

--- a/src/ai/backend/client/cli/v2/admin/client_ip_masking.py
+++ b/src/ai/backend/client/cli/v2/admin/client_ip_masking.py
@@ -109,7 +109,19 @@ def search(
 @client_ip_masking_policy.command()
 @click.argument("target_type", type=click.Choice(_TARGET_TYPES, case_sensitive=False))
 @click.argument("mode", type=click.Choice(_MODES, case_sensitive=False))
-def upsert(target_type: str, mode: str) -> None:
+@click.option(
+    "--ipv4-prefix",
+    default=None,
+    type=click.IntRange(0, 32),
+    help="IPv4 bits 'truncate' keeps; omit to take the built-in width of 24.",
+)
+@click.option(
+    "--ipv6-prefix",
+    default=None,
+    type=click.IntRange(0, 128),
+    help="IPv6 bits 'truncate' keeps; omit to take the built-in width of 48.",
+)
+def upsert(target_type: str, mode: str, ipv4_prefix: int | None, ipv6_prefix: int | None) -> None:
     """Set the masking one target gets (superadmin only)."""
     from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
         AdminUpsertClientIPMaskingPolicyInput,
@@ -126,6 +138,8 @@ def upsert(target_type: str, mode: str) -> None:
                 AdminUpsertClientIPMaskingPolicyInput(
                     target_type=ClientIPMaskingTarget(target_type),
                     mode=ClientIPMaskingMode(mode),
+                    ipv4_prefix=ipv4_prefix,
+                    ipv6_prefix=ipv6_prefix,
                 ),
             )
             print_result(payload)

--- a/src/ai/backend/client/cli/v2/admin/client_ip_masking.py
+++ b/src/ai/backend/client/cli/v2/admin/client_ip_masking.py
@@ -1,0 +1,156 @@
+"""Admin CLI commands for the client IP masking policies."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+_TARGET_TYPES = ["default", "login_history"]
+_MODES = ["none", "truncate", "drop"]
+
+
+@click.group(name="client-ip-masking-policy")
+def client_ip_masking_policy() -> None:
+    """Client IP masking policy admin commands."""
+
+
+@client_ip_masking_policy.command()
+@click.option("--first", default=None, type=int, help="Cursor-based: return first N items.")
+@click.option("--after", default=None, type=str, help="Cursor-based: return items after cursor.")
+@click.option("--last", default=None, type=int, help="Cursor-based: return last N items.")
+@click.option("--before", default=None, type=str, help="Cursor-based: return items before cursor.")
+@click.option("--limit", default=None, type=int, help="Maximum number of results to return.")
+@click.option("--offset", default=None, type=int, help="Number of results to skip.")
+@click.option(
+    "--target-type",
+    type=click.Choice(_TARGET_TYPES, case_sensitive=False),
+    default=None,
+    help="Filter by the governed target.",
+)
+@click.option(
+    "--mode",
+    type=click.Choice(_MODES, case_sensitive=False),
+    default=None,
+    help="Filter by masking mode.",
+)
+@click.option(
+    "--order-by",
+    multiple=True,
+    help=(
+        "Order by field:direction (e.g., target_type:asc). "
+        "Fields: target_type, mode, created_at, updated_at."
+    ),
+)
+def search(
+    first: int | None,
+    after: str | None,
+    last: int | None,
+    before: str | None,
+    limit: int | None,
+    offset: int | None,
+    target_type: str | None,
+    mode: str | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Read the masking set for every target (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+        AdminSearchClientIPMaskingPoliciesInput,
+        ClientIPMaskingPolicyFilter,
+        ClientIPMaskingPolicyOrder,
+    )
+    from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+        ClientIPMaskingMode,
+        ClientIPMaskingPolicyOrderField,
+        ClientIPMaskingTarget,
+    )
+
+    filter_dto: ClientIPMaskingPolicyFilter | None = None
+    if target_type is not None or mode is not None:
+        filter_dto = ClientIPMaskingPolicyFilter(
+            target_type=ClientIPMaskingTarget(target_type) if target_type else None,
+            mode=ClientIPMaskingMode(mode) if mode else None,
+        )
+    orders = (
+        parse_order_options(order_by, ClientIPMaskingPolicyOrderField, ClientIPMaskingPolicyOrder)
+        if order_by
+        else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            payload = await registry.client_ip_masking.admin_search(
+                AdminSearchClientIPMaskingPoliciesInput(
+                    filter=filter_dto,
+                    order=orders,
+                    first=first,
+                    after=after,
+                    last=last,
+                    before=before,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(payload)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@client_ip_masking_policy.command()
+@click.argument("target_type", type=click.Choice(_TARGET_TYPES, case_sensitive=False))
+@click.argument("mode", type=click.Choice(_MODES, case_sensitive=False))
+def upsert(target_type: str, mode: str) -> None:
+    """Set the masking one target gets (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+        AdminUpsertClientIPMaskingPolicyInput,
+    )
+    from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+        ClientIPMaskingMode,
+        ClientIPMaskingTarget,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            payload = await registry.client_ip_masking.admin_upsert(
+                AdminUpsertClientIPMaskingPolicyInput(
+                    target_type=ClientIPMaskingTarget(target_type),
+                    mode=ClientIPMaskingMode(mode),
+                ),
+            )
+            print_result(payload)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@client_ip_masking_policy.command()
+@click.argument("policy_id", type=click.UUID)
+def purge(policy_id: str) -> None:
+    """Drop one target's policy so it falls back to the default (superadmin only)."""
+    from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+        AdminPurgeClientIPMaskingPolicyInput,
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            payload = await registry.client_ip_masking.admin_purge(
+                AdminPurgeClientIPMaskingPolicyInput(id=policy_id),
+            )
+            print_result(payload)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/admin/client_ip_masking.py
+++ b/src/ai/backend/client/cli/v2/admin/client_ip_masking.py
@@ -13,7 +13,7 @@ from ai.backend.client.cli.v2.helpers import (
     print_result,
 )
 
-_TARGET_TYPES = ["default", "login_history"]
+_TARGET_TYPES = ["default", "login_history", "audit_logs"]
 _MODES = ["none", "truncate", "drop"]
 
 

--- a/src/ai/backend/client/v2/domains_v2/client_ip_masking.py
+++ b/src/ai/backend/client/v2/domains_v2/client_ip_masking.py
@@ -1,0 +1,58 @@
+"""V2 SDK client for the client IP masking domain."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    AdminPurgeClientIPMaskingPolicyInput,
+    AdminSearchClientIPMaskingPoliciesInput,
+    AdminUpsertClientIPMaskingPolicyInput,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.response import (
+    AdminSearchClientIPMaskingPoliciesPayload,
+    ClientIPMaskingPolicyPayload,
+)
+
+_PATH: Final = "/v2/client-ip-masking-policies"
+
+
+class V2ClientIPMaskingClient(BaseDomainClient):
+    """SDK client for the client IP masking policies."""
+
+    async def admin_search(
+        self,
+        request: AdminSearchClientIPMaskingPoliciesInput,
+    ) -> AdminSearchClientIPMaskingPoliciesPayload:
+        """Read the masking set for every target."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=AdminSearchClientIPMaskingPoliciesPayload,
+        )
+
+    async def admin_upsert(
+        self,
+        request: AdminUpsertClientIPMaskingPolicyInput,
+    ) -> ClientIPMaskingPolicyPayload:
+        """Set the masking one target gets."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/upsert",
+            request=request,
+            response_model=ClientIPMaskingPolicyPayload,
+        )
+
+    async def admin_purge(
+        self,
+        request: AdminPurgeClientIPMaskingPolicyInput,
+    ) -> ClientIPMaskingPolicyPayload:
+        """Drop one target's policy so it falls back to the default."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/purge",
+            request=request,
+            response_model=ClientIPMaskingPolicyPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from .domains_v2.artifact import V2ArtifactClient
     from .domains_v2.artifact_registry import V2ArtifactRegistryClient
     from .domains_v2.audit_log import V2AuditLogClient
+    from .domains_v2.client_ip_masking import V2ClientIPMaskingClient
     from .domains_v2.container_registry import V2ContainerRegistryClient
     from .domains_v2.deployment import V2DeploymentClient
     from .domains_v2.deployment_revision_preset import V2DeploymentRevisionPresetClient
@@ -213,6 +214,12 @@ class V2ClientRegistry:
         from .domains_v2.login_client_type import V2LoginClientTypeClient
 
         return V2LoginClientTypeClient(self._client)
+
+    @cached_property
+    def client_ip_masking(self) -> V2ClientIPMaskingClient:
+        from .domains_v2.client_ip_masking import V2ClientIPMaskingClient
+
+        return V2ClientIPMaskingClient(self._client)
 
     @cached_property
     def login_history(self) -> V2LoginHistoryClient:

--- a/src/ai/backend/common/data/entity/client_ip_masking.py
+++ b/src/ai/backend/common/data/entity/client_ip_masking.py
@@ -1,0 +1,19 @@
+from typing import override
+
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+
+__all__ = (
+    "CLIENT_IP_MASKING_POLICY_ENTITY_TYPE",
+    "ClientIPMaskingPolicyID",
+)
+
+
+# One policy row per masking target. Named on its own rather than under the record it
+# governs: the same policy answers for login history, login sessions and audit logs.
+CLIENT_IP_MASKING_POLICY_ENTITY_TYPE = EntityType("client_ip_masking_policy")
+
+
+class ClientIPMaskingPolicyID(EntityIdentifier):
+    @override
+    def entity_type(self) -> EntityType:
+        return CLIENT_IP_MASKING_POLICY_ENTITY_TYPE

--- a/src/ai/backend/common/dto/manager/v2/audit_log/response.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/response.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 from .types import AuditLogStatus
 
@@ -39,6 +40,14 @@ class AuditLogNode(BaseResponseModel):
     )
     description: str = Field(description="Human-readable description of the operation")
     duration: str | None = Field(default=None, description="Duration of the operation as a string")
+    client_ip: str | None = Field(
+        default=None,
+        description=(
+            f"Added in {NEXT_RELEASE_VERSION}. IP address of the request that produced this "
+            "record, masked per the client IP masking policy. Null when the policy records "
+            "none, or when the address was unavailable or unusable."
+        ),
+    )
     status: AuditLogStatus = Field(description="Status of the operation")
 
 

--- a/src/ai/backend/common/dto/manager/v2/client_ip_masking/request.py
+++ b/src/ai/backend/common/dto/manager/v2/client_ip_masking/request.py
@@ -50,6 +50,22 @@ class AdminUpsertClientIPMaskingPolicyInput(BaseRequestModel):
 
     target_type: ClientIPMaskingTarget = Field(description="Which recorded client IP to govern")
     mode: ClientIPMaskingMode = Field(description="Masking applied before the address is stored")
+    ipv4_prefix: int | None = Field(
+        default=None,
+        ge=0,
+        le=32,
+        description=(
+            "IPv4 bits 'truncate' keeps; the rest are zeroed. Null takes the built-in width of 24."
+        ),
+    )
+    ipv6_prefix: int | None = Field(
+        default=None,
+        ge=0,
+        le=128,
+        description=(
+            "IPv6 bits 'truncate' keeps; the rest are zeroed. Null takes the built-in width of 48."
+        ),
+    )
 
 
 class AdminPurgeClientIPMaskingPolicyInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/client_ip_masking/request.py
+++ b/src/ai/backend/common/dto/manager/v2/client_ip_masking/request.py
@@ -1,0 +1,58 @@
+"""Request DTOs for the client IP masking DTO v2."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+from .types import ClientIPMaskingMode, ClientIPMaskingPolicyOrderField, ClientIPMaskingTarget
+
+__all__ = (
+    "AdminPurgeClientIPMaskingPolicyInput",
+    "AdminSearchClientIPMaskingPoliciesInput",
+    "AdminUpsertClientIPMaskingPolicyInput",
+    "ClientIPMaskingPolicyFilter",
+    "ClientIPMaskingPolicyOrder",
+)
+
+
+class ClientIPMaskingPolicyFilter(BaseRequestModel):
+    target_type: ClientIPMaskingTarget | None = Field(
+        default=None, description="Filter by the governed target."
+    )
+    mode: ClientIPMaskingMode | None = Field(default=None, description="Filter by masking mode.")
+
+
+class ClientIPMaskingPolicyOrder(BaseRequestModel):
+    field: ClientIPMaskingPolicyOrderField
+    direction: OrderDirection = OrderDirection.ASC
+
+
+class AdminSearchClientIPMaskingPoliciesInput(BaseRequestModel):
+    """Read the masking set for every target."""
+
+    filter: ClientIPMaskingPolicyFilter | None = Field(default=None)
+    order: list[ClientIPMaskingPolicyOrder] | None = Field(default=None)
+    first: int | None = Field(default=None, ge=1)
+    after: str | None = Field(default=None)
+    last: int | None = Field(default=None, ge=1)
+    before: str | None = Field(default=None)
+    limit: int | None = Field(default=None, ge=1)
+    offset: int | None = Field(default=None, ge=0)
+
+
+class AdminUpsertClientIPMaskingPolicyInput(BaseRequestModel):
+    """Set the masking one target gets."""
+
+    target_type: ClientIPMaskingTarget = Field(description="Which recorded client IP to govern")
+    mode: ClientIPMaskingMode = Field(description="Masking applied before the address is stored")
+
+
+class AdminPurgeClientIPMaskingPolicyInput(BaseRequestModel):
+    """Drop one target's policy so it falls back to the default."""
+
+    id: UUID = Field(description="Policy ID")

--- a/src/ai/backend/common/dto/manager/v2/client_ip_masking/response.py
+++ b/src/ai/backend/common/dto/manager/v2/client_ip_masking/response.py
@@ -24,6 +24,12 @@ class ClientIPMaskingPolicyNode(BaseResponseModel):
     id: UUID = Field(description="Policy ID")
     target_type: ClientIPMaskingTarget = Field(description="Which recorded client IP is governed")
     mode: ClientIPMaskingMode = Field(description="Masking applied before the address is stored")
+    ipv4_prefix: int | None = Field(
+        default=None, description="IPv4 bits 'truncate' keeps; null takes the built-in width"
+    )
+    ipv6_prefix: int | None = Field(
+        default=None, description="IPv6 bits 'truncate' keeps; null takes the built-in width"
+    )
     created_at: datetime = Field(description="Timestamp when the policy was first written")
     updated_at: datetime = Field(description="Timestamp when the policy was last changed")
 

--- a/src/ai/backend/common/dto/manager/v2/client_ip_masking/response.py
+++ b/src/ai/backend/common/dto/manager/v2/client_ip_masking/response.py
@@ -1,0 +1,43 @@
+"""Response DTOs for the client IP masking DTO v2."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+
+from .types import ClientIPMaskingMode, ClientIPMaskingTarget
+
+__all__ = (
+    "AdminSearchClientIPMaskingPoliciesPayload",
+    "ClientIPMaskingPolicyNode",
+    "ClientIPMaskingPolicyPayload",
+)
+
+
+class ClientIPMaskingPolicyNode(BaseResponseModel):
+    """Node model representing the masking set for one target."""
+
+    id: UUID = Field(description="Policy ID")
+    target_type: ClientIPMaskingTarget = Field(description="Which recorded client IP is governed")
+    mode: ClientIPMaskingMode = Field(description="Masking applied before the address is stored")
+    created_at: datetime = Field(description="Timestamp when the policy was first written")
+    updated_at: datetime = Field(description="Timestamp when the policy was last changed")
+
+
+class AdminSearchClientIPMaskingPoliciesPayload(BaseResponseModel):
+    """Payload for the client IP masking policies search result (admin)."""
+
+    items: list[ClientIPMaskingPolicyNode] = Field(description="Client IP masking policies")
+    total_count: int = Field(description="Total count")
+    has_next_page: bool = Field(description="Whether a next page exists")
+    has_previous_page: bool = Field(description="Whether a previous page exists")
+
+
+class ClientIPMaskingPolicyPayload(BaseResponseModel):
+    """Payload carrying the settled policy row."""
+
+    policy: ClientIPMaskingPolicyNode = Field(description="The policy the operation left")

--- a/src/ai/backend/common/dto/manager/v2/client_ip_masking/types.py
+++ b/src/ai/backend/common/dto/manager/v2/client_ip_masking/types.py
@@ -1,0 +1,35 @@
+"""Shared enums for the client IP masking DTO v2."""
+
+from __future__ import annotations
+
+import enum
+
+__all__ = (
+    "ClientIPMaskingMode",
+    "ClientIPMaskingPolicyOrderField",
+    "ClientIPMaskingTarget",
+)
+
+
+class ClientIPMaskingTarget(enum.StrEnum):
+    """Which recorded client IP a policy row governs.
+
+    ``DEFAULT`` is the fallback the other targets inherit; it is a target value rather
+    than a column so a row exists for each and no row has to be singled out.
+    """
+
+    DEFAULT = "default"
+    LOGIN_HISTORY = "login_history"
+
+
+class ClientIPMaskingMode(enum.StrEnum):
+    NONE = "none"
+    TRUNCATE = "truncate"
+    DROP = "drop"
+
+
+class ClientIPMaskingPolicyOrderField(enum.StrEnum):
+    TARGET_TYPE = "target_type"
+    MODE = "mode"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"

--- a/src/ai/backend/common/dto/manager/v2/client_ip_masking/types.py
+++ b/src/ai/backend/common/dto/manager/v2/client_ip_masking/types.py
@@ -20,6 +20,7 @@ class ClientIPMaskingTarget(enum.StrEnum):
 
     DEFAULT = "default"
     LOGIN_HISTORY = "login_history"
+    AUDIT_LOGS = "audit_logs"
 
 
 class ClientIPMaskingMode(enum.StrEnum):

--- a/src/ai/backend/common/dto/manager/v2/login_history/response.py
+++ b/src/ai/backend/common/dto/manager/v2/login_history/response.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 from .types import LoginAttemptResult
 
@@ -27,6 +28,14 @@ class LoginHistoryNode(BaseResponseModel):
     result: LoginAttemptResult = Field(description="Result of the login attempt")
     fail_reason: str | None = Field(
         default=None, description="Detailed reason for the login failure"
+    )
+    client_ip: str | None = Field(
+        default=None,
+        description=(
+            f"Added in {NEXT_RELEASE_VERSION}. IP address of the request that produced this "
+            "entry, masked per the client IP masking policy. Null when the policy records "
+            "none, or when the address was unavailable or unusable."
+        ),
     )
     created_at: datetime = Field(description="Timestamp when the login attempt occurred")
 

--- a/src/ai/backend/manager/actions/monitors/audit_log.py
+++ b/src/ai/backend/manager/actions/monitors/audit_log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.common.data.entity.types import EntityType
@@ -12,7 +13,11 @@ from ai.backend.manager.actions.audit_policy import AuditLogPolicy
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.types import BLANK_ID
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import LegacyAuditLogCreator
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -21,14 +26,24 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 class AuditLogMonitor(ActionMonitor):
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     async def _generate_log(self, action: BaseAction, result: ProcessResult) -> None:
         trigger = triggered_user()
         acting = current_user()
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         creator = LegacyAuditLogCreator(
             action_id=result.meta.action_id,
             operation=action.operation_type(),
@@ -42,6 +57,7 @@ class AuditLogMonitor(ActionMonitor):
             triggered_by=str(trigger.user_id) if trigger else None,
             acted_as=acting.user_id if acting else None,
             duration=result.meta.duration,
+            client_ip=client_ip,
         )
         await self._repository.create_dangling_field(EntityType(action.entity_type()), creator)
 

--- a/src/ai/backend/manager/actions/v2/bulk/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/bulk/monitor/audit_log.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.manager.actions.audit_policy import AuditLogPolicy
@@ -10,8 +11,12 @@ from ai.backend.manager.actions.v2.bulk.monitor.base import BulkActionMonitor
 from ai.backend.manager.actions.v2.bulk.result import BulkActionProcessResult
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import BulkAuditLogCreator
 from ai.backend.manager.models.specs.creator import FieldToCreate
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 __all__ = ("BulkActionAuditLogMonitor",)
@@ -28,10 +33,17 @@ class BulkActionAuditLogMonitor(BulkActionMonitor):
 
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     @override
     async def prepare(self, meta: BulkActionTriggerMeta) -> None:
@@ -41,6 +53,9 @@ class BulkActionAuditLogMonitor(BulkActionMonitor):
     async def done(self, meta: BulkActionTriggerMeta, result: BulkActionProcessResult) -> None:
         trigger = triggered_user()
         acting = current_user()
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         request_id = current_request_id() or BLANK_ID
         creations = [
             FieldToCreate(
@@ -56,6 +71,7 @@ class BulkActionAuditLogMonitor(BulkActionMonitor):
                     triggered_by=str(trigger.user_id) if trigger else None,
                     acted_as=acting.user_id if acting else None,
                     duration=result.meta.duration,
+                    client_ip=client_ip,
                 ),
             )
             for entity_result in result.meta.entity_results

--- a/src/ai/backend/manager/actions/v2/global_scope/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/global_scope/monitor/audit_log.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE
@@ -12,7 +13,11 @@ from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.global_scope.monitor.base import GlobalActionMonitor
 from ai.backend.manager.actions.v2.global_scope.result import GlobalActionProcessResult
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import GlobalAuditLogCreator
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 __all__ = ("GlobalActionAuditLogMonitor",)
@@ -27,10 +32,17 @@ class GlobalActionAuditLogMonitor(GlobalActionMonitor):
 
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     @override
     async def prepare(self, action: BaseGlobalAction, meta: BaseActionTriggerMeta) -> None:
@@ -43,6 +55,9 @@ class GlobalActionAuditLogMonitor(GlobalActionMonitor):
             return
         trigger = triggered_user()
         acting = current_user()
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         creator = GlobalAuditLogCreator(
             action_id=meta.action_id,
             operation=action.operation_type(),
@@ -54,5 +69,6 @@ class GlobalActionAuditLogMonitor(GlobalActionMonitor):
             triggered_by=str(trigger.user_id) if trigger else None,
             acted_as=acting.user_id if acting else None,
             duration=meta.duration,
+            client_ip=client_ip,
         )
         await self._repository.create_dangling_field(GLOBAL_ENTITY_TYPE, creator)

--- a/src/ai/backend/manager/actions/v2/lookup/bulk_monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/lookup/bulk_monitor/audit_log.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.common.data.entity.types import EntityIdentifier
@@ -12,12 +13,16 @@ from ai.backend.manager.actions.v2.lookup.bulk_monitor.base import BulkLookupAct
 from ai.backend.manager.actions.v2.lookup.bulk_result import BulkLookupActionProcessResult
 from ai.backend.manager.actions.v2.lookup.bulk_trigger import BulkLookupActionTriggerMeta
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import (
     LookupAuditLogCreator,
     MissedLookupAuditLogCreator,
 )
 from ai.backend.manager.models.audit_log.row import AuditLogRow
 from ai.backend.manager.models.specs.creator import FieldToCreate
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 __all__ = ("BulkLookupActionAuditLogMonitor",)
@@ -33,10 +38,17 @@ class BulkLookupActionAuditLogMonitor(BulkLookupActionMonitor):
 
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     @override
     async def prepare(self, meta: BulkLookupActionTriggerMeta) -> None:
@@ -48,6 +60,9 @@ class BulkLookupActionAuditLogMonitor(BulkLookupActionMonitor):
     ) -> None:
         trigger = triggered_user()
         acting = current_user()
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         request_id = current_request_id() or BLANK_ID
         resolved: list[FieldToCreate[EntityIdentifier, AuditLogRow, AuditLogData]] = []
         missed: list[MissedLookupAuditLogCreator] = []
@@ -70,6 +85,7 @@ class BulkLookupActionAuditLogMonitor(BulkLookupActionMonitor):
                         triggered_by=str(trigger.user_id) if trigger else None,
                         acted_as=acting.user_id if acting else None,
                         duration=result.meta.duration,
+                        client_ip=client_ip,
                     )
                 )
                 continue
@@ -89,6 +105,7 @@ class BulkLookupActionAuditLogMonitor(BulkLookupActionMonitor):
                         triggered_by=str(trigger.user_id) if trigger else None,
                         acted_as=acting.user_id if acting else None,
                         duration=result.meta.duration,
+                        client_ip=client_ip,
                     ),
                 )
             )

--- a/src/ai/backend/manager/actions/v2/lookup/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/lookup/monitor/audit_log.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
@@ -11,9 +12,13 @@ from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction, LookupKe
 from ai.backend.manager.actions.v2.lookup.monitor.base import LookupActionMonitor
 from ai.backend.manager.actions.v2.lookup.result import LookupActionProcessResult
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import (
     LookupAuditLogCreator,
     MissedLookupAuditLogCreator,
+)
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
 )
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
@@ -34,10 +39,17 @@ class LookupActionAuditLogMonitor(LookupActionMonitor):
 
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     @override
     async def prepare(self, action: BaseLookupAction, meta: BaseActionTriggerMeta) -> None:
@@ -51,6 +63,9 @@ class LookupActionAuditLogMonitor(LookupActionMonitor):
         key = action.lookup_key()
         trigger = triggered_user()
         acting = current_user()
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         if meta.entity_id is None:
             # The key named nothing, so only the key itself identifies the row.
             await self._repository.create_dangling_field(
@@ -68,6 +83,7 @@ class LookupActionAuditLogMonitor(LookupActionMonitor):
                     triggered_by=str(trigger.user_id) if trigger else None,
                     acted_as=acting.user_id if acting else None,
                     duration=meta.duration,
+                    client_ip=client_ip,
                 ),
             )
             return
@@ -86,6 +102,7 @@ class LookupActionAuditLogMonitor(LookupActionMonitor):
                 triggered_by=str(trigger.user_id) if trigger else None,
                 acted_as=acting.user_id if acting else None,
                 duration=meta.duration,
+                client_ip=client_ip,
             ),
         )
 

--- a/src/ai/backend/manager/actions/v2/scope/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/scope/monitor/audit_log.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
@@ -11,12 +12,16 @@ from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.monitor.base import ScopeActionMonitor
 from ai.backend.manager.actions.v2.scope.result import ScopeActionProcessResult
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import (
     AuditLogScopeCreator,
     EmptyScopeAuditLogCreator,
     ScopeAuditLogCreator,
 )
 from ai.backend.manager.models.specs.creator import FieldToCreate
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
 __all__ = ("ScopeActionAuditLogMonitor",)
@@ -32,10 +37,17 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
 
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     @override
     async def prepare(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
@@ -50,10 +62,16 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
             AuditLogScopeCreator(scope_type=str(s.scope_type), scope_id=s.scope_id)
             for s in meta.scope_targets
         ]
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         if meta.entity_ids:
             await self._repository.atomic_create_fields_with_nested(
                 [
-                    FieldToCreate(owner_id=entity_id, creator=self._build_spec(action, result))
+                    FieldToCreate(
+                        owner_id=entity_id,
+                        creator=self._build_spec(action, result, client_ip),
+                    )
                     for entity_id in meta.entity_ids
                 ],
                 nested,
@@ -62,21 +80,32 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
         # Nothing was touched, but the run still has to leave a trace.
         await self._repository.atomic_create_dangling_fields_with_nested(
             action.entity_type(),
-            [self._build_empty_spec(action, result)],
+            [self._build_empty_spec(action, result, client_ip)],
             nested,
         )
 
     def _build_spec(
-        self, action: BaseScopeAction, result: ScopeActionProcessResult
+        self,
+        action: BaseScopeAction,
+        result: ScopeActionProcessResult,
+        client_ip: str | None,
     ) -> ScopeAuditLogCreator:
-        return ScopeAuditLogCreator(**self._fields(action, result))
+        return ScopeAuditLogCreator(**self._fields(action, result, client_ip))
 
     def _build_empty_spec(
-        self, action: BaseScopeAction, result: ScopeActionProcessResult
+        self,
+        action: BaseScopeAction,
+        result: ScopeActionProcessResult,
+        client_ip: str | None,
     ) -> EmptyScopeAuditLogCreator:
-        return EmptyScopeAuditLogCreator(**self._fields(action, result))
+        return EmptyScopeAuditLogCreator(**self._fields(action, result, client_ip))
 
-    def _fields(self, action: BaseScopeAction, result: ScopeActionProcessResult) -> dict[str, Any]:
+    def _fields(
+        self,
+        action: BaseScopeAction,
+        result: ScopeActionProcessResult,
+        client_ip: str | None,
+    ) -> dict[str, Any]:
         trigger = triggered_user()
         acting = current_user()
         meta = result.meta
@@ -91,4 +120,5 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
             "triggered_by": str(trigger.user_id) if trigger else None,
             "acted_as": acting.user_id if acting else None,
             "duration": meta.duration,
+            "client_ip": client_ip,
         }

--- a/src/ai/backend/manager/actions/v2/single_entity/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/single_entity/monitor/audit_log.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import override
 
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
 from ai.backend.manager.actions.audit_policy import AuditLogPolicy
@@ -12,8 +13,12 @@ from ai.backend.manager.actions.v2.single_entity.trigger import (
     SingleEntityActionTriggerMeta,
 )
 from ai.backend.manager.data.audit_log.types import AuditLogData
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.models.audit_log.creators import (
     SingleEntityAuditLogCreator,
+)
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
 )
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
@@ -29,10 +34,17 @@ class SingleEntityActionAuditLogMonitor(SingleEntityActionMonitor):
 
     _repository: OpsRepository[AuditLogData]
     _policy: AuditLogPolicy
+    _client_ip_masking: ClientIPMaskingRepository
 
-    def __init__(self, repository: OpsRepository[AuditLogData], policy: AuditLogPolicy) -> None:
+    def __init__(
+        self,
+        repository: OpsRepository[AuditLogData],
+        policy: AuditLogPolicy,
+        client_ip_masking: ClientIPMaskingRepository,
+    ) -> None:
         self._repository = repository
         self._policy = policy
+        self._client_ip_masking = client_ip_masking
 
     @override
     async def prepare(self, meta: SingleEntityActionTriggerMeta) -> None:
@@ -46,6 +58,9 @@ class SingleEntityActionAuditLogMonitor(SingleEntityActionMonitor):
             return
         trigger = triggered_user()
         acting = current_user()
+        client_ip = await self._client_ip_masking.mask(
+            ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
+        )
         creator = SingleEntityAuditLogCreator(
             action_id=meta.action_id,
             operation=meta.operation_type,
@@ -57,5 +72,6 @@ class SingleEntityActionAuditLogMonitor(SingleEntityActionMonitor):
             triggered_by=str(trigger.user_id) if trigger else None,
             acted_as=acting.user_id if acting else None,
             duration=result.meta.duration,
+            client_ip=client_ip,
         )
         await self._repository.create_field(meta.entity, creator)

--- a/src/ai/backend/manager/api/adapters/audit_log/adapter.py
+++ b/src/ai/backend/manager/api/adapters/audit_log/adapter.py
@@ -259,5 +259,6 @@ class AuditLogAdapter(BaseAdapter):
             acted_as=data.acted_as,
             description=data.description,
             duration=str(data.duration) if data.duration is not None else None,
+            client_ip=data.client_ip,
             status=AuditLogStatus(data.status.value),
         )

--- a/src/ai/backend/manager/api/adapters/client_ip_masking/adapter.py
+++ b/src/ai/backend/manager/api/adapters/client_ip_masking/adapter.py
@@ -1,0 +1,143 @@
+"""Client IP masking adapter bridging DTOs and Processors."""
+
+from __future__ import annotations
+
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    AdminSearchClientIPMaskingPoliciesInput,
+    AdminUpsertClientIPMaskingPolicyInput,
+    ClientIPMaskingPolicyFilter,
+    ClientIPMaskingPolicyOrder,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.response import (
+    AdminSearchClientIPMaskingPoliciesPayload,
+    ClientIPMaskingPolicyNode,
+    ClientIPMaskingPolicyPayload,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+    ClientIPMaskingMode as ClientIPMaskingModeDTO,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+    ClientIPMaskingPolicyOrderField,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+    ClientIPMaskingTarget as ClientIPMaskingTargetDTO,
+)
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.api.adapters.base import BaseAdapter
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
+from ai.backend.manager.models.client_ip_masking.conditions import ClientIPMaskingPolicyConditions
+from ai.backend.manager.models.client_ip_masking.orders import ClientIPMaskingPolicyOrders
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.client_ip_masking.searchers import ClientIPMaskingPolicySearcher
+from ai.backend.manager.services.client_ip_masking.actions.purge import (
+    PurgeClientIPMaskingPolicyAction,
+)
+from ai.backend.manager.services.client_ip_masking.actions.search import (
+    SearchClientIPMaskingPoliciesAction,
+)
+from ai.backend.manager.services.client_ip_masking.actions.upsert import (
+    UpsertClientIPMaskingPolicyAction,
+)
+
+
+def _pagination_spec() -> PaginationSpec:
+    return PaginationSpec(
+        forward_order=ClientIPMaskingPolicyOrders.target_type(ascending=True),
+        backward_order=ClientIPMaskingPolicyOrders.target_type(ascending=False),
+        forward_condition_factory=ClientIPMaskingPolicyConditions.by_cursor_forward,
+        backward_condition_factory=ClientIPMaskingPolicyConditions.by_cursor_backward,
+        tiebreaker_order=ClientIPMaskingPolicyRow.id.asc(),
+    )
+
+
+class ClientIPMaskingAdapter(BaseAdapter):
+    """Adapter for the client IP masking policies."""
+
+    async def admin_search(
+        self, input: AdminSearchClientIPMaskingPoliciesInput
+    ) -> AdminSearchClientIPMaskingPoliciesPayload:
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        searcher = self._build_searcher(
+            ClientIPMaskingPolicySearcher,
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        result = await self._processors.client_ip_masking.global_search.run(
+            SearchClientIPMaskingPoliciesAction(searcher=searcher)
+        )
+        return AdminSearchClientIPMaskingPoliciesPayload(
+            items=[self._data_to_node(item) for item in result.items],
+            total_count=result.total_count,
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+        )
+
+    async def admin_upsert(
+        self, input: AdminUpsertClientIPMaskingPolicyInput
+    ) -> ClientIPMaskingPolicyPayload:
+        result = await self._processors.client_ip_masking.global_upsert.run(
+            UpsertClientIPMaskingPolicyAction(
+                target_type=ClientIPMaskingTarget(input.target_type.value),
+                mode=ClientIPMaskingMode(input.mode.value),
+            )
+        )
+        return ClientIPMaskingPolicyPayload(policy=self._data_to_node(result.data))
+
+    async def admin_purge(self, policy_id: ClientIPMaskingPolicyID) -> ClientIPMaskingPolicyPayload:
+        result = await self._processors.client_ip_masking.purge.run(
+            PurgeClientIPMaskingPolicyAction(id=policy_id)
+        )
+        return ClientIPMaskingPolicyPayload(policy=self._data_to_node(result.data))
+
+    @staticmethod
+    def _convert_filter(f: ClientIPMaskingPolicyFilter) -> list[QueryCondition]:
+        conditions: list[QueryCondition] = []
+        if f.target_type is not None:
+            conditions.append(
+                ClientIPMaskingPolicyConditions.by_target_type(
+                    ClientIPMaskingTarget(f.target_type.value)
+                )
+            )
+        if f.mode is not None:
+            conditions.append(
+                ClientIPMaskingPolicyConditions.by_mode(ClientIPMaskingMode(f.mode.value))
+            )
+        return conditions
+
+    @staticmethod
+    def _convert_orders(orders: list[ClientIPMaskingPolicyOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for o in orders:
+            ascending = o.direction == OrderDirection.ASC
+            match o.field:
+                case ClientIPMaskingPolicyOrderField.TARGET_TYPE:
+                    result.append(ClientIPMaskingPolicyOrders.target_type(ascending))
+                case ClientIPMaskingPolicyOrderField.MODE:
+                    result.append(ClientIPMaskingPolicyOrders.mode(ascending))
+                case ClientIPMaskingPolicyOrderField.CREATED_AT:
+                    result.append(ClientIPMaskingPolicyOrders.created_at(ascending))
+                case ClientIPMaskingPolicyOrderField.UPDATED_AT:
+                    result.append(ClientIPMaskingPolicyOrders.updated_at(ascending))
+        return result
+
+    @staticmethod
+    def _data_to_node(data: ClientIPMaskingPolicyData) -> ClientIPMaskingPolicyNode:
+        return ClientIPMaskingPolicyNode(
+            id=data.id,
+            target_type=ClientIPMaskingTargetDTO(data.target_type.value),
+            mode=ClientIPMaskingModeDTO(data.mode.value),
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )

--- a/src/ai/backend/manager/api/adapters/client_ip_masking/adapter.py
+++ b/src/ai/backend/manager/api/adapters/client_ip_masking/adapter.py
@@ -91,6 +91,8 @@ class ClientIPMaskingAdapter(BaseAdapter):
             UpsertClientIPMaskingPolicyAction(
                 target_type=ClientIPMaskingTarget(input.target_type.value),
                 mode=ClientIPMaskingMode(input.mode.value),
+                ipv4_prefix=input.ipv4_prefix,
+                ipv6_prefix=input.ipv6_prefix,
             )
         )
         return ClientIPMaskingPolicyPayload(policy=self._data_to_node(result.data))
@@ -138,6 +140,8 @@ class ClientIPMaskingAdapter(BaseAdapter):
             id=data.id,
             target_type=ClientIPMaskingTargetDTO(data.target_type.value),
             mode=ClientIPMaskingModeDTO(data.mode.value),
+            ipv4_prefix=data.ipv4_prefix,
+            ipv6_prefix=data.ipv6_prefix,
             created_at=data.created_at,
             updated_at=data.updated_at,
         )

--- a/src/ai/backend/manager/api/adapters/login_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_history/adapter.py
@@ -180,5 +180,6 @@ class LoginHistoryAdapter(BaseAdapter):
             domain_name=data.domain_name,
             result=LoginAttemptResult(data.result.value),
             fail_reason=data.fail_reason,
+            client_ip=data.client_ip,
             created_at=data.created_at,
         )

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -18,6 +18,7 @@ from ai.backend.manager.api.adapters.app_config_fragment.adapter import (
 from ai.backend.manager.api.adapters.artifact.adapter import ArtifactAdapter
 from ai.backend.manager.api.adapters.artifact_registry.adapter import ArtifactRegistryAdapter
 from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
+from ai.backend.manager.api.adapters.client_ip_masking.adapter import ClientIPMaskingAdapter
 from ai.backend.manager.api.adapters.container_registry.adapter import ContainerRegistryAdapter
 from ai.backend.manager.api.adapters.deployment.adapter import DeploymentAdapter
 from ai.backend.manager.api.adapters.deployment_revision_preset.adapter import (
@@ -103,6 +104,7 @@ class Adapters:
         idle_checker_assignment: IdleCheckerAssignmentAdapter,
         image: ImageAdapter,
         login_client_type: LoginClientTypeAdapter,
+        client_ip_masking: ClientIPMaskingAdapter,
         login_history: LoginHistoryAdapter,
         login_session: LoginSessionAdapter,
         notification: NotificationAdapter,
@@ -151,6 +153,7 @@ class Adapters:
         self.idle_checker_assignment = idle_checker_assignment
         self.image = image
         self.login_client_type = login_client_type
+        self.client_ip_masking = client_ip_masking
         self.login_history = login_history
         self.login_session = login_session
         self.notification = notification
@@ -218,6 +221,7 @@ class Adapters:
             idle_checker_assignment=IdleCheckerAssignmentAdapter(processors),
             image=ImageAdapter(processors),
             login_client_type=LoginClientTypeAdapter(processors),
+            client_ip_masking=ClientIPMaskingAdapter(processors),
             login_history=LoginHistoryAdapter(processors),
             login_session=LoginSessionAdapter(processors),
             notification=NotificationAdapter(processors),

--- a/src/ai/backend/manager/api/gql/audit_log/types/node.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/node.py
@@ -13,6 +13,7 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.audit_log.response import AuditLogNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_added_field,
@@ -74,6 +75,16 @@ class AuditLogV2GQL(PydanticNodeMixin[AuditLogNode]):
         description="Duration of the operation as a string representation."
     )
     status: AuditLogStatusGQL = gql_field(description="Status of the operation.")
+    client_ip: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "IP address of the request that produced this record, masked per the client "
+                "IP masking policy. Null when the policy records none, or when the address "
+                "was unavailable or unusable."
+            ),
+        )
+    )
 
     @gql_field(
         description="The user who triggered this audit log entry, resolved from triggered_by UUID."

--- a/src/ai/backend/manager/api/gql/client_ip_masking/__init__.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/__init__.py
@@ -1,0 +1,11 @@
+from .resolver import (
+    admin_client_ip_masking_policies,
+    admin_purge_client_ip_masking_policy,
+    admin_upsert_client_ip_masking_policy,
+)
+
+__all__ = (
+    "admin_client_ip_masking_policies",
+    "admin_purge_client_ip_masking_policy",
+    "admin_upsert_client_ip_masking_policy",
+)

--- a/src/ai/backend/manager/api/gql/client_ip_masking/resolver.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/resolver.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from strawberry import Info
+from strawberry.relay import PageInfo
+
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    AdminSearchClientIPMaskingPoliciesInput,
+    ClientIPMaskingPolicyOrder,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+    ClientIPMaskingPolicyOrderField,
+)
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.client_ip_masking.types import (
+    ClientIPMaskingPolicyConnectionGQL,
+    ClientIPMaskingPolicyEdgeGQL,
+    ClientIPMaskingPolicyFilterGQL,
+    ClientIPMaskingPolicyGQL,
+    ClientIPMaskingPolicyOrderByGQL,
+    ClientIPMaskingPolicyPayloadGQL,
+    UpsertClientIPMaskingPolicyInputGQL,
+)
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+from ai.backend.manager.api.gql.utils import check_admin_only
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Read the client IP masking set for every target (superadmin only).",
+    )
+)  # type: ignore[misc]
+async def admin_client_ip_masking_policies(
+    info: Info[StrawberryGQLContext],
+    filter: ClientIPMaskingPolicyFilterGQL | None = None,
+    order_by: list[ClientIPMaskingPolicyOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> ClientIPMaskingPolicyConnectionGQL | None:
+    check_admin_only()
+    orders: list[ClientIPMaskingPolicyOrder] | None = None
+    if order_by:
+        orders = [
+            ClientIPMaskingPolicyOrder(
+                field=ClientIPMaskingPolicyOrderField(o.field.value),
+                direction=OrderDirection(o.direction),
+            )
+            for o in order_by
+        ]
+    payload = await info.context.adapters.client_ip_masking.admin_search(
+        AdminSearchClientIPMaskingPoliciesInput(
+            filter=filter.to_pydantic() if filter else None,
+            order=orders,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    nodes = [ClientIPMaskingPolicyGQL.from_pydantic(item) for item in payload.items]
+    edges = [
+        ClientIPMaskingPolicyEdgeGQL(node=node, cursor=encode_cursor(node.id)) for node in nodes
+    ]
+    return ClientIPMaskingPolicyConnectionGQL(
+        edges=edges,
+        page_info=PageInfo(
+            has_next_page=payload.has_next_page,
+            has_previous_page=payload.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=payload.total_count,
+    )
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Set the client IP masking one target gets (superadmin only).",
+    )
+)
+async def admin_upsert_client_ip_masking_policy(
+    info: Info[StrawberryGQLContext],
+    input: UpsertClientIPMaskingPolicyInputGQL,
+) -> ClientIPMaskingPolicyPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.client_ip_masking.admin_upsert(input.to_pydantic())
+    return ClientIPMaskingPolicyPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Drop one target's client IP masking policy so it falls back to the "
+            "default (superadmin only)."
+        ),
+    )
+)
+async def admin_purge_client_ip_masking_policy(
+    info: Info[StrawberryGQLContext],
+    id: UUID,
+) -> ClientIPMaskingPolicyPayloadGQL | None:
+    check_admin_only()
+    payload = await info.context.adapters.client_ip_masking.admin_purge(ClientIPMaskingPolicyID(id))
+    return ClientIPMaskingPolicyPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/client_ip_masking/types.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/types.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    AdminUpsertClientIPMaskingPolicyInput as UpsertInputDTO,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    ClientIPMaskingPolicyFilter as FilterDTO,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    ClientIPMaskingPolicyOrder as OrderDTO,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.response import (
+    ClientIPMaskingPolicyNode as NodeDTO,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.response import (
+    ClientIPMaskingPolicyPayload as PolicyPayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    PydanticInputMixin,
+    gql_connection_type,
+    gql_enum,
+    gql_field,
+    gql_node_type,
+    gql_pydantic_input,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Which recorded client IP a masking policy governs.",
+    ),
+    name="ClientIPMaskingTarget",
+)
+class ClientIPMaskingTargetGQL(StrEnum):
+    DEFAULT = "default"
+    LOGIN_HISTORY = "login_history"
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "Masking applied before a client IP is stored. 'none' keeps the address as "
+            "observed, 'truncate' zeroes the host bits — keeping an IPv4 /24 and an "
+            "IPv6 /48 — and 'drop' records no address at all."
+        ),
+    ),
+    name="ClientIPMaskingMode",
+)
+class ClientIPMaskingModeGQL(StrEnum):
+    NONE = "none"
+    TRUNCATE = "truncate"
+    DROP = "drop"
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Order fields for client IP masking policies.",
+    ),
+    name="ClientIPMaskingPolicyOrderField",
+)
+class ClientIPMaskingPolicyOrderFieldGQL(StrEnum):
+    TARGET_TYPE = "target_type"
+    MODE = "mode"
+    CREATED_AT = "created_at"
+    UPDATED_AT = "updated_at"
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description=(
+            "The masking one target gets. A target with no policy falls back to the "
+            "'default' target, and no default means the address is recorded as observed."
+        ),
+    ),
+    name="ClientIPMaskingPolicy",
+)
+class ClientIPMaskingPolicyGQL(PydanticNodeMixin[NodeDTO]):
+    id: NodeID[str] = gql_field(description="Relay-style global node identifier.")
+    target_type: ClientIPMaskingTargetGQL = gql_field(
+        description="Which recorded client IP is governed."
+    )
+    mode: ClientIPMaskingModeGQL = gql_field(
+        description="Masking applied before the address is stored."
+    )
+    created_at: datetime = gql_field(description="Timestamp when the policy was first written.")
+    updated_at: datetime = gql_field(description="Timestamp when the policy was last changed.")
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Set the masking one target gets, replacing the policy it already has.",
+    ),
+    name="UpsertClientIPMaskingPolicyInput",
+)
+class UpsertClientIPMaskingPolicyInputGQL(PydanticInputMixin[UpsertInputDTO]):
+    target_type: ClientIPMaskingTargetGQL = gql_field(
+        description="Which recorded client IP to govern."
+    )
+    mode: ClientIPMaskingModeGQL = gql_field(
+        description="Masking applied before the address is stored."
+    )
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Payload carrying the settled client IP masking policy.",
+    ),
+    model=PolicyPayloadDTO,
+    name="ClientIPMaskingPolicyPayload",
+)
+class ClientIPMaskingPolicyPayloadGQL(PydanticOutputMixin[PolicyPayloadDTO]):
+    policy: ClientIPMaskingPolicyGQL = gql_field(description="The policy the operation left.")
+
+
+ClientIPMaskingPolicyEdgeGQL = Edge[ClientIPMaskingPolicyGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Paginated list of client IP masking policies.",
+    ),
+    name="ClientIPMaskingPolicyConnection",
+)
+class ClientIPMaskingPolicyConnectionGQL(Connection[ClientIPMaskingPolicyGQL]):
+    count: int = gql_field(description="Total number of policies matching the query.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Filter for client IP masking policies.",
+    ),
+    name="ClientIPMaskingPolicyFilter",
+)
+class ClientIPMaskingPolicyFilterGQL(PydanticInputMixin[FilterDTO]):
+    target_type: ClientIPMaskingTargetGQL | None = gql_field(
+        default=None, description="Filter by the governed target."
+    )
+    mode: ClientIPMaskingModeGQL | None = gql_field(
+        default=None, description="Filter by masking mode."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Order specification for client IP masking policies.",
+    ),
+    name="ClientIPMaskingPolicyOrderBy",
+)
+class ClientIPMaskingPolicyOrderByGQL(PydanticInputMixin[OrderDTO]):
+    field: ClientIPMaskingPolicyOrderFieldGQL = gql_field(description="Field to order by.")
+    direction: str = gql_field(default="ASC", description="ASC or DESC.")
+
+
+__all__ = (
+    "ClientIPMaskingModeGQL",
+    "ClientIPMaskingPolicyConnectionGQL",
+    "ClientIPMaskingPolicyEdgeGQL",
+    "ClientIPMaskingPolicyFilterGQL",
+    "ClientIPMaskingPolicyGQL",
+    "ClientIPMaskingPolicyOrderByGQL",
+    "ClientIPMaskingPolicyOrderFieldGQL",
+    "ClientIPMaskingPolicyPayloadGQL",
+    "ClientIPMaskingTargetGQL",
+    "UpsertClientIPMaskingPolicyInputGQL",
+)

--- a/src/ai/backend/manager/api/gql/client_ip_masking/types.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/types.py
@@ -143,15 +143,7 @@ class ClientIPMaskingPolicyPayloadGQL(PydanticOutputMixin[PolicyPayloadDTO]):
     policy: ClientIPMaskingPolicyGQL = gql_field(description="The policy the operation left.")
 
 
-@gql_connection_type(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description="An edge of the client IP masking policy connection.",
-    ),
-    name="ClientIPMaskingPolicyEdge",
-)
-class ClientIPMaskingPolicyEdgeGQL(Edge[ClientIPMaskingPolicyGQL]):
-    pass
+ClientIPMaskingPolicyEdgeGQL = Edge[ClientIPMaskingPolicyGQL]
 
 
 @gql_connection_type(

--- a/src/ai/backend/manager/api/gql/client_ip_masking/types.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/types.py
@@ -97,6 +97,12 @@ class ClientIPMaskingPolicyGQL(PydanticNodeMixin[NodeDTO]):
     mode: ClientIPMaskingModeGQL = gql_field(
         description="Masking applied before the address is stored."
     )
+    ipv4_prefix: int | None = gql_field(
+        description="IPv4 bits 'truncate' keeps; null takes the built-in width of 24."
+    )
+    ipv6_prefix: int | None = gql_field(
+        description="IPv6 bits 'truncate' keeps; null takes the built-in width of 48."
+    )
     created_at: datetime = gql_field(description="Timestamp when the policy was first written.")
     updated_at: datetime = gql_field(description="Timestamp when the policy was last changed.")
 
@@ -114,6 +120,14 @@ class UpsertClientIPMaskingPolicyInputGQL(PydanticInputMixin[UpsertInputDTO]):
     )
     mode: ClientIPMaskingModeGQL = gql_field(
         description="Masking applied before the address is stored."
+    )
+    ipv4_prefix: int | None = gql_field(
+        default=None,
+        description="IPv4 bits 'truncate' keeps; null takes the built-in width of 24.",
+    )
+    ipv6_prefix: int | None = gql_field(
+        default=None,
+        description="IPv6 bits 'truncate' keeps; null takes the built-in width of 48.",
     )
 
 

--- a/src/ai/backend/manager/api/gql/client_ip_masking/types.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/types.py
@@ -143,7 +143,15 @@ class ClientIPMaskingPolicyPayloadGQL(PydanticOutputMixin[PolicyPayloadDTO]):
     policy: ClientIPMaskingPolicyGQL = gql_field(description="The policy the operation left.")
 
 
-ClientIPMaskingPolicyEdgeGQL = Edge[ClientIPMaskingPolicyGQL]
+@gql_connection_type(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="An edge of the client IP masking policy connection.",
+    ),
+    name="ClientIPMaskingPolicyEdge",
+)
+class ClientIPMaskingPolicyEdgeGQL(Edge[ClientIPMaskingPolicyGQL]):
+    pass
 
 
 @gql_connection_type(

--- a/src/ai/backend/manager/api/gql/client_ip_masking/types.py
+++ b/src/ai/backend/manager/api/gql/client_ip_masking/types.py
@@ -45,6 +45,7 @@ from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, Pydant
 class ClientIPMaskingTargetGQL(StrEnum):
     DEFAULT = "default"
     LOGIN_HISTORY = "login_history"
+    AUDIT_LOGS = "audit_logs"
 
 
 @gql_enum(

--- a/src/ai/backend/manager/api/gql/decorators.py
+++ b/src/ai/backend/manager/api/gql/decorators.py
@@ -31,7 +31,7 @@ import strawberry.experimental.pydantic
 import strawberry.federation
 from pydantic import BaseModel
 from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
-from strawberry.relay import Connection
+from strawberry.relay import Connection, Edge
 from strawberry.schema_directives import OneOf
 from strawberry.types.base import get_object_definition
 from strawberry.types.field import StrawberryField
@@ -61,7 +61,9 @@ __all__ = (
 )
 
 T = TypeVar("T", bound="PydanticNodeMixin[Any]")
-T_conn = TypeVar("T_conn", bound="Connection[Any]")
+# Both, as the decorator's stated role covers: a connection type and the edge type it
+# carries are documented the same way.
+T_conn = TypeVar("T_conn", bound="Connection[Any] | Edge[Any]")
 T_input = TypeVar("T_input", bound="PydanticInputMixin[Any]")
 
 

--- a/src/ai/backend/manager/api/gql/decorators.py
+++ b/src/ai/backend/manager/api/gql/decorators.py
@@ -31,7 +31,7 @@ import strawberry.experimental.pydantic
 import strawberry.federation
 from pydantic import BaseModel
 from strawberry.experimental.pydantic.conversion_types import StrawberryTypeFromPydantic
-from strawberry.relay import Connection, Edge
+from strawberry.relay import Connection
 from strawberry.schema_directives import OneOf
 from strawberry.types.base import get_object_definition
 from strawberry.types.field import StrawberryField
@@ -61,9 +61,7 @@ __all__ = (
 )
 
 T = TypeVar("T", bound="PydanticNodeMixin[Any]")
-# Both, as the decorator's stated role covers: a connection type and the edge type it
-# carries are documented the same way.
-T_conn = TypeVar("T_conn", bound="Connection[Any] | Edge[Any]")
+T_conn = TypeVar("T_conn", bound="Connection[Any]")
 T_input = TypeVar("T_input", bound="PydanticInputMixin[Any]")
 
 

--- a/src/ai/backend/manager/api/gql/login_history/types/node.py
+++ b/src/ai/backend/manager/api/gql/login_history/types/node.py
@@ -12,6 +12,7 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.login_history.response import LoginHistoryNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_added_field,
@@ -61,6 +62,16 @@ class LoginHistoryV2GQL(PydanticNodeMixin[LoginHistoryNode]):
     domain_name: str = gql_field(description="Domain name of the user at the time of the attempt.")
     result: LoginAttemptResultGQL = gql_field(description="Result of the login attempt.")
     fail_reason: str | None = gql_field(description="Detailed reason for the login failure.")
+    client_ip: str | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "IP address of the request that produced this entry, masked per the client "
+                "IP masking policy. Null when the policy records none, or when the address "
+                "was unavailable or unusable."
+            ),
+        )
+    )
     created_at: datetime = gql_field(description="Timestamp when the login attempt occurred.")
 
     @gql_added_field(

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -69,6 +69,11 @@ from .artifact import (
 from .artifact_registry import default_artifact_registry
 from .audit_log import admin_audit_logs_v2, scoped_audit_logs_v2
 from .background_task import background_task_events
+from .client_ip_masking import (
+    admin_client_ip_masking_policies,
+    admin_purge_client_ip_masking_policy,
+    admin_upsert_client_ip_masking_policy,
+)
 from .container_registry import (
     admin_container_registries_v2,
     admin_create_container_registry_v2,
@@ -741,6 +746,8 @@ class Query:
     # Runtime Variant APIs
     runtime_variants = runtime_variants
     runtime_variant = runtime_variant
+    # Client IP Masking APIs
+    admin_client_ip_masking_policies = admin_client_ip_masking_policies
     # Retention Policy APIs
     admin_retention_policies = admin_retention_policies
     admin_retention_policy = admin_retention_policy
@@ -988,6 +995,9 @@ class Mutation:
     admin_update_runtime_variant = admin_update_runtime_variant
     admin_delete_runtime_variant = admin_delete_runtime_variant
     admin_delete_runtime_variants = admin_delete_runtime_variants
+    # Client IP Masking mutations
+    admin_upsert_client_ip_masking_policy = admin_upsert_client_ip_masking_policy
+    admin_purge_client_ip_masking_policy = admin_purge_client_ip_masking_policy
     # Retention Policy mutations
     admin_create_retention_policy = admin_create_retention_policy
     admin_update_retention_policy = admin_update_retention_policy

--- a/src/ai/backend/manager/api/rest/app.py
+++ b/src/ai/backend/manager/api/rest/app.py
@@ -22,7 +22,7 @@ from ai.backend.manager.errors.common import (
     ServerMisconfiguredError,
 )
 
-from .middleware import build_api_metric_middleware, request_id_middleware
+from .middleware import build_api_metric_middleware, client_ip_middleware, request_id_middleware
 from .routing import RouteRegistry
 
 if TYPE_CHECKING:
@@ -181,6 +181,7 @@ def build_root_app(
     app = web.Application(
         middlewares=[
             request_id_middleware,
+            client_ip_middleware,
             # exception_middleware and auth_middleware are inserted later
             # in server_main() after dependencies are available.
             api_middleware,

--- a/src/ai/backend/manager/api/rest/middleware/__init__.py
+++ b/src/ai/backend/manager/api/rest/middleware/__init__.py
@@ -8,11 +8,13 @@ from ai.backend.common.metrics.http import build_api_metric_middleware
 from ai.backend.common.middlewares.request_id import request_id_middleware
 
 from .auth import build_auth_middleware
+from .client_ip import client_ip_middleware
 from .exception import build_exception_middleware
 
 __all__ = (
     "build_api_metric_middleware",
     "build_auth_middleware",
     "build_exception_middleware",
+    "client_ip_middleware",
     "request_id_middleware",
 )

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -38,7 +38,6 @@ from dateutil.parser import parse as dtparse
 from dateutil.tz import tzutc
 from sqlalchemy.orm import load_only
 
-from ai.backend.common.contexts.client_ip import with_client_ip
 from ai.backend.common.contexts.user import with_triggered_user, with_user
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.user import UserID
@@ -803,7 +802,6 @@ async def _resolve_effective_user(
 
 
 def _setup_user_context(
-    request: web.Request,
     effective_user: UserData | None,
     trigger_user: UserData | None,
 ) -> ExitStack:
@@ -815,10 +813,6 @@ def _setup_user_context(
         stack.enter_context(with_log_context_fields({"user_id": str(effective_user.user_id)}))
     if trigger_user is not None:
         stack.enter_context(with_triggered_user(trigger_user))
-
-    client_ip = extract_client_ip(request)
-    if client_ip:
-        stack.enter_context(with_client_ip(client_ip))
 
     return stack
 
@@ -980,7 +974,7 @@ def build_auth_middleware(
             if authenticated_user is not None
             else None
         )
-        with _setup_user_context(request, effective_user, authenticated_user):
+        with _setup_user_context(effective_user, authenticated_user):
             return await handler(request)
 
     return _middleware

--- a/src/ai/backend/manager/api/rest/middleware/client_ip.py
+++ b/src/ai/backend/manager/api/rest/middleware/client_ip.py
@@ -1,0 +1,26 @@
+from collections.abc import Awaitable, Callable
+
+from aiohttp import web
+
+from ai.backend.common.contexts.client_ip import with_client_ip
+
+from .auth import extract_client_ip
+
+type Handler = Callable[
+    [web.Request],
+    Awaitable[web.StreamResponse],
+]
+
+
+@web.middleware
+async def client_ip_middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
+    """Push the caller's address into the context for the whole request.
+
+    Runs ahead of authentication so that unauthenticated routes — a login attempt
+    above all — record where they came from.
+    """
+    client_ip = extract_client_ip(request)
+    if client_ip is None:
+        return await handler(request)
+    with with_client_ip(client_ip):
+        return await handler(request)

--- a/src/ai/backend/manager/api/rest/v2/client_ip_masking/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/client_ip_masking/handler.py
@@ -1,0 +1,48 @@
+"""REST v2 handler for the client IP masking domain."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+from ai.backend.common.api_handlers import APIResponse, BodyParam
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    AdminPurgeClientIPMaskingPolicyInput,
+    AdminSearchClientIPMaskingPoliciesInput,
+    AdminUpsertClientIPMaskingPolicyInput,
+)
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.client_ip_masking.adapter import ClientIPMaskingAdapter
+
+
+class V2ClientIPMaskingHandler:
+    """REST v2 handler for the client IP masking policies."""
+
+    def __init__(self, *, adapter: ClientIPMaskingAdapter) -> None:
+        self._adapter = adapter
+
+    async def admin_search(
+        self,
+        body: BodyParam[AdminSearchClientIPMaskingPoliciesInput],
+    ) -> APIResponse:
+        """Read the masking set for every target."""
+        result = await self._adapter.admin_search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_upsert(
+        self,
+        body: BodyParam[AdminUpsertClientIPMaskingPolicyInput],
+    ) -> APIResponse:
+        """Set the masking one target gets."""
+        result = await self._adapter.admin_upsert(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def admin_purge(
+        self,
+        body: BodyParam[AdminPurgeClientIPMaskingPolicyInput],
+    ) -> APIResponse:
+        """Drop one target's policy so it falls back to the default."""
+        result = await self._adapter.admin_purge(ClientIPMaskingPolicyID(body.parsed.id))
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/client_ip_masking/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/client_ip_masking/registry.py
@@ -1,0 +1,27 @@
+"""Route registry for REST v2 client IP masking endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import superadmin_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2ClientIPMaskingHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_client_ip_masking_routes(
+    handler: V2ClientIPMaskingHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all REST v2 client IP masking routes and return the sub-registry."""
+    registry = RouteRegistry.create("client-ip-masking-policies", route_deps.cors_options)
+
+    registry.add("POST", "/search", handler.admin_search, middlewares=[superadmin_required])
+    registry.add("POST", "/upsert", handler.admin_upsert, middlewares=[superadmin_required])
+    registry.add("POST", "/purge", handler.admin_purge, middlewares=[superadmin_required])
+
+    return registry

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -42,6 +42,8 @@ def build_v2_routes(
     from .artifact_registry.registry import register_v2_artifact_registry_routes
     from .audit_log.handler import V2AuditLogHandler
     from .audit_log.registry import register_v2_audit_log_routes
+    from .client_ip_masking.handler import V2ClientIPMaskingHandler
+    from .client_ip_masking.registry import register_v2_client_ip_masking_routes
     from .container_registry.handler import V2ContainerRegistryHandler
     from .container_registry.registry import register_v2_container_registry_routes
     from .deployment.handler import V2DeploymentHandler
@@ -156,6 +158,7 @@ def build_v2_routes(
     image_handler = V2ImageHandler(adapter=adapters.image)
     keypair_handler = V2KeypairHandler(adapter=adapters.user)
     login_client_type_handler = V2LoginClientTypeHandler(adapter=adapters.login_client_type)
+    client_ip_masking_handler = V2ClientIPMaskingHandler(adapter=adapters.client_ip_masking)
     login_history_handler = V2LoginHistoryHandler(adapter=adapters.login_history)
     login_session_handler = V2LoginSessionHandler(adapter=adapters.login_session)
     notification_handler = V2NotificationHandler(adapter=adapters.notification)
@@ -238,6 +241,9 @@ def build_v2_routes(
     v2_reg.add_subregistry(register_v2_keypair_routes(keypair_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_login_client_type_routes(login_client_type_handler, route_deps)
+    )
+    v2_reg.add_subregistry(
+        register_v2_client_ip_masking_routes(client_ip_masking_handler, route_deps)
     )
     v2_reg.add_subregistry(register_v2_login_history_routes(login_history_handler, route_deps))
     v2_reg.add_subregistry(register_v2_login_session_routes(login_session_handler, route_deps))

--- a/src/ai/backend/manager/data/audit_log/types.py
+++ b/src/ai/backend/manager/data/audit_log/types.py
@@ -34,6 +34,7 @@ class AuditLogData(FieldData):
     triggered_by: str | None
     acted_as: uuid.UUID | None
     duration: timedelta | None
+    client_ip: str | None
 
 
 @dataclass

--- a/src/ai/backend/manager/data/auth/login_session_types.py
+++ b/src/ai/backend/manager/data/auth/login_session_types.py
@@ -48,4 +48,5 @@ class LoginHistoryData(FieldData):
     domain_name: str
     result: LoginAttemptResult
     fail_reason: str | None
+    client_ip: str | None
     created_at: datetime

--- a/src/ai/backend/manager/data/client_ip/masking.py
+++ b/src/ai/backend/manager/data/client_ip/masking.py
@@ -14,6 +14,7 @@ class ClientIPMaskingTarget(enum.StrEnum):
 
     DEFAULT = "default"
     LOGIN_HISTORY = "login_history"
+    AUDIT_LOGS = "audit_logs"
 
 
 class ClientIPMaskingMode(enum.StrEnum):

--- a/src/ai/backend/manager/data/client_ip/masking.py
+++ b/src/ai/backend/manager/data/client_ip/masking.py
@@ -1,0 +1,54 @@
+import enum
+import ipaddress
+from dataclasses import dataclass
+
+_IPV4_MASK_PREFIX = 24
+_IPV6_MASK_PREFIX = 48
+
+
+class ClientIPMaskingTarget(enum.StrEnum):
+    """Which recorded client IP a policy row governs.
+
+    ``DEFAULT`` is the fallback the other targets inherit.
+    """
+
+    DEFAULT = "default"
+    LOGIN_HISTORY = "login_history"
+
+
+class ClientIPMaskingMode(enum.StrEnum):
+    NONE = "none"
+    TRUNCATE = "truncate"
+    DROP = "drop"
+
+
+@dataclass(frozen=True)
+class ClientIPMasker:
+    """Turns a raw client IP into the value a record keeps.
+
+    Parsing runs in every mode: the address may come from a client-controlled
+    ``X-Forwarded-For`` when no trusted proxy is configured, and an unparsable
+    value is dropped rather than stored.
+    """
+
+    mode: ClientIPMaskingMode
+
+    def mask(self, client_ip: str | None) -> str | None:
+        if client_ip is None:
+            return None
+        try:
+            address = ipaddress.ip_address(client_ip)
+        except ValueError:
+            return None
+        match self.mode:
+            case ClientIPMaskingMode.NONE:
+                return str(address)
+            case ClientIPMaskingMode.TRUNCATE:
+                return self._truncate(address)
+            case ClientIPMaskingMode.DROP:
+                return None
+
+    def _truncate(self, address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
+        prefix = _IPV4_MASK_PREFIX if address.version == 4 else _IPV6_MASK_PREFIX
+        network = ipaddress.ip_network(f"{address}/{prefix}", strict=False)
+        return str(network.network_address)

--- a/src/ai/backend/manager/data/client_ip/masking.py
+++ b/src/ai/backend/manager/data/client_ip/masking.py
@@ -2,8 +2,11 @@ import enum
 import ipaddress
 from dataclasses import dataclass
 
-_IPV4_MASK_PREFIX = 24
-_IPV6_MASK_PREFIX = 48
+DEFAULT_IPV4_MASK_PREFIX = 24
+DEFAULT_IPV6_MASK_PREFIX = 48
+
+MAX_IPV4_PREFIX = 32
+MAX_IPV6_PREFIX = 128
 
 
 class ClientIPMaskingTarget(enum.StrEnum):
@@ -27,12 +30,18 @@ class ClientIPMaskingMode(enum.StrEnum):
 class ClientIPMasker:
     """Turns a raw client IP into the value a record keeps.
 
+    The prefixes say how much of the address ``TRUNCATE`` leaves; how deep an
+    address has to be cut before it counts as anonymous differs by jurisdiction,
+    and an IPv6 prefix an ISP hands out whole is no anonymisation at all.
+
     Parsing runs in every mode: the address may come from a client-controlled
     ``X-Forwarded-For`` when no trusted proxy is configured, and an unparsable
     value is dropped rather than stored.
     """
 
     mode: ClientIPMaskingMode
+    ipv4_prefix: int = DEFAULT_IPV4_MASK_PREFIX
+    ipv6_prefix: int = DEFAULT_IPV6_MASK_PREFIX
 
     def mask(self, client_ip: str | None) -> str | None:
         if client_ip is None:
@@ -50,6 +59,6 @@ class ClientIPMasker:
                 return None
 
     def _truncate(self, address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str:
-        prefix = _IPV4_MASK_PREFIX if address.version == 4 else _IPV6_MASK_PREFIX
+        prefix = self.ipv4_prefix if address.version == 4 else self.ipv6_prefix
         network = ipaddress.ip_network(f"{address}/{prefix}", strict=False)
         return str(network.network_address)

--- a/src/ai/backend/manager/data/client_ip/types.py
+++ b/src/ai/backend/manager/data/client_ip/types.py
@@ -15,6 +15,8 @@ class ClientIPMaskingPolicyData(EntityData):
     id: ClientIPMaskingPolicyID
     target_type: ClientIPMaskingTarget
     mode: ClientIPMaskingMode
+    ipv4_prefix: int | None
+    ipv6_prefix: int | None
     created_at: datetime
     updated_at: datetime
 

--- a/src/ai/backend/manager/data/client_ip/types.py
+++ b/src/ai/backend/manager/data/client_ip/types.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import override
+
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.common.data.entity.types import EntityData, EntityIdentifier
+
+from .masking import ClientIPMaskingMode, ClientIPMaskingTarget
+
+
+@dataclass(frozen=True)
+class ClientIPMaskingPolicyData(EntityData):
+    id: ClientIPMaskingPolicyID
+    target_type: ClientIPMaskingTarget
+    mode: ClientIPMaskingMode
+    created_at: datetime
+    updated_at: datetime
+
+    @override
+    def entity_id(self) -> EntityIdentifier:
+        return self.id

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -279,35 +279,62 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
         audit_log_policy = AuditLogPolicy(
             setup_input.config_provider.config.audit_log.record_read_operations
         )
-        audit_log_monitor = AuditLogMonitor(audit_log_repository, audit_log_policy)
+        client_ip_masking_repository = setup_input.repositories.client_ip_masking.repository
+        audit_log_monitor = AuditLogMonitor(
+            audit_log_repository, audit_log_policy, client_ip_masking_repository
+        )
         action_monitors = ActionMonitors(
             legacy=[reporter_monitor, prometheus_monitor, audit_log_monitor],
             single_entity=[
                 SingleEntityActionReporterMonitor(reporter_hub),
                 SingleEntityActionPrometheusMonitor(),
-                SingleEntityActionAuditLogMonitor(audit_log_repository, audit_log_policy),
+                SingleEntityActionAuditLogMonitor(
+                    audit_log_repository,
+                    audit_log_policy,
+                    client_ip_masking_repository,
+                ),
             ],
             bulk=[
                 BulkActionReporterMonitor(reporter_hub),
                 BulkActionPrometheusMonitor(),
-                BulkActionAuditLogMonitor(audit_log_repository, audit_log_policy),
+                BulkActionAuditLogMonitor(
+                    audit_log_repository,
+                    audit_log_policy,
+                    client_ip_masking_repository,
+                ),
             ],
             scope=[
                 ScopeActionReporterMonitor(reporter_hub),
                 ScopeActionPrometheusMonitor(),
-                ScopeActionAuditLogMonitor(audit_log_repository, audit_log_policy),
+                ScopeActionAuditLogMonitor(
+                    audit_log_repository,
+                    audit_log_policy,
+                    client_ip_masking_repository,
+                ),
             ],
             global_scope=[
                 GlobalActionReporterMonitor(reporter_hub),
                 GlobalActionPrometheusMonitor(),
-                GlobalActionAuditLogMonitor(audit_log_repository, audit_log_policy),
+                GlobalActionAuditLogMonitor(
+                    audit_log_repository,
+                    audit_log_policy,
+                    client_ip_masking_repository,
+                ),
             ],
             lookup=[
                 LookupActionPrometheusMonitor(),
-                LookupActionAuditLogMonitor(audit_log_repository, audit_log_policy),
+                LookupActionAuditLogMonitor(
+                    audit_log_repository,
+                    audit_log_policy,
+                    client_ip_masking_repository,
+                ),
             ],
             bulk_lookup=[
-                BulkLookupActionAuditLogMonitor(audit_log_repository, audit_log_policy),
+                BulkLookupActionAuditLogMonitor(
+                    audit_log_repository,
+                    audit_log_policy,
+                    client_ip_masking_repository,
+                ),
             ],
         )
 

--- a/src/ai/backend/manager/models/alembic/versions/b8c3f5d21e07_add_login_history_client_ip.py
+++ b/src/ai/backend/manager/models/alembic/versions/b8c3f5d21e07_add_login_history_client_ip.py
@@ -1,0 +1,29 @@
+"""add the login_history client IP column
+
+Revision ID: b8c3f5d21e07
+Revises: a3f1c7d92b04
+Create Date: 2026-08-24 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql as pgsql
+
+# revision identifiers, used by Alembic.
+revision = "b8c3f5d21e07"
+down_revision = "a3f1c7d92b04"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "login_history",
+        sa.Column("client_ip", pgsql.INET, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("login_history", "client_ip")

--- a/src/ai/backend/manager/models/alembic/versions/c4e7a1b93f60_add_client_ip_masking_policies.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4e7a1b93f60_add_client_ip_masking_policies.py
@@ -1,0 +1,40 @@
+"""add the client IP masking policies table
+
+Revision ID: c4e7a1b93f60
+Revises: b8c3f5d21e07
+Create Date: 2026-08-24 00:10:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.models.base import GUID, StrEnumType
+
+# revision identifiers, used by Alembic.
+revision = "c4e7a1b93f60"
+down_revision = "b8c3f5d21e07"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "client_ip_masking_policies",
+        sa.Column("id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("target_type", StrEnumType(ClientIPMaskingTarget), nullable=False),
+        sa.Column("mode", StrEnumType(ClientIPMaskingMode), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.UniqueConstraint("target_type", name="uq_client_ip_masking_policies_target_type"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("client_ip_masking_policies")

--- a/src/ai/backend/manager/models/alembic/versions/c4e7a1b93f60_add_client_ip_masking_policies.py
+++ b/src/ai/backend/manager/models/alembic/versions/c4e7a1b93f60_add_client_ip_masking_policies.py
@@ -9,7 +9,12 @@ Create Date: 2026-08-24 00:10:00.000000
 import sqlalchemy as sa
 from alembic import op
 
-from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.masking import (
+    MAX_IPV4_PREFIX,
+    MAX_IPV6_PREFIX,
+    ClientIPMaskingMode,
+    ClientIPMaskingTarget,
+)
 from ai.backend.manager.models.base import GUID, StrEnumType
 
 # revision identifiers, used by Alembic.
@@ -26,6 +31,8 @@ def upgrade() -> None:
         sa.Column("id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v4()")),
         sa.Column("target_type", StrEnumType(ClientIPMaskingTarget), nullable=False),
         sa.Column("mode", StrEnumType(ClientIPMaskingMode), nullable=False),
+        sa.Column("ipv4_prefix", sa.SmallInteger, nullable=True),
+        sa.Column("ipv6_prefix", sa.SmallInteger, nullable=True),
         sa.Column(
             "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
         ),
@@ -33,6 +40,14 @@ def upgrade() -> None:
             "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
         ),
         sa.UniqueConstraint("target_type", name="uq_client_ip_masking_policies_target_type"),
+        sa.CheckConstraint(
+            f"ipv4_prefix IS NULL OR (ipv4_prefix BETWEEN 0 AND {MAX_IPV4_PREFIX})",
+            name="ck_client_ip_masking_policies_ipv4_prefix",
+        ),
+        sa.CheckConstraint(
+            f"ipv6_prefix IS NULL OR (ipv6_prefix BETWEEN 0 AND {MAX_IPV6_PREFIX})",
+            name="ck_client_ip_masking_policies_ipv6_prefix",
+        ),
     )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/d7a2f4c86b13_add_audit_logs_client_ip.py
+++ b/src/ai/backend/manager/models/alembic/versions/d7a2f4c86b13_add_audit_logs_client_ip.py
@@ -1,0 +1,29 @@
+"""add the audit_logs client IP column
+
+Revision ID: d7a2f4c86b13
+Revises: c4e7a1b93f60
+Create Date: 2026-08-24 00:20:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql as pgsql
+
+# revision identifiers, used by Alembic.
+revision = "d7a2f4c86b13"
+down_revision = "c4e7a1b93f60"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audit_logs",
+        sa.Column("client_ip", pgsql.INET, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("audit_logs", "client_ip")

--- a/src/ai/backend/manager/models/audit_log/creators.py
+++ b/src/ai/backend/manager/models/audit_log/creators.py
@@ -57,6 +57,7 @@ class BaseAuditLogFields:
     triggered_by: str | None
     acted_as: uuid.UUID | None
     duration: timedelta | None
+    client_ip: str | None
 
     @classmethod
     @abstractmethod
@@ -96,6 +97,7 @@ class BaseAuditLogFields:
             triggered_by=self.triggered_by,
             acted_as=self.acted_as,
             duration=self.duration,
+            client_ip=self.client_ip,
         )
 
 

--- a/src/ai/backend/manager/models/audit_log/row.py
+++ b/src/ai/backend/manager/models/audit_log/row.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import override
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.audit_log import AuditLogID
@@ -72,6 +73,9 @@ class AuditLogRow(Base):
     acted_as: Mapped[UserID | None] = mapped_column("acted_as", GUID(UserID), nullable=True)
     description: Mapped[str] = mapped_column("description", sa.String, nullable=False)
     duration: Mapped[timedelta | None] = mapped_column("duration", sa.Interval, nullable=True)
+    # The address of the request that produced this record, masked per the client IP
+    # masking policy. NULL when the policy records none, or the address was unusable.
+    client_ip: Mapped[str | None] = mapped_column("client_ip", pgsql.INET, nullable=True)
 
     status: Mapped[OperationStatus] = mapped_column(
         "status",
@@ -123,4 +127,5 @@ class AuditLogRow(Base):
             triggered_by=self.triggered_by,
             acted_as=self.acted_as,
             duration=self.duration,
+            client_ip=self.client_ip,
         )

--- a/src/ai/backend/manager/models/client_ip_masking/conditions.py
+++ b/src/ai/backend/manager/models/client_ip_masking/conditions.py
@@ -1,0 +1,59 @@
+"""Query conditions for client IP masking policy rows."""
+
+from __future__ import annotations
+
+import uuid
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+
+__all__ = ("ClientIPMaskingPolicyConditions",)
+
+
+class ClientIPMaskingPolicyConditions:
+    @staticmethod
+    def by_target_type(target_type: ClientIPMaskingTarget) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ClientIPMaskingPolicyRow.target_type == target_type
+
+        return inner
+
+    @staticmethod
+    def by_mode(mode: ClientIPMaskingMode) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ClientIPMaskingPolicyRow.mode == mode
+
+        return inner
+
+    @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for forward pagination, keyed on the ordered column."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(ClientIPMaskingPolicyRow.target_type)
+                .where(ClientIPMaskingPolicyRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ClientIPMaskingPolicyRow.target_type > subquery
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Cursor condition for backward pagination, keyed on the ordered column."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            subquery = (
+                sa.select(ClientIPMaskingPolicyRow.target_type)
+                .where(ClientIPMaskingPolicyRow.id == cursor_uuid)
+                .scalar_subquery()
+            )
+            return ClientIPMaskingPolicyRow.target_type < subquery
+
+        return inner

--- a/src/ai/backend/manager/models/client_ip_masking/orders.py
+++ b/src/ai/backend/manager/models/client_ip_masking/orders.py
@@ -1,0 +1,34 @@
+"""Query orders for client IP masking policy rows."""
+
+from __future__ import annotations
+
+from ai.backend.manager.models.clauses import QueryOrder
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+
+__all__ = ("ClientIPMaskingPolicyOrders",)
+
+
+class ClientIPMaskingPolicyOrders:
+    @staticmethod
+    def target_type(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return ClientIPMaskingPolicyRow.target_type.asc()
+        return ClientIPMaskingPolicyRow.target_type.desc()
+
+    @staticmethod
+    def mode(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return ClientIPMaskingPolicyRow.mode.asc()
+        return ClientIPMaskingPolicyRow.mode.desc()
+
+    @staticmethod
+    def created_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return ClientIPMaskingPolicyRow.created_at.asc()
+        return ClientIPMaskingPolicyRow.created_at.desc()
+
+    @staticmethod
+    def updated_at(ascending: bool = True) -> QueryOrder:
+        if ascending:
+            return ClientIPMaskingPolicyRow.updated_at.asc()
+        return ClientIPMaskingPolicyRow.updated_at.desc()

--- a/src/ai/backend/manager/models/client_ip_masking/purgers.py
+++ b/src/ai/backend/manager/models/client_ip_masking/purgers.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.specs.purger import EntityPurger
+from ai.backend.manager.models.specs.types import ConflictCheck
+
+__all__ = ("ClientIPMaskingPolicyPurger",)
+
+
+@dataclass
+class ClientIPMaskingPolicyPurger(
+    EntityPurger[ClientIPMaskingPolicyRow, ClientIPMaskingPolicyData]
+):
+    """Drop one target's policy so it falls back to ``default``."""
+
+    policy_id: ClientIPMaskingPolicyID
+
+    @override
+    def row_class(self) -> type[ClientIPMaskingPolicyRow]:
+        return ClientIPMaskingPolicyRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return ClientIPMaskingPolicyRow.id
+
+    @override
+    def entity_id(self) -> EntityIdentifier:
+        return self.policy_id
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
+
+    @override
+    def to_data(self, row: ClientIPMaskingPolicyRow) -> ClientIPMaskingPolicyData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/client_ip_masking/row.py
+++ b/src/ai/backend/manager/models/client_ip_masking/row.py
@@ -4,7 +4,12 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
-from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.masking import (
+    MAX_IPV4_PREFIX,
+    MAX_IPV6_PREFIX,
+    ClientIPMaskingMode,
+    ClientIPMaskingTarget,
+)
 from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
 from ai.backend.manager.models.base import GUID, Base, StrEnumType
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
@@ -23,6 +28,14 @@ class ClientIPMaskingPolicyRow(LifecycleTimestampsMixin, Base):
 
     __table_args__ = (
         sa.UniqueConstraint("target_type", name="uq_client_ip_masking_policies_target_type"),
+        sa.CheckConstraint(
+            f"ipv4_prefix IS NULL OR (ipv4_prefix BETWEEN 0 AND {MAX_IPV4_PREFIX})",
+            name="ck_client_ip_masking_policies_ipv4_prefix",
+        ),
+        sa.CheckConstraint(
+            f"ipv6_prefix IS NULL OR (ipv6_prefix BETWEEN 0 AND {MAX_IPV6_PREFIX})",
+            name="ck_client_ip_masking_policies_ipv6_prefix",
+        ),
     )
 
     id: Mapped[ClientIPMaskingPolicyID] = mapped_column(
@@ -37,12 +50,17 @@ class ClientIPMaskingPolicyRow(LifecycleTimestampsMixin, Base):
     mode: Mapped[ClientIPMaskingMode] = mapped_column(
         "mode", StrEnumType(ClientIPMaskingMode), nullable=False
     )
+    # How much of the address ``truncate`` leaves. NULL takes the built-in width.
+    ipv4_prefix: Mapped[int | None] = mapped_column("ipv4_prefix", sa.SmallInteger, nullable=True)
+    ipv6_prefix: Mapped[int | None] = mapped_column("ipv6_prefix", sa.SmallInteger, nullable=True)
 
     def to_data(self) -> ClientIPMaskingPolicyData:
         return ClientIPMaskingPolicyData(
             id=self.id,
             target_type=self.target_type,
             mode=self.mode,
+            ipv4_prefix=self.ipv4_prefix,
+            ipv6_prefix=self.ipv6_prefix,
             created_at=self.created_at,
             updated_at=self.updated_at,
         )

--- a/src/ai/backend/manager/models/client_ip_masking/row.py
+++ b/src/ai/backend/manager/models/client_ip_masking/row.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.base import GUID, Base, StrEnumType
+from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
+
+__all__ = ("ClientIPMaskingPolicyRow",)
+
+
+class ClientIPMaskingPolicyRow(LifecycleTimestampsMixin, Base):
+    """The masking a recorded client IP gets, one row per target.
+
+    A target with no row falls back to the ``default`` row, and no ``default`` row
+    means the address is recorded as observed.
+    """
+
+    __tablename__ = "client_ip_masking_policies"
+
+    __table_args__ = (
+        sa.UniqueConstraint("target_type", name="uq_client_ip_masking_policies_target_type"),
+    )
+
+    id: Mapped[ClientIPMaskingPolicyID] = mapped_column(
+        "id",
+        GUID(ClientIPMaskingPolicyID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v4()"),
+    )
+    target_type: Mapped[ClientIPMaskingTarget] = mapped_column(
+        "target_type", StrEnumType(ClientIPMaskingTarget), nullable=False
+    )
+    mode: Mapped[ClientIPMaskingMode] = mapped_column(
+        "mode", StrEnumType(ClientIPMaskingMode), nullable=False
+    )
+
+    def to_data(self) -> ClientIPMaskingPolicyData:
+        return ClientIPMaskingPolicyData(
+            id=self.id,
+            target_type=self.target_type,
+            mode=self.mode,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )

--- a/src/ai/backend/manager/models/client_ip_masking/searchers.py
+++ b/src/ai/backend/manager/models/client_ip_masking/searchers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.specs.searcher import Searcher
+
+__all__ = ("ClientIPMaskingPolicySearcher",)
+
+
+@dataclass
+class ClientIPMaskingPolicySearcher(Searcher[ClientIPMaskingPolicyRow, ClientIPMaskingPolicyData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(ClientIPMaskingPolicyRow)
+
+    @override
+    def to_data(self, row: ClientIPMaskingPolicyRow) -> ClientIPMaskingPolicyData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/client_ip_masking/upserters.py
+++ b/src/ai/backend/manager/models/client_ip_masking/upserters.py
@@ -28,6 +28,8 @@ class ClientIPMaskingPolicyUpserter(
 
     target_type: ClientIPMaskingTarget
     mode: ClientIPMaskingMode
+    ipv4_prefix: int | None
+    ipv6_prefix: int | None
 
     @override
     def entity_id(self, row: ClientIPMaskingPolicyRow) -> EntityIdentifier:
@@ -47,11 +49,21 @@ class ClientIPMaskingPolicyUpserter(
 
     @override
     def build_insert_values(self) -> dict[str, Any]:
-        return {"target_type": self.target_type, "mode": self.mode}
+        return {
+            "target_type": self.target_type,
+            "mode": self.mode,
+            "ipv4_prefix": self.ipv4_prefix,
+            "ipv6_prefix": self.ipv6_prefix,
+        }
 
     @override
     def build_update_values(self) -> dict[str, Any]:
-        return {"mode": self.mode, "updated_at": sa.func.now()}
+        return {
+            "mode": self.mode,
+            "ipv4_prefix": self.ipv4_prefix,
+            "ipv6_prefix": self.ipv6_prefix,
+            "updated_at": sa.func.now(),
+        }
 
     @override
     def to_data(self, row: ClientIPMaskingPolicyRow) -> ClientIPMaskingPolicyData:

--- a/src/ai/backend/manager/models/client_ip_masking/upserters.py
+++ b/src/ai/backend/manager/models/client_ip_masking/upserters.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.upserter import GlobalEntityUpserter
+
+__all__ = ("ClientIPMaskingPolicyUpserter",)
+
+
+@dataclass
+class ClientIPMaskingPolicyUpserter(
+    GlobalEntityUpserter[ClientIPMaskingPolicyRow, ClientIPMaskingPolicyData]
+):
+    """Set the masking one target gets, replacing the row it already has.
+
+    Conflicts are detected on ``target_type``: a target holds one policy, so naming it
+    is what identifies the row rather than an id the caller has to look up first.
+    """
+
+    target_type: ClientIPMaskingTarget
+    mode: ClientIPMaskingMode
+
+    @override
+    def entity_id(self, row: ClientIPMaskingPolicyRow) -> EntityIdentifier:
+        return row.id
+
+    @override
+    def row_class(self) -> type[ClientIPMaskingPolicyRow]:
+        return ClientIPMaskingPolicyRow
+
+    @override
+    def index_elements(self) -> list[str]:
+        return ["target_type"]
+
+    @override
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return ()
+
+    @override
+    def build_insert_values(self) -> dict[str, Any]:
+        return {"target_type": self.target_type, "mode": self.mode}
+
+    @override
+    def build_update_values(self) -> dict[str, Any]:
+        return {"mode": self.mode, "updated_at": sa.func.now()}
+
+    @override
+    def to_data(self, row: ClientIPMaskingPolicyRow) -> ClientIPMaskingPolicyData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/login_session/row.py
+++ b/src/ai/backend/manager/models/login_session/row.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.login_client_type import LoginClientTypeID
@@ -106,6 +107,9 @@ class LoginHistoryRow(Base):
         index=True,
     )
     fail_reason: Mapped[str | None] = mapped_column("fail_reason", sa.Text, nullable=True)
+    # The address of the request that produced this record, not of the session it closes:
+    # an eviction or an admin revocation carries the address of whoever triggered it.
+    client_ip: Mapped[str | None] = mapped_column("client_ip", pgsql.INET, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         "created_at",
         sa.DateTime(timezone=True),
@@ -127,5 +131,6 @@ class LoginHistoryRow(Base):
             domain_name=self.domain_name,
             result=self.result,
             fail_reason=self.fail_reason,
+            client_ip=self.client_ip,
             created_at=self.created_at,
         )

--- a/src/ai/backend/manager/models/user/creators.py
+++ b/src/ai/backend/manager/models/user/creators.py
@@ -78,8 +78,17 @@ class UserCreator(RoleManagedEntityCreator[UserRow, UserData]):
                 violation_type=NotNullViolationError,
                 error=UserCreationBadRequest(f"Domain '{self.domain_id}' does not exist."),
             ),
+            # Named, so only the domain's own keys answer as a missing domain: an
+            # unnamed check claimed every foreign key the row has, and a bad
+            # ``resource_policy`` was reported as a bad domain.
             IntegrityErrorCheck(
                 violation_type=ForeignKeyViolationError,
+                constraint_name="fk_users_domain_id_domains",
+                error=UserCreationBadRequest(f"Domain '{self.domain_id}' does not exist."),
+            ),
+            IntegrityErrorCheck(
+                violation_type=ForeignKeyViolationError,
+                constraint_name="fk_users_domain_name_domains",
                 error=UserCreationBadRequest(f"Domain '{self.domain_id}' does not exist."),
             ),
         )

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from uuid import UUID
 
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql as pgsql
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
@@ -350,6 +351,7 @@ class AuthDBSource:
         domain_name: str,
         result: LoginAttemptResult,
         fail_reason: str | None,
+        client_ip: str | None,
     ) -> None:
         """Insert a login history record (internal, within an existing connection)."""
         await conn.execute(
@@ -358,6 +360,7 @@ class AuthDBSource:
                 domain_name=domain_name,
                 result=result,
                 fail_reason=fail_reason,
+                client_ip=client_ip,
             )
         )
 
@@ -368,6 +371,7 @@ class AuthDBSource:
         domain_name: str,
         result: LoginAttemptResult,
         fail_reason: str | None = None,
+        client_ip: str | None = None,
     ) -> None:
         """Insert a login history record (public, manages its own transaction)."""
         async with self._db.begin_session() as db_session:
@@ -377,6 +381,7 @@ class AuthDBSource:
                     domain_name=domain_name,
                     result=result,
                     fail_reason=fail_reason,
+                    client_ip=client_ip,
                 )
             )
 
@@ -444,6 +449,7 @@ class AuthDBSource:
         self,
         session_tokens: list[str],
         result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> None:
         """Delete the given login sessions and record history for each.
 
@@ -462,11 +468,12 @@ class AuthDBSource:
                 .cte("deleted")
             )
             insert_query = lh.insert().from_select(
-                ["user_id", "domain_name", "result"],
+                ["user_id", "domain_name", "result", "client_ip"],
                 sa.select(
                     deleted.c.user_id,
                     users.c.domain_name,
                     sa.literal(result.value).label("result"),
+                    sa.literal(client_ip, type_=pgsql.INET).label("client_ip"),
                 ).select_from(deleted.join(users, deleted.c.user_id == users.c.uuid)),
             )
             await conn.execute(insert_query)
@@ -480,6 +487,7 @@ class AuthDBSource:
         domain_name: str,
         *,
         login_client_type_id: UUID | None = None,
+        client_ip: str | None = None,
     ) -> LoginSessionCreationResult:
         """Create a new active login session and record a successful login history entry.
 
@@ -502,7 +510,12 @@ class AuthDBSource:
 
             # Record successful login in the same transaction.
             await self._record_login_history(
-                conn, user_id, domain_name, LoginAttemptResult.SUCCESS, fail_reason=None
+                conn,
+                user_id,
+                domain_name,
+                LoginAttemptResult.SUCCESS,
+                fail_reason=None,
+                client_ip=client_ip,
             )
 
             await conn.commit()
@@ -588,6 +601,7 @@ class AuthDBSource:
         self,
         session_token: str,
         result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> None:
         """Delete a single login session by its token and record history.
 
@@ -604,11 +618,12 @@ class AuthDBSource:
                 .cte("deleted")
             )
             insert_query = lh.insert().from_select(
-                ["user_id", "domain_name", "result"],
+                ["user_id", "domain_name", "result", "client_ip"],
                 sa.select(
                     deleted.c.user_id,
                     users.c.domain_name,
                     sa.literal(result.value).label("result"),
+                    sa.literal(client_ip, type_=pgsql.INET).label("client_ip"),
                 ).select_from(deleted.join(users, deleted.c.user_id == users.c.uuid)),
             )
             await conn.execute(insert_query)
@@ -620,6 +635,7 @@ class AuthDBSource:
         user_id: UUID,
         domain_name: str,
         result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> list[str]:
         """Delete all login sessions for a user, record history, return tokens.
 
@@ -641,6 +657,7 @@ class AuthDBSource:
                             "user_id": user_id,
                             "domain_name": domain_name,
                             "result": result,
+                            "client_ip": client_ip,
                         }
                         for _ in deleted_tokens
                     ],
@@ -653,6 +670,7 @@ class AuthDBSource:
         self,
         session_id: UUID,
         result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> str:
         """Delete a login session by its ID, record history, return session_token.
 
@@ -686,6 +704,7 @@ class AuthDBSource:
                     user_id=row.user_id,
                     domain_name=domain_name,
                     result=result,
+                    client_ip=client_ip,
                 )
             )
             await conn.commit()

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -130,19 +130,24 @@ class AuthRepository:
         domain_name: str,
         *,
         login_client_type_id: UUID | None = None,
+        client_ip: str | None = None,
     ) -> LoginSessionCreationResult:
         return await self._db_source.create_login_session(
             user_id,
             access_key,
             domain_name,
             login_client_type_id=login_client_type_id,
+            client_ip=client_ip,
         )
 
     @auth_repository_resilience.apply()
     async def delete_login_sessions_by_tokens(
-        self, session_tokens: list[str], result: LoginAttemptResult
+        self,
+        session_tokens: list[str],
+        result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> None:
-        await self._db_source.delete_sessions_by_tokens(session_tokens, result)
+        await self._db_source.delete_sessions_by_tokens(session_tokens, result, client_ip)
 
     @auth_repository_resilience.apply()
     async def check_credential_without_migration(
@@ -177,20 +182,34 @@ class AuthRepository:
 
     @auth_repository_resilience.apply()
     async def delete_login_session_by_token(
-        self, session_token: str, result: LoginAttemptResult
+        self,
+        session_token: str,
+        result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> None:
-        await self._db_source.delete_session_by_token(session_token, result)
+        await self._db_source.delete_session_by_token(session_token, result, client_ip)
 
     @auth_repository_resilience.apply()
     async def delete_user_login_sessions(
-        self, user_id: UUID, domain_name: str, result: LoginAttemptResult
+        self,
+        user_id: UUID,
+        domain_name: str,
+        result: LoginAttemptResult,
+        client_ip: str | None = None,
     ) -> list[str]:
-        return await self._db_source.delete_sessions_by_user(user_id, domain_name, result)
+        return await self._db_source.delete_sessions_by_user(
+            user_id, domain_name, result, client_ip
+        )
 
     @auth_repository_resilience.apply()
-    async def delete_login_session_by_id(self, session_id: UUID, result: LoginAttemptResult) -> str:
+    async def delete_login_session_by_id(
+        self,
+        session_id: UUID,
+        result: LoginAttemptResult,
+        client_ip: str | None = None,
+    ) -> str:
         """Delete a login session, record history, and return its session_token."""
-        return await self._db_source.delete_session_by_id(session_id, result)
+        return await self._db_source.delete_session_by_id(session_id, result, client_ip)
 
     @auth_repository_resilience.apply()
     async def record_login_history(
@@ -199,5 +218,8 @@ class AuthRepository:
         domain_name: str,
         result: LoginAttemptResult,
         fail_reason: str | None = None,
+        client_ip: str | None = None,
     ) -> None:
-        await self._db_source.record_login_history(user_id, domain_name, result, fail_reason)
+        await self._db_source.record_login_history(
+            user_id, domain_name, result, fail_reason, client_ip
+        )

--- a/src/ai/backend/manager/repositories/client_ip_masking/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/client_ip_masking/db_source/db_source.py
@@ -1,0 +1,35 @@
+"""Database source for client IP masking policies."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+
+class ClientIPMaskingDBSource:
+    _db: ExtendedAsyncSAEngine
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db = db
+
+    async def resolve_mode(self, target_type: ClientIPMaskingTarget) -> ClientIPMaskingMode:
+        """The masking that applies to one target.
+
+        The target's own row wins over the ``default`` row, and neither being present
+        means the address is recorded as observed.
+        """
+        async with self._db.begin_readonly_session_read_committed() as session:
+            stmt = sa.select(ClientIPMaskingPolicyRow).where(
+                ClientIPMaskingPolicyRow.target_type.in_([
+                    target_type,
+                    ClientIPMaskingTarget.DEFAULT,
+                ])
+            )
+            rows = (await session.execute(stmt)).scalars().all()
+        modes = {row.target_type: row.mode for row in rows}
+        if target_type in modes:
+            return modes[target_type]
+        return modes.get(ClientIPMaskingTarget.DEFAULT, ClientIPMaskingMode.NONE)

--- a/src/ai/backend/manager/repositories/client_ip_masking/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/client_ip_masking/db_source/db_source.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import sqlalchemy as sa
 
-from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.masking import (
+    ClientIPMasker,
+    ClientIPMaskingMode,
+    ClientIPMaskingTarget,
+)
 from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
@@ -15,11 +19,12 @@ class ClientIPMaskingDBSource:
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db = db
 
-    async def resolve_mode(self, target_type: ClientIPMaskingTarget) -> ClientIPMaskingMode:
+    async def resolve_masker(self, target_type: ClientIPMaskingTarget) -> ClientIPMasker:
         """The masking that applies to one target.
 
-        The target's own row wins over the ``default`` row, and neither being present
-        means the address is recorded as observed.
+        The row is the unit: the target's own row wins over the ``default`` row whole,
+        prefixes included. Neither being present means the address is recorded as
+        observed.
         """
         async with self._db.begin_readonly_session_read_committed() as session:
             stmt = sa.select(ClientIPMaskingPolicyRow).where(
@@ -29,7 +34,17 @@ class ClientIPMaskingDBSource:
                 ])
             )
             rows = (await session.execute(stmt)).scalars().all()
-        modes = {row.target_type: row.mode for row in rows}
-        if target_type in modes:
-            return modes[target_type]
-        return modes.get(ClientIPMaskingTarget.DEFAULT, ClientIPMaskingMode.NONE)
+        by_target = {row.target_type: row for row in rows}
+        row = by_target.get(target_type) or by_target.get(ClientIPMaskingTarget.DEFAULT)
+        if row is None:
+            return ClientIPMasker(ClientIPMaskingMode.NONE)
+        return self._to_masker(row)
+
+    def _to_masker(self, row: ClientIPMaskingPolicyRow) -> ClientIPMasker:
+        """A NULL prefix takes the built-in width."""
+        defaults = ClientIPMasker(row.mode)
+        return ClientIPMasker(
+            mode=row.mode,
+            ipv4_prefix=row.ipv4_prefix if row.ipv4_prefix is not None else defaults.ipv4_prefix,
+            ipv6_prefix=row.ipv6_prefix if row.ipv6_prefix is not None else defaults.ipv6_prefix,
+        )

--- a/src/ai/backend/manager/repositories/client_ip_masking/repositories.py
+++ b/src/ai/backend/manager/repositories/client_ip_masking/repositories.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from typing import Self
+
+from ai.backend.manager.repositories.client_ip_masking.repository import ClientIPMaskingRepository
+from ai.backend.manager.repositories.types import RepositoryArgs
+
+
+@dataclass
+class ClientIPMaskingRepositories:
+    repository: ClientIPMaskingRepository
+
+    @classmethod
+    def create(cls, args: RepositoryArgs) -> Self:
+        return cls(repository=ClientIPMaskingRepository(args.db))

--- a/src/ai/backend/manager/repositories/client_ip_masking/repository.py
+++ b/src/ai/backend/manager/repositories/client_ip_masking/repository.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from ai.backend.manager.data.client_ip.masking import (
-    ClientIPMasker,
-    ClientIPMaskingMode,
-    ClientIPMaskingTarget,
-)
+from ai.backend.manager.data.client_ip.masking import ClientIPMasker, ClientIPMaskingTarget
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 from .db_source.db_source import ClientIPMaskingDBSource
@@ -18,8 +14,8 @@ class ClientIPMaskingRepository:
     def __init__(self, db: ExtendedAsyncSAEngine) -> None:
         self._db_source = ClientIPMaskingDBSource(db)
 
-    async def resolve_mode(self, target_type: ClientIPMaskingTarget) -> ClientIPMaskingMode:
-        return await self._db_source.resolve_mode(target_type)
+    async def resolve_masker(self, target_type: ClientIPMaskingTarget) -> ClientIPMasker:
+        return await self._db_source.resolve_masker(target_type)
 
     async def mask(self, target_type: ClientIPMaskingTarget, client_ip: str | None) -> str | None:
         """The address a record of this target keeps.
@@ -27,5 +23,5 @@ class ClientIPMaskingRepository:
         The single place masking is applied: every record type resolves its own
         policy here rather than repeating the two steps at each write.
         """
-        mode = await self.resolve_mode(target_type)
-        return ClientIPMasker(mode).mask(client_ip)
+        masker = await self.resolve_masker(target_type)
+        return masker.mask(client_ip)

--- a/src/ai/backend/manager/repositories/client_ip_masking/repository.py
+++ b/src/ai/backend/manager/repositories/client_ip_masking/repository.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.masking import (
+    ClientIPMasker,
+    ClientIPMaskingMode,
+    ClientIPMaskingTarget,
+)
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 from .db_source.db_source import ClientIPMaskingDBSource
@@ -16,3 +20,12 @@ class ClientIPMaskingRepository:
 
     async def resolve_mode(self, target_type: ClientIPMaskingTarget) -> ClientIPMaskingMode:
         return await self._db_source.resolve_mode(target_type)
+
+    async def mask(self, target_type: ClientIPMaskingTarget, client_ip: str | None) -> str | None:
+        """The address a record of this target keeps.
+
+        The single place masking is applied: every record type resolves its own
+        policy here rather than repeating the two steps at each write.
+        """
+        mode = await self.resolve_mode(target_type)
+        return ClientIPMasker(mode).mask(client_ip)

--- a/src/ai/backend/manager/repositories/client_ip_masking/repository.py
+++ b/src/ai/backend/manager/repositories/client_ip_masking/repository.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+
+from .db_source.db_source import ClientIPMaskingDBSource
+
+
+class ClientIPMaskingRepository:
+    """The read other domains resolve their masking through; the writes run against ops."""
+
+    _db_source: ClientIPMaskingDBSource
+
+    def __init__(self, db: ExtendedAsyncSAEngine) -> None:
+        self._db_source = ClientIPMaskingDBSource(db)
+
+    async def resolve_mode(self, target_type: ClientIPMaskingTarget) -> ClientIPMaskingMode:
+        return await self._db_source.resolve_mode(target_type)

--- a/src/ai/backend/manager/repositories/repositories.py
+++ b/src/ai/backend/manager/repositories/repositories.py
@@ -7,6 +7,9 @@ from ai.backend.manager.repositories.artifact_registry.repositories import (
     ArtifactRegistryRepositories,
 )
 from ai.backend.manager.repositories.auth.repositories import AuthRepositories
+from ai.backend.manager.repositories.client_ip_masking.repositories import (
+    ClientIPMaskingRepositories,
+)
 from ai.backend.manager.repositories.container_registry.repositories import (
     ContainerRegistryRepositories,
 )
@@ -101,6 +104,7 @@ class Repositories:
     resource_preset: ResourcePresetRepositories
     resource_slot: ResourceSlotRepositories
     runtime_variant: RuntimeVariantRepositories
+    client_ip_masking: ClientIPMaskingRepositories
     runtime_variant_preset: RuntimeVariantPresetRepositories
     deployment_revision_preset: DeploymentPresetRepositories
     model_card: ModelCardRepositories
@@ -148,6 +152,7 @@ class Repositories:
         resource_preset_repositories = ResourcePresetRepositories.create(args)
         resource_slot_repositories = ResourceSlotRepositories.create(args)
         runtime_variant_repositories = RuntimeVariantRepositories.create(args)
+        client_ip_masking_repositories = ClientIPMaskingRepositories.create(args)
         runtime_variant_preset_repositories = RuntimeVariantPresetRepositories.create(args)
         deployment_revision_preset_repositories = DeploymentPresetRepositories.create(args)
         model_card_repositories = ModelCardRepositories.create(args)
@@ -196,6 +201,7 @@ class Repositories:
             resource_preset=resource_preset_repositories,
             resource_slot=resource_slot_repositories,
             runtime_variant=runtime_variant_repositories,
+            client_ip_masking=client_ip_masking_repositories,
             runtime_variant_preset=runtime_variant_preset_repositories,
             deployment_revision_preset=deployment_revision_preset_repositories,
             model_card=model_card_repositories,

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -340,9 +340,9 @@ async def server_main(
         _error_monitor_ref = dep_resources.monitoring.error_monitor
 
         # Insert DI-based middlewares now that dependencies are available.
-        # Maintain order: request_id(0) → exception(1) → auth(2) → api → metric
+        # Maintain order: request_id(0) → client_ip(1) → exception(2) → auth(3) → api → metric
         root_app.middlewares.insert(
-            1,
+            2,
             build_exception_middleware(
                 error_monitor=dep_resources.monitoring.error_monitor,
                 stats_monitor=dep_resources.monitoring.stats_monitor,
@@ -350,7 +350,7 @@ async def server_main(
             ),
         )
         root_app.middlewares.insert(
-            2,
+            3,
             build_auth_middleware(
                 db=dep_resources.infrastructure.db,
                 jwt_validator=dep_resources.system.jwt_validator,

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -16,6 +16,7 @@ from ai.backend.common.clients.valkey_client.valkey_session.types import (
     LoginSessionInner,
     LoginSessionTokenData,
 )
+from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.dto.manager.auth.types import AuthTokenType
 from ai.backend.common.exception import InvalidAPIParameters, UserResourcePolicyNotFound
@@ -26,6 +27,7 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.config.unified import AuthConfig
 from ai.backend.manager.data.auth.login_session_types import LoginAttemptResult
 from ai.backend.manager.data.auth.types import AuthorizationResult, SSHKeypair
+from ai.backend.manager.data.client_ip.masking import ClientIPMasker, ClientIPMaskingTarget
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.defs import DEFAULT_PROJECT_NAME
 from ai.backend.manager.errors.auth import (
@@ -56,6 +58,9 @@ from ai.backend.manager.models.user import (
 from ai.backend.manager.models.user.creators import UserCreator
 from ai.backend.manager.repositories.auth.db_source.db_source import ActiveSessionInfo
 from ai.backend.manager.repositories.auth.repository import AuthRepository
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.project.repository import ProjectRepository
 from ai.backend.manager.repositories.user.repository import UserRepository
 from ai.backend.manager.repositories.user_resource_policy.repository import (
@@ -138,6 +143,7 @@ class AuthService:
     _user_repository: UserRepository
     _group_repository: ProjectRepository
     _ssh_key_validator: SSHKeyValidator
+    _client_ip_masking_repository: ClientIPMaskingRepository
 
     def __init__(
         self,
@@ -149,6 +155,7 @@ class AuthService:
         user_repository: UserRepository,
         group_repository: ProjectRepository,
         ssh_key_validator: SSHKeyValidator,
+        client_ip_masking_repository: ClientIPMaskingRepository,
     ) -> None:
         self._hook_plugin_ctx = hook_plugin_ctx
         self._auth_repository = auth_repository
@@ -158,6 +165,7 @@ class AuthService:
         self._user_repository = user_repository
         self._group_repository = group_repository
         self._ssh_key_validator = ssh_key_validator
+        self._client_ip_masking_repository = client_ip_masking_repository
 
     async def get_role(self, action: PublicGetRoleAction) -> PublicGetRoleActionResult:
         group_role = None
@@ -313,7 +321,9 @@ class AuthService:
                 live_sessions.append(session_info)
             else:
                 await self._auth_repository.delete_login_session_by_token(
-                    session_info.session_token, LoginAttemptResult.EXPIRED
+                    session_info.session_token,
+                    LoginAttemptResult.EXPIRED,
+                    await self._recorded_client_ip(),
                 )
 
         return default_keypair, live_sessions
@@ -394,13 +404,14 @@ class AuthService:
             access_key=keypair.access_key,
             domain_name=action.domain_name,
             login_client_type_id=login_client_type_id,
+            client_ip=await self._recorded_client_ip(),
         )
 
         if tokens_to_invalidate:
             for token in tokens_to_invalidate:
                 await self._valkey_session_client.delete_login_session(token)
             await self._auth_repository.delete_login_sessions_by_tokens(
-                tokens_to_invalidate, LoginAttemptResult.EVICTED
+                tokens_to_invalidate, LoginAttemptResult.EVICTED, await self._recorded_client_ip()
             )
 
         session_data = LoginSessionData(
@@ -435,6 +446,13 @@ class AuthService:
             ),
         )
 
+    async def _recorded_client_ip(self) -> str | None:
+        """The caller's address as login history keeps it, masked per the stored setting."""
+        mode = await self._client_ip_masking_repository.resolve_mode(
+            ClientIPMaskingTarget.LOGIN_HISTORY
+        )
+        return ClientIPMasker(mode).mask(current_client_ip())
+
     async def _record_login_failure(
         self,
         user_uuid: uuid.UUID,
@@ -442,7 +460,9 @@ class AuthService:
         result: LoginAttemptResult,
     ) -> None:
         try:
-            await self._auth_repository.record_login_history(user_uuid, domain_name, result)
+            await self._auth_repository.record_login_history(
+                user_uuid, domain_name, result, client_ip=await self._recorded_client_ip()
+            )
         except Exception:
             log.warning("Failed to record login history: {} for user {}", result, user_uuid)
 
@@ -550,7 +570,7 @@ class AuthService:
 
     async def logout(self, action: LogoutAction) -> LogoutActionResult:
         await self._auth_repository.delete_login_session_by_token(
-            action.session_token, LoginAttemptResult.LOGOUT
+            action.session_token, LoginAttemptResult.LOGOUT, await self._recorded_client_ip()
         )
         await self._valkey_session_client.delete_login_session(action.session_token)
         return LogoutActionResult(success=True)
@@ -559,7 +579,7 @@ class AuthService:
         self, action: GlobalRevokeLoginSessionAction
     ) -> RevokeLoginSessionActionResult:
         session_token = await self._auth_repository.delete_login_session_by_id(
-            action.session_id, LoginAttemptResult.REVOKED_BY_ADMIN
+            action.session_id, LoginAttemptResult.REVOKED_BY_ADMIN, await self._recorded_client_ip()
         )
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
@@ -568,7 +588,7 @@ class AuthService:
         self, action: RevokeLoginSessionAction
     ) -> RevokeLoginSessionActionResult:
         session_token = await self._auth_repository.delete_login_session_by_id(
-            action.session_id, LoginAttemptResult.REVOKED_BY_USER
+            action.session_id, LoginAttemptResult.REVOKED_BY_USER, await self._recorded_client_ip()
         )
         await self._valkey_session_client.delete_login_session(session_token)
         return RevokeLoginSessionActionResult(success=True)
@@ -589,7 +609,10 @@ class AuthService:
             action.password,
         )
         deleted_tokens = await self._auth_repository.delete_user_login_sessions(
-            action.user_id, action.domain_name, LoginAttemptResult.LOGOUT
+            action.user_id,
+            action.domain_name,
+            LoginAttemptResult.LOGOUT,
+            await self._recorded_client_ip(),
         )
         for token in deleted_tokens:
             await self._valkey_session_client.delete_login_session(token)

--- a/src/ai/backend/manager/services/auth/service.py
+++ b/src/ai/backend/manager/services/auth/service.py
@@ -27,7 +27,7 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.config.unified import AuthConfig
 from ai.backend.manager.data.auth.login_session_types import LoginAttemptResult
 from ai.backend.manager.data.auth.types import AuthorizationResult, SSHKeypair
-from ai.backend.manager.data.client_ip.masking import ClientIPMasker, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.defs import DEFAULT_PROJECT_NAME
 from ai.backend.manager.errors.auth import (
@@ -447,11 +447,10 @@ class AuthService:
         )
 
     async def _recorded_client_ip(self) -> str | None:
-        """The caller's address as login history keeps it, masked per the stored setting."""
-        mode = await self._client_ip_masking_repository.resolve_mode(
-            ClientIPMaskingTarget.LOGIN_HISTORY
+        """The caller's address as login history keeps it, masked per the stored policy."""
+        return await self._client_ip_masking_repository.mask(
+            ClientIPMaskingTarget.LOGIN_HISTORY, current_client_ip()
         )
-        return ClientIPMasker(mode).mask(current_client_ip())
 
     async def _record_login_failure(
         self,

--- a/src/ai/backend/manager/services/client_ip_masking/actions/purge.py
+++ b/src/ai/backend/manager/services/client_ip_masking/actions/purge.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PurgeEntityOpsAction
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.client_ip_masking.purgers import ClientIPMaskingPolicyPurger
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+
+
+@dataclass
+class PurgeClientIPMaskingPolicyAction(
+    PurgeEntityOpsAction[ClientIPMaskingPolicyRow, ClientIPMaskingPolicyData]
+):
+    """Drop one target's policy so it falls back to ``default``.
+
+    Purge-shaped: the table carries no lifecycle column, so removing a policy has
+    always been the row leaving the table.
+    """
+
+    id: ClientIPMaskingPolicyID
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "purge_client_ip_masking_policy"
+
+    @override
+    def entity_id(self) -> EntityIdentifier:
+        return self.to_purger().entity_id()
+
+    @override
+    def to_purger(self) -> ClientIPMaskingPolicyPurger:
+        return ClientIPMaskingPolicyPurger(policy_id=self.id)

--- a/src/ai/backend/manager/services/client_ip_masking/actions/search.py
+++ b/src/ai/backend/manager/services/client_ip_masking/actions/search.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.client_ip_masking.searchers import ClientIPMaskingPolicySearcher
+
+
+@dataclass
+class SearchClientIPMaskingPoliciesAction(
+    SearchGlobalOpsAction[ClientIPMaskingPolicyRow, ClientIPMaskingPolicyData]
+):
+    """Read the masking set for every target."""
+
+    searcher: ClientIPMaskingPolicySearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "search_client_ip_masking_policies"
+
+    @override
+    def to_searcher(self) -> ClientIPMaskingPolicySearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/client_ip_masking/actions/upsert.py
+++ b/src/ai/backend/manager/services/client_ip_masking/actions/upsert.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import UpsertGlobalOpsAction
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.client_ip_masking.upserters import ClientIPMaskingPolicyUpserter
+
+
+@dataclass
+class UpsertClientIPMaskingPolicyAction(
+    UpsertGlobalOpsAction[ClientIPMaskingPolicyRow, ClientIPMaskingPolicyData]
+):
+    """Set the masking one target gets.
+
+    Upsert-shaped: a target holds one policy, so the caller names the target rather
+    than looking up whether a row is already there.
+    """
+
+    target_type: ClientIPMaskingTarget
+    mode: ClientIPMaskingMode
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "upsert_client_ip_masking_policy"
+
+    @override
+    def to_upserter(self) -> ClientIPMaskingPolicyUpserter:
+        return ClientIPMaskingPolicyUpserter(target_type=self.target_type, mode=self.mode)

--- a/src/ai/backend/manager/services/client_ip_masking/actions/upsert.py
+++ b/src/ai/backend/manager/services/client_ip_masking/actions/upsert.py
@@ -24,6 +24,8 @@ class UpsertClientIPMaskingPolicyAction(
 
     target_type: ClientIPMaskingTarget
     mode: ClientIPMaskingMode
+    ipv4_prefix: int | None
+    ipv6_prefix: int | None
 
     @override
     @classmethod
@@ -37,4 +39,9 @@ class UpsertClientIPMaskingPolicyAction(
 
     @override
     def to_upserter(self) -> ClientIPMaskingPolicyUpserter:
-        return ClientIPMaskingPolicyUpserter(target_type=self.target_type, mode=self.mode)
+        return ClientIPMaskingPolicyUpserter(
+            target_type=self.target_type,
+            mode=self.mode,
+            ipv4_prefix=self.ipv4_prefix,
+            ipv6_prefix=self.ipv6_prefix,
+        )

--- a/src/ai/backend/manager/services/client_ip_masking/processors.py
+++ b/src/ai/backend/manager/services/client_ip_masking/processors.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
+from ai.backend.manager.actions.v2.ops.result import BatchOpsResult, EntityOpsResult
+from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
+from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
+from ai.backend.manager.services.client_ip_masking.actions.purge import (
+    PurgeClientIPMaskingPolicyAction,
+)
+from ai.backend.manager.services.client_ip_masking.actions.search import (
+    SearchClientIPMaskingPoliciesAction,
+)
+from ai.backend.manager.services.client_ip_masking.actions.upsert import (
+    UpsertClientIPMaskingPolicyAction,
+)
+
+
+class ClientIPMaskingProcessors:
+    """Every operation runs against ops: the policies carry no rule of their own."""
+
+    global_search: GlobalActionProcessor[
+        SearchClientIPMaskingPoliciesAction, BatchOpsResult[ClientIPMaskingPolicyData]
+    ]
+    global_upsert: GlobalActionProcessor[
+        UpsertClientIPMaskingPolicyAction, EntityOpsResult[ClientIPMaskingPolicyData]
+    ]
+    purge: SingleEntityActionProcessor[
+        PurgeClientIPMaskingPolicyAction, EntityOpsResult[ClientIPMaskingPolicyData]
+    ]
+
+    def __init__(self, group: ProcessorGroup[ClientIPMaskingPolicyData]) -> None:
+        self.global_search = group.global_search_ops(SearchClientIPMaskingPoliciesAction)
+        self.global_upsert = group.global_upsert_ops(UpsertClientIPMaskingPolicyAction)
+        self.purge = group.entity_purge_ops(PurgeClientIPMaskingPolicyAction)

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -12,6 +12,7 @@ from ai.backend.common.data.entity.artifact_registry import ARTIFACT_REGISTRY_EN
 from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
 from ai.backend.common.data.entity.audit_log import AUDIT_LOG_FIELD_TYPE
 from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
+from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
 from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
 from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
 from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
@@ -108,6 +109,7 @@ from ai.backend.manager.services.artifact_registry.service import ArtifactRegist
 from ai.backend.manager.services.audit_log.processors import AuditLogProcessors
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.auth.service import AuthService
+from ai.backend.manager.services.client_ip_masking.processors import ClientIPMaskingProcessors
 from ai.backend.manager.services.container_registry.processors import ContainerRegistryProcessors
 from ai.backend.manager.services.container_registry.service import ContainerRegistryService
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
@@ -394,6 +396,7 @@ def create_services(args: ServiceArgs) -> Services:
             user_repository=repositories.user.repository,
             group_repository=repositories.project.repository,
             ssh_key_validator=args.ssh_key_validator,
+            client_ip_masking_repository=repositories.client_ip_masking.repository,
         ),
         notification=NotificationService(
             repository=repositories.notification.repository,
@@ -634,6 +637,9 @@ def create_processors(
         ),
         runtime_variant=RuntimeVariantProcessors(
             system_groups.group(GroupMeta(RUNTIME_VARIANT_ENTITY_TYPE))
+        ),
+        client_ip_masking=ClientIPMaskingProcessors(
+            system_groups.group(GroupMeta(CLIENT_IP_MASKING_POLICY_ENTITY_TYPE))
         ),
         runtime_variant_preset=RuntimeVariantPresetProcessors(
             system_groups.group(GroupMeta(RUNTIME_VARIANT_PRESET_ENTITY_TYPE)),

--- a/src/ai/backend/manager/services/processors.py
+++ b/src/ai/backend/manager/services/processors.py
@@ -70,6 +70,9 @@ if TYPE_CHECKING:
     )
     from ai.backend.manager.services.auth.processors import AuthProcessors
     from ai.backend.manager.services.auth.service import AuthService
+    from ai.backend.manager.services.client_ip_masking.processors import (
+        ClientIPMaskingProcessors,
+    )
     from ai.backend.manager.services.container_registry.processors import (
         ContainerRegistryProcessors,
     )
@@ -416,6 +419,7 @@ class Processors:
     retention_policy: RetentionPolicyProcessors
     role_preset: RolePresetProcessors
     runtime_variant: RuntimeVariantProcessors
+    client_ip_masking: ClientIPMaskingProcessors
     runtime_variant_preset: RuntimeVariantPresetProcessors
     deployment_revision_preset: DeploymentPresetProcessors
     model_card: ModelCardProcessors

--- a/tests/component/client_ip_masking/BUILD
+++ b/tests/component/client_ip_masking/BUILD
@@ -1,0 +1,5 @@
+python_test_utils()
+
+python_tests(
+    name="tests",
+)

--- a/tests/component/client_ip_masking/conftest.py
+++ b/tests/component/client_ip_masking/conftest.py
@@ -1,0 +1,112 @@
+"""Component test fixtures for the client IP masking policies."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+import sqlalchemy as sa
+import yarl
+
+from ai.backend.client.v2.auth import HMACAuth
+from ai.backend.client.v2.config import ClientConfig
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+from ai.backend.manager.actions.registry.registry import ProcessorRegistry
+from ai.backend.manager.actions.registry.types import GroupMeta
+from ai.backend.manager.api.adapters.client_ip_masking.adapter import ClientIPMaskingAdapter
+from ai.backend.manager.api.rest.routing import RouteRegistry
+from ai.backend.manager.api.rest.types import RouteDeps
+from ai.backend.manager.api.rest.v2.client_ip_masking.handler import V2ClientIPMaskingHandler
+from ai.backend.manager.api.rest.v2.client_ip_masking.registry import (
+    register_v2_client_ip_masking_routes,
+)
+from ai.backend.manager.models.client_ip_masking.row import ClientIPMaskingPolicyRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.repositories.client_ip_masking.repository import ClientIPMaskingRepository
+from ai.backend.manager.services.client_ip_masking.processors import ClientIPMaskingProcessors
+from ai.backend.manager.services.processors import Processors
+
+if TYPE_CHECKING:
+    from tests.component.conftest import ServerInfo, UserFixtureData
+
+
+@pytest.fixture()
+def client_ip_masking_processors(
+    processor_registry: ProcessorRegistry[Any],
+) -> ClientIPMaskingProcessors:
+    return ClientIPMaskingProcessors(
+        processor_registry.group(GroupMeta(CLIENT_IP_MASKING_POLICY_ENTITY_TYPE))
+    )
+
+
+@pytest.fixture()
+def server_module_registries(
+    route_deps: RouteDeps,
+    client_ip_masking_processors: ClientIPMaskingProcessors,
+) -> list[RouteRegistry]:
+    processors = MagicMock(spec=Processors)
+    processors.client_ip_masking = client_ip_masking_processors
+    adapter = ClientIPMaskingAdapter(processors)
+    handler = V2ClientIPMaskingHandler(adapter=adapter)
+    v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
+    v2_reg.add_subregistry(register_v2_client_ip_masking_routes(handler, route_deps))
+    return [v2_reg]
+
+
+@pytest.fixture()
+def masking_repository(database_engine: ExtendedAsyncSAEngine) -> ClientIPMaskingRepository:
+    """The read the login path resolves its masking through."""
+    return ClientIPMaskingRepository(database_engine)
+
+
+@pytest.fixture(autouse=True)
+async def clean_policies(database_engine: ExtendedAsyncSAEngine) -> AsyncIterator[None]:
+    """Empty the table around each test.
+
+    The policies are global, so a row one test leaves behind would decide what the
+    next one resolves.
+    """
+    async with database_engine.begin() as conn:
+        await conn.execute(sa.delete(ClientIPMaskingPolicyRow.__table__))
+    yield
+    async with database_engine.begin() as conn:
+        await conn.execute(sa.delete(ClientIPMaskingPolicyRow.__table__))
+
+
+@pytest.fixture()
+async def admin_v2_registry(
+    server: ServerInfo,
+    admin_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=admin_user_fixture.keypair.access_key,
+            secret_key=admin_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()
+
+
+@pytest.fixture()
+async def user_v2_registry(
+    server: ServerInfo,
+    regular_user_fixture: UserFixtureData,
+) -> AsyncIterator[V2ClientRegistry]:
+    registry = await V2ClientRegistry.create(
+        ClientConfig(endpoint=yarl.URL(server.url)),
+        HMACAuth(
+            access_key=regular_user_fixture.keypair.access_key,
+            secret_key=regular_user_fixture.keypair.secret_key,
+        ),
+    )
+    try:
+        yield registry
+    finally:
+        await registry.close()

--- a/tests/component/client_ip_masking/test_client_ip_masking_policies.py
+++ b/tests/component/client_ip_masking/test_client_ip_masking_policies.py
@@ -38,9 +38,17 @@ async def _upsert(
     registry: V2ClientRegistry,
     target_type: ClientIPMaskingTarget,
     mode: ClientIPMaskingMode,
+    *,
+    ipv4_prefix: int | None = None,
+    ipv6_prefix: int | None = None,
 ) -> None:
     await registry.client_ip_masking.admin_upsert(
-        AdminUpsertClientIPMaskingPolicyInput(target_type=target_type, mode=mode),
+        AdminUpsertClientIPMaskingPolicyInput(
+            target_type=target_type,
+            mode=mode,
+            ipv4_prefix=ipv4_prefix,
+            ipv6_prefix=ipv6_prefix,
+        ),
     )
 
 
@@ -290,6 +298,98 @@ class TestClientIPMaskingPoliciesSearchArguments:
         assert second_page.items[0].id != first_page.items[0].id
 
 
+class TestTruncationWidth:
+    """How much of the address `truncate` leaves is the policy's to say."""
+
+    async def test_the_width_round_trips(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.TRUNCATE,
+            ipv4_prefix=16,
+            ipv6_prefix=32,
+        )
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+
+        assert [(item.ipv4_prefix, item.ipv6_prefix) for item in result.items] == [(16, 32)]
+
+    async def test_an_omitted_width_stays_null(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        """A policy that names no width takes the built-in one rather than storing it."""
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+
+        assert [(item.ipv4_prefix, item.ipv6_prefix) for item in result.items] == [(None, None)]
+
+    async def test_the_width_reaches_the_masker_the_login_path_resolves(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.TRUNCATE,
+            ipv4_prefix=16,
+        )
+
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert masker.mask("203.0.113.7") == "203.0.0.0"
+
+    async def test_an_omitted_width_falls_back_to_the_built_in_one(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert masker.mask("203.0.113.7") == "203.0.113.0"
+
+    async def test_the_target_row_wins_whole_including_its_width(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        """The row is the unit: an override does not inherit the default's width."""
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.DEFAULT,
+            ClientIPMaskingMode.TRUNCATE,
+            ipv4_prefix=8,
+        )
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert masker.mask("203.0.113.7") == "203.0.113.0"
+
+
 class TestWhatTheLoginPathResolves:
     """The API writes the row; the login path reads it through the repository."""
 
@@ -297,9 +397,9 @@ class TestWhatTheLoginPathResolves:
         self,
         masking_repository: ClientIPMaskingRepository,
     ) -> None:
-        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
 
-        assert mode == ClientIPMaskingModeData.NONE
+        assert masker.mode == ClientIPMaskingModeData.NONE
 
     async def test_the_default_applies_where_the_target_has_none(
         self,
@@ -312,9 +412,9 @@ class TestWhatTheLoginPathResolves:
             ClientIPMaskingMode.TRUNCATE,
         )
 
-        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
 
-        assert mode == ClientIPMaskingModeData.TRUNCATE
+        assert masker.mode == ClientIPMaskingModeData.TRUNCATE
 
     async def test_the_target_policy_wins_over_the_default(
         self,
@@ -332,9 +432,9 @@ class TestWhatTheLoginPathResolves:
             ClientIPMaskingMode.NONE,
         )
 
-        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
 
-        assert mode == ClientIPMaskingModeData.NONE
+        assert masker.mode == ClientIPMaskingModeData.NONE
 
     async def test_purging_the_override_falls_back_to_the_default(
         self,
@@ -357,6 +457,6 @@ class TestWhatTheLoginPathResolves:
             AdminPurgeClientIPMaskingPolicyInput(id=override.policy.id),
         )
 
-        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+        masker = await masking_repository.resolve_masker(ClientIPMaskingTargetData.LOGIN_HISTORY)
 
-        assert mode == ClientIPMaskingModeData.TRUNCATE
+        assert masker.mode == ClientIPMaskingModeData.TRUNCATE

--- a/tests/component/client_ip_masking/test_client_ip_masking_policies.py
+++ b/tests/component/client_ip_masking/test_client_ip_masking_policies.py
@@ -1,0 +1,362 @@
+"""The masking policies over the real REST stack.
+
+Covers what the unit tests cannot: that the upsert conflicts on ``target_type``
+rather than inserting a second row, that the DTO round-trips through the adapter,
+and that the login path's read sees what the API wrote.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.client.v2.exceptions import PermissionDeniedError
+from ai.backend.client.v2.v2_registry import V2ClientRegistry
+from ai.backend.common.dto.manager.v2.client_ip_masking.request import (
+    AdminPurgeClientIPMaskingPolicyInput,
+    AdminSearchClientIPMaskingPoliciesInput,
+    AdminUpsertClientIPMaskingPolicyInput,
+    ClientIPMaskingPolicyFilter,
+    ClientIPMaskingPolicyOrder,
+)
+from ai.backend.common.dto.manager.v2.client_ip_masking.types import (
+    ClientIPMaskingMode,
+    ClientIPMaskingPolicyOrderField,
+    ClientIPMaskingTarget,
+)
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.manager.api.adapter_options.cursor.cursor import encode_cursor
+from ai.backend.manager.data.client_ip.masking import (
+    ClientIPMaskingMode as ClientIPMaskingModeData,
+)
+from ai.backend.manager.data.client_ip.masking import (
+    ClientIPMaskingTarget as ClientIPMaskingTargetData,
+)
+from ai.backend.manager.repositories.client_ip_masking.repository import ClientIPMaskingRepository
+
+
+async def _upsert(
+    registry: V2ClientRegistry,
+    target_type: ClientIPMaskingTarget,
+    mode: ClientIPMaskingMode,
+) -> None:
+    await registry.client_ip_masking.admin_upsert(
+        AdminUpsertClientIPMaskingPolicyInput(target_type=target_type, mode=mode),
+    )
+
+
+class TestClientIPMaskingPoliciesAccess:
+    async def test_a_regular_user_cannot_read_the_policies(
+        self,
+        user_v2_registry: V2ClientRegistry,
+    ) -> None:
+        with pytest.raises(PermissionDeniedError):
+            await user_v2_registry.client_ip_masking.admin_search(
+                AdminSearchClientIPMaskingPoliciesInput(),
+            )
+
+    async def test_a_regular_user_cannot_change_the_policies(
+        self,
+        user_v2_registry: V2ClientRegistry,
+    ) -> None:
+        with pytest.raises(PermissionDeniedError):
+            await _upsert(
+                user_v2_registry,
+                ClientIPMaskingTarget.DEFAULT,
+                ClientIPMaskingMode.TRUNCATE,
+            )
+
+
+class TestClientIPMaskingPoliciesCrud:
+    async def test_nothing_is_set_to_begin_with(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+
+        assert result.items == []
+        assert result.total_count == 0
+
+    async def test_an_upsert_is_read_back(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+
+        assert [(item.target_type, item.mode) for item in result.items] == [
+            (ClientIPMaskingTarget.LOGIN_HISTORY, ClientIPMaskingMode.TRUNCATE)
+        ]
+
+    async def test_upserting_the_same_target_replaces_its_row(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        """The conflict is on ``target_type``: a target holds one policy, not a history."""
+        first = await admin_v2_registry.client_ip_masking.admin_upsert(
+            AdminUpsertClientIPMaskingPolicyInput(
+                target_type=ClientIPMaskingTarget.DEFAULT,
+                mode=ClientIPMaskingMode.TRUNCATE,
+            ),
+        )
+        second = await admin_v2_registry.client_ip_masking.admin_upsert(
+            AdminUpsertClientIPMaskingPolicyInput(
+                target_type=ClientIPMaskingTarget.DEFAULT,
+                mode=ClientIPMaskingMode.NONE,
+            ),
+        )
+
+        assert second.policy.id == first.policy.id
+        assert second.policy.mode == ClientIPMaskingMode.NONE
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+        assert result.total_count == 1
+
+    async def test_each_target_holds_its_own_row(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.DEFAULT,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.NONE,
+        )
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+
+        assert result.total_count == 2
+        assert {item.target_type: item.mode for item in result.items} == {
+            ClientIPMaskingTarget.DEFAULT: ClientIPMaskingMode.TRUNCATE,
+            ClientIPMaskingTarget.LOGIN_HISTORY: ClientIPMaskingMode.NONE,
+        }
+
+    async def test_the_drop_mode_round_trips(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        """A deployment that must keep no address at all can say so."""
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.DROP,
+        )
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+
+        assert [item.mode for item in result.items] == [ClientIPMaskingMode.DROP]
+
+    async def test_a_purged_policy_is_gone(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        created = await admin_v2_registry.client_ip_masking.admin_upsert(
+            AdminUpsertClientIPMaskingPolicyInput(
+                target_type=ClientIPMaskingTarget.LOGIN_HISTORY,
+                mode=ClientIPMaskingMode.TRUNCATE,
+            ),
+        )
+
+        await admin_v2_registry.client_ip_masking.admin_purge(
+            AdminPurgeClientIPMaskingPolicyInput(id=created.policy.id),
+        )
+
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(),
+        )
+        assert result.items == []
+
+
+class TestClientIPMaskingPoliciesSearchArguments:
+    """filter / order / pagination, the same arguments every other v2 search takes."""
+
+    @pytest.fixture(autouse=True)
+    async def both_targets_set(self, admin_v2_registry: V2ClientRegistry) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.DEFAULT,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.NONE,
+        )
+
+    async def test_filtering_by_target_narrows_the_result(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(
+                filter=ClientIPMaskingPolicyFilter(target_type=ClientIPMaskingTarget.LOGIN_HISTORY),
+            ),
+        )
+
+        assert [item.target_type for item in result.items] == [ClientIPMaskingTarget.LOGIN_HISTORY]
+
+    async def test_filtering_by_mode_narrows_the_result(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        result = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(
+                filter=ClientIPMaskingPolicyFilter(mode=ClientIPMaskingMode.TRUNCATE),
+            ),
+        )
+
+        assert [item.target_type for item in result.items] == [ClientIPMaskingTarget.DEFAULT]
+
+    async def test_ordering_by_target_type_reverses(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        ascending = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(
+                order=[
+                    ClientIPMaskingPolicyOrder(
+                        field=ClientIPMaskingPolicyOrderField.TARGET_TYPE,
+                        direction=OrderDirection.ASC,
+                    )
+                ],
+            ),
+        )
+        descending = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(
+                order=[
+                    ClientIPMaskingPolicyOrder(
+                        field=ClientIPMaskingPolicyOrderField.TARGET_TYPE,
+                        direction=OrderDirection.DESC,
+                    )
+                ],
+            ),
+        )
+
+        assert [item.target_type for item in ascending.items] == list(
+            reversed([item.target_type for item in descending.items])
+        )
+
+    async def test_offset_pagination_splits_the_result(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        first_page = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(limit=1, offset=0),
+        )
+        second_page = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(limit=1, offset=1),
+        )
+
+        assert len(first_page.items) == 1
+        assert len(second_page.items) == 1
+        assert first_page.items[0].id != second_page.items[0].id
+        assert first_page.total_count == 2
+
+    async def test_cursor_pagination_walks_forward(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+    ) -> None:
+        first_page = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(first=1),
+        )
+        assert len(first_page.items) == 1
+        assert first_page.has_next_page is True
+
+        second_page = await admin_v2_registry.client_ip_masking.admin_search(
+            AdminSearchClientIPMaskingPoliciesInput(
+                first=1, after=encode_cursor(first_page.items[0].id)
+            ),
+        )
+
+        assert len(second_page.items) == 1
+        assert second_page.items[0].id != first_page.items[0].id
+
+
+class TestWhatTheLoginPathResolves:
+    """The API writes the row; the login path reads it through the repository."""
+
+    async def test_no_policy_leaves_the_address_alone(
+        self,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert mode == ClientIPMaskingModeData.NONE
+
+    async def test_the_default_applies_where_the_target_has_none(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.DEFAULT,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+
+        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert mode == ClientIPMaskingModeData.TRUNCATE
+
+    async def test_the_target_policy_wins_over_the_default(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.DEFAULT,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.LOGIN_HISTORY,
+            ClientIPMaskingMode.NONE,
+        )
+
+        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert mode == ClientIPMaskingModeData.NONE
+
+    async def test_purging_the_override_falls_back_to_the_default(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        masking_repository: ClientIPMaskingRepository,
+    ) -> None:
+        await _upsert(
+            admin_v2_registry,
+            ClientIPMaskingTarget.DEFAULT,
+            ClientIPMaskingMode.TRUNCATE,
+        )
+        override = await admin_v2_registry.client_ip_masking.admin_upsert(
+            AdminUpsertClientIPMaskingPolicyInput(
+                target_type=ClientIPMaskingTarget.LOGIN_HISTORY,
+                mode=ClientIPMaskingMode.NONE,
+            ),
+        )
+
+        await admin_v2_registry.client_ip_masking.admin_purge(
+            AdminPurgeClientIPMaskingPolicyInput(id=override.policy.id),
+        )
+
+        mode = await masking_repository.resolve_mode(ClientIPMaskingTargetData.LOGIN_HISTORY)
+
+        assert mode == ClientIPMaskingModeData.TRUNCATE

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -144,6 +144,9 @@ from ai.backend.manager.notification.notification_center import NotificationCent
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.auth.repository import AuthRepository
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 from ai.backend.manager.repositories.db.engine import (
     connect_database,
     create_async_engine,
@@ -1450,6 +1453,7 @@ def auth_processors(
         user_repository=user_repository,
         group_repository=group_repository,
         ssh_key_validator=SSHKeyValidator(),
+        client_ip_masking_repository=ClientIPMaskingRepository(database_engine),
     )
     return AuthProcessors(
         processor_registry.group(GroupMeta(AUTH_ENTITY_TYPE)),
@@ -1500,9 +1504,10 @@ async def server(
         # JWT validator mock — HMAC auth only, JWT not called in tests
         jwt_validator = MagicMock()
 
-        # Insert DI-based middlewares with real plugin contexts
+        # Insert DI-based middlewares with real plugin contexts.
+        # Same order as server_main(): request_id(0) → client_ip(1) → exception(2) → auth(3)
         app.middlewares.insert(
-            1,
+            2,
             build_exception_middleware(
                 error_monitor=error_monitor,
                 stats_monitor=stats_monitor,
@@ -1510,7 +1515,7 @@ async def server(
             ),
         )
         app.middlewares.insert(
-            2,
+            3,
             build_auth_middleware(
                 db=db,
                 jwt_validator=jwt_validator,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -806,9 +806,10 @@ async def server_factory(
             dep_input,
         )
 
-        # Insert DI-based middlewares
+        # Insert DI-based middlewares.
+        # Same order as server_main(): request_id(0) → client_ip(1) → exception(2) → auth(3)
         root_app.middlewares.insert(
-            1,
+            2,
             build_exception_middleware(
                 error_monitor=r.monitoring.error_monitor,
                 stats_monitor=r.monitoring.stats_monitor,
@@ -816,7 +817,7 @@ async def server_factory(
             ),
         )
         root_app.middlewares.insert(
-            2,
+            3,
             build_auth_middleware(
                 db=r.infrastructure.db,
                 jwt_validator=r.system.jwt_validator,

--- a/tests/unit/manager/actions/test_processor.py
+++ b/tests/unit/manager/actions/test_processor.py
@@ -26,6 +26,9 @@ from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.models.audit_log.creators import LegacyAuditLogCreator
+from ai.backend.manager.repositories.client_ip_masking.repository import (
+    ClientIPMaskingRepository,
+)
 
 _MOCK_ACTION_TYPE: Final[str] = "test"
 _MOCK_OPERATION_TYPE: Final[str] = "create"
@@ -183,7 +186,13 @@ class TestAuditLogMonitorExclusionAtSetupTime:
 
     @pytest.fixture
     def audit_log_monitor(self, mock_audit_log_repository: MagicMock) -> AuditLogMonitor:
-        return AuditLogMonitor(repository=mock_audit_log_repository, policy=AuditLogPolicy([]))
+        masking_repository = AsyncMock(spec=ClientIPMaskingRepository)
+        masking_repository.mask.return_value = None
+        return AuditLogMonitor(
+            repository=mock_audit_log_repository,
+            policy=AuditLogPolicy([]),
+            client_ip_masking=masking_repository,
+        )
 
     @pytest.fixture
     def mock_action(self) -> MockAction:
@@ -231,7 +240,13 @@ class TestAuditLogMonitorActorIdentities:
 
     @pytest.fixture
     def audit_log_monitor(self, mock_audit_log_repository: MagicMock) -> AuditLogMonitor:
-        return AuditLogMonitor(repository=mock_audit_log_repository, policy=AuditLogPolicy([]))
+        masking_repository = AsyncMock(spec=ClientIPMaskingRepository)
+        masking_repository.mask.return_value = None
+        return AuditLogMonitor(
+            repository=mock_audit_log_repository,
+            policy=AuditLogPolicy([]),
+            client_ip_masking=masking_repository,
+        )
 
     def _result(self) -> ProcessResult:
         now = datetime.now(tz=UTC)

--- a/tests/unit/manager/api/test_client_ip_middleware.py
+++ b/tests/unit/manager/api/test_client_ip_middleware.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aiohttp import web
+
+from ai.backend.common.contexts.client_ip import current_client_ip
+from ai.backend.manager.api.rest.middleware.auth import (
+    TRUSTED_PROXY_NETWORKS_KEY,
+    parse_trusted_proxy_networks,
+)
+from ai.backend.manager.api.rest.middleware.client_ip import client_ip_middleware
+
+CLIENT = "203.0.113.7"
+TRUSTED_PROXY = "10.0.0.1"
+
+
+def _make_request(
+    *,
+    peer: str | None = CLIENT,
+    forwarded_for: str | None = None,
+    trusted_proxies: list[str] | None = None,
+) -> web.Request:
+    request = MagicMock(spec=web.Request)
+    request.headers = {} if forwarded_for is None else {"X-Forwarded-For": forwarded_for}
+    request.remote = peer
+    request.config_dict = {
+        TRUSTED_PROXY_NETWORKS_KEY: parse_trusted_proxy_networks(trusted_proxies or [])
+    }
+    if peer is None:
+        request.transport = None
+    else:
+        transport = MagicMock()
+        transport.get_extra_info.return_value = (peer, 54321)
+        request.transport = transport
+    return request
+
+
+async def _run(request: web.Request) -> str | None:
+    seen: list[str | None] = []
+
+    async def handler(_: web.Request) -> web.StreamResponse:
+        seen.append(current_client_ip())
+        return web.Response()
+
+    await client_ip_middleware(request, handler)
+    return seen[0]
+
+
+async def test_the_handler_sees_the_client_ip() -> None:
+    """The middleware runs before authentication, so a login attempt carries its address."""
+    assert await _run(_make_request()) == CLIENT
+
+
+async def test_the_address_is_resolved_through_the_trusted_proxy_chain() -> None:
+    request = _make_request(
+        peer=TRUSTED_PROXY,
+        forwarded_for=f"{CLIENT}, {TRUSTED_PROXY}",
+        trusted_proxies=[TRUSTED_PROXY],
+    )
+
+    assert await _run(request) == CLIENT
+
+
+async def test_a_request_without_an_address_leaves_the_context_empty() -> None:
+    assert await _run(_make_request(peer=None)) is None
+
+
+async def test_the_client_ip_does_not_leak_past_the_request() -> None:
+    await _run(_make_request())
+
+    assert current_client_ip() is None

--- a/tests/unit/manager/api/test_impersonation.py
+++ b/tests/unit/manager/api/test_impersonation.py
@@ -121,7 +121,6 @@ class TestResolveEffectiveUser:
 
 class TestSetupUserContext:
     def test_pushes_effective_as_current_and_trigger_as_triggered(self) -> None:
-        request = _make_request()
         effective = UserData(
             user_id=uuid.uuid4(),
             is_authorized=True,
@@ -140,14 +139,13 @@ class TestSetupUserContext:
             domain_name="default",
             domain_id=DomainID(uuid.uuid4()),
         )
-        with _setup_user_context(request, effective, trigger):
+        with _setup_user_context(effective, trigger):
             assert current_user() == effective
             assert triggered_user() == trigger
         assert current_user() is None
         assert triggered_user() is None
 
     def test_none_identities_push_nothing(self) -> None:
-        request = _make_request()
-        with _setup_user_context(request, None, None):
+        with _setup_user_context(None, None):
             assert current_user() is None
             assert triggered_user() is None

--- a/tests/unit/manager/data/client_ip/BUILD
+++ b/tests/unit/manager/data/client_ip/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/data/client_ip/test_masking.py
+++ b/tests/unit/manager/data/client_ip/test_masking.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from ai.backend.manager.data.client_ip.masking import ClientIPMasker, ClientIPMaskingMode
+
+
+@pytest.mark.parametrize(
+    ("client_ip", "expected"),
+    [
+        ("203.0.113.7", "203.0.113.7"),
+        ("2001:db8:1:2::1", "2001:db8:1:2::1"),
+        ("2001:0db8:0001:0002:0000:0000:0000:0001", "2001:db8:1:2::1"),
+    ],
+)
+def test_no_masking_keeps_the_address(client_ip: str, expected: str) -> None:
+    masker = ClientIPMasker(ClientIPMaskingMode.NONE)
+
+    assert masker.mask(client_ip) == expected
+
+
+@pytest.mark.parametrize(
+    ("client_ip", "expected"),
+    [
+        ("203.0.113.7", "203.0.113.0"),
+        ("10.1.2.34", "10.1.2.0"),
+        ("2001:db8:1:2::1", "2001:db8:1::"),
+        ("::1", "::"),
+    ],
+)
+def test_truncation_zeroes_the_host_bits(client_ip: str, expected: str) -> None:
+    masker = ClientIPMasker(ClientIPMaskingMode.TRUNCATE)
+
+    assert masker.mask(client_ip) == expected
+
+
+@pytest.mark.parametrize("mode", list(ClientIPMaskingMode))
+def test_a_missing_address_stays_missing(mode: ClientIPMaskingMode) -> None:
+    assert ClientIPMasker(mode).mask(None) is None
+
+
+@pytest.mark.parametrize("mode", list(ClientIPMaskingMode))
+@pytest.mark.parametrize(
+    "client_ip",
+    [
+        "not-an-address",
+        "203.0.113.7, 10.0.0.1",
+        "203.0.113.7:8080",
+        "",
+        "10.1.2.0/24",
+    ],
+)
+def test_an_unusable_address_is_dropped(mode: ClientIPMaskingMode, client_ip: str) -> None:
+    """A forged X-Forwarded-For must not reach the INET column and break the write."""
+    assert ClientIPMasker(mode).mask(client_ip) is None
+
+
+@pytest.mark.parametrize("client_ip", ["203.0.113.7", "2001:db8:1:2::1"])
+def test_dropping_records_no_address(client_ip: str) -> None:
+    """A deployment that must keep no address at all has a mode for it."""
+    assert ClientIPMasker(ClientIPMaskingMode.DROP).mask(client_ip) is None

--- a/tests/unit/manager/data/client_ip/test_masking.py
+++ b/tests/unit/manager/data/client_ip/test_masking.py
@@ -59,3 +59,53 @@ def test_an_unusable_address_is_dropped(mode: ClientIPMaskingMode, client_ip: st
 def test_dropping_records_no_address(client_ip: str) -> None:
     """A deployment that must keep no address at all has a mode for it."""
     assert ClientIPMasker(ClientIPMaskingMode.DROP).mask(client_ip) is None
+
+
+@pytest.mark.parametrize(
+    ("client_ip", "ipv4_prefix", "expected"),
+    [
+        ("203.0.113.7", 24, "203.0.113.0"),
+        ("203.0.113.7", 16, "203.0.0.0"),
+        ("203.0.113.7", 8, "203.0.0.0"),
+        ("203.0.113.7", 0, "0.0.0.0"),
+        ("203.0.113.7", 32, "203.0.113.7"),
+    ],
+)
+def test_the_ipv4_width_is_what_the_policy_says(
+    client_ip: str, ipv4_prefix: int, expected: str
+) -> None:
+    """How deep an address must be cut to count as anonymous differs by jurisdiction."""
+    masker = ClientIPMasker(ClientIPMaskingMode.TRUNCATE, ipv4_prefix=ipv4_prefix)
+
+    assert masker.mask(client_ip) == expected
+
+
+@pytest.mark.parametrize(
+    ("client_ip", "ipv6_prefix", "expected"),
+    [
+        ("2001:db8:1:2::1", 48, "2001:db8:1::"),
+        ("2001:db8:1:2::1", 32, "2001:db8::"),
+        ("2001:db8:1:2::1", 64, "2001:db8:1:2::"),
+    ],
+)
+def test_the_ipv6_width_is_what_the_policy_says(
+    client_ip: str, ipv6_prefix: int, expected: str
+) -> None:
+    """An ISP handing out a /48 whole makes /48 masking no anonymisation at all."""
+    masker = ClientIPMasker(ClientIPMaskingMode.TRUNCATE, ipv6_prefix=ipv6_prefix)
+
+    assert masker.mask(client_ip) == expected
+
+
+def test_the_built_in_widths_are_the_google_ones() -> None:
+    masker = ClientIPMasker(ClientIPMaskingMode.TRUNCATE)
+
+    assert (masker.ipv4_prefix, masker.ipv6_prefix) == (24, 48)
+
+
+@pytest.mark.parametrize("mode", [ClientIPMaskingMode.NONE, ClientIPMaskingMode.DROP])
+def test_the_widths_are_ignored_outside_truncation(mode: ClientIPMaskingMode) -> None:
+    masker = ClientIPMasker(mode, ipv4_prefix=8, ipv6_prefix=16)
+    plain = ClientIPMasker(mode)
+
+    assert masker.mask("203.0.113.7") == plain.mask("203.0.113.7")

--- a/tests/unit/manager/services/auth/conftest.py
+++ b/tests/unit/manager/services/auth/conftest.py
@@ -10,7 +10,7 @@ from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.config.unified import AuthConfig, ManagerConfig
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
-from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode
+from ai.backend.manager.data.client_ip.masking import ClientIPMasker, ClientIPMaskingMode
 from ai.backend.manager.repositories.client_ip_masking.repository import ClientIPMaskingRepository
 from ai.backend.manager.repositories.project.repository import ProjectRepository
 from ai.backend.manager.repositories.user.repository import UserRepository
@@ -55,5 +55,6 @@ def sample_client_type_id() -> UUID:
 @pytest.fixture
 def mock_client_ip_masking_repository() -> AsyncMock:
     repo = AsyncMock(spec=ClientIPMaskingRepository)
-    repo.resolve_mode.return_value = ClientIPMaskingMode.NONE
+    repo.resolve_masker.return_value = ClientIPMasker(ClientIPMaskingMode.NONE)
+    repo.mask.side_effect = lambda _target, client_ip: client_ip
     return repo

--- a/tests/unit/manager/services/auth/conftest.py
+++ b/tests/unit/manager/services/auth/conftest.py
@@ -10,6 +10,8 @@ from ai.backend.common.plugin.hook import HookPluginContext
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.config.unified import AuthConfig, ManagerConfig
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode
+from ai.backend.manager.repositories.client_ip_masking.repository import ClientIPMaskingRepository
 from ai.backend.manager.repositories.project.repository import ProjectRepository
 from ai.backend.manager.repositories.user.repository import UserRepository
 
@@ -48,3 +50,10 @@ def mock_group_repository() -> AsyncMock:
 @pytest.fixture
 def sample_client_type_id() -> UUID:
     return uuid4()
+
+
+@pytest.fixture
+def mock_client_ip_masking_repository() -> AsyncMock:
+    repo = AsyncMock(spec=ClientIPMaskingRepository)
+    repo.resolve_mode.return_value = ClientIPMaskingMode.NONE
+    return repo

--- a/tests/unit/manager/services/auth/test_authorize.py
+++ b/tests/unit/manager/services/auth/test_authorize.py
@@ -12,8 +12,7 @@ from ai.backend.common.data.entity.resource_policy import (
 from ai.backend.common.dto.manager.auth.types import AuthTokenType
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.plugin.hook import HookPluginContext, HookResult, HookResults
-from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.config.unified import AuthConfig, ManagerConfig
+from ai.backend.manager.config.unified import AuthConfig
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.auth.login_session_types import LoginAttemptResult
 from ai.backend.manager.data.resource.types import UserResourcePolicyData
@@ -47,20 +46,6 @@ def mock_auth_repository() -> AsyncMock:
 
 
 @pytest.fixture
-def mock_config_provider() -> MagicMock:
-    mock_provider = MagicMock(spec=ManagerConfigProvider)
-    mock_provider.config = MagicMock(spec=ManagerConfig)
-    mock_provider.config.auth = AuthConfig(
-        max_password_age=timedelta(days=90),
-        password_hash_algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
-        password_hash_rounds=100_000,
-        password_hash_salt_size=32,
-        login_session_max_age=604800,
-    )
-    return mock_provider
-
-
-@pytest.fixture
 def mock_valkey_session_client() -> AsyncMock:
     return AsyncMock(spec=ValkeySessionClient)
 
@@ -90,6 +75,7 @@ def auth_service(
     mock_user_resource_policy_repository: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -100,6 +86,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 
@@ -436,7 +423,7 @@ async def test_authorize_with_valkey_cross_check_cleans_stale_sessions(
 
     # Stale session should have been invalidated in DB
     mock_auth_repository.delete_login_session_by_token.assert_awaited_once_with(
-        "stale_token", LoginAttemptResult.EXPIRED
+        "stale_token", LoginAttemptResult.EXPIRED, None
     )
     assert result.authorization_result is not None
     assert result.authorization_result.session_token == "new_session_token"
@@ -505,7 +492,7 @@ async def test_authorize_force_invalidates_existing_sessions(
 
     # Eviction happens via a dedicated repository call before create_login_session.
     mock_auth_repository.delete_login_sessions_by_tokens.assert_awaited_once_with(
-        ["existing_live_token"], LoginAttemptResult.EVICTED
+        ["existing_live_token"], LoginAttemptResult.EVICTED, None
     )
     mock_auth_repository.create_login_session.assert_awaited_once()
     create_kwargs = mock_auth_repository.create_login_session.call_args.kwargs

--- a/tests/unit/manager/services/auth/test_get_role.py
+++ b/tests/unit/manager/services/auth/test_get_role.py
@@ -25,6 +25,7 @@ def auth_service(
     mock_config_provider: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -35,6 +36,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_max_concurrent_logins.py
+++ b/tests/unit/manager/services/auth/test_max_concurrent_logins.py
@@ -129,6 +129,7 @@ def auth_service(
     mock_user_resource_policy_repository: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -139,6 +140,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 
@@ -358,6 +360,6 @@ class TestMaxConcurrentLoginsEnforcement:
             delete_mock.assert_not_called()
         else:
             delete_mock.assert_called_once_with(
-                case.expected_evicted_tokens, LoginAttemptResult.EVICTED
+                case.expected_evicted_tokens, LoginAttemptResult.EVICTED, None
             )
         assert result.authorization_result is not None

--- a/tests/unit/manager/services/auth/test_resolve_scope.py
+++ b/tests/unit/manager/services/auth/test_resolve_scope.py
@@ -32,6 +32,7 @@ def auth_service(
     mock_config_provider: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -42,6 +43,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_signout.py
+++ b/tests/unit/manager/services/auth/test_signout.py
@@ -27,6 +27,7 @@ def auth_service(
     mock_config_provider: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -37,6 +38,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_signup.py
+++ b/tests/unit/manager/services/auth/test_signup.py
@@ -38,6 +38,7 @@ def auth_service(
     mock_config_provider: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -48,6 +49,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_ssh_keypair.py
+++ b/tests/unit/manager/services/auth/test_ssh_keypair.py
@@ -40,6 +40,7 @@ def auth_service(
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
     mock_ssh_key_validator: MagicMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -50,6 +51,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=mock_ssh_key_validator,
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_update_full_name.py
+++ b/tests/unit/manager/services/auth/test_update_full_name.py
@@ -27,6 +27,7 @@ def auth_service(
     mock_config_provider: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -37,6 +38,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_update_password.py
+++ b/tests/unit/manager/services/auth/test_update_password.py
@@ -30,6 +30,7 @@ def auth_service(
     mock_config_provider: AsyncMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -40,6 +41,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 

--- a/tests/unit/manager/services/auth/test_update_password_no_auth.py
+++ b/tests/unit/manager/services/auth/test_update_password_no_auth.py
@@ -48,6 +48,7 @@ def auth_service(
     mock_config_provider: MagicMock,
     mock_user_repository: AsyncMock,
     mock_group_repository: AsyncMock,
+    mock_client_ip_masking_repository: AsyncMock,
 ) -> AuthService:
     return AuthService(
         hook_plugin_ctx=mock_hook_plugin_ctx,
@@ -58,6 +59,7 @@ def auth_service(
         user_repository=mock_user_repository,
         group_repository=mock_group_repository,
         ssh_key_validator=AsyncMock(),
+        client_ip_masking_repository=mock_client_ip_masking_repository,
     )
 
 


### PR DESCRIPTION
## Summary

- `login_history` and `audit_logs` each gain a `client_ip` column holding the address of the request that produced the row.
- A new `client_ip_masking_policies` table decides what is stored, one row per target (`default`, `login_history`, `audit_logs`) holding a mode: `none` keeps the address as observed, `truncate` zeroes the host bits, `drop` records nothing. A target with no row falls back to `default`; no `default` row means no masking. Superadmins set it over GraphQL, REST v2, the SDK and the CLI, and each change lands in `audit_logs`.
- `truncate` takes the width from the policy — `ipv4_prefix` and `ipv6_prefix`, defaulting to a /24 and a /48 when unset. How deep an address must be cut before a regulator calls it anonymous differs by jurisdiction, and an ISP that hands a customer a /48 whole makes /48 masking no anonymisation at all.
- The client IP is now resolved before authentication, so an unauthenticated route — a login attempt above all — carries its address. It used to be pushed only after a caller was identified, which left every login history row without one.

## Test plan

- [ ] `tests/component/client_ip_masking/` — policy CRUD, truncation width, filter/order/pagination, the superadmin gate, and the fallback the login path resolves, over the real REST stack
- [ ] `tests/unit/manager/data/client_ip/` — masking form at each width and unparsable-address handling
- [ ] `tests/unit/manager/api/test_client_ip_middleware.py` — the address reaches an unauthenticated route and does not leak past the request
- [ ] Migrations apply in order: `a3f1c7d92b04 → b8c3f5d21e07 → c4e7a1b93f60 → d7a2f4c86b13`

Resolves BA-5733

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13941.org.readthedocs.build/en/13941/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13941.org.readthedocs.build/ko/13941/

<!-- readthedocs-preview sorna-ko end -->