### PR TITLE
feat(BA-7475): expose entity labels through REST v2, GraphQL, the SDK, and the CLI

### DIFF
--- a/.claude/skills/bai-cli/SKILL.md
+++ b/.claude/skills/bai-cli/SKILL.md
@@ -44,6 +44,7 @@ Check options with `--help`.
 - **project**: user(get, assign-users, unassign-users · sub role: search) · admin(search, create, update, delete, purge)
 - **agent**: user(empty group) · admin(search, total-resources, update-resource-group)
 - **image**: user(empty group) · admin(search, forget, purge, update · sub alias: create, remove, search)
+- **entity-label**: user(upsert, purge, search)
 - **session**: user(compute-schedule, enqueue, exclude-idle-checks, include-idle-checks, get, logs, project-search, start-service, shutdown-service, terminate, update) · admin(search · sub kernel: search) · my(search)
 
 ### Compute & Serving

--- a/changes/13954.feature.md
+++ b/changes/13954.feature.md
@@ -1,0 +1,1 @@
+Entities can now carry `key=value` labels, and sessions, deployments, vfolders, and agents can be searched by them.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -417,6 +417,9 @@ input AgentFilter
   status: AgentStatusFilter = null
   schedulable: Boolean = null
   scalingGroup: StringFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [AgentFilter!] = null
   OR: [AgentFilter!] = null
   NOT: [AgentFilter!] = null
@@ -6164,6 +6167,9 @@ input DeploymentFilter
 
   """Added in 26.8.0. Filter by conditions on deployment replicas."""
   replicas: ReplicaNestedFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [DeploymentFilter!] = null
   OR: [DeploymentFilter!] = null
   NOT: [DeploymentFilter!] = null
@@ -7798,6 +7804,32 @@ input EntityInvitationTargetScope
 
   """Id of the entity being offered."""
   entityId: UUID!
+}
+
+"""
+Added in 26.9.0. Filter matching a single label. A key and a value given together constrain the same label rather than two different ones.
+"""
+input EntityLabelFilter
+  @join__type(graph: STRAWBERRY)
+{
+  key: StringFilter = null
+  value: StringFilter = null
+  entityType: StringFilter = null
+  entityId: UUIDFilter = null
+  AND: [EntityLabelFilter!] = null
+  OR: [EntityLabelFilter!] = null
+  NOT: [EntityLabelFilter!] = null
+}
+
+"""
+Added in 26.9.0. Filter selecting entities by the labels on them. Each relation matches one label at a time; requiring two different labels is two relations combined by the entity filter's own AND.
+"""
+input EntityLabelNestedFilter
+  @join__type(graph: STRAWBERRY)
+{
+  some: EntityLabelFilter = null
+  every: EntityLabelFilter = null
+  none: EntityLabelFilter = null
 }
 
 union EntityNode
@@ -20943,6 +20975,9 @@ input SessionV2Filter
   domainName: StringFilter = null
   projectId: UUIDFilter = null
   userUuid: UUIDFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [SessionV2Filter!] = null
   OR: [SessionV2Filter!] = null
   NOT: [SessionV2Filter!] = null
@@ -24253,6 +24288,9 @@ input VFolderFilter
   usageMode: VFolderUsageModeFilter = null
   cloneable: Boolean = null
   createdAt: DateTimeFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [VFolderFilter!] = null
   OR: [VFolderFilter!] = null
   NOT: [VFolderFilter!] = null

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -733,6 +733,11 @@ type AgentV2 implements Node
   id: ID!
 
   """
+  Added in 26.9.0. Agent UUID. The agent's primary key is its name, so rows keyed on the agent carry this instead.
+  """
+  uuid: UUID!
+
+  """
   Hardware resource capacity, usage, and availability information. Contains capacity (total), used (occupied by sessions), and free (available) resource slots including CPU cores, memory, accelerators (GPUs, TPUs), and other compute resources.
   """
   resourceInfo: AgentResource!
@@ -761,6 +766,9 @@ type AgentV2 implements Node
   Name of the scaling group this agent belongs to. Scaling groups are logical collections of agents used for resource scheduling, quota management, and workload isolation across different user groups or projects.
   """
   scalingGroup: String!
+
+  """Added in 26.9.0. The labels on this agent."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 
   """Added in 26.1.0. Load the container count for this agent."""
   containerCount: Int
@@ -7672,6 +7680,58 @@ input EntityFilter
   NOT: [EntityFilter!] = null
 }
 
+"""Added in 26.9.0. One `key=value` label and the entity carrying it."""
+type EntityLabel implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Type of the labeled entity."""
+  entityType: String!
+
+  """ID of the labeled entity."""
+  entityId: UUID!
+
+  """Label key."""
+  key: String!
+
+  """Label value."""
+  value: String!
+
+  """When the label was first put on the entity."""
+  createdAt: DateTime!
+
+  """When the label's value was last replaced."""
+  updatedAt: DateTime!
+}
+
+"""Added in 26.9.0. Paginated connection for label records."""
+type EntityLabelConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [EntityLabelEdge!]!
+
+  """Total number of label records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type EntityLabelEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: EntityLabel!
+}
+
 """
 Added in 26.9.0. An offer of one existing entity to one address, settled by the answer.
 """
@@ -7830,6 +7890,23 @@ input EntityLabelNestedFilter
   some: EntityLabelFilter = null
   every: EntityLabelFilter = null
   none: EntityLabelFilter = null
+}
+
+"""Added in 26.9.0. Ordering specification for labels."""
+input EntityLabelOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  field: EntityLabelOrderField!
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.9.0. Fields available for ordering labels."""
+enum EntityLabelOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  KEY @join__enumValue(graph: STRAWBERRY)
+  VALUE @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
 union EntityNode
@@ -11290,6 +11367,9 @@ type ModelDeployment implements Node
 
   """The access tokens of this entity."""
   accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection
+
+  """Added in 26.9.0. The labels on this deployment."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 }
 
 """Added in 25.19.0. Connection for model deployments."""
@@ -13675,6 +13755,16 @@ type Mutation
   Added in 26.9.0. Include checker-session pairs into idle checks, resetting them so checks start from the initial grace period. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   includeSessionIdleChecks(input: IncludeSessionIdleChecksInput!): IncludeSessionIdleChecksPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.9.0. Set one key on an entity, replacing the value it carries. Reachable by any caller RBAC authorizes to write the entity.
+  """
+  upsertEntityLabel(input: UpsertEntityLabelInput!): UpsertEntityLabelPayload @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.9.0. Take one label off, named by its own id. Which entity answers for it is read from the row before the delete runs.
+  """
+  purgeEntityLabel(id: ID!): PurgeEntityLabelPayload @join__field(graph: STRAWBERRY)
 }
 
 """
@@ -15604,6 +15694,14 @@ type PurgeDomainPayload
   purged: Boolean!
 }
 
+"""Added in 26.9.0. Payload returned after taking a label off an entity."""
+type PurgeEntityLabelPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The label taken off the entity."""
+  label: EntityLabel!
+}
+
 """
 Completely deletes a group from DB.
 
@@ -16483,6 +16581,11 @@ type Query
   Added in 26.9.0. Every entity type the manager has operations wired for, in name order. What a field taking an entity type may be given is what this lists.
   """
   entityTypes: [EntityType!]! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.9.0. Read the labels on the entities named. Scope items are OR'd, and naming an entity the caller cannot read refuses the whole read.
+  """
+  entityLabels(scope: [EntityTypeScope!]!, filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
@@ -20940,6 +21043,9 @@ type SessionV2 implements Node
   Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the session is freed or terminated (for statistics and billing).
   """
   resourceAllocation: ResourceAllocation!
+
+  """Added in 26.9.0. The labels on this session."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""
@@ -22898,6 +23004,30 @@ type UpsertDomainFairShareWeightPayload
 }
 
 """
+Added in 26.9.0. Input for putting one key on one entity. A key holds one value, so naming a key the entity already carries replaces that value.
+"""
+input UpsertEntityLabelInput
+  @join__type(graph: STRAWBERRY)
+{
+  """The entity to label."""
+  target: EntityTypeScope!
+
+  """Label key."""
+  key: String!
+
+  """Label value."""
+  value: String!
+}
+
+"""Added in 26.9.0. Payload returned after putting a label on an entity."""
+type UpsertEntityLabelPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The label as it now stands."""
+  label: EntityLabel!
+}
+
+"""
 Added in 26.1.0. Input for upserting project fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
 """
 input UpsertProjectFairShareWeightInput
@@ -24207,6 +24337,9 @@ type VFolder implements Node
 
   """Added in 26.4.4. Model cards backed by this vfolder."""
   modelCards(filter: ModelCardV2Filter = null, orderBy: [ModelCardV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelCardV2Connection
+
+  """Added in 26.9.0. The labels on this vfolder."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 }
 
 """

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -7680,58 +7680,6 @@ input EntityFilter
   NOT: [EntityFilter!] = null
 }
 
-"""Added in 26.9.0. One `key=value` label and the entity carrying it."""
-type EntityLabel implements Node
-  @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
-  id: ID!
-
-  """Type of the labeled entity."""
-  entityType: String!
-
-  """ID of the labeled entity."""
-  entityId: UUID!
-
-  """Label key."""
-  key: String!
-
-  """Label value."""
-  value: String!
-
-  """When the label was first put on the entity."""
-  createdAt: DateTime!
-
-  """When the label's value was last replaced."""
-  updatedAt: DateTime!
-}
-
-"""Added in 26.9.0. Paginated connection for label records."""
-type EntityLabelConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection"""
-  edges: [EntityLabelEdge!]!
-
-  """Total number of label records matching the query criteria."""
-  count: Int!
-}
-
-"""An edge in a connection."""
-type EntityLabelEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: EntityLabel!
-}
-
 """
 Added in 26.9.0. An offer of one existing entity to one address, settled by the answer.
 """
@@ -7866,6 +7814,58 @@ input EntityInvitationTargetScope
   entityId: UUID!
 }
 
+"""Added in 26.9.0. One `key=value` label and the entity carrying it."""
+type EntityLabel implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Type of the labeled entity."""
+  entityType: String!
+
+  """ID of the labeled entity."""
+  entityId: UUID!
+
+  """Label key."""
+  key: String!
+
+  """Label value."""
+  value: String!
+
+  """When the label was first put on the entity."""
+  createdAt: DateTime!
+
+  """When the label's value was last replaced."""
+  updatedAt: DateTime!
+}
+
+"""Added in 26.9.0. Paginated connection for label records."""
+type EntityLabelConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [EntityLabelEdge!]!
+
+  """Total number of label records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type EntityLabelEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: EntityLabel!
+}
+
 """
 Added in 26.9.0. Filter matching a single label. A key and a value given together constrain the same label rather than two different ones.
 """
@@ -7989,6 +7989,19 @@ type EntityRefEdge
 
   """The item at the end of the edge"""
   node: EntityRef!
+}
+
+"""
+Added in 26.9.0. One entity, named by its type and its id. `entityTypes` lists the types a request may name.
+"""
+input EntityTarget
+  @join__type(graph: STRAWBERRY)
+{
+  """Type of the entity."""
+  entityType: String!
+
+  """ID of the entity."""
+  entityId: UUID!
 }
 
 """
@@ -16585,7 +16598,7 @@ type Query
   """
   Added in 26.9.0. Read the labels on the entities named. Scope items are OR'd, and naming an entity the caller cannot read refuses the whole read.
   """
-  entityLabels(scope: [EntityTypeScope!]!, filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection @join__field(graph: STRAWBERRY)
+  entityLabels(scope: [EntityTarget!]!, filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
@@ -23010,7 +23023,7 @@ input UpsertEntityLabelInput
   @join__type(graph: STRAWBERRY)
 {
   """The entity to label."""
-  target: EntityTypeScope!
+  target: EntityTarget!
 
   """Label key."""
   key: String!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -283,6 +283,9 @@ input AgentFilter {
   status: AgentStatusFilter = null
   schedulable: Boolean = null
   scalingGroup: StringFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [AgentFilter!] = null
   OR: [AgentFilter!] = null
   NOT: [AgentFilter!] = null
@@ -4316,6 +4319,9 @@ input DeploymentFilter {
 
   """Added in 26.8.0. Filter by conditions on deployment replicas."""
   replicas: ReplicaNestedFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [DeploymentFilter!] = null
   OR: [DeploymentFilter!] = null
   NOT: [DeploymentFilter!] = null
@@ -5403,6 +5409,28 @@ input EntityInvitationTargetScope {
 
   """Id of the entity being offered."""
   entityId: UUID!
+}
+
+"""
+Added in 26.9.0. Filter matching a single label. A key and a value given together constrain the same label rather than two different ones.
+"""
+input EntityLabelFilter {
+  key: StringFilter = null
+  value: StringFilter = null
+  entityType: StringFilter = null
+  entityId: UUIDFilter = null
+  AND: [EntityLabelFilter!] = null
+  OR: [EntityLabelFilter!] = null
+  NOT: [EntityLabelFilter!] = null
+}
+
+"""
+Added in 26.9.0. Filter selecting entities by the labels on them. Each relation matches one label at a time; requiring two different labels is two relations combined by the entity filter's own AND.
+"""
+input EntityLabelNestedFilter {
+  some: EntityLabelFilter = null
+  every: EntityLabelFilter = null
+  none: EntityLabelFilter = null
 }
 
 union EntityNode = UserV2 | ProjectV2 | DomainV2 | VirtualFolderNode | ImageV2 | ComputeSessionNode | SessionV2 | Artifact | ArtifactRegistry | NotificationChannel | NotificationRule | ModelDeployment | ResourceGroup | ContainerRegistryV2 | ArtifactRevision | Role
@@ -15005,6 +15033,9 @@ input SessionV2Filter {
   domainName: StringFilter = null
   projectId: UUIDFilter = null
   userUuid: UUIDFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [SessionV2Filter!] = null
   OR: [SessionV2Filter!] = null
   NOT: [SessionV2Filter!] = null
@@ -17606,6 +17637,9 @@ input VFolderFilter {
   usageMode: VFolderUsageModeFilter = null
   cloneable: Boolean = null
   createdAt: DateTimeFilter = null
+
+  """Added in 26.9.0. Select entities by the labels on them."""
+  labels: EntityLabelNestedFilter = null
   AND: [VFolderFilter!] = null
   OR: [VFolderFilter!] = null
   NOT: [VFolderFilter!] = null

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -5306,51 +5306,6 @@ input EntityFilter {
   NOT: [EntityFilter!] = null
 }
 
-"""Added in 26.9.0. One `key=value` label and the entity carrying it."""
-type EntityLabel implements Node {
-  """The Globally Unique ID of this object"""
-  id: ID!
-
-  """Type of the labeled entity."""
-  entityType: String!
-
-  """ID of the labeled entity."""
-  entityId: UUID!
-
-  """Label key."""
-  key: String!
-
-  """Label value."""
-  value: String!
-
-  """When the label was first put on the entity."""
-  createdAt: DateTime!
-
-  """When the label's value was last replaced."""
-  updatedAt: DateTime!
-}
-
-"""Added in 26.9.0. Paginated connection for label records."""
-type EntityLabelConnection {
-  """Pagination data for this connection"""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection"""
-  edges: [EntityLabelEdge!]!
-
-  """Total number of label records matching the query criteria."""
-  count: Int!
-}
-
-"""An edge in a connection."""
-type EntityLabelEdge {
-  """A cursor for use in pagination"""
-  cursor: String!
-
-  """The item at the end of the edge"""
-  node: EntityLabel!
-}
-
 """
 Added in 26.9.0. An offer of one existing entity to one address, settled by the answer.
 """
@@ -5464,6 +5419,51 @@ input EntityInvitationTargetScope {
   entityId: UUID!
 }
 
+"""Added in 26.9.0. One `key=value` label and the entity carrying it."""
+type EntityLabel implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Type of the labeled entity."""
+  entityType: String!
+
+  """ID of the labeled entity."""
+  entityId: UUID!
+
+  """Label key."""
+  key: String!
+
+  """Label value."""
+  value: String!
+
+  """When the label was first put on the entity."""
+  createdAt: DateTime!
+
+  """When the label's value was last replaced."""
+  updatedAt: DateTime!
+}
+
+"""Added in 26.9.0. Paginated connection for label records."""
+type EntityLabelConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [EntityLabelEdge!]!
+
+  """Total number of label records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type EntityLabelEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: EntityLabel!
+}
+
 """
 Added in 26.9.0. Filter matching a single label. A key and a value given together constrain the same label rather than two different ones.
 """
@@ -5550,6 +5550,17 @@ type EntityRefEdge {
 
   """The item at the end of the edge"""
   node: EntityRef!
+}
+
+"""
+Added in 26.9.0. One entity, named by its type and its id. `entityTypes` lists the types a request may name.
+"""
+input EntityTarget {
+  """Type of the entity."""
+  entityType: String!
+
+  """ID of the entity."""
+  entityId: UUID!
 }
 
 """
@@ -11407,7 +11418,7 @@ type Query {
   """
   Added in 26.9.0. Read the labels on the entities named. Scope items are OR'd, and naming an entity the caller cannot read refuses the whole read.
   """
-  entityLabels(scope: [EntityTypeScope!]!, filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
+  entityLabels(scope: [EntityTarget!]!, filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
@@ -16732,7 +16743,7 @@ Added in 26.9.0. Input for putting one key on one entity. A key holds one value,
 """
 input UpsertEntityLabelInput {
   """The entity to label."""
-  target: EntityTypeScope!
+  target: EntityTarget!
 
   """Label key."""
   key: String!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -491,6 +491,11 @@ type AgentV2 implements Node {
   id: ID!
 
   """
+  Added in 26.9.0. Agent UUID. The agent's primary key is its name, so rows keyed on the agent carry this instead.
+  """
+  uuid: UUID!
+
+  """
   Hardware resource capacity, usage, and availability information. Contains capacity (total), used (occupied by sessions), and free (available) resource slots including CPU cores, memory, accelerators (GPUs, TPUs), and other compute resources.
   """
   resourceInfo: AgentResource!
@@ -519,6 +524,9 @@ type AgentV2 implements Node {
   Name of the scaling group this agent belongs to. Scaling groups are logical collections of agents used for resource scheduling, quota management, and workload isolation across different user groups or projects.
   """
   scalingGroup: String!
+
+  """Added in 26.9.0. The labels on this agent."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 
   """Added in 26.1.0. Load the container count for this agent."""
   containerCount: Int
@@ -5298,6 +5306,51 @@ input EntityFilter {
   NOT: [EntityFilter!] = null
 }
 
+"""Added in 26.9.0. One `key=value` label and the entity carrying it."""
+type EntityLabel implements Node {
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """Type of the labeled entity."""
+  entityType: String!
+
+  """ID of the labeled entity."""
+  entityId: UUID!
+
+  """Label key."""
+  key: String!
+
+  """Label value."""
+  value: String!
+
+  """When the label was first put on the entity."""
+  createdAt: DateTime!
+
+  """When the label's value was last replaced."""
+  updatedAt: DateTime!
+}
+
+"""Added in 26.9.0. Paginated connection for label records."""
+type EntityLabelConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [EntityLabelEdge!]!
+
+  """Total number of label records matching the query criteria."""
+  count: Int!
+}
+
+"""An edge in a connection."""
+type EntityLabelEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: EntityLabel!
+}
+
 """
 Added in 26.9.0. An offer of one existing entity to one address, settled by the answer.
 """
@@ -5431,6 +5484,19 @@ input EntityLabelNestedFilter {
   some: EntityLabelFilter = null
   every: EntityLabelFilter = null
   none: EntityLabelFilter = null
+}
+
+"""Added in 26.9.0. Ordering specification for labels."""
+input EntityLabelOrderBy {
+  field: EntityLabelOrderField!
+  direction: OrderDirection! = DESC
+}
+
+"""Added in 26.9.0. Fields available for ordering labels."""
+enum EntityLabelOrderField {
+  KEY
+  VALUE
+  CREATED_AT
 }
 
 union EntityNode = UserV2 | ProjectV2 | DomainV2 | VirtualFolderNode | ImageV2 | ComputeSessionNode | SessionV2 | Artifact | ArtifactRegistry | NotificationChannel | NotificationRule | ModelDeployment | ResourceGroup | ContainerRegistryV2 | ArtifactRevision | Role
@@ -7858,6 +7924,9 @@ type ModelDeployment implements Node {
 
   """The access tokens of this entity."""
   accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection
+
+  """Added in 26.9.0. The labels on this deployment."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 }
 
 """Added in 25.19.0. Connection for model deployments."""
@@ -9355,6 +9424,16 @@ type Mutation {
   Added in 26.9.0. Include checker-session pairs into idle checks, resetting them so checks start from the initial grace period. Per-session RBAC permission is enforced by the bulk validator; any denial fails the whole request.
   """
   includeSessionIdleChecks(input: IncludeSessionIdleChecksInput!): IncludeSessionIdleChecksPayload
+
+  """
+  Added in 26.9.0. Set one key on an entity, replacing the value it carries. Reachable by any caller RBAC authorizes to write the entity.
+  """
+  upsertEntityLabel(input: UpsertEntityLabelInput!): UpsertEntityLabelPayload
+
+  """
+  Added in 26.9.0. Take one label off, named by its own id. Which entity answers for it is read from the row before the delete runs.
+  """
+  purgeEntityLabel(id: ID!): PurgeEntityLabelPayload
 }
 
 """
@@ -10937,6 +11016,12 @@ type PurgeDomainPayload {
   purged: Boolean!
 }
 
+"""Added in 26.9.0. Payload returned after taking a label off an entity."""
+type PurgeEntityLabelPayload {
+  """The label taken off the entity."""
+  label: EntityLabel!
+}
+
 """Added in 26.8.0. Identifies the idle checker assignment to purge."""
 input PurgeIdleCheckerAssignmentInput {
   """Idle checker assignment ID to purge."""
@@ -11318,6 +11403,11 @@ type Query {
   Added in 26.9.0. Every entity type the manager has operations wired for, in name order. What a field taking an entity type may be given is what this lists.
   """
   entityTypes: [EntityType!]!
+
+  """
+  Added in 26.9.0. Read the labels on the entities named. Scope items are OR'd, and naming an entity the caller cannot read refuses the whole read.
+  """
+  entityLabels(scope: [EntityTypeScope!]!, filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 
   """
   Added in 26.4.2. List container registries with filtering, ordering, and pagination (admin only).
@@ -15004,6 +15094,9 @@ type SessionV2 implements Node {
   Added in 26.8.0. Resource allocation (requested / used / allocated) computed on-demand from the resource_allocations table. Unlike the deprecated eager `resource.allocation`, `allocated` here persists after the session is freed or terminated (for statistics and billing).
   """
   resourceAllocation: ResourceAllocation!
+
+  """Added in 26.9.0. The labels on this session."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 }
 
 """Added in 26.3.0. Connection type for paginated session results."""
@@ -16635,6 +16728,26 @@ type UpsertDomainFairShareWeightPayload {
 }
 
 """
+Added in 26.9.0. Input for putting one key on one entity. A key holds one value, so naming a key the entity already carries replaces that value.
+"""
+input UpsertEntityLabelInput {
+  """The entity to label."""
+  target: EntityTypeScope!
+
+  """Label key."""
+  key: String!
+
+  """Label value."""
+  value: String!
+}
+
+"""Added in 26.9.0. Payload returned after putting a label on an entity."""
+type UpsertEntityLabelPayload {
+  """The label as it now stands."""
+  label: EntityLabel!
+}
+
+"""
 Added in 26.1.0. Input for upserting project fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
 """
 input UpsertProjectFairShareWeightInput {
@@ -17566,6 +17679,9 @@ type VFolder implements Node {
 
   """Added in 26.4.4. Model cards backed by this vfolder."""
   modelCards(filter: ModelCardV2Filter = null, orderBy: [ModelCardV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelCardV2Connection
+
+  """Added in 26.9.0. The labels on this vfolder."""
+  entityLabels(filter: EntityLabelFilter = null, orderBy: [EntityLabelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityLabelConnection
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -154,6 +154,152 @@
         "title": "AgentStatusFilter",
         "type": "object"
       },
+      "EntityLabelFilter": {
+        "description": "Filter over label rows.\n\nOne instance matches a single label at a time, so `key` and `value` given together\nconstrain the same label rather than two different ones.",
+        "properties": {
+          "key": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Label key filter"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Label value filter"
+          },
+          "entity_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StringFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Type of the labeled entity"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UUIDFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "ID of the labeled entity"
+          },
+          "AND": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EntityLabelFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "All conditions must match",
+            "title": "And"
+          },
+          "OR": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EntityLabelFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "At least one condition must match",
+            "title": "Or"
+          },
+          "NOT": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EntityLabelFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "None of the conditions must match",
+            "title": "Not"
+          }
+        },
+        "title": "EntityLabelFilter",
+        "type": "object"
+      },
+      "EntityLabelNestedFilter": {
+        "description": "The `labels` field of a labelable entity's filter.\n\nEach relation matches one label at a time. To require two different labels, combine\ntwo of these with the entity filter's own `AND`.",
+        "properties": {
+          "some": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EntityLabelFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "At least one of the entity's labels matches"
+          },
+          "every": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EntityLabelFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "All of the entity's labels match; true for an unlabeled entity"
+          },
+          "none": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EntityLabelFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "None of the entity's labels matches"
+          }
+        },
+        "title": "EntityLabelNestedFilter",
+        "type": "object"
+      },
       "OrderDirection": {
         "description": "Order direction for sorting.",
         "enum": [
@@ -440,6 +586,75 @@
           }
         },
         "title": "StringFilter",
+        "type": "object"
+      },
+      "UUIDFilter": {
+        "description": "Filter for UUID fields supporting equality and set operations.\n\nProvides UUID matching with equals/not_equals and in/not_in operations.",
+        "properties": {
+          "equals": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Exact UUID match",
+            "title": "Equals"
+          },
+          "in": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "UUID is in list",
+            "title": "In"
+          },
+          "not_equals": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Not equals UUID",
+            "title": "Not Equals"
+          },
+          "not_in": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "UUID is not in list",
+            "title": "Not In"
+          }
+        },
+        "title": "UUIDFilter",
         "type": "object"
       },
       "AdminSearchAgentsInput": {
@@ -2396,75 +2611,6 @@
         "title": "AuditLogStatusFilter",
         "type": "object"
       },
-      "UUIDFilter": {
-        "description": "Filter for UUID fields supporting equality and set operations.\n\nProvides UUID matching with equals/not_equals and in/not_in operations.",
-        "properties": {
-          "equals": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Exact UUID match",
-            "title": "Equals"
-          },
-          "in": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "UUID is in list",
-            "title": "In"
-          },
-          "not_equals": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Not equals UUID",
-            "title": "Not Equals"
-          },
-          "not_in": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "UUID is not in list",
-            "title": "Not In"
-          }
-        },
-        "title": "UUIDFilter",
-        "type": "object"
-      },
       "AdminSearchAuditLogsInput": {
         "description": "Input for searching audit logs (admin, no scope).",
         "properties": {
@@ -2580,6 +2726,215 @@
           }
         },
         "title": "AdminSearchAuditLogsInput",
+        "type": "object"
+      },
+      "EntityTarget": {
+        "description": "One entity, named by its type and its id.\n\nThe type is a plain string rather than a closed enum: an entity type is declared\nwhere its operations are wired, so `entityTypes` is what lists the valid ones.",
+        "properties": {
+          "entity_type": {
+            "description": "Type of the entity, as `entityTypes` lists them",
+            "minLength": 1,
+            "title": "Entity Type",
+            "type": "string"
+          },
+          "entity_id": {
+            "description": "ID of the entity",
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "entity_type",
+          "entity_id"
+        ],
+        "title": "EntityTarget",
+        "type": "object"
+      },
+      "UpsertEntityLabelInput": {
+        "description": "Input for putting one key on one entity, replacing the value it carries.",
+        "properties": {
+          "target": {
+            "$ref": "#/components/schemas/EntityTarget",
+            "description": "The entity to label"
+          },
+          "key": {
+            "description": "Label key",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Key",
+            "type": "string"
+          },
+          "value": {
+            "description": "Label value",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target",
+          "key",
+          "value"
+        ],
+        "title": "UpsertEntityLabelInput",
+        "type": "object"
+      },
+      "EntityLabelOrder": {
+        "description": "Ordering specification for labels.",
+        "properties": {
+          "field": {
+            "$ref": "#/components/schemas/EntityLabelOrderField"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/OrderDirection",
+            "default": "DESC"
+          }
+        },
+        "required": [
+          "field"
+        ],
+        "title": "EntityLabelOrder",
+        "type": "object"
+      },
+      "EntityLabelOrderField": {
+        "description": "Fields available for ordering labels.",
+        "enum": [
+          "key",
+          "value",
+          "created_at"
+        ],
+        "title": "EntityLabelOrderField",
+        "type": "string"
+      },
+      "SearchEntityLabelsInput": {
+        "description": "Input for reading the labels on the entities named.",
+        "properties": {
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EntityLabelFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter criteria"
+          },
+          "order": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EntityLabelOrder"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Sort order",
+            "title": "Order"
+          },
+          "first": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-forward page size",
+            "title": "First"
+          },
+          "after": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-forward start cursor",
+            "title": "After"
+          },
+          "last": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-backward page size",
+            "title": "Last"
+          },
+          "before": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Cursor-backward end cursor",
+            "title": "Before"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset-based page size",
+            "title": "Limit"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Offset-based page offset",
+            "title": "Offset"
+          },
+          "scope": {
+            "description": "The entities whose labels to read (OR across items)",
+            "items": {
+              "$ref": "#/components/schemas/EntityTarget"
+            },
+            "minItems": 1,
+            "title": "Scope",
+            "type": "array"
+          }
+        },
+        "required": [
+          "scope"
+        ],
+        "title": "SearchEntityLabelsInput",
         "type": "object"
       },
       "ContainerRegistryFilter": {
@@ -29378,6 +29733,18 @@
             ],
             "default": null
           },
+          "labels": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EntityLabelNestedFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by the labels on the entity"
+          },
           "AND": {
             "anyOf": [
               {
@@ -31248,6 +31615,18 @@
             ],
             "default": null,
             "description": "Filter by creation time."
+          },
+          "labels": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EntityLabelNestedFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by the labels on the entity"
           },
           "AND": {
             "anyOf": [
@@ -43557,6 +43936,93 @@
         },
         "parameters": [],
         "description": "Search audit logs with admin scope.\n\n**Preconditions:**\n* Superadmin privilege required.\n"
+      }
+    },
+    "/v2/entity-labels": {
+      "put": {
+        "operationId": "v2/entity-labels.upsert_label",
+        "tags": [
+          "v2/entity-labels"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertEntityLabelInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Set one key on an entity, replacing the value it carries.\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/entity-labels/{label_id}": {
+      "delete": {
+        "operationId": "v2/entity-labels.purge_label",
+        "tags": [
+          "v2/entity-labels"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "description": "Take one label off, named by its own id.\n\n**Preconditions:**\n* User privilege required.\n"
+      }
+    },
+    "/v2/entity-labels/search": {
+      "post": {
+        "operationId": "v2/entity-labels.search_labels",
+        "tags": [
+          "v2/entity-labels"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          }
+        },
+        "security": [
+          {
+            "TokenAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchEntityLabelsInput"
+              }
+            }
+          }
+        },
+        "parameters": [],
+        "description": "Read the labels on the entities named.\n\n**Preconditions:**\n* User privilege required.\n"
       }
     },
     "/v2/container-registries/search": {

--- a/src/ai/backend/client/cli/v2/__init__.py
+++ b/src/ai/backend/client/cli/v2/__init__.py
@@ -211,6 +211,15 @@ def object_storage() -> None:
 
 @v2.group(
     cls=LazyGroup,
+    import_name="ai.backend.client.cli.v2.entity_label:entity_label",
+    name="entity-label",
+)
+def entity_label() -> None:
+    """Entity label commands."""
+
+
+@v2.group(
+    cls=LazyGroup,
     import_name="ai.backend.client.cli.v2.login_client_type.commands:login_client_type",
     name="login-client-type",
 )

--- a/src/ai/backend/client/cli/v2/admin/agent.py
+++ b/src/ai/backend/client/cli/v2/admin/agent.py
@@ -8,9 +8,10 @@ import uuid
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     parse_order_options,
     print_result,
@@ -55,7 +56,7 @@ def search(
     scaling_group: str | None,
     schedulable: bool | None,
     order_by: tuple[str, ...],
-    label: EntityLabelTerms,
+    label: tuple[EntityLabelTerm, ...],
 ) -> None:
     """Search agents (superadmin only)."""
     from ai.backend.common.dto.manager.query import StringFilter
@@ -70,8 +71,10 @@ def search(
         AgentStatusFilter,
     )
 
-    filter_dto = label.attach(
-        AgentFilter(
+    relations = entity_label_relations(label)
+    filter_dto: AgentFilter | None = None
+    if relations or any(opt is not None for opt in (status, scaling_group, schedulable)):
+        filter_dto = AgentFilter(
             status=(
                 AgentStatusFilter(equals=AgentStatusEnum(status.upper()))
                 if status is not None
@@ -81,8 +84,8 @@ def search(
                 StringFilter(contains=scaling_group) if scaling_group is not None else None
             ),
             schedulable=schedulable,
+            AND=[AgentFilter(labels=rel) for rel in relations] or None,
         )
-    )
 
     # Build order only if --order-by is provided
     orders = parse_order_options(order_by, AgentOrderField, AgentOrder) if order_by else None

--- a/src/ai/backend/client/cli/v2/admin/agent.py
+++ b/src/ai/backend/client/cli/v2/admin/agent.py
@@ -8,7 +8,9 @@ import uuid
 import click
 
 from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
     create_v2_registry,
+    entity_label_filter_options,
     load_v2_config,
     parse_order_options,
     print_result,
@@ -40,6 +42,7 @@ def agent() -> None:
     default=None,
     help="Filter by schedulable flag.",
 )
+@entity_label_filter_options
 @click.option(
     "--order-by",
     multiple=True,
@@ -52,22 +55,23 @@ def search(
     scaling_group: str | None,
     schedulable: bool | None,
     order_by: tuple[str, ...],
+    label: EntityLabelTerms,
 ) -> None:
     """Search agents (superadmin only)."""
+    from ai.backend.common.dto.manager.query import StringFilter
     from ai.backend.common.dto.manager.v2.agent.request import (
         AdminSearchAgentsInput,
         AgentFilter,
         AgentOrder,
     )
-    from ai.backend.common.dto.manager.v2.agent.types import AgentOrderField
+    from ai.backend.common.dto.manager.v2.agent.types import (
+        AgentOrderField,
+        AgentStatusEnum,
+        AgentStatusFilter,
+    )
 
-    # Build filter only if any filter option is provided
-    filter_dto: AgentFilter | None = None
-    if any(opt is not None for opt in (status, scaling_group, schedulable)):
-        from ai.backend.common.dto.manager.query import StringFilter
-        from ai.backend.common.dto.manager.v2.agent.types import AgentStatusEnum, AgentStatusFilter
-
-        filter_dto = AgentFilter(
+    filter_dto = label.attach(
+        AgentFilter(
             status=(
                 AgentStatusFilter(equals=AgentStatusEnum(status.upper()))
                 if status is not None
@@ -78,6 +82,7 @@ def search(
             ),
             schedulable=schedulable,
         )
+    )
 
     # Build order only if --order-by is provided
     orders = parse_order_options(order_by, AgentOrderField, AgentOrder) if order_by else None

--- a/src/ai/backend/client/cli/v2/admin/deployment.py
+++ b/src/ai/backend/client/cli/v2/admin/deployment.py
@@ -8,7 +8,9 @@ from uuid import UUID
 import click
 
 from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
     create_v2_registry,
+    entity_label_filter_options,
     load_v2_config,
     parse_order_options,
     print_result,
@@ -49,6 +51,7 @@ def deployment() -> None:
     default=None,
     help="Filter by endpoint URL (contains).",
 )
+@entity_label_filter_options
 def search(
     limit: int | None,
     offset: int | None,
@@ -58,6 +61,7 @@ def search(
     open_to_public: bool | None,
     tags_contains: str | None,
     endpoint_url_contains: str | None,
+    label: EntityLabelTerms,
 ) -> None:
     """Search all deployments (admin)."""
     from ai.backend.common.dto.manager.query import StringFilter
@@ -70,15 +74,8 @@ def search(
     from ai.backend.common.dto.manager.v2.deployment.types import DeploymentOrderField
 
     # Build filter only if any filter option is provided
-    filter_dto: DeploymentFilter | None = None
-    if any([
-        name_contains is not None,
-        status,
-        open_to_public is not None,
-        tags_contains is not None,
-        endpoint_url_contains is not None,
-    ]):
-        filter_dto = DeploymentFilter(
+    filter_dto = label.attach(
+        DeploymentFilter(
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
             status=(DeploymentStatusFilter(in_=list(status)) if status else None),
             open_to_public=open_to_public,
@@ -89,6 +86,7 @@ def search(
                 else None
             ),
         )
+    )
 
     # Build order only if --order-by is provided
     orders = (

--- a/src/ai/backend/client/cli/v2/admin/deployment.py
+++ b/src/ai/backend/client/cli/v2/admin/deployment.py
@@ -8,9 +8,10 @@ from uuid import UUID
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     parse_order_options,
     print_result,
@@ -61,7 +62,7 @@ def search(
     open_to_public: bool | None,
     tags_contains: str | None,
     endpoint_url_contains: str | None,
-    label: EntityLabelTerms,
+    label: tuple[EntityLabelTerm, ...],
 ) -> None:
     """Search all deployments (admin)."""
     from ai.backend.common.dto.manager.query import StringFilter
@@ -73,9 +74,16 @@ def search(
     )
     from ai.backend.common.dto.manager.v2.deployment.types import DeploymentOrderField
 
-    # Build filter only if any filter option is provided
-    filter_dto = label.attach(
-        DeploymentFilter(
+    relations = entity_label_relations(label)
+    filter_dto: DeploymentFilter | None = None
+    if relations or any([
+        name_contains is not None,
+        status,
+        open_to_public is not None,
+        tags_contains is not None,
+        endpoint_url_contains is not None,
+    ]):
+        filter_dto = DeploymentFilter(
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
             status=(DeploymentStatusFilter(in_=list(status)) if status else None),
             open_to_public=open_to_public,
@@ -85,8 +93,8 @@ def search(
                 if endpoint_url_contains is not None
                 else None
             ),
+            AND=[DeploymentFilter(labels=rel) for rel in relations] or None,
         )
-    )
 
     # Build order only if --order-by is provided
     orders = (

--- a/src/ai/backend/client/cli/v2/admin/session.py
+++ b/src/ai/backend/client/cli/v2/admin/session.py
@@ -7,7 +7,9 @@ import asyncio
 import click
 
 from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
     create_v2_registry,
+    entity_label_filter_options,
     load_v2_config,
     parse_order_options,
     print_result,
@@ -38,6 +40,7 @@ def session() -> None:
     default=None,
     help="Scope to sessions running on a specific agent.",
 )
+@entity_label_filter_options
 @click.option(
     "--order-by",
     multiple=True,
@@ -54,6 +57,7 @@ def search(
     domain_name: str | None,
     agent_id: str | None,
     order_by: tuple[str, ...],
+    label: EntityLabelTerms,
 ) -> None:
     """Search sessions with admin scope.
 
@@ -72,15 +76,15 @@ def search(
     )
 
     # Build filter only if any filter option is provided
-    filter_dto: SessionFilter | None = None
-    if name_contains is not None or status or domain_name is not None:
-        filter_dto = SessionFilter(
+    filter_dto = label.attach(
+        SessionFilter(
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
             status=(
                 SessionStatusFilter(in_=[SessionStatusEnum(s) for s in status]) if status else None
             ),
             domain_name=(StringFilter(contains=domain_name) if domain_name is not None else None),
         )
+    )
 
     # Build order only if --order-by is provided
     orders = parse_order_options(order_by, SessionOrderField, SessionOrder) if order_by else None

--- a/src/ai/backend/client/cli/v2/admin/session.py
+++ b/src/ai/backend/client/cli/v2/admin/session.py
@@ -7,9 +7,10 @@ import asyncio
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     parse_order_options,
     print_result,
@@ -57,7 +58,7 @@ def search(
     domain_name: str | None,
     agent_id: str | None,
     order_by: tuple[str, ...],
-    label: EntityLabelTerms,
+    label: tuple[EntityLabelTerm, ...],
 ) -> None:
     """Search sessions with admin scope.
 
@@ -75,16 +76,17 @@ def search(
         SessionStatusFilter,
     )
 
-    # Build filter only if any filter option is provided
-    filter_dto = label.attach(
-        SessionFilter(
+    relations = entity_label_relations(label)
+    filter_dto: SessionFilter | None = None
+    if relations or any([name_contains is not None, status, domain_name is not None]):
+        filter_dto = SessionFilter(
             name=StringFilter(contains=name_contains) if name_contains is not None else None,
             status=(
                 SessionStatusFilter(in_=[SessionStatusEnum(s) for s in status]) if status else None
             ),
             domain_name=(StringFilter(contains=domain_name) if domain_name is not None else None),
+            AND=[SessionFilter(labels=rel) for rel in relations] or None,
         )
-    )
 
     # Build order only if --order-by is provided
     orders = parse_order_options(order_by, SessionOrderField, SessionOrder) if order_by else None

--- a/src/ai/backend/client/cli/v2/deployment/commands.py
+++ b/src/ai/backend/client/cli/v2/deployment/commands.py
@@ -9,9 +9,10 @@ from uuid import UUID
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     print_result,
 )
@@ -52,7 +53,7 @@ def project_search(
     name_contains: str | None,
     status: tuple[str, ...],
     open_to_public: bool | None,
-    label: EntityLabelTerms,
+    label: tuple[EntityLabelTerm, ...],
 ) -> None:
     """Search deployments within a project."""
 
@@ -65,13 +66,15 @@ def project_search(
     )
     from ai.backend.common.dto.manager.v2.deployment.types import DeploymentOrderField
 
-    filter_dto = label.attach(
-        DeploymentFilter(
+    relations = entity_label_relations(label)
+    filter_dto: DeploymentFilter | None = None
+    if relations or name_contains or status or open_to_public is not None:
+        filter_dto = DeploymentFilter(
             name=StringFilter(contains=name_contains) if name_contains else None,
             status=DeploymentStatusFilter(in_=list(status)) if status else None,
             open_to_public=open_to_public,
+            AND=[DeploymentFilter(labels=rel) for rel in relations] or None,
         )
-    )
 
     orders: list[DeploymentOrder] | None = None
     if order_by:

--- a/src/ai/backend/client/cli/v2/deployment/commands.py
+++ b/src/ai/backend/client/cli/v2/deployment/commands.py
@@ -8,7 +8,13 @@ from uuid import UUID
 
 import click
 
-from ai.backend.client.cli.v2.helpers import create_v2_registry, load_v2_config, print_result
+from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
+    create_v2_registry,
+    entity_label_filter_options,
+    load_v2_config,
+    print_result,
+)
 
 
 @click.group()
@@ -37,6 +43,7 @@ def deployment() -> None:
     type=bool,
     help="Filter by public access (true/false).",
 )
+@entity_label_filter_options
 def project_search(
     project_id: str,
     limit: int,
@@ -45,6 +52,7 @@ def project_search(
     name_contains: str | None,
     status: tuple[str, ...],
     open_to_public: bool | None,
+    label: EntityLabelTerms,
 ) -> None:
     """Search deployments within a project."""
 
@@ -57,13 +65,13 @@ def project_search(
     )
     from ai.backend.common.dto.manager.v2.deployment.types import DeploymentOrderField
 
-    filter_dto: DeploymentFilter | None = None
-    if name_contains or status or open_to_public is not None:
-        filter_dto = DeploymentFilter(
+    filter_dto = label.attach(
+        DeploymentFilter(
             name=StringFilter(contains=name_contains) if name_contains else None,
             status=DeploymentStatusFilter(in_=list(status)) if status else None,
             open_to_public=open_to_public,
         )
+    )
 
     orders: list[DeploymentOrder] | None = None
     if order_by:

--- a/src/ai/backend/client/cli/v2/entity_label/__init__.py
+++ b/src/ai/backend/client/cli/v2/entity_label/__init__.py
@@ -1,0 +1,3 @@
+from .commands import entity_label as entity_label
+
+__all__ = ("entity_label",)

--- a/src/ai/backend/client/cli/v2/entity_label/commands.py
+++ b/src/ai/backend/client/cli/v2/entity_label/commands.py
@@ -1,0 +1,139 @@
+"""CLI commands for entity labels."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import click
+
+from ai.backend.client.cli.v2.helpers import (
+    create_v2_registry,
+    load_v2_config,
+    parse_order_options,
+    print_result,
+)
+
+
+@click.group(name="entity-label")
+def entity_label() -> None:
+    """Entity label commands."""
+
+
+@entity_label.command()
+@click.option("--entity-type", required=True, type=str, help="Type of the entity to label.")
+@click.option("--entity-id", required=True, type=click.UUID, help="ID of the entity to label.")
+@click.option("--key", required=True, type=str, help="Label key.")
+@click.option("--value", required=True, type=str, help="Label value.")
+def upsert(entity_type: str, entity_id: uuid.UUID, key: str, value: str) -> None:
+    """Set one key on an entity, replacing the value it carries."""
+    from ai.backend.common.dto.manager.v2.entity_label.request import UpsertEntityLabelInput
+    from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, RBACElementTypeDTO
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.entity_label.upsert(
+                UpsertEntityLabelInput(
+                    target=EntityTypeScope(
+                        entity_type=RBACElementTypeDTO(entity_type),
+                        entity_id=str(entity_id),
+                    ),
+                    key=key,
+                    value=value,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@entity_label.command()
+@click.argument("label_id", type=click.UUID)
+def purge(label_id: uuid.UUID) -> None:
+    """Take one label off, named by its own ID."""
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.entity_label.purge(label_id)
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())
+
+
+@entity_label.command()
+@click.option("--entity-type", required=True, type=str, help="Type of the entity to read.")
+@click.option(
+    "--entity-id",
+    required=True,
+    multiple=True,
+    type=click.UUID,
+    help="ID of an entity to read the labels of. Repeat to name several.",
+)
+@click.option("--key", type=str, default=None, help="Filter by label key (exact match).")
+@click.option("--value", type=str, default=None, help="Filter by label value (exact match).")
+@click.option("--limit", type=int, default=None, help="Maximum items to return.")
+@click.option("--offset", type=int, default=None, help="Number of items to skip.")
+@click.option(
+    "--order-by",
+    multiple=True,
+    help="Order by field:direction (e.g., created_at:desc). Fields: key, value, created_at.",
+)
+def search(
+    entity_type: str,
+    entity_id: tuple[uuid.UUID, ...],
+    key: str | None,
+    value: str | None,
+    limit: int | None,
+    offset: int | None,
+    order_by: tuple[str, ...],
+) -> None:
+    """Read the labels on the entities named."""
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.entity_label.request import (
+        EntityLabelFilter,
+        EntityLabelOrder,
+        SearchEntityLabelsInput,
+    )
+    from ai.backend.common.dto.manager.v2.entity_label.types import EntityLabelOrderField
+    from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, RBACElementTypeDTO
+
+    filter_dto: EntityLabelFilter | None = None
+    if key is not None or value is not None:
+        filter_dto = EntityLabelFilter(
+            key=StringFilter(equals=key) if key is not None else None,
+            value=StringFilter(equals=value) if value is not None else None,
+        )
+
+    orders = (
+        parse_order_options(order_by, EntityLabelOrderField, EntityLabelOrder) if order_by else None
+    )
+
+    async def _run() -> None:
+        registry = await create_v2_registry(load_v2_config())
+        try:
+            result = await registry.entity_label.search(
+                SearchEntityLabelsInput(
+                    scope=[
+                        EntityTypeScope(
+                            entity_type=RBACElementTypeDTO(entity_type),
+                            entity_id=str(one_id),
+                        )
+                        for one_id in entity_id
+                    ],
+                    filter=filter_dto,
+                    order=orders,
+                    limit=limit,
+                    offset=offset,
+                ),
+            )
+            print_result(result)
+        finally:
+            await registry.close()
+
+    asyncio.run(_run())

--- a/src/ai/backend/client/cli/v2/entity_label/commands.py
+++ b/src/ai/backend/client/cli/v2/entity_label/commands.py
@@ -27,18 +27,15 @@ def entity_label() -> None:
 @click.option("--value", required=True, type=str, help="Label value.")
 def upsert(entity_type: str, entity_id: uuid.UUID, key: str, value: str) -> None:
     """Set one key on an entity, replacing the value it carries."""
+    from ai.backend.common.dto.manager.v2.entity.types import EntityTarget
     from ai.backend.common.dto.manager.v2.entity_label.request import UpsertEntityLabelInput
-    from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, RBACElementTypeDTO
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             result = await registry.entity_label.upsert(
                 UpsertEntityLabelInput(
-                    target=EntityTypeScope(
-                        entity_type=RBACElementTypeDTO(entity_type),
-                        entity_id=str(entity_id),
-                    ),
+                    target=EntityTarget(entity_type=entity_type, entity_id=entity_id),
                     key=key,
                     value=value,
                 ),
@@ -95,13 +92,13 @@ def search(
 ) -> None:
     """Read the labels on the entities named."""
     from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.entity.types import EntityTarget
     from ai.backend.common.dto.manager.v2.entity_label.request import (
         EntityLabelFilter,
         EntityLabelOrder,
         SearchEntityLabelsInput,
     )
     from ai.backend.common.dto.manager.v2.entity_label.types import EntityLabelOrderField
-    from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope, RBACElementTypeDTO
 
     filter_dto: EntityLabelFilter | None = None
     if key is not None or value is not None:
@@ -120,10 +117,7 @@ def search(
             result = await registry.entity_label.search(
                 SearchEntityLabelsInput(
                     scope=[
-                        EntityTypeScope(
-                            entity_type=RBACElementTypeDTO(entity_type),
-                            entity_id=str(one_id),
-                        )
+                        EntityTarget(entity_type=entity_type, entity_id=one_id)
                         for one_id in entity_id
                     ],
                     filter=filter_dto,

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -16,6 +16,8 @@ import click
 from pydantic import TypeAdapter, ValidationError
 from yarl import URL
 
+from ai.backend.common.api_handlers import BaseRequestModel
+
 if TYPE_CHECKING:
     from ai.backend.client.v2.v2_registry import V2ClientRegistry
 
@@ -219,3 +221,69 @@ def print_result(data: Any) -> None:
         dumped = data
     json_str = json.dumps(dumped, indent=2, ensure_ascii=False, default=str)
     sys.stdout.write(json_str + "\n")
+
+
+@dataclass(frozen=True)
+class EntityLabelTerms:
+    """The labels a search was narrowed by, ready to attach to any entity filter.
+
+    Each term is its own relation, because a relation matches a single label. What
+    combines them is the entity filter's own ``AND``, which is what requiring two
+    different labels means — so attaching is the same work for every entity and lives
+    here rather than in each command.
+    """
+
+    terms: tuple[Any, ...]
+
+    def attach[TFilter: BaseRequestModel](self, base: TFilter) -> TFilter | None:
+        """The filter to send, or ``None`` when nothing was asked for.
+
+        Answers ``None`` for an untouched base and no labels, so a command need not test
+        its own options before deciding whether to send a filter at all.
+        """
+        merged = base.model_copy(
+            update={"AND": [*(getattr(base, "AND", None) or []), *self._as_filters(type(base))]}
+            if self.terms
+            else {}
+        )
+        return merged if merged.model_dump(exclude_none=True) else None
+
+    def _as_filters(self, filter_cls: type[Any]) -> list[Any]:
+        return [filter_cls(labels=term) for term in self.terms]
+
+
+def _parse_entity_label_terms(
+    _ctx: click.Context, _param: click.Parameter, value: tuple[str, ...]
+) -> EntityLabelTerms:
+    """Turn each ``KEY=VALUE`` into the nested filter matching that one label."""
+    from ai.backend.common.dto.manager.query import StringFilter
+    from ai.backend.common.dto.manager.v2.entity_label.request import (
+        EntityLabelFilter,
+        EntityLabelNestedFilter,
+    )
+
+    def to_filter(term: str) -> EntityLabelFilter:
+        key, sep, val = term.partition("=")
+        if not key:
+            raise click.BadParameter(f"{term!r} names no label key")
+        return EntityLabelFilter(
+            key=StringFilter(equals=key),
+            value=StringFilter(equals=val) if sep else None,
+        )
+
+    return EntityLabelTerms(tuple(EntityLabelNestedFilter(some=to_filter(t)) for t in value))
+
+
+def entity_label_filter_options(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Add ``--label`` to a search command, parsed into :class:`EntityLabelTerms`.
+
+    Takes ``KEY=VALUE``, or ``KEY`` alone to match the key whatever its value.
+    Repeating it narrows further: an entity must carry every label given.
+    """
+    return click.option(
+        "--label",
+        multiple=True,
+        metavar="KEY[=VALUE]",
+        callback=_parse_entity_label_terms,
+        help="Only entities carrying this label. Repeatable (all must match).",
+    )(fn)

--- a/src/ai/backend/client/cli/v2/helpers.py
+++ b/src/ai/backend/client/cli/v2/helpers.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import os
 import sys
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -16,10 +16,9 @@ import click
 from pydantic import TypeAdapter, ValidationError
 from yarl import URL
 
-from ai.backend.common.api_handlers import BaseRequestModel
-
 if TYPE_CHECKING:
     from ai.backend.client.v2.v2_registry import V2ClientRegistry
+    from ai.backend.common.dto.manager.v2.entity_label.request import EntityLabelNestedFilter
 
 CONFIG_DIR = Path.home() / ".backend.ai"
 CONFIG_FILE = CONFIG_DIR / "config.toml"
@@ -224,58 +223,54 @@ def print_result(data: Any) -> None:
 
 
 @dataclass(frozen=True)
-class EntityLabelTerms:
-    """The labels a search was narrowed by, ready to attach to any entity filter.
+class EntityLabelTerm:
+    """One ``KEY`` or ``KEY=VALUE`` a search was narrowed by."""
 
-    Each term is its own relation, because a relation matches a single label. What
-    combines them is the entity filter's own ``AND``, which is what requiring two
-    different labels means — so attaching is the same work for every entity and lives
-    here rather than in each command.
+    key: str
+    value: str | None
+
+
+def entity_label_relations(
+    terms: Sequence[EntityLabelTerm],
+) -> list[EntityLabelNestedFilter]:
+    """One relation per term, since a relation matches a single label.
+
+    Requiring every term is the entity filter's own ``AND`` over these, which the
+    command building that filter writes itself.
     """
-
-    terms: tuple[Any, ...]
-
-    def attach[TFilter: BaseRequestModel](self, base: TFilter) -> TFilter | None:
-        """The filter to send, or ``None`` when nothing was asked for.
-
-        Answers ``None`` for an untouched base and no labels, so a command need not test
-        its own options before deciding whether to send a filter at all.
-        """
-        merged = base.model_copy(
-            update={"AND": [*(getattr(base, "AND", None) or []), *self._as_filters(type(base))]}
-            if self.terms
-            else {}
-        )
-        return merged if merged.model_dump(exclude_none=True) else None
-
-    def _as_filters(self, filter_cls: type[Any]) -> list[Any]:
-        return [filter_cls(labels=term) for term in self.terms]
-
-
-def _parse_entity_label_terms(
-    _ctx: click.Context, _param: click.Parameter, value: tuple[str, ...]
-) -> EntityLabelTerms:
-    """Turn each ``KEY=VALUE`` into the nested filter matching that one label."""
     from ai.backend.common.dto.manager.query import StringFilter
     from ai.backend.common.dto.manager.v2.entity_label.request import (
         EntityLabelFilter,
         EntityLabelNestedFilter,
     )
 
-    def to_filter(term: str) -> EntityLabelFilter:
+    return [
+        EntityLabelNestedFilter(
+            some=EntityLabelFilter(
+                key=StringFilter(equals=term.key),
+                value=StringFilter(equals=term.value) if term.value is not None else None,
+            )
+        )
+        for term in terms
+    ]
+
+
+def _parse_entity_label_terms(
+    _ctx: click.Context, _param: click.Parameter, value: tuple[str, ...]
+) -> tuple[EntityLabelTerm, ...]:
+    """Split each ``KEY=VALUE``; a bare ``KEY`` leaves the value unconstrained."""
+
+    def to_term(term: str) -> EntityLabelTerm:
         key, sep, val = term.partition("=")
         if not key:
             raise click.BadParameter(f"{term!r} names no label key")
-        return EntityLabelFilter(
-            key=StringFilter(equals=key),
-            value=StringFilter(equals=val) if sep else None,
-        )
+        return EntityLabelTerm(key=key, value=val if sep else None)
 
-    return EntityLabelTerms(tuple(EntityLabelNestedFilter(some=to_filter(t)) for t in value))
+    return tuple(to_term(term) for term in value)
 
 
 def entity_label_filter_options(fn: Callable[..., Any]) -> Callable[..., Any]:
-    """Add ``--label`` to a search command, parsed into :class:`EntityLabelTerms`.
+    """Add ``--label`` to a search command, parsed into :class:`EntityLabelTerm` values.
 
     Takes ``KEY=VALUE``, or ``KEY`` alone to match the key whatever its value.
     Repeating it narrows further: an entity must carry every label given.

--- a/src/ai/backend/client/cli/v2/my/deployment.py
+++ b/src/ai/backend/client/cli/v2/my/deployment.py
@@ -7,9 +7,10 @@ import asyncio
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     print_result,
 )
@@ -43,7 +44,7 @@ def search(
     before: str | None,
     name_contains: str | None,
     status: tuple[str, ...],
-    label: EntityLabelTerms,
+    label: tuple[EntityLabelTerm, ...],
 ) -> None:
     """Search my deployments."""
 
@@ -54,12 +55,14 @@ def search(
         DeploymentStatusFilter,
     )
 
-    filter_dto = label.attach(
-        DeploymentFilter(
+    relations = entity_label_relations(label)
+    filter_dto: DeploymentFilter | None = None
+    if relations or name_contains or status:
+        filter_dto = DeploymentFilter(
             name=StringFilter(contains=name_contains) if name_contains else None,
             status=DeploymentStatusFilter(in_=list(status)) if status else None,
+            AND=[DeploymentFilter(labels=rel) for rel in relations] or None,
         )
-    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())

--- a/src/ai/backend/client/cli/v2/my/deployment.py
+++ b/src/ai/backend/client/cli/v2/my/deployment.py
@@ -6,7 +6,13 @@ import asyncio
 
 import click
 
-from ai.backend.client.cli.v2.helpers import create_v2_registry, load_v2_config, print_result
+from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
+    create_v2_registry,
+    entity_label_filter_options,
+    load_v2_config,
+    print_result,
+)
 
 
 @click.group()
@@ -22,6 +28,7 @@ def deployment() -> None:
 @click.option("--last", default=None, type=int, help="Cursor-based: return last N items.")
 @click.option("--before", default=None, type=str, help="Cursor-based: return items before cursor.")
 @click.option("--name-contains", default=None, type=str, help="Filter by name (contains).")
+@entity_label_filter_options
 @click.option(
     "--status",
     multiple=True,
@@ -36,6 +43,7 @@ def search(
     before: str | None,
     name_contains: str | None,
     status: tuple[str, ...],
+    label: EntityLabelTerms,
 ) -> None:
     """Search my deployments."""
 
@@ -46,12 +54,12 @@ def search(
         DeploymentStatusFilter,
     )
 
-    filter_dto: DeploymentFilter | None = None
-    if name_contains or status:
-        filter_dto = DeploymentFilter(
+    filter_dto = label.attach(
+        DeploymentFilter(
             name=StringFilter(contains=name_contains) if name_contains else None,
             status=DeploymentStatusFilter(in_=list(status)) if status else None,
         )
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())

--- a/src/ai/backend/client/cli/v2/my/session.py
+++ b/src/ai/backend/client/cli/v2/my/session.py
@@ -7,9 +7,10 @@ import asyncio
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     print_result,
 )
@@ -35,7 +36,7 @@ def search(
     after: str | None,
     last: int | None,
     before: str | None,
-    label: EntityLabelTerms,
+    label: tuple[EntityLabelTerm, ...],
 ) -> None:
     """Search my sessions."""
 
@@ -44,11 +45,17 @@ def search(
         SessionFilter,
     )
 
+    relations = entity_label_relations(label)
+
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             request = AdminSearchSessionsInput(
-                filter=label.attach(SessionFilter()),
+                filter=(
+                    SessionFilter(AND=[SessionFilter(labels=rel) for rel in relations])
+                    if relations
+                    else None
+                ),
                 first=first,
                 after=after,
                 last=last,

--- a/src/ai/backend/client/cli/v2/my/session.py
+++ b/src/ai/backend/client/cli/v2/my/session.py
@@ -6,7 +6,13 @@ import asyncio
 
 import click
 
-from ai.backend.client.cli.v2.helpers import create_v2_registry, load_v2_config, print_result
+from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
+    create_v2_registry,
+    entity_label_filter_options,
+    load_v2_config,
+    print_result,
+)
 
 
 @click.group()
@@ -21,6 +27,7 @@ def session() -> None:
 @click.option("--after", default=None, type=str, help="Cursor-based: return items after cursor.")
 @click.option("--last", default=None, type=int, help="Cursor-based: return last N items.")
 @click.option("--before", default=None, type=str, help="Cursor-based: return items before cursor.")
+@entity_label_filter_options
 def search(
     limit: int | None,
     offset: int | None,
@@ -28,15 +35,20 @@ def search(
     after: str | None,
     last: int | None,
     before: str | None,
+    label: EntityLabelTerms,
 ) -> None:
     """Search my sessions."""
 
-    from ai.backend.common.dto.manager.v2.session.request import AdminSearchSessionsInput
+    from ai.backend.common.dto.manager.v2.session.request import (
+        AdminSearchSessionsInput,
+        SessionFilter,
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             request = AdminSearchSessionsInput(
+                filter=label.attach(SessionFilter()),
                 first=first,
                 after=after,
                 last=last,

--- a/src/ai/backend/client/cli/v2/session/commands.py
+++ b/src/ai/backend/client/cli/v2/session/commands.py
@@ -10,7 +10,9 @@ from uuid import UUID
 import click
 
 from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
     create_v2_registry,
+    entity_label_filter_options,
     load_v2_config,
     print_result,
 )
@@ -192,15 +194,21 @@ def get(session_id: str) -> None:
 @click.argument("project_id", type=str)
 @click.option("--limit", type=int, default=20)
 @click.option("--offset", type=int, default=0)
-def project_search(project_id: str, limit: int, offset: int) -> None:
+@entity_label_filter_options
+def project_search(project_id: str, limit: int, offset: int, label: EntityLabelTerms) -> None:
     """Search sessions within a project."""
 
-    from ai.backend.common.dto.manager.v2.session.request import AdminSearchSessionsInput
+    from ai.backend.common.dto.manager.v2.session.request import (
+        AdminSearchSessionsInput,
+        SessionFilter,
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            request = AdminSearchSessionsInput(limit=limit, offset=offset)
+            request = AdminSearchSessionsInput(
+                filter=label.attach(SessionFilter()), limit=limit, offset=offset
+            )
             result = await registry.session.project_search(UUID(project_id), request)
             print_result(result)
         finally:

--- a/src/ai/backend/client/cli/v2/session/commands.py
+++ b/src/ai/backend/client/cli/v2/session/commands.py
@@ -10,9 +10,10 @@ from uuid import UUID
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     print_result,
 )
@@ -195,7 +196,9 @@ def get(session_id: str) -> None:
 @click.option("--limit", type=int, default=20)
 @click.option("--offset", type=int, default=0)
 @entity_label_filter_options
-def project_search(project_id: str, limit: int, offset: int, label: EntityLabelTerms) -> None:
+def project_search(
+    project_id: str, limit: int, offset: int, label: tuple[EntityLabelTerm, ...]
+) -> None:
     """Search sessions within a project."""
 
     from ai.backend.common.dto.manager.v2.session.request import (
@@ -203,11 +206,19 @@ def project_search(project_id: str, limit: int, offset: int, label: EntityLabelT
         SessionFilter,
     )
 
+    relations = entity_label_relations(label)
+
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             request = AdminSearchSessionsInput(
-                filter=label.attach(SessionFilter()), limit=limit, offset=offset
+                filter=(
+                    SessionFilter(AND=[SessionFilter(labels=rel) for rel in relations])
+                    if relations
+                    else None
+                ),
+                limit=limit,
+                offset=offset,
             )
             result = await registry.session.project_search(UUID(project_id), request)
             print_result(result)

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -8,7 +8,13 @@ from uuid import UUID
 
 import click
 
-from ai.backend.client.cli.v2.helpers import create_v2_registry, load_v2_config, print_result
+from ai.backend.client.cli.v2.helpers import (
+    EntityLabelTerms,
+    create_v2_registry,
+    entity_label_filter_options,
+    load_v2_config,
+    print_result,
+)
 
 
 @click.group()
@@ -19,15 +25,21 @@ def vfolder() -> None:
 @vfolder.command(name="my-search")
 @click.option("--limit", type=int, default=20)
 @click.option("--offset", type=int, default=0)
-def my_search(limit: int, offset: int) -> None:
+@entity_label_filter_options
+def my_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
     """Search vfolders owned by the current user."""
 
-    from ai.backend.common.dto.manager.v2.vfolder.request import SearchVFoldersInput
+    from ai.backend.common.dto.manager.v2.vfolder.request import (
+        SearchVFoldersInput,
+        VFolderFilter,
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            request = SearchVFoldersInput(limit=limit, offset=offset)
+            request = SearchVFoldersInput(
+                filter=label.attach(VFolderFilter()), limit=limit, offset=offset
+            )
             result = await registry.vfolder.my_search(request)
             print_result(result)
         finally:
@@ -40,15 +52,21 @@ def my_search(limit: int, offset: int) -> None:
 @click.argument("project_id", type=str)
 @click.option("--limit", type=int, default=20)
 @click.option("--offset", type=int, default=0)
-def project_search(project_id: str, limit: int, offset: int) -> None:
+@entity_label_filter_options
+def project_search(project_id: str, limit: int, offset: int, label: EntityLabelTerms) -> None:
     """Search vfolders within a project."""
 
-    from ai.backend.common.dto.manager.v2.vfolder.request import SearchVFoldersInput
+    from ai.backend.common.dto.manager.v2.vfolder.request import (
+        SearchVFoldersInput,
+        VFolderFilter,
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            request = SearchVFoldersInput(limit=limit, offset=offset)
+            request = SearchVFoldersInput(
+                filter=label.attach(VFolderFilter()), limit=limit, offset=offset
+            )
             result = await registry.vfolder.project_search(UUID(project_id), request)
             print_result(result)
         finally:
@@ -130,15 +148,21 @@ def upload(vfolder_id: UUID, filenames: tuple[str, ...]) -> None:
 @vfolder.command(name="admin-search")
 @click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
 @click.option("--offset", type=int, default=0, help="Number of items to skip.")
-def admin_search(limit: int, offset: int) -> None:
+@entity_label_filter_options
+def admin_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
     """Search all vfolders (admin)."""
 
-    from ai.backend.common.dto.manager.v2.vfolder.request import SearchVFoldersInput
+    from ai.backend.common.dto.manager.v2.vfolder.request import (
+        SearchVFoldersInput,
+        VFolderFilter,
+    )
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
-            request = SearchVFoldersInput(limit=limit, offset=offset)
+            request = SearchVFoldersInput(
+                filter=label.attach(VFolderFilter()), limit=limit, offset=offset
+            )
             result = await registry.vfolder.admin_search(request)
             print_result(result)
         finally:

--- a/src/ai/backend/client/cli/v2/vfolder/commands.py
+++ b/src/ai/backend/client/cli/v2/vfolder/commands.py
@@ -9,9 +9,10 @@ from uuid import UUID
 import click
 
 from ai.backend.client.cli.v2.helpers import (
-    EntityLabelTerms,
+    EntityLabelTerm,
     create_v2_registry,
     entity_label_filter_options,
+    entity_label_relations,
     load_v2_config,
     print_result,
 )
@@ -26,7 +27,7 @@ def vfolder() -> None:
 @click.option("--limit", type=int, default=20)
 @click.option("--offset", type=int, default=0)
 @entity_label_filter_options
-def my_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
+def my_search(limit: int, offset: int, label: tuple[EntityLabelTerm, ...]) -> None:
     """Search vfolders owned by the current user."""
 
     from ai.backend.common.dto.manager.v2.vfolder.request import (
@@ -34,11 +35,19 @@ def my_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
         VFolderFilter,
     )
 
+    relations = entity_label_relations(label)
+
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             request = SearchVFoldersInput(
-                filter=label.attach(VFolderFilter()), limit=limit, offset=offset
+                filter=(
+                    VFolderFilter(AND=[VFolderFilter(labels=rel) for rel in relations])
+                    if relations
+                    else None
+                ),
+                limit=limit,
+                offset=offset,
             )
             result = await registry.vfolder.my_search(request)
             print_result(result)
@@ -53,7 +62,9 @@ def my_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
 @click.option("--limit", type=int, default=20)
 @click.option("--offset", type=int, default=0)
 @entity_label_filter_options
-def project_search(project_id: str, limit: int, offset: int, label: EntityLabelTerms) -> None:
+def project_search(
+    project_id: str, limit: int, offset: int, label: tuple[EntityLabelTerm, ...]
+) -> None:
     """Search vfolders within a project."""
 
     from ai.backend.common.dto.manager.v2.vfolder.request import (
@@ -61,11 +72,19 @@ def project_search(project_id: str, limit: int, offset: int, label: EntityLabelT
         VFolderFilter,
     )
 
+    relations = entity_label_relations(label)
+
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             request = SearchVFoldersInput(
-                filter=label.attach(VFolderFilter()), limit=limit, offset=offset
+                filter=(
+                    VFolderFilter(AND=[VFolderFilter(labels=rel) for rel in relations])
+                    if relations
+                    else None
+                ),
+                limit=limit,
+                offset=offset,
             )
             result = await registry.vfolder.project_search(UUID(project_id), request)
             print_result(result)
@@ -149,7 +168,7 @@ def upload(vfolder_id: UUID, filenames: tuple[str, ...]) -> None:
 @click.option("--limit", type=int, default=20, help="Maximum number of items to return.")
 @click.option("--offset", type=int, default=0, help="Number of items to skip.")
 @entity_label_filter_options
-def admin_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
+def admin_search(limit: int, offset: int, label: tuple[EntityLabelTerm, ...]) -> None:
     """Search all vfolders (admin)."""
 
     from ai.backend.common.dto.manager.v2.vfolder.request import (
@@ -157,11 +176,19 @@ def admin_search(limit: int, offset: int, label: EntityLabelTerms) -> None:
         VFolderFilter,
     )
 
+    relations = entity_label_relations(label)
+
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             request = SearchVFoldersInput(
-                filter=label.attach(VFolderFilter()), limit=limit, offset=offset
+                filter=(
+                    VFolderFilter(AND=[VFolderFilter(labels=rel) for rel in relations])
+                    if relations
+                    else None
+                ),
+                limit=limit,
+                offset=offset,
             )
             result = await registry.vfolder.admin_search(request)
             print_result(result)

--- a/src/ai/backend/client/v2/domains_v2/entity_label.py
+++ b/src/ai/backend/client/v2/domains_v2/entity_label.py
@@ -1,0 +1,48 @@
+"""V2 SDK client for the label domain."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from ai.backend.client.v2.base_domain import BaseDomainClient
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    SearchEntityLabelsInput,
+    UpsertEntityLabelInput,
+)
+from ai.backend.common.dto.manager.v2.entity_label.response import (
+    PurgeEntityLabelPayload,
+    SearchEntityLabelsPayload,
+    UpsertEntityLabelPayload,
+)
+
+_PATH = "/v2/entity-labels"
+
+
+class V2EntityLabelClient(BaseDomainClient):
+    """SDK client for label operations."""
+
+    async def upsert(self, request: UpsertEntityLabelInput) -> UpsertEntityLabelPayload:
+        """Set one key on an entity, replacing the value it carries."""
+        return await self._client.typed_request(
+            "PUT",
+            _PATH,
+            request=request,
+            response_model=UpsertEntityLabelPayload,
+        )
+
+    async def purge(self, label_id: UUID) -> PurgeEntityLabelPayload:
+        """Take one label off, named by its own id."""
+        return await self._client.typed_request(
+            "DELETE",
+            f"{_PATH}/{label_id}",
+            response_model=PurgeEntityLabelPayload,
+        )
+
+    async def search(self, request: SearchEntityLabelsInput) -> SearchEntityLabelsPayload:
+        """Read the labels on the entities named."""
+        return await self._client.typed_request(
+            "POST",
+            f"{_PATH}/search",
+            request=request,
+            response_model=SearchEntityLabelsPayload,
+        )

--- a/src/ai/backend/client/v2/v2_registry.py
+++ b/src/ai/backend/client/v2/v2_registry.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from .domains_v2.deployment_revision_preset import V2DeploymentRevisionPresetClient
     from .domains_v2.domain import V2DomainClient
     from .domains_v2.entity_invitation import V2EntityInvitationClient
+    from .domains_v2.entity_label import V2EntityLabelClient
     from .domains_v2.entity_type import V2EntityTypeClient
     from .domains_v2.export import V2ExportClient
     from .domains_v2.fair_share import V2FairShareClient
@@ -222,6 +223,12 @@ class V2ClientRegistry:
         from .domains_v2.keypair import V2KeypairClient
 
         return V2KeypairClient(self._client)
+
+    @cached_property
+    def entity_label(self) -> V2EntityLabelClient:
+        from .domains_v2.entity_label import V2EntityLabelClient
+
+        return V2EntityLabelClient(self._client)
 
     @cached_property
     def login_client_type(self) -> V2LoginClientTypeClient:

--- a/src/ai/backend/common/dto/manager/v2/agent/request.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/request.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.manager.v2.agent.types import (
     ConflictingSessionCleanupPolicyEnum,
     OrderDirection,
 )
+from ai.backend.common.dto.manager.v2.entity_label.request import EntityLabelNestedFilter
 from ai.backend.common.types import AgentId
 
 __all__ = (
@@ -69,6 +70,9 @@ class AgentFilter(BaseRequestModel):
             "Supports equals, contains, starts_with, ends_with, "
             "and their case-insensitive and negated variants."
         ),
+    )
+    labels: EntityLabelNestedFilter | None = Field(
+        default=None, description="Filter by the labels on the entity"
     )
     AND: list[AgentFilter] | None = Field(
         default=None, description="All sub-conditions must match."

--- a/src/ai/backend/common/dto/manager/v2/agent/response.py
+++ b/src/ai/backend/common/dto/manager/v2/agent/response.py
@@ -13,6 +13,7 @@ from typing import Any
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.data.entity.session import SessionID
 from ai.backend.common.dto.manager.pagination import PaginationInfo
@@ -149,6 +150,7 @@ class AgentNode(BaseResponseModel):
     """Node model representing an agent entity with nested information groups."""
 
     id: str = Field(description="Agent ID.")
+    uuid: AgentUUID = Field(description="Agent UUID, which is what rows keyed on the agent carry.")
     resource_info: AgentResourceInfo = Field(
         description="Hardware resource capacity, usage, and availability information."
     )

--- a/src/ai/backend/common/dto/manager/v2/deployment/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment/request.py
@@ -47,6 +47,7 @@ from ai.backend.common.dto.manager.v2.deployment.types import (
     RouteOrderField,
 )
 from ai.backend.common.dto.manager.v2.deployment_options import DeploymentOptionsInput
+from ai.backend.common.dto.manager.v2.entity_label.request import EntityLabelNestedFilter
 from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsDTOInput
 from ai.backend.common.schema.deployment import IntOrPercent
 from ai.backend.common.types import (
@@ -708,6 +709,9 @@ class DeploymentFilter(BaseRequestModel):
     )
     replicas: ReplicaNestedFilter | None = Field(
         default=None, description="Filter by conditions on deployment replicas"
+    )
+    labels: EntityLabelNestedFilter | None = Field(
+        default=None, description="Filter by the labels on the entity"
     )
     AND: list[DeploymentFilter] | None = Field(default=None, description="AND conjunction")
     OR: list[DeploymentFilter] | None = Field(default=None, description="OR conjunction")

--- a/src/ai/backend/common/dto/manager/v2/entity_label/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_label/__init__.py
@@ -1,0 +1,33 @@
+"""Label DTOs v2 for Manager API."""
+
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    EntityLabelFilter,
+    EntityLabelNestedFilter,
+    EntityLabelOrder,
+    SearchEntityLabelsInput,
+    UpsertEntityLabelInput,
+)
+from ai.backend.common.dto.manager.v2.entity_label.response import (
+    EntityLabelNode,
+    PurgeEntityLabelPayload,
+    SearchEntityLabelsPayload,
+    UpsertEntityLabelPayload,
+)
+from ai.backend.common.dto.manager.v2.entity_label.types import (
+    EntityLabelOrderField,
+    OrderDirection,
+)
+
+__all__ = (
+    "UpsertEntityLabelInput",
+    "UpsertEntityLabelPayload",
+    "EntityLabelFilter",
+    "EntityLabelNestedFilter",
+    "EntityLabelNode",
+    "EntityLabelOrder",
+    "EntityLabelOrderField",
+    "OrderDirection",
+    "PurgeEntityLabelPayload",
+    "SearchEntityLabelsInput",
+    "SearchEntityLabelsPayload",
+)

--- a/src/ai/backend/common/dto/manager/v2/entity_label/request.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_label/request.py
@@ -1,0 +1,94 @@
+"""Request DTOs for Label DTO v2."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseRequestModel
+from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope
+
+from .types import EntityLabelOrderField, OrderDirection
+
+__all__ = (
+    "UpsertEntityLabelInput",
+    "EntityLabelFilter",
+    "EntityLabelNestedFilter",
+    "EntityLabelOrder",
+    "SearchEntityLabelsInput",
+)
+
+
+class EntityLabelFilter(BaseRequestModel):
+    """Filter over label rows.
+
+    One instance matches a single label at a time, so `key` and `value` given together
+    constrain the same label rather than two different ones.
+    """
+
+    key: StringFilter | None = Field(default=None, description="Label key filter")
+    value: StringFilter | None = Field(default=None, description="Label value filter")
+    entity_type: StringFilter | None = Field(default=None, description="Type of the labeled entity")
+    entity_id: UUIDFilter | None = Field(default=None, description="ID of the labeled entity")
+    AND: list[EntityLabelFilter] | None = Field(
+        default=None, description="All conditions must match"
+    )
+    OR: list[EntityLabelFilter] | None = Field(
+        default=None, description="At least one condition must match"
+    )
+    NOT: list[EntityLabelFilter] | None = Field(
+        default=None, description="None of the conditions must match"
+    )
+
+
+EntityLabelFilter.model_rebuild()
+
+
+class EntityLabelNestedFilter(BaseRequestModel):
+    """The `labels` field of a labelable entity's filter.
+
+    Each relation matches one label at a time. To require two different labels, combine
+    two of these with the entity filter's own `AND`.
+    """
+
+    some: EntityLabelFilter | None = Field(
+        default=None, description="At least one of the entity's labels matches"
+    )
+    every: EntityLabelFilter | None = Field(
+        default=None,
+        description="All of the entity's labels match; true for an unlabeled entity",
+    )
+    none: EntityLabelFilter | None = Field(
+        default=None, description="None of the entity's labels matches"
+    )
+
+
+class EntityLabelOrder(BaseRequestModel):
+    """Ordering specification for labels."""
+
+    field: EntityLabelOrderField
+    direction: OrderDirection = OrderDirection.DESC
+
+
+class UpsertEntityLabelInput(BaseRequestModel):
+    """Input for putting one key on one entity, replacing the value it carries."""
+
+    target: EntityTypeScope = Field(description="The entity to label")
+    key: str = Field(min_length=1, max_length=255, description="Label key")
+    value: str = Field(min_length=1, max_length=255, description="Label value")
+
+
+class SearchEntityLabelsInput(BaseRequestModel):
+    """Input for reading the labels on the entities named."""
+
+    scope: list[EntityTypeScope] = Field(
+        min_length=1, description="The entities whose labels to read (OR across items)"
+    )
+    filter: EntityLabelFilter | None = Field(default=None, description="Filter criteria")
+    order: list[EntityLabelOrder] | None = Field(default=None, description="Sort order")
+    first: int | None = Field(default=None, ge=1, description="Cursor-forward page size")
+    after: str | None = Field(default=None, description="Cursor-forward start cursor")
+    last: int | None = Field(default=None, ge=1, description="Cursor-backward page size")
+    before: str | None = Field(default=None, description="Cursor-backward end cursor")
+    limit: int | None = Field(default=None, ge=1, description="Offset-based page size")
+    offset: int | None = Field(default=None, ge=0, description="Offset-based page offset")

--- a/src/ai/backend/common/dto/manager/v2/entity_label/request.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_label/request.py
@@ -15,6 +15,7 @@ __all__ = (
     "EntityLabelFilter",
     "EntityLabelNestedFilter",
     "EntityLabelOrder",
+    "EntityLabelPageInput",
     "SearchEntityLabelsInput",
 )
 
@@ -78,12 +79,9 @@ class UpsertEntityLabelInput(BaseRequestModel):
     value: str = Field(min_length=1, max_length=255, description="Label value")
 
 
-class SearchEntityLabelsInput(BaseRequestModel):
-    """Input for reading the labels on the entities named."""
+class EntityLabelPageInput(BaseRequestModel):
+    """One page of labels, over whatever entities the caller has already been fixed to."""
 
-    scope: list[EntityTypeScope] = Field(
-        min_length=1, description="The entities whose labels to read (OR across items)"
-    )
     filter: EntityLabelFilter | None = Field(default=None, description="Filter criteria")
     order: list[EntityLabelOrder] | None = Field(default=None, description="Sort order")
     first: int | None = Field(default=None, ge=1, description="Cursor-forward page size")
@@ -92,3 +90,11 @@ class SearchEntityLabelsInput(BaseRequestModel):
     before: str | None = Field(default=None, description="Cursor-backward end cursor")
     limit: int | None = Field(default=None, ge=1, description="Offset-based page size")
     offset: int | None = Field(default=None, ge=0, description="Offset-based page offset")
+
+
+class SearchEntityLabelsInput(EntityLabelPageInput):
+    """Input for reading the labels on the entities named."""
+
+    scope: list[EntityTypeScope] = Field(
+        min_length=1, description="The entities whose labels to read (OR across items)"
+    )

--- a/src/ai/backend/common/dto/manager/v2/entity_label/request.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_label/request.py
@@ -6,7 +6,7 @@ from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
-from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope
+from ai.backend.common.dto.manager.v2.entity.types import EntityTarget
 
 from .types import EntityLabelOrderField, OrderDirection
 
@@ -74,7 +74,7 @@ class EntityLabelOrder(BaseRequestModel):
 class UpsertEntityLabelInput(BaseRequestModel):
     """Input for putting one key on one entity, replacing the value it carries."""
 
-    target: EntityTypeScope = Field(description="The entity to label")
+    target: EntityTarget = Field(description="The entity to label")
     key: str = Field(min_length=1, max_length=255, description="Label key")
     value: str = Field(min_length=1, max_length=255, description="Label value")
 
@@ -95,6 +95,6 @@ class EntityLabelPageInput(BaseRequestModel):
 class SearchEntityLabelsInput(EntityLabelPageInput):
     """Input for reading the labels on the entities named."""
 
-    scope: list[EntityTypeScope] = Field(
+    scope: list[EntityTarget] = Field(
         min_length=1, description="The entities whose labels to read (OR across items)"
     )

--- a/src/ai/backend/common/dto/manager/v2/entity_label/response.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_label/response.py
@@ -1,0 +1,50 @@
+"""Response DTOs for Label DTO v2."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import BaseResponseModel
+
+__all__ = (
+    "UpsertEntityLabelPayload",
+    "EntityLabelNode",
+    "PurgeEntityLabelPayload",
+    "SearchEntityLabelsPayload",
+)
+
+
+class EntityLabelNode(BaseResponseModel):
+    """One `key=value` label and the entity carrying it."""
+
+    id: UUID = Field(description="Label ID")
+    entity_type: str = Field(description="Type of the labeled entity")
+    entity_id: UUID = Field(description="ID of the labeled entity")
+    key: str = Field(description="Label key")
+    value: str = Field(description="Label value")
+    created_at: datetime = Field(description="When the label was first put on the entity")
+    updated_at: datetime = Field(description="When the label's value was last replaced")
+
+
+class UpsertEntityLabelPayload(BaseResponseModel):
+    """Payload for the label as it now stands."""
+
+    label: EntityLabelNode = Field(description="The label put on the entity")
+
+
+class PurgeEntityLabelPayload(BaseResponseModel):
+    """Payload for the label that was removed."""
+
+    label: EntityLabelNode = Field(description="The label taken off the entity")
+
+
+class SearchEntityLabelsPayload(BaseResponseModel):
+    """Payload for a page of labels."""
+
+    items: list[EntityLabelNode] = Field(description="Label list")
+    total_count: int = Field(description="Total count")
+    has_next_page: bool = Field(description="Whether a next page exists")
+    has_previous_page: bool = Field(description="Whether a previous page exists")

--- a/src/ai/backend/common/dto/manager/v2/entity_label/types.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_label/types.py
@@ -1,0 +1,20 @@
+"""Common types for Label DTO v2."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+
+__all__ = (
+    "EntityLabelOrderField",
+    "OrderDirection",
+)
+
+
+class EntityLabelOrderField(StrEnum):
+    """Fields available for ordering labels."""
+
+    KEY = "key"
+    VALUE = "value"
+    CREATED_AT = "created_at"

--- a/src/ai/backend/common/dto/manager/v2/session/request.py
+++ b/src/ai/backend/common/dto/manager/v2/session/request.py
@@ -22,6 +22,7 @@ from ai.backend.common.dto.manager.v2.common import (
     MountItemInput,
     ResourceSlotEntryInput,
 )
+from ai.backend.common.dto.manager.v2.entity_label.request import EntityLabelNestedFilter
 from ai.backend.common.dto.manager.v2.session.types import (
     ClusterModeEnum,
     CreateSessionTypeEnum,
@@ -98,6 +99,9 @@ class SessionFilter(BaseRequestModel):
     project_id: UUIDFilter | None = None
     user_uuid: UUIDFilter | None = None
     created_at: DateTimeFilter | None = None
+    labels: EntityLabelNestedFilter | None = Field(
+        default=None, description="Filter by the labels on the entity"
+    )
     AND: list[SessionFilter] | None = None
     OR: list[SessionFilter] | None = None
     NOT: list[SessionFilter] | None = None

--- a/src/ai/backend/common/dto/manager/v2/vfolder/request.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/request.py
@@ -12,6 +12,7 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.data.entity.deployment_preset import DeploymentPresetID
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter
 from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
+from ai.backend.common.dto.manager.v2.entity_label.request import EntityLabelNestedFilter
 from ai.backend.common.typed_validators import VFolderName
 
 from .types import (
@@ -354,6 +355,9 @@ class VFolderFilter(BaseRequestModel):
     )
     cloneable: bool | None = Field(default=None, description="Filter by cloneable flag.")
     created_at: DateTimeFilter | None = Field(default=None, description="Filter by creation time.")
+    labels: EntityLabelNestedFilter | None = Field(
+        default=None, description="Filter by the labels on the entity"
+    )
     AND: list[VFolderFilter] | None = Field(default=None, description="AND logical combinator.")
     OR: list[VFolderFilter] | None = Field(default=None, description="OR logical combinator.")
     NOT: list[VFolderFilter] | None = Field(default=None, description="NOT logical combinator.")

--- a/src/ai/backend/manager/actions/registry/types.py
+++ b/src/ai/backend/manager/actions/registry/types.py
@@ -31,6 +31,7 @@ class Concern(enum.StrEnum):
     ARTIFACT_REGISTRY = "artifact_registry"
     CONTAINER_REGISTRY = "container_registry"
     DEPLOYMENT = "deployment"
+    ENTITY_LABEL = "label"
     METRIC = "metric"
     NOTIFICATION_CENTER = "notification_center"
     ORGANIZATION = "organization"
@@ -53,6 +54,8 @@ class Concern(enum.StrEnum):
                 return "the domain reading the images a session runs from"
             case Concern.DEPLOYMENT:
                 return "the domain creating and running the deployments that serve a model"
+            case Concern.ENTITY_LABEL:
+                return "the domain of the labels an entity of any kind is tagged with"
             case Concern.METRIC:
                 return "the domain keeping the queries a metric is read with"
             case Concern.NOTIFICATION_CENTER:

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -146,6 +146,10 @@ class AgentAdapter(BaseAdapter):
             condition = self._convert_resource_group_filter(f.scaling_group)
             if condition is not None:
                 conditions.append(condition)
+        if f.labels is not None:
+            conditions.extend(
+                self._convert_entity_label_nested_filter(f.labels, AgentConditions.labels)
+            )
         if f.AND:
             for sub_filter in f.AND:
                 conditions.extend(self._convert_filter(sub_filter))

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -270,6 +270,7 @@ class AgentAdapter(BaseAdapter):
         data = detail.agent
         return AgentNode(
             id=str(data.id),
+            uuid=data.uuid,
             resource_info=AgentResourceInfo(
                 capacity=dict(data.available_slots.to_json()),
                 used=dict(data.occupied_slots.to_json()),

--- a/src/ai/backend/manager/api/adapters/base.py
+++ b/src/ai/backend/manager/api/adapters/base.py
@@ -12,11 +12,20 @@ from ai.backend.manager.api.adapter_options.pagination.pagination import (
 )
 from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
+from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
+from ai.backend.manager.models.entity_label.conditions import (
+    EntityLabelConditions,
+    EntityLabelNestedConditions,
+)
 from ai.backend.manager.models.specs.searcher import Searcher
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.filter_adapter import BaseFilterAdapter
 
 if TYPE_CHECKING:
+    from ai.backend.common.dto.manager.v2.entity_label.request import (
+        EntityLabelFilter,
+        EntityLabelNestedFilter,
+    )
     from ai.backend.manager.services.processors import Processors
 
 
@@ -35,6 +44,89 @@ class BaseAdapter(BaseFilterAdapter):
 
     def __init__(self, processors: Processors) -> None:
         self._processors = processors
+
+    def _convert_entity_label_filter(self, f: EntityLabelFilter) -> list[QueryCondition]:
+        """Conditions matching a single label row.
+
+        One instance narrows one row, so a `key` and a `value` given together constrain
+        the same label rather than two different ones.
+        """
+        conditions: list[QueryCondition] = []
+        if f.key is not None:
+            condition = self.convert_string_filter(
+                f.key,
+                contains_factory=EntityLabelConditions.by_key_contains,
+                equals_factory=EntityLabelConditions.by_key_equals,
+                starts_with_factory=EntityLabelConditions.by_key_starts_with,
+                ends_with_factory=EntityLabelConditions.by_key_ends_with,
+                in_factory=EntityLabelConditions.by_key_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.value is not None:
+            condition = self.convert_string_filter(
+                f.value,
+                contains_factory=EntityLabelConditions.by_value_contains,
+                equals_factory=EntityLabelConditions.by_value_equals,
+                starts_with_factory=EntityLabelConditions.by_value_starts_with,
+                ends_with_factory=EntityLabelConditions.by_value_ends_with,
+                in_factory=EntityLabelConditions.by_value_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.entity_type is not None:
+            condition = self.convert_string_filter(
+                f.entity_type,
+                contains_factory=EntityLabelConditions.by_entity_type_contains,
+                equals_factory=EntityLabelConditions.by_entity_type_equals,
+                starts_with_factory=EntityLabelConditions.by_entity_type_starts_with,
+                ends_with_factory=EntityLabelConditions.by_entity_type_ends_with,
+                in_factory=EntityLabelConditions.by_entity_type_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.entity_id is not None:
+            condition = self.convert_uuid_filter(
+                f.entity_id,
+                equals_factory=EntityLabelConditions.by_entity_id_equals,
+                in_factory=EntityLabelConditions.by_entity_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
+        if f.AND:
+            for sub in f.AND:
+                conditions.extend(self._convert_entity_label_filter(sub))
+        if f.OR:
+            or_conditions: list[QueryCondition] = []
+            for sub in f.OR:
+                or_conditions.extend(self._convert_entity_label_filter(sub))
+            if or_conditions:
+                conditions.append(combine_conditions_or(or_conditions))
+        if f.NOT:
+            not_conditions: list[QueryCondition] = []
+            for sub in f.NOT:
+                not_conditions.extend(self._convert_entity_label_filter(sub))
+            if not_conditions:
+                conditions.append(negate_conditions(not_conditions))
+        return conditions
+
+    def _convert_entity_label_nested_filter(
+        self, f: EntityLabelNestedFilter, nested: EntityLabelNestedConditions
+    ) -> list[QueryCondition]:
+        """Conditions selecting entities by the labels on them.
+
+        Each relation compiles to one correlated EXISTS, so a relation's `key` and
+        `value` land on the same label. Requiring two different labels is two relations
+        combined by the entity filter's own AND.
+        """
+        conditions: list[QueryCondition] = []
+        if f.some is not None:
+            conditions.append(nested.some(self._convert_entity_label_filter(f.some)))
+        if f.every is not None:
+            conditions.append(nested.every(self._convert_entity_label_filter(f.every)))
+        if f.none is not None:
+            conditions.append(nested.none(self._convert_entity_label_filter(f.none)))
+        return conditions
 
     def batch_load_failure(self, error: Exception | None) -> Exception | None:
         """What a DataLoader is handed for an id a bulk read returned no data for.

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -1758,6 +1758,10 @@ class DeploymentAdapter(BaseAdapter):
                 conditions.append(
                     negate_conditions([DeploymentConditions.by_replica_exists([violating_replica])])
                 )
+        if f.labels is not None:
+            conditions.extend(
+                self._convert_entity_label_nested_filter(f.labels, DeploymentConditions.labels)
+            )
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_deployment_filter(sub))

--- a/src/ai/backend/manager/api/adapters/entity_label/adapter.py
+++ b/src/ai/backend/manager/api/adapters/entity_label/adapter.py
@@ -1,0 +1,141 @@
+"""Label adapter bridging DTOs and Processors."""
+
+from __future__ import annotations
+
+import uuid
+
+from ai.backend.common.data.entity.entity_label import EntityLabelID, EntityLabelKey
+from ai.backend.common.data.entity.types import EntityType, RuntimeEntityID
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    EntityLabelOrder,
+    SearchEntityLabelsInput,
+    UpsertEntityLabelInput,
+)
+from ai.backend.common.dto.manager.v2.entity_label.response import (
+    EntityLabelNode,
+    PurgeEntityLabelPayload,
+    SearchEntityLabelsPayload,
+    UpsertEntityLabelPayload,
+)
+from ai.backend.common.dto.manager.v2.entity_label.types import (
+    EntityLabelOrderField,
+    OrderDirection,
+)
+from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
+from ai.backend.manager.api.adapters.base import BaseAdapter
+from ai.backend.manager.data.entity_label.types import EntityLabelData
+from ai.backend.manager.errors.api import InvalidAPIParameters
+from ai.backend.manager.models.clauses import QueryOrder
+from ai.backend.manager.models.entity_label.conditions import (
+    EntityLabelConditions,
+    EntityLabelOrders,
+)
+from ai.backend.manager.models.entity_label.row import EntityLabelRow
+from ai.backend.manager.models.entity_label.searchers import EntityLabelSearcher
+from ai.backend.manager.models.entity_label.upserters import EntityLabelUpserter
+from ai.backend.manager.services.entity_label.actions.purge import PurgeEntityLabelAction
+from ai.backend.manager.services.entity_label.actions.search import SearchEntityLabelsAction
+from ai.backend.manager.services.entity_label.actions.upsert import UpsertEntityLabelAction
+
+_LABEL_PAGINATION_SPEC = PaginationSpec(
+    forward_order=EntityLabelOrders.created_at(ascending=False),
+    backward_order=EntityLabelOrders.created_at(ascending=True),
+    forward_condition_factory=EntityLabelConditions.by_cursor_forward,
+    backward_condition_factory=EntityLabelConditions.by_cursor_backward,
+    tiebreaker_order=EntityLabelRow.id.asc(),
+)
+
+
+class EntityLabelAdapter(BaseAdapter):
+    """Adapter for label domain operations."""
+
+    async def upsert(self, input: UpsertEntityLabelInput) -> UpsertEntityLabelPayload:
+        """Set one key on the entity the request names, replacing the value it carries."""
+        action_result = await self._processors.entity_label.upsert.run(
+            UpsertEntityLabelAction(
+                owner=self._target(input.target),
+                upserter=EntityLabelUpserter(key=EntityLabelKey(input.key), value=input.value),
+            )
+        )
+        return UpsertEntityLabelPayload(label=self._data_to_node(action_result.data))
+
+    async def purge(self, label_id: EntityLabelID) -> PurgeEntityLabelPayload:
+        """Take one label off, named by its own id.
+
+        Which entity answers for it is read from the row before the delete runs, so a
+        caller reaching for a label on an entity they cannot see is refused there.
+        """
+        action_result = await self._processors.entity_label.purge.run(
+            PurgeEntityLabelAction(label_id=label_id)
+        )
+        return PurgeEntityLabelPayload(label=self._data_to_node(action_result.data))
+
+    async def search(self, input: SearchEntityLabelsInput) -> SearchEntityLabelsPayload:
+        """Read a page of the labels on the entities named, OR'd across them and
+        restricted to the ones the caller is RBAC-authorized for."""
+        conditions = self._convert_entity_label_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+        searcher = self._build_searcher(
+            EntityLabelSearcher,
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_LABEL_PAGINATION_SPEC,
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+        action_result = await self._processors.entity_label.search.run(
+            SearchEntityLabelsAction(
+                owners=[self._target(scope) for scope in input.scope], searcher=searcher
+            )
+        )
+        return SearchEntityLabelsPayload(
+            items=[self._data_to_node(item) for item in action_result.items],
+            total_count=action_result.total_count,
+            has_next_page=action_result.has_next_page,
+            has_previous_page=action_result.has_previous_page,
+        )
+
+    @staticmethod
+    def _target(scope: EntityTypeScope) -> RuntimeEntityID:
+        """The entity the request names; an id that is not an entity id is refused here."""
+        try:
+            entity_id = uuid.UUID(scope.entity_id)
+        except ValueError as e:
+            raise InvalidAPIParameters(
+                f"Label target id {scope.entity_id!r} is not an entity id"
+            ) from e
+        return RuntimeEntityID(EntityType(scope.entity_type.value), entity_id)
+
+    @staticmethod
+    def _convert_orders(orders: list[EntityLabelOrder]) -> list[QueryOrder]:
+        result: list[QueryOrder] = []
+        for o in orders:
+            ascending = o.direction == OrderDirection.ASC
+            match o.field:
+                case EntityLabelOrderField.KEY:
+                    result.append(EntityLabelOrders.key(ascending))
+                case EntityLabelOrderField.VALUE:
+                    result.append(EntityLabelOrders.value(ascending))
+                case EntityLabelOrderField.CREATED_AT:
+                    result.append(EntityLabelOrders.created_at(ascending))
+        return result
+
+    @staticmethod
+    def _data_to_node(data: EntityLabelData) -> EntityLabelNode:
+        return EntityLabelNode(
+            id=data.id,
+            entity_type=data.entity_type,
+            entity_id=data.entity_id,
+            key=data.key,
+            value=data.value,
+            created_at=data.created_at,
+            updated_at=data.updated_at,
+        )
+
+
+__all__ = ("EntityLabelAdapter",)

--- a/src/ai/backend/manager/api/adapters/entity_label/adapter.py
+++ b/src/ai/backend/manager/api/adapters/entity_label/adapter.py
@@ -8,6 +8,7 @@ from ai.backend.common.data.entity.entity_label import EntityLabelID, EntityLabe
 from ai.backend.common.data.entity.types import EntityType, RuntimeEntityID
 from ai.backend.common.dto.manager.v2.entity_label.request import (
     EntityLabelOrder,
+    EntityLabelPageInput,
     SearchEntityLabelsInput,
     UpsertEntityLabelInput,
 )
@@ -74,6 +75,18 @@ class EntityLabelAdapter(BaseAdapter):
     async def search(self, input: SearchEntityLabelsInput) -> SearchEntityLabelsPayload:
         """Read a page of the labels on the entities named, OR'd across them and
         restricted to the ones the caller is RBAC-authorized for."""
+        return await self._search([self._target(scope) for scope in input.scope], input)
+
+    async def search_on(
+        self, owner: RuntimeEntityID, input: EntityLabelPageInput
+    ) -> SearchEntityLabelsPayload:
+        """Read a page of the labels on one entity the caller already holds, so the
+        entity names itself rather than being named again as a scope."""
+        return await self._search([owner], input)
+
+    async def _search(
+        self, owners: list[RuntimeEntityID], input: EntityLabelPageInput
+    ) -> SearchEntityLabelsPayload:
         conditions = self._convert_entity_label_filter(input.filter) if input.filter else []
         orders = self._convert_orders(input.order) if input.order else []
         searcher = self._build_searcher(
@@ -89,9 +102,7 @@ class EntityLabelAdapter(BaseAdapter):
             offset=input.offset,
         )
         action_result = await self._processors.entity_label.search.run(
-            SearchEntityLabelsAction(
-                owners=[self._target(scope) for scope in input.scope], searcher=searcher
-            )
+            SearchEntityLabelsAction(owners=owners, searcher=searcher)
         )
         return SearchEntityLabelsPayload(
             items=[self._data_to_node(item) for item in action_result.items],

--- a/src/ai/backend/manager/api/adapters/entity_label/adapter.py
+++ b/src/ai/backend/manager/api/adapters/entity_label/adapter.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-import uuid
-
 from ai.backend.common.data.entity.entity_label import EntityLabelID, EntityLabelKey
-from ai.backend.common.data.entity.types import EntityType, RuntimeEntityID
+from ai.backend.common.data.entity.types import RuntimeEntityID
+from ai.backend.common.dto.manager.v2.entity.types import EntityTarget
 from ai.backend.common.dto.manager.v2.entity_label.request import (
     EntityLabelOrder,
     EntityLabelPageInput,
@@ -22,11 +21,10 @@ from ai.backend.common.dto.manager.v2.entity_label.types import (
     EntityLabelOrderField,
     OrderDirection,
 )
-from ai.backend.common.dto.manager.v2.rbac.types import EntityTypeScope
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
+from ai.backend.manager.api.adapters.entity.types import WiredEntityTypes
 from ai.backend.manager.data.entity_label.types import EntityLabelData
-from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.models.clauses import QueryOrder
 from ai.backend.manager.models.entity_label.conditions import (
     EntityLabelConditions,
@@ -38,6 +36,7 @@ from ai.backend.manager.models.entity_label.upserters import EntityLabelUpserter
 from ai.backend.manager.services.entity_label.actions.purge import PurgeEntityLabelAction
 from ai.backend.manager.services.entity_label.actions.search import SearchEntityLabelsAction
 from ai.backend.manager.services.entity_label.actions.upsert import UpsertEntityLabelAction
+from ai.backend.manager.services.processors import Processors
 
 _LABEL_PAGINATION_SPEC = PaginationSpec(
     forward_order=EntityLabelOrders.created_at(ascending=False),
@@ -50,6 +49,12 @@ _LABEL_PAGINATION_SPEC = PaginationSpec(
 
 class EntityLabelAdapter(BaseAdapter):
     """Adapter for label domain operations."""
+
+    _entity_types: WiredEntityTypes
+
+    def __init__(self, processors: Processors, entity_types: WiredEntityTypes) -> None:
+        super().__init__(processors)
+        self._entity_types = entity_types
 
     async def upsert(self, input: UpsertEntityLabelInput) -> UpsertEntityLabelPayload:
         """Set one key on the entity the request names, replacing the value it carries."""
@@ -111,16 +116,9 @@ class EntityLabelAdapter(BaseAdapter):
             has_previous_page=action_result.has_previous_page,
         )
 
-    @staticmethod
-    def _target(scope: EntityTypeScope) -> RuntimeEntityID:
-        """The entity the request names; an id that is not an entity id is refused here."""
-        try:
-            entity_id = uuid.UUID(scope.entity_id)
-        except ValueError as e:
-            raise InvalidAPIParameters(
-                f"Label target id {scope.entity_id!r} is not an entity id"
-            ) from e
-        return RuntimeEntityID(EntityType(scope.entity_type.value), entity_id)
+    def _target(self, target: EntityTarget) -> RuntimeEntityID:
+        """The entity the request names; a type nothing is wired for is refused here."""
+        return RuntimeEntityID(self._entity_types.resolve(target.entity_type), target.entity_id)
 
     @staticmethod
     def _convert_orders(orders: list[EntityLabelOrder]) -> list[QueryOrder]:

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -29,6 +29,7 @@ from ai.backend.manager.api.adapters.domain.adapter import DomainAdapter
 from ai.backend.manager.api.adapters.entity.adapter import EntityAdapter
 from ai.backend.manager.api.adapters.entity.types import WiredEntityTypes
 from ai.backend.manager.api.adapters.entity_invitation.adapter import EntityInvitationAdapter
+from ai.backend.manager.api.adapters.entity_label.adapter import EntityLabelAdapter
 from ai.backend.manager.api.adapters.fair_share.adapter import FairShareAdapter
 from ai.backend.manager.api.adapters.huggingface_registry.adapter import HuggingFaceRegistryAdapter
 from ai.backend.manager.api.adapters.idle_checker.adapter import IdleCheckerAdapter
@@ -101,6 +102,7 @@ class Adapters:
         artifact_registry: ArtifactRegistryAdapter,
         audit_log: AuditLogAdapter,
         entity: EntityAdapter,
+        entity_label: EntityLabelAdapter,
         container_registry: ContainerRegistryAdapter,
         deployment: DeploymentAdapter,
         domain: DomainAdapter,
@@ -152,6 +154,7 @@ class Adapters:
         self.artifact_registry = artifact_registry
         self.audit_log = audit_log
         self.entity = entity
+        self.entity_label = entity_label
         self.container_registry = container_registry
         self.deployment = deployment
         self.domain = domain
@@ -225,6 +228,7 @@ class Adapters:
             artifact_registry=ArtifactRegistryAdapter(processors),
             audit_log=AuditLogAdapter(processors),
             entity=EntityAdapter(entity_types),
+            entity_label=EntityLabelAdapter(processors),
             container_registry=ContainerRegistryAdapter(processors),
             deployment=DeploymentAdapter(processors, deployment_coordinator),
             domain=DomainAdapter(processors),

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -228,7 +228,7 @@ class Adapters:
             artifact_registry=ArtifactRegistryAdapter(processors),
             audit_log=AuditLogAdapter(processors),
             entity=EntityAdapter(entity_types),
-            entity_label=EntityLabelAdapter(processors),
+            entity_label=EntityLabelAdapter(processors, entity_types),
             container_registry=ContainerRegistryAdapter(processors),
             deployment=DeploymentAdapter(processors, deployment_coordinator),
             domain=DomainAdapter(processors),

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -794,6 +794,10 @@ class SessionAdapter(BaseAdapter):
             )
             if c is not None:
                 conditions.append(c)
+        if f.labels is not None:
+            conditions.extend(
+                self._convert_entity_label_nested_filter(f.labels, SessionConditions.labels)
+            )
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_session_filter(sub))

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -743,6 +743,10 @@ class VFolderAdapter(BaseAdapter):
                 conditions.append(c)
         if f.cloneable is not None:
             conditions.append(VFolderConditions.by_cloneable(f.cloneable))
+        if f.labels is not None:
+            conditions.extend(
+                self._convert_entity_label_nested_filter(f.labels, VFolderConditions.labels)
+            )
         if f.AND:
             for sub in f.AND:
                 conditions.extend(self._convert_vfolder_filter(sub))

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -11,6 +11,8 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
+from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.types import RuntimeEntityID
 from ai.backend.common.dto.manager.v2.agent.request import (
     AgentFilter,
     AgentOrder,
@@ -44,7 +46,13 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
-from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
+from ai.backend.manager.api.gql.entity_label.types import (
+    EntityLabelConnection,
+    EntityLabelFilterGQL,
+    EntityLabelNestedFilterGQL,
+    EntityLabelOrderByGQL,
+    resolve_entity_labels,
+)
 from ai.backend.manager.api.gql.pydantic_compat import (
     PydanticInputMixin,
     PydanticNodeMixin,
@@ -353,6 +361,15 @@ class AgentNetworkInfoGQL:
 )
 class AgentV2GQL(PydanticNodeMixin[AgentNode]):
     id: NodeID[str]
+    uuid: UUID = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Agent UUID. The agent's primary key is its name, so rows keyed on the "
+                "agent carry this instead."
+            ),
+        )
+    )
     resource_info: AgentResourceGQL = gql_field(
         description="Hardware resource capacity, usage, and availability information. Contains capacity (total), used (occupied by sessions), and free (available) resource slots including CPU cores, memory, accelerators (GPUs, TPUs), and other compute resources."
     )
@@ -371,6 +388,37 @@ class AgentV2GQL(PydanticNodeMixin[AgentNode]):
     scaling_group: str = gql_field(
         description="Name of the scaling group this agent belongs to. Scaling groups are logical collections of agents used for resource scheduling, quota management, and workload isolation across different user groups or projects."
     )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The labels on this agent.",
+        )
+    )  # type: ignore[misc]
+    async def entity_labels(
+        self,
+        info: Info[StrawberryGQLContext],
+        filter: EntityLabelFilterGQL | None = None,
+        order_by: list[EntityLabelOrderByGQL] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        last: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> EntityLabelConnection | None:
+        return await resolve_entity_labels(
+            info,
+            RuntimeEntityID(AGENT_ENTITY_TYPE, self.uuid),
+            filter=filter,
+            order_by=order_by,
+            before=before,
+            after=after,
+            first=first,
+            last=last,
+            limit=limit,
+            offset=offset,
+        )
 
     @gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -31,6 +31,7 @@ from ai.backend.common.dto.manager.v2.agent.types import (
     AgentStatusEnum,
     AgentStatusFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import AgentId
 from ai.backend.manager.api.gql.base import OrderDirection, StringFilter
 from ai.backend.manager.api.gql.decorators import (
@@ -43,6 +44,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_input,
     gql_pydantic_type,
 )
+from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
 from ai.backend.manager.api.gql.pydantic_compat import (
     PydanticInputMixin,
     PydanticNodeMixin,
@@ -118,6 +120,14 @@ class AgentFilterGQL(PydanticInputMixin[AgentFilter]):
     status: AgentStatusFilterGQL | None = None
     schedulable: bool | None = None
     scaling_group: StringFilter | None = None
+
+    labels: EntityLabelNestedFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Select entities by the labels on them.",
+        ),
+        default=None,
+    )
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -101,6 +101,7 @@ from ai.backend.common.dto.manager.v2.scheduling_history.request import (
 from ai.backend.common.dto.manager.v2.scheduling_history.types import (
     ReplicaGroupHistoryScopeDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     NullableDateTimeFilter,
@@ -160,6 +161,7 @@ from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelRevisionOrderBy,
 )
 from ai.backend.manager.api.gql.domain import Domain
+from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
 from ai.backend.manager.api.gql.project import Project
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
@@ -786,6 +788,14 @@ class DeploymentFilter(PydanticInputMixin[DeploymentFilterDTO]):
         BackendAIGQLMeta(
             added_version="26.8.0",
             description="Filter by conditions on deployment replicas.",
+        ),
+        default=None,
+    )
+
+    labels: EntityLabelNestedFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Select entities by the labels on them.",
         ),
         default=None,
     )

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -12,6 +12,8 @@ from strawberry import ID, UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID, PageInfo
 
 from ai.backend.common.data.endpoint.types import ScalingState
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.types import RuntimeEntityID
 from ai.backend.common.data.model_deployment.types import (
     ModelDeploymentStatus,
 )
@@ -161,7 +163,13 @@ from ai.backend.manager.api.gql.deployment.types.revision import (
     ModelRevisionOrderBy,
 )
 from ai.backend.manager.api.gql.domain import Domain
-from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
+from ai.backend.manager.api.gql.entity_label.types import (
+    EntityLabelConnection,
+    EntityLabelFilterGQL,
+    EntityLabelNestedFilterGQL,
+    EntityLabelOrderByGQL,
+    resolve_entity_labels,
+)
 from ai.backend.manager.api.gql.project import Project
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
@@ -671,6 +679,37 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
                 start_cursor=edges[0].cursor if edges else None,
                 end_cursor=edges[-1].cursor if edges else None,
             ),
+        )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The labels on this deployment.",
+        )
+    )  # type: ignore[misc]
+    async def entity_labels(
+        self,
+        info: Info[StrawberryGQLContext],
+        filter: EntityLabelFilterGQL | None = None,
+        order_by: list[EntityLabelOrderByGQL] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        last: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> EntityLabelConnection | None:
+        return await resolve_entity_labels(
+            info,
+            RuntimeEntityID(DEPLOYMENT_ENTITY_TYPE, UUID(str(self.id))),
+            filter=filter,
+            order_by=order_by,
+            before=before,
+            after=after,
+            first=first,
+            last=last,
+            limit=limit,
+            offset=offset,
         )
 
     @classmethod

--- a/src/ai/backend/manager/api/gql/entity_label/__init__.py
+++ b/src/ai/backend/manager/api/gql/entity_label/__init__.py
@@ -1,0 +1,6 @@
+from .types import EntityLabelFilterGQL, EntityLabelNestedFilterGQL
+
+__all__ = (
+    "EntityLabelFilterGQL",
+    "EntityLabelNestedFilterGQL",
+)

--- a/src/ai/backend/manager/api/gql/entity_label/resolver/__init__.py
+++ b/src/ai/backend/manager/api/gql/entity_label/resolver/__init__.py
@@ -1,0 +1,10 @@
+"""Label GQL resolvers."""
+
+from .mutation import purge_entity_label, upsert_entity_label
+from .query import entity_labels
+
+__all__ = [
+    "entity_labels",
+    "upsert_entity_label",
+    "purge_entity_label",
+]

--- a/src/ai/backend/manager/api/gql/entity_label/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/entity_label/resolver/mutation.py
@@ -14,9 +14,9 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.entity_label.types import (
     PurgeEntityLabelPayloadGQL,
+    UpsertEntityLabelInputGQL,
     UpsertEntityLabelPayloadGQL,
 )
-from ai.backend.manager.api.gql.entity_label.types.inputs import UpsertEntityLabelInputGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 

--- a/src/ai/backend/manager/api/gql/entity_label/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/entity_label/resolver/mutation.py
@@ -1,0 +1,54 @@
+"""Label GQL mutation resolvers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from strawberry import ID, Info
+
+from ai.backend.common.data.entity.entity_label import EntityLabelID
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_mutation,
+)
+from ai.backend.manager.api.gql.entity_label.types import (
+    PurgeEntityLabelPayloadGQL,
+    UpsertEntityLabelPayloadGQL,
+)
+from ai.backend.manager.api.gql.entity_label.types.inputs import UpsertEntityLabelInputGQL
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        description=(
+            "Set one key on an entity, replacing the value it carries. Reachable by any "
+            "caller RBAC authorizes to write the entity."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    )
+)
+async def upsert_entity_label(
+    info: Info[StrawberryGQLContext],
+    input: UpsertEntityLabelInputGQL,
+) -> UpsertEntityLabelPayloadGQL | None:
+    payload = await info.context.adapters.entity_label.upsert(input.to_pydantic())
+    return UpsertEntityLabelPayloadGQL.from_pydantic(payload)
+
+
+@gql_mutation(
+    BackendAIGQLMeta(
+        description=(
+            "Take one label off, named by its own id. Which entity answers for it is read "
+            "from the row before the delete runs."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    )
+)
+async def purge_entity_label(
+    info: Info[StrawberryGQLContext],
+    id: ID,
+) -> PurgeEntityLabelPayloadGQL | None:
+    payload = await info.context.adapters.entity_label.purge(EntityLabelID(UUID(str(id))))
+    return PurgeEntityLabelPayloadGQL.from_pydantic(payload)

--- a/src/ai/backend/manager/api/gql/entity_label/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/entity_label/resolver/query.py
@@ -1,0 +1,84 @@
+"""Label GQL query resolvers."""
+
+from __future__ import annotations
+
+from strawberry import Info
+from strawberry.relay import PageInfo
+
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    EntityLabelFilter,
+    EntityLabelOrder,
+    SearchEntityLabelsInput,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import encode_cursor
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_root_field,
+)
+from ai.backend.manager.api.gql.entity_label.types import (
+    EntityLabelConnection,
+    EntityLabelEdge,
+    EntityLabelFilterGQL,
+    EntityLabelGQL,
+    EntityLabelOrderByGQL,
+)
+from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+
+@gql_root_field(
+    BackendAIGQLMeta(
+        description=(
+            "Read the labels on the entities named. Scope items are OR'd, and naming an "
+            "entity the caller cannot read refuses the whole read."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    )
+)  # type: ignore[misc]
+async def entity_labels(
+    info: Info[StrawberryGQLContext],
+    scope: list[EntityTypeScopeGQL],
+    filter: EntityLabelFilterGQL | None = None,
+    order_by: list[EntityLabelOrderByGQL] | None = None,
+    before: str | None = None,
+    after: str | None = None,
+    first: int | None = None,
+    last: int | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> EntityLabelConnection | None:
+    filter_dto: EntityLabelFilter | None = filter.to_pydantic() if filter else None
+    orders_dto: list[EntityLabelOrder] | None = (
+        [o.to_pydantic() for o in order_by] if order_by else None
+    )
+    result = await info.context.adapters.entity_label.search(
+        SearchEntityLabelsInput(
+            scope=[s.to_pydantic() for s in scope],
+            filter=filter_dto,
+            order=orders_dto,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        )
+    )
+    edges = [
+        EntityLabelEdge(
+            node=EntityLabelGQL.from_pydantic(item),
+            cursor=encode_cursor(str(item.id)),
+        )
+        for item in result.items
+    ]
+    return EntityLabelConnection(
+        edges=edges,
+        page_info=PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )

--- a/src/ai/backend/manager/api/gql/entity_label/resolver/query.py
+++ b/src/ai/backend/manager/api/gql/entity_label/resolver/query.py
@@ -16,6 +16,7 @@ from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_root_field,
 )
+from ai.backend.manager.api.gql.entity.types.inputs import EntityTargetGQL
 from ai.backend.manager.api.gql.entity_label.types import (
     EntityLabelConnection,
     EntityLabelEdge,
@@ -23,7 +24,6 @@ from ai.backend.manager.api.gql.entity_label.types import (
     EntityLabelGQL,
     EntityLabelOrderByGQL,
 )
-from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL
 from ai.backend.manager.api.gql.types import StrawberryGQLContext
 
 
@@ -38,7 +38,7 @@ from ai.backend.manager.api.gql.types import StrawberryGQLContext
 )  # type: ignore[misc]
 async def entity_labels(
     info: Info[StrawberryGQLContext],
-    scope: list[EntityTypeScopeGQL],
+    scope: list[EntityTargetGQL],
     filter: EntityLabelFilterGQL | None = None,
     order_by: list[EntityLabelOrderByGQL] | None = None,
     before: str | None = None,

--- a/src/ai/backend/manager/api/gql/entity_label/types.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types.py
@@ -1,0 +1,57 @@
+"""GraphQL input types for filtering entities by the labels on them."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    EntityLabelFilter,
+    EntityLabelNestedFilter,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.base import StringFilter, UUIDFilter
+from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_pydantic_input
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+
+__all__ = (
+    "EntityLabelFilterGQL",
+    "EntityLabelNestedFilterGQL",
+)
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Filter matching a single label. A key and a value given together constrain "
+            "the same label rather than two different ones."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="EntityLabelFilter",
+)
+class EntityLabelFilterGQL(PydanticInputMixin[EntityLabelFilter]):
+    key: StringFilter | None = None
+    value: StringFilter | None = None
+    entity_type: StringFilter | None = None
+    entity_id: UUIDFilter | None = None
+
+    AND: list[Self] | None = None
+    OR: list[Self] | None = None
+    NOT: list[Self] | None = None
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Filter selecting entities by the labels on them. Each relation matches one "
+            "label at a time; requiring two different labels is two relations combined "
+            "by the entity filter's own AND."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="EntityLabelNestedFilter",
+)
+class EntityLabelNestedFilterGQL(PydanticInputMixin[EntityLabelNestedFilter]):
+    some: EntityLabelFilterGQL | None = None
+    every: EntityLabelFilterGQL | None = None
+    none: EntityLabelFilterGQL | None = None

--- a/src/ai/backend/manager/api/gql/entity_label/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/__init__.py
@@ -1,0 +1,39 @@
+"""Label GQL types.
+
+`inputs` is deliberately absent: it reaches the RBAC scope input, whose package pulls
+in the deployment types that import this one. Mutation resolvers import it directly.
+"""
+
+from .field import resolve_entity_labels
+from .filters import (
+    EntityLabelFilterGQL,
+    EntityLabelNestedFilterGQL,
+    EntityLabelOrderByGQL,
+    EntityLabelOrderFieldGQL,
+)
+from .node import (
+    EntityLabelConnection,
+    EntityLabelEdge,
+    EntityLabelGQL,
+)
+from .payloads import (
+    PurgeEntityLabelPayloadGQL,
+    UpsertEntityLabelPayloadGQL,
+)
+
+__all__ = [
+    # Node / Connection types
+    "EntityLabelGQL",
+    "EntityLabelEdge",
+    "EntityLabelConnection",
+    # Filter / OrderBy types
+    "EntityLabelFilterGQL",
+    "EntityLabelNestedFilterGQL",
+    "EntityLabelOrderByGQL",
+    "EntityLabelOrderFieldGQL",
+    # Payload types
+    "UpsertEntityLabelPayloadGQL",
+    "PurgeEntityLabelPayloadGQL",
+    # Shared node field resolver
+    "resolve_entity_labels",
+]

--- a/src/ai/backend/manager/api/gql/entity_label/types/__init__.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/__init__.py
@@ -1,8 +1,4 @@
-"""Label GQL types.
-
-`inputs` is deliberately absent: it reaches the RBAC scope input, whose package pulls
-in the deployment types that import this one. Mutation resolvers import it directly.
-"""
+"""Label GQL types."""
 
 from .field import resolve_entity_labels
 from .filters import (
@@ -11,6 +7,7 @@ from .filters import (
     EntityLabelOrderByGQL,
     EntityLabelOrderFieldGQL,
 )
+from .inputs import UpsertEntityLabelInputGQL
 from .node import (
     EntityLabelConnection,
     EntityLabelEdge,
@@ -31,6 +28,8 @@ __all__ = [
     "EntityLabelNestedFilterGQL",
     "EntityLabelOrderByGQL",
     "EntityLabelOrderFieldGQL",
+    # Input types
+    "UpsertEntityLabelInputGQL",
     # Payload types
     "UpsertEntityLabelPayloadGQL",
     "PurgeEntityLabelPayloadGQL",

--- a/src/ai/backend/manager/api/gql/entity_label/types/field.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/field.py
@@ -1,0 +1,70 @@
+"""The `entityLabels` connection field carried by every labelable entity."""
+
+from __future__ import annotations
+
+from strawberry import Info
+from strawberry.relay import PageInfo
+
+from ai.backend.common.data.entity.types import RuntimeEntityID
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    EntityLabelFilter,
+    EntityLabelOrder,
+    EntityLabelPageInput,
+)
+from ai.backend.manager.api.adapter_options.cursor.cursor import encode_cursor
+from ai.backend.manager.api.gql.types import StrawberryGQLContext
+
+from .filters import EntityLabelFilterGQL, EntityLabelOrderByGQL
+from .node import EntityLabelConnection, EntityLabelEdge, EntityLabelGQL
+
+__all__ = ("resolve_entity_labels",)
+
+
+async def resolve_entity_labels(
+    info: Info[StrawberryGQLContext],
+    owner: RuntimeEntityID,
+    *,
+    filter: EntityLabelFilterGQL | None,
+    order_by: list[EntityLabelOrderByGQL] | None,
+    before: str | None,
+    after: str | None,
+    first: int | None,
+    last: int | None,
+    limit: int | None,
+    offset: int | None,
+) -> EntityLabelConnection:
+    """Page the labels on one entity, which names itself as the owner."""
+    filter_dto: EntityLabelFilter | None = filter.to_pydantic() if filter else None
+    orders_dto: list[EntityLabelOrder] | None = (
+        [o.to_pydantic() for o in order_by] if order_by else None
+    )
+    result = await info.context.adapters.entity_label.search_on(
+        owner,
+        EntityLabelPageInput(
+            filter=filter_dto,
+            order=orders_dto,
+            first=first,
+            after=after,
+            last=last,
+            before=before,
+            limit=limit,
+            offset=offset,
+        ),
+    )
+    edges = [
+        EntityLabelEdge(
+            node=EntityLabelGQL.from_pydantic(item),
+            cursor=encode_cursor(str(item.id)),
+        )
+        for item in result.items
+    ]
+    return EntityLabelConnection(
+        edges=edges,
+        page_info=PageInfo(
+            has_next_page=result.has_next_page,
+            has_previous_page=result.has_previous_page,
+            start_cursor=edges[0].cursor if edges else None,
+            end_cursor=edges[-1].cursor if edges else None,
+        ),
+        count=result.total_count,
+    )

--- a/src/ai/backend/manager/api/gql/entity_label/types/filters.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/filters.py
@@ -1,21 +1,29 @@
-"""GraphQL input types for filtering entities by the labels on them."""
+"""GraphQL filter and order input types for labels."""
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Self
 
 from ai.backend.common.dto.manager.v2.entity_label.request import (
     EntityLabelFilter,
     EntityLabelNestedFilter,
+    EntityLabelOrder,
 )
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
-from ai.backend.manager.api.gql.base import StringFilter, UUIDFilter
-from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_pydantic_input
+from ai.backend.manager.api.gql.base import OrderDirection, StringFilter, UUIDFilter
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_enum,
+    gql_pydantic_input,
+)
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
 
 __all__ = (
     "EntityLabelFilterGQL",
     "EntityLabelNestedFilterGQL",
+    "EntityLabelOrderByGQL",
+    "EntityLabelOrderFieldGQL",
 )
 
 
@@ -55,3 +63,28 @@ class EntityLabelNestedFilterGQL(PydanticInputMixin[EntityLabelNestedFilter]):
     some: EntityLabelFilterGQL | None = None
     every: EntityLabelFilterGQL | None = None
     none: EntityLabelFilterGQL | None = None
+
+
+@gql_enum(
+    BackendAIGQLMeta(
+        description="Fields available for ordering labels.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="EntityLabelOrderField",
+)
+class EntityLabelOrderFieldGQL(StrEnum):
+    KEY = "key"
+    VALUE = "value"
+    CREATED_AT = "created_at"
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description="Ordering specification for labels.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="EntityLabelOrderBy",
+)
+class EntityLabelOrderByGQL(PydanticInputMixin[EntityLabelOrder]):
+    field: EntityLabelOrderFieldGQL
+    direction: OrderDirection = OrderDirection.DESC

--- a/src/ai/backend/manager/api/gql/entity_label/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/inputs.py
@@ -11,8 +11,8 @@ from ai.backend.manager.api.gql.decorators import (
     gql_field,
     gql_pydantic_input,
 )
+from ai.backend.manager.api.gql.entity.types.inputs import EntityTargetGQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
-from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL
 
 __all__ = ("UpsertEntityLabelInputGQL",)
 
@@ -28,6 +28,6 @@ __all__ = ("UpsertEntityLabelInputGQL",)
     name="UpsertEntityLabelInput",
 )
 class UpsertEntityLabelInputGQL(PydanticInputMixin[UpsertEntityLabelInputDTO]):
-    target: EntityTypeScopeGQL = gql_field(description="The entity to label.")
+    target: EntityTargetGQL = gql_field(description="The entity to label.")
     key: str = gql_field(description="Label key.")
     value: str = gql_field(description="Label value.")

--- a/src/ai/backend/manager/api/gql/entity_label/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/inputs.py
@@ -1,0 +1,33 @@
+"""Label GQL mutation input types."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    UpsertEntityLabelInput as UpsertEntityLabelInputDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_input,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
+from ai.backend.manager.api.gql.rbac.types.scope import EntityTypeScopeGQL
+
+__all__ = ("UpsertEntityLabelInputGQL",)
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        description=(
+            "Input for putting one key on one entity. A key holds one value, so naming a "
+            "key the entity already carries replaces that value."
+        ),
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="UpsertEntityLabelInput",
+)
+class UpsertEntityLabelInputGQL(PydanticInputMixin[UpsertEntityLabelInputDTO]):
+    target: EntityTypeScopeGQL = gql_field(description="The entity to label.")
+    key: str = gql_field(description="Label key.")
+    value: str = gql_field(description="Label value.")

--- a/src/ai/backend/manager/api/gql/entity_label/types/node.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/node.py
@@ -1,0 +1,59 @@
+"""Label GQL Node, Edge, and Connection types."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from strawberry.relay import Connection, Edge, NodeID
+
+from ai.backend.common.dto.manager.v2.entity_label.response import EntityLabelNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_connection_type,
+    gql_field,
+    gql_node_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin
+
+__all__ = (
+    "EntityLabelConnection",
+    "EntityLabelEdge",
+    "EntityLabelGQL",
+)
+
+
+@gql_node_type(
+    BackendAIGQLMeta(
+        description="One `key=value` label and the entity carrying it.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    name="EntityLabel",
+)
+class EntityLabelGQL(PydanticNodeMixin[EntityLabelNode]):
+    id: NodeID[str] = gql_field(description="Label UUID (primary key).")
+    entity_type: str = gql_field(description="Type of the labeled entity.")
+    entity_id: UUID = gql_field(description="ID of the labeled entity.")
+    key: str = gql_field(description="Label key.")
+    value: str = gql_field(description="Label value.")
+    created_at: datetime = gql_field(description="When the label was first put on the entity.")
+    updated_at: datetime = gql_field(description="When the label's value was last replaced.")
+
+
+EntityLabelEdge = Edge[EntityLabelGQL]
+
+
+@gql_connection_type(
+    BackendAIGQLMeta(
+        description="Paginated connection for label records.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+)
+class EntityLabelConnection(Connection[EntityLabelGQL]):
+    count: int = gql_field(description="Total number of label records matching the query criteria.")
+
+    def __init__(self, *args: Any, count: int, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.count = count

--- a/src/ai/backend/manager/api/gql/entity_label/types/payloads.py
+++ b/src/ai/backend/manager/api/gql/entity_label/types/payloads.py
@@ -1,0 +1,48 @@
+"""Label GQL mutation payload types."""
+
+from __future__ import annotations
+
+from ai.backend.common.dto.manager.v2.entity_label.response import (
+    PurgeEntityLabelPayload as PurgeEntityLabelPayloadDTO,
+)
+from ai.backend.common.dto.manager.v2.entity_label.response import (
+    UpsertEntityLabelPayload as UpsertEntityLabelPayloadDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
+from ai.backend.manager.api.gql.decorators import (
+    BackendAIGQLMeta,
+    gql_field,
+    gql_pydantic_type,
+)
+from ai.backend.manager.api.gql.pydantic_compat import PydanticOutputMixin
+
+from .node import EntityLabelGQL
+
+__all__ = (
+    "PurgeEntityLabelPayloadGQL",
+    "UpsertEntityLabelPayloadGQL",
+)
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        description="Payload returned after putting a label on an entity.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    model=UpsertEntityLabelPayloadDTO,
+    name="UpsertEntityLabelPayload",
+)
+class UpsertEntityLabelPayloadGQL(PydanticOutputMixin[UpsertEntityLabelPayloadDTO]):
+    label: EntityLabelGQL = gql_field(description="The label as it now stands.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
+        description="Payload returned after taking a label off an entity.",
+        added_version=NEXT_RELEASE_VERSION,
+    ),
+    model=PurgeEntityLabelPayloadDTO,
+    name="PurgeEntityLabelPayload",
+)
+class PurgeEntityLabelPayloadGQL(PydanticOutputMixin[PurgeEntityLabelPayloadDTO]):
+    label: EntityLabelGQL = gql_field(description="The label taken off the entity.")

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -142,6 +142,11 @@ from .entity_invitation import (
     entity_invitations,
     reject_entity_invitation,
 )
+from .entity_label.resolver import (
+    entity_labels,
+    purge_entity_label,
+    upsert_entity_label,
+)
 from .fair_share import (
     admin_bulk_upsert_domain_fair_share_weight,
     admin_bulk_upsert_project_fair_share_weight,
@@ -631,6 +636,8 @@ class Query:
     scoped_audit_logs_v2 = scoped_audit_logs_v2
     # Entity APIs
     entity_types = entity_types
+    # Entity Label APIs
+    entity_labels = entity_labels
     admin_container_registries_v2 = admin_container_registries_v2
     admin_login_sessions_v2 = admin_login_sessions_v2
     admin_login_history_v2 = admin_login_history_v2
@@ -1062,6 +1069,9 @@ class Mutation:
     terminate_sessions_v2 = terminate_sessions_v2
     exclude_session_idle_checks = exclude_session_idle_checks
     include_session_idle_checks = include_session_idle_checks
+    # Entity Label mutations
+    upsert_entity_label = upsert_entity_label
+    purge_entity_label = purge_entity_label
 
 
 @strawberry.type

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -13,6 +13,8 @@ from strawberry import ID, Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.types import RuntimeEntityID
 from ai.backend.common.dto.manager.v2.common import (
     ResourceSlotEntryInput as ResourceSlotEntryInputDTO,
 )
@@ -97,7 +99,13 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.deployment.types.revision import EnvironmentVariablesGQL
 from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
-from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
+from ai.backend.manager.api.gql.entity_label.types import (
+    EntityLabelConnection,
+    EntityLabelFilterGQL,
+    EntityLabelNestedFilterGQL,
+    EntityLabelOrderByGQL,
+    resolve_entity_labels,
+)
 from ai.backend.manager.api.gql.image.types import ImageV2ConnectionGQL
 from ai.backend.manager.api.gql.kernel.types import (
     KernelV2ConnectionGQL,
@@ -531,6 +539,37 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
     async def resource_allocation(self, info: Info[StrawberryGQLContext]) -> ResourceAllocationGQL:
         return await info.context.data_loaders.session_resource_allocation_loader.load(
             SessionId(UUID(str(self.id)))
+        )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The labels on this session.",
+        )
+    )  # type: ignore[misc]
+    async def entity_labels(
+        self,
+        info: Info[StrawberryGQLContext],
+        filter: EntityLabelFilterGQL | None = None,
+        order_by: list[EntityLabelOrderByGQL] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        last: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> EntityLabelConnection | None:
+        return await resolve_entity_labels(
+            info,
+            RuntimeEntityID(SESSION_ENTITY_TYPE, UUID(str(self.id))),
+            filter=filter,
+            order_by=order_by,
+            before=before,
+            after=after,
+            first=first,
+            last=last,
+            limit=limit,
+            offset=offset,
         )
 
     # TODO: Add `vfolder_mounts` dynamic field (VFolder connection type needed)

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -97,6 +97,7 @@ from ai.backend.manager.api.gql.decorators import (
 )
 from ai.backend.manager.api.gql.deployment.types.revision import EnvironmentVariablesGQL
 from ai.backend.manager.api.gql.domain_v2.types.node import DomainV2GQL
+from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
 from ai.backend.manager.api.gql.image.types import ImageV2ConnectionGQL
 from ai.backend.manager.api.gql.kernel.types import (
     KernelV2ConnectionGQL,
@@ -182,6 +183,14 @@ class SessionV2FilterGQL(PydanticInputMixin[SessionFilter]):
     domain_name: StringFilter | None = None
     project_id: UUIDFilter | None = None
     user_uuid: UUIDFilter | None = None
+
+    labels: EntityLabelNestedFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Select entities by the labels on them.",
+        ),
+        default=None,
+    )
 
     AND: list[Self] | None = None
     OR: list[Self] | None = None

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/filters.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/filters.py
@@ -10,6 +10,7 @@ from ai.backend.common.dto.manager.v2.vfolder.types import (
     VFolderStatusFilter,
     VFolderUsageModeFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     DateTimeFilter,
     OrderDirection,
@@ -17,10 +18,12 @@ from ai.backend.manager.api.gql.base import (
 )
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
+    gql_added_field,
     gql_enum,
     gql_field,
     gql_pydantic_input,
 )
+from ai.backend.manager.api.gql.entity_label.types import EntityLabelNestedFilterGQL
 from ai.backend.manager.api.gql.pydantic_compat import PydanticInputMixin
 
 from .enum import VFolderOperationStatusGQL, VFolderUsageModeGQL
@@ -86,6 +89,14 @@ class VFolderFilterGQL(PydanticInputMixin[VFolderFilter]):
     usage_mode: VFolderUsageModeFilterGQL | None = None
     cloneable: bool | None = None
     created_at: DateTimeFilter | None = None
+    labels: EntityLabelNestedFilterGQL | None = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Select entities by the labels on them.",
+        ),
+        default=None,
+    )
+
     AND: list[Self] | None = None
     OR: list[Self] | None = None
     NOT: list[Self] | None = None

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/node.py
@@ -9,9 +9,11 @@ from uuid import UUID
 from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID, PageInfo
 
-from ai.backend.common.data.entity.vfolder import VFolderUUID
+from ai.backend.common.data.entity.types import RuntimeEntityID
+from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
 from ai.backend.common.dto.manager.v2.model_card.request import SearchModelCardsInput
 from ai.backend.common.dto.manager.v2.vfolder.response import VFolderNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.common_types import BinarySizeInfoGQL
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -19,6 +21,12 @@ from ai.backend.manager.api.gql.decorators import (
     gql_connection_type,
     gql_field,
     gql_node_type,
+)
+from ai.backend.manager.api.gql.entity_label.types import (
+    EntityLabelConnection,
+    EntityLabelFilterGQL,
+    EntityLabelOrderByGQL,
+    resolve_entity_labels,
 )
 from ai.backend.manager.api.gql.model_card.types import (
     ModelCardFilterGQL,
@@ -156,6 +164,37 @@ class VFolderGQL(PydanticNodeMixin[VFolderNode]):
                 end_cursor=edges[-1].cursor if edges else None,
             ),
             count=result.total_count,
+        )
+
+    @gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The labels on this vfolder.",
+        )
+    )  # type: ignore[misc]
+    async def entity_labels(
+        self,
+        info: Info[StrawberryGQLContext],
+        filter: EntityLabelFilterGQL | None = None,
+        order_by: list[EntityLabelOrderByGQL] | None = None,
+        before: str | None = None,
+        after: str | None = None,
+        first: int | None = None,
+        last: int | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> EntityLabelConnection | None:
+        return await resolve_entity_labels(
+            info,
+            RuntimeEntityID(VFOLDER_ENTITY_TYPE, UUID(self.id)),
+            filter=filter,
+            order_by=order_by,
+            before=before,
+            after=after,
+            first=first,
+            last=last,
+            limit=limit,
+            offset=offset,
         )
 
     @classmethod

--- a/src/ai/backend/manager/api/rest/v2/entity_label/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/entity_label/handler.py
@@ -1,0 +1,58 @@
+"""REST v2 handler for the label domain."""
+
+from __future__ import annotations
+
+import logging
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Final
+from uuid import UUID
+
+from pydantic import Field
+
+from ai.backend.common.api_handlers import APIResponse, BaseRequestModel, BodyParam, PathParam
+from ai.backend.common.data.entity.entity_label import EntityLabelID
+from ai.backend.common.dto.manager.v2.entity_label.request import (
+    SearchEntityLabelsInput,
+    UpsertEntityLabelInput,
+)
+from ai.backend.logging import BraceStyleAdapter
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.adapters.entity_label.adapter import EntityLabelAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class EntityLabelIdPathParam(BaseRequestModel):
+    label_id: UUID = Field(description="Label ID.")
+
+
+class V2EntityLabelHandler:
+    """REST v2 handler for label operations."""
+
+    def __init__(self, *, adapter: EntityLabelAdapter) -> None:
+        self._adapter = adapter
+
+    async def upsert_label(
+        self,
+        body: BodyParam[UpsertEntityLabelInput],
+    ) -> APIResponse:
+        """Set one key on an entity, replacing the value it carries."""
+        result = await self._adapter.upsert(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def purge_label(
+        self,
+        path: PathParam[EntityLabelIdPathParam],
+    ) -> APIResponse:
+        """Take one label off, named by its own id."""
+        result = await self._adapter.purge(EntityLabelID(path.parsed.label_id))
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
+
+    async def search_labels(
+        self,
+        body: BodyParam[SearchEntityLabelsInput],
+    ) -> APIResponse:
+        """Read the labels on the entities named."""
+        result = await self._adapter.search(body.parsed)
+        return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)

--- a/src/ai/backend/manager/api/rest/v2/entity_label/registry.py
+++ b/src/ai/backend/manager/api/rest/v2/entity_label/registry.py
@@ -1,0 +1,31 @@
+"""Route registry for REST v2 label endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai.backend.manager.api.rest.middleware.auth import auth_required
+from ai.backend.manager.api.rest.routing import RouteRegistry
+
+from .handler import V2EntityLabelHandler
+
+if TYPE_CHECKING:
+    from ai.backend.manager.api.rest.types import RouteDeps
+
+
+def register_v2_entity_label_routes(
+    handler: V2EntityLabelHandler,
+    route_deps: RouteDeps,
+) -> RouteRegistry:
+    """Register all REST v2 label routes and return the sub-registry.
+
+    Behind `auth_required` rather than an admin gate: every operation is checked against
+    the labeled entity, so what a caller may reach is what RBAC already gives them.
+    """
+    registry = RouteRegistry.create("entity-labels", route_deps.cors_options)
+
+    registry.add("PUT", "", handler.upsert_label, middlewares=[auth_required])
+    registry.add("DELETE", "/{label_id}", handler.purge_label, middlewares=[auth_required])
+    registry.add("POST", "/search", handler.search_labels, middlewares=[auth_required])
+
+    return registry

--- a/src/ai/backend/manager/api/rest/v2/tree.py
+++ b/src/ai/backend/manager/api/rest/v2/tree.py
@@ -56,6 +56,8 @@ def build_v2_routes(
     from .domain.registry import register_v2_domain_routes
     from .entity_invitation.handler import V2EntityInvitationHandler
     from .entity_invitation.registry import register_v2_entity_invitation_routes
+    from .entity_label.handler import V2EntityLabelHandler
+    from .entity_label.registry import register_v2_entity_label_routes
     from .entity_type.handler import V2EntityTypeHandler
     from .entity_type.registry import register_v2_entity_type_routes
     from .fair_share.handler import V2FairShareHandler
@@ -148,6 +150,7 @@ def build_v2_routes(
     artifact_handler = V2ArtifactHandler(adapter=adapters.artifact)
     artifact_registry_handler = V2ArtifactRegistryHandler(adapter=adapters.artifact_registry)
     audit_log_handler = V2AuditLogHandler(adapter=adapters.audit_log)
+    entity_label_handler = V2EntityLabelHandler(adapter=adapters.entity_label)
     container_registry_handler = V2ContainerRegistryHandler(adapter=adapters.container_registry)
     deployment_handler = V2DeploymentHandler(adapter=adapters.deployment)
     domain_handler = V2DomainHandler(adapter=adapters.domain)
@@ -225,6 +228,7 @@ def build_v2_routes(
         register_v2_artifact_registry_routes(artifact_registry_handler, route_deps)
     )
     v2_reg.add_subregistry(register_v2_audit_log_routes(audit_log_handler, route_deps))
+    v2_reg.add_subregistry(register_v2_entity_label_routes(entity_label_handler, route_deps))
     v2_reg.add_subregistry(
         register_v2_container_registry_routes(container_registry_handler, route_deps)
     )

--- a/src/ai/backend/manager/models/agent/conditions.py
+++ b/src/ai/backend/manager/models/agent/conditions.py
@@ -6,16 +6,23 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import make_string_in_factory
+from ai.backend.manager.models.entity_label.conditions import (
+    make_entity_label_nested_conditions,
+)
 
 from .row import AgentRow
 
 
 class AgentConditions:
     """Query condition factories for filtering agent rows."""
+
+    labels = make_entity_label_nested_conditions(AgentRow, AgentRow.uuid, AGENT_ENTITY_TYPE)
+    """The `labels` nested filter: some / every / none over the labels on a agent."""
 
     @staticmethod
     def by_ids(ids: Collection[str]) -> QueryCondition:

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import sqlalchemy as sa
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle, ScalingState
-from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
 from ai.backend.common.data.filter_specs import (
     StringMatchSpec,
     UUIDEqualMatchSpec,
@@ -23,11 +23,19 @@ from ai.backend.manager.models.endpoint import (
     EndpointRow,
     EndpointTokenRow,
 )
+from ai.backend.manager.models.entity_label.conditions import (
+    make_entity_label_nested_conditions,
+)
 from ai.backend.manager.models.routing import RoutingRow
 
 
 class DeploymentConditions:
     """Query conditions for deployments."""
+
+    labels = make_entity_label_nested_conditions(
+        EndpointRow, EndpointRow.id, DEPLOYMENT_ENTITY_TYPE
+    )
+    """The `labels` nested filter: some / every / none over the labels on a endpoint."""
 
     by_replica_exists = staticmethod(
         make_correlated_exists(

--- a/src/ai/backend/manager/models/entity_label/row.py
+++ b/src/ai/backend/manager/models/entity_label/row.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import override
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -53,19 +51,3 @@ class EntityLabelRow(LifecycleTimestampsMixin, Base):
             created_at=self.created_at,
             updated_at=self.updated_at,
         )
-
-    @override
-    def __str__(self) -> str:
-        return (
-            f"EntityLabelRow("
-            f"id: {self.id}, "
-            f"entity_type: {self.entity_type}, "
-            f"entity_id: {self.entity_id}, "
-            f"key: {self.key}, "
-            f"value: {self.value}"
-            f")"
-        )
-
-    @override
-    def __repr__(self) -> str:
-        return self.__str__()

--- a/src/ai/backend/manager/models/session/conditions.py
+++ b/src/ai/backend/manager/models/session/conditions.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.manager.models.entity_label.conditions import (
+    make_entity_label_nested_conditions,
+)
+
 if TYPE_CHECKING:
     from ai.backend.common.data.filter_specs import (
         StringMatchSpec,
@@ -30,6 +35,9 @@ from .row import SessionRow
 
 class SessionConditions:
     """Query conditions for sessions."""
+
+    labels = make_entity_label_nested_conditions(SessionRow, SessionRow.id, SESSION_ENTITY_TYPE)
+    """The `labels` nested filter: some / every / none over the labels on a session."""
 
     @staticmethod
     def by_ids(session_ids: Collection[SessionId]) -> QueryCondition:

--- a/src/ai/backend/manager/models/vfolder/conditions.py
+++ b/src/ai/backend/manager/models/vfolder/conditions.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.manager.models.entity_label.conditions import (
+    make_entity_label_nested_conditions,
+)
+
 if TYPE_CHECKING:
     from ai.backend.common.data.filter_specs import StringMatchSpec
 
@@ -23,6 +28,9 @@ from .row import VFolderRow
 
 class VFolderConditions:
     """Query conditions for vfolders."""
+
+    labels = make_entity_label_nested_conditions(VFolderRow, VFolderRow.id, VFOLDER_ENTITY_TYPE)
+    """The `labels` nested filter: some / every / none over the labels on a vfolder."""
 
     @staticmethod
     def not_being_purged() -> QueryCondition:

--- a/src/ai/backend/manager/services/entity_label/actions/purge.py
+++ b/src/ai/backend/manager/services/entity_label/actions/purge.py
@@ -15,7 +15,7 @@ from ai.backend.manager.services.entity_label.actions.lookup_owner import (
 
 
 @dataclass
-class RemoveEntityLabelAction(
+class PurgeEntityLabelAction(
     RuntimePurgeFieldOpsAction[EntityLabelID, EntityLabelRow, EntityLabelData]
 ):
     """Take one label off, named by its own id.
@@ -29,7 +29,7 @@ class RemoveEntityLabelAction(
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "remove_entity_label"
+        return "purge_entity_label"
 
     @override
     def to_owner_lookup_action(self) -> LookupRuntimeFieldOwnerOpsAction[EntityLabelID]:

--- a/src/ai/backend/manager/services/entity_label/actions/upsert.py
+++ b/src/ai/backend/manager/services/entity_label/actions/upsert.py
@@ -11,8 +11,10 @@ from ai.backend.manager.models.entity_label.upserters import EntityLabelUpserter
 
 
 @dataclass
-class PutEntityLabelAction(UpsertFieldOpsAction[RuntimeEntityID, EntityLabelRow, EntityLabelData]):
-    """Put one key on the entity the caller named, replacing the value it carries."""
+class UpsertEntityLabelAction(
+    UpsertFieldOpsAction[RuntimeEntityID, EntityLabelRow, EntityLabelData]
+):
+    """Set one key on the entity the caller named, replacing the value it carries."""
 
     owner: RuntimeEntityID
     upserter: EntityLabelUpserter
@@ -20,7 +22,7 @@ class PutEntityLabelAction(UpsertFieldOpsAction[RuntimeEntityID, EntityLabelRow,
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "put_entity_label"
+        return "upsert_entity_label"
 
     @override
     def entity_id(self) -> EntityIdentifier:

--- a/src/ai/backend/manager/services/entity_label/processors.py
+++ b/src/ai/backend/manager/services/entity_label/processors.py
@@ -9,26 +9,26 @@ from ai.backend.manager.actions.v2.ops.result import (
 )
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.entity_label.types import EntityLabelData
-from ai.backend.manager.services.entity_label.actions.put import PutEntityLabelAction
-from ai.backend.manager.services.entity_label.actions.remove import RemoveEntityLabelAction
+from ai.backend.manager.services.entity_label.actions.purge import PurgeEntityLabelAction
 from ai.backend.manager.services.entity_label.actions.search import SearchEntityLabelsAction
+from ai.backend.manager.services.entity_label.actions.upsert import UpsertEntityLabelAction
 
 
 class EntityLabelProcessors:
     """The three operations over labels, all straight against ops.
 
     A label is a field of the entity it is on, so each of these is answered for by that
-    entity: the put names it as its target, the removal reads it from the row it names,
+    entity: the upsert names it as its target, the removal reads it from the row it names,
     and the search names the entities whose labels it returns. Which kind of entity is
     not fixed, which is why the group is reached from the registry rather than from an
     entity's own group.
     """
 
-    put: SingleEntityActionProcessor[PutEntityLabelAction, EntityOpsResult[EntityLabelData]]
-    remove: SingleFieldActionProcessor[RemoveEntityLabelAction, EntityOpsResult[EntityLabelData]]
+    upsert: SingleEntityActionProcessor[UpsertEntityLabelAction, EntityOpsResult[EntityLabelData]]
+    purge: SingleFieldActionProcessor[PurgeEntityLabelAction, EntityOpsResult[EntityLabelData]]
     search: BulkActionProcessor[SearchEntityLabelsAction, ScopedFieldsOpsResult[EntityLabelData]]
 
     def __init__(self, group: LookupFieldGroup[EntityLabelData]) -> None:
-        self.put = group.upsert_ops(PutEntityLabelAction)
-        self.remove = group.runtime_purge_ops(RemoveEntityLabelAction)
+        self.upsert = group.upsert_ops(UpsertEntityLabelAction)
+        self.purge = group.runtime_purge_ops(PurgeEntityLabelAction)
         self.search = group.atomic_bulk_scoped_search_ops(SearchEntityLabelsAction)

--- a/tests/unit/common/dto/manager/v2/agent/test_response.py
+++ b/tests/unit/common/dto/manager/v2/agent/test_response.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import uuid
 from datetime import UTC, datetime
 
+from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.dto.manager.v2.agent.response import (
     AgentNetworkInfo,
@@ -43,6 +45,7 @@ def _make_network_info() -> AgentNetworkInfo:
 def _make_agent_node(agent_id: str = "agent-001") -> AgentNode:
     return AgentNode(
         id=agent_id,
+        uuid=AgentUUID(uuid.uuid4()),
         resource_info=_make_resource_info(),
         status_info=_make_status_info(),
         system_info=_make_system_info(),


### PR DESCRIPTION
## Summary

- Adds the label operations to REST v2: `PUT /v2/entity-labels` sets a key on an entity, `DELETE /v2/entity-labels/{id}` takes one off, `POST /v2/entity-labels/search` reads a page. One surface, gated by the labeled entity's own permission rather than by an admin flag.
- Adds `labels` to the filter of session, deployment, vfolder, and agent, with the `some` / `every` / `none` relations of BEP-1060. Each relation is one correlated `EXISTS`, so a relation's key and value narrow the same label.
- Adds the GraphQL inputs `EntityLabelFilter` and `EntityLabelNestedFilter`, and regenerates the supergraph.
- Adds the SDK client and `./bai entity-label {put,remove,search}`, plus `--label KEY[=VALUE]` on every search of a labelable entity.

Design: `proposals/BEP-1073-entity-labels.md`. Depends on #13946.

## Test plan

- [x] `./bai entity-label put` twice on one key replaces the value in place and moves `updated_at`
- [x] `--label gpu=reserved` selects the labeled agent, `--label gpu=nope` selects none, two `--label`s require both
- [x] A non-admin is refused `put` and `remove` on an entity they cannot write, and a search naming an entity they cannot read is refused rather than answered with an empty page
- [x] The four filters carry `labels: EntityLabelNestedFilter` in the regenerated supergraph

Resolves BA-7475


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--13954.org.readthedocs.build/en/13954/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--13954.org.readthedocs.build/ko/13954/

<!-- readthedocs-preview sorna-ko end -->