### PR TITLE
fix: Keep client pool cleanup from closing sessions mid-response (#13425)

### DIFF
--- a/changes/13425.fix.md
+++ b/changes/13425.fix.md
@@ -1,0 +1,1 @@
+Fix the shared HTTP client pool closing a session while one of its requests is still streaming a response.

--- a/configs/app-proxy-worker/sample.toml
+++ b/configs/app-proxy-worker/sample.toml
@@ -180,6 +180,11 @@
   # connections.
   # Added in 25.9.0
   client_pool_cleanup_interval = 60.0
+  # Skip idle-session cleanup for sessions with a request still in flight, so
+  # streamed responses longer than client_pool_cleanup_interval are not cut off.
+  # Experimental; off by default.
+  # Added in 26.9.0
+  client_pool_keep_inflight_sessions = false
   # The address this worker announces to the service discovery system. Other
   # components use this address to locate and connect to the worker. If not set,
   # defaults to api_bind_addr. Required when behind NAT or containers.

--- a/src/ai/backend/appproxy/worker/config.py
+++ b/src/ai/backend/appproxy/worker/config.py
@@ -772,6 +772,20 @@ class ProxyWorkerConfig(BaseSchema):
         ),
     ]
 
+    client_pool_keep_inflight_sessions: Annotated[
+        bool,
+        Field(default=False),
+        BackendAIConfigMeta(
+            description=(
+                "Skip idle-session cleanup for sessions with a request still in flight, "
+                "so streamed responses longer than client_pool_cleanup_interval are not cut off. "
+                "Experimental; off by default."
+            ),
+            added_version="26.9.0",
+            example=ConfigExample(local="false", prod="false"),
+        ),
+    ]
+
     announce_addr: Annotated[
         HostPortPair | None,
         Field(default=None),

--- a/src/ai/backend/appproxy/worker/proxy/backend/http.py
+++ b/src/ai/backend/appproxy/worker/proxy/backend/http.py
@@ -62,14 +62,15 @@ class HTTPBackend(BaseBackend):
             sock_connect=10.0,
             sock_read=None,
         )
-        cleanup_interval = self.root_context.local_config.proxy_worker.client_pool_cleanup_interval
+        worker_config = self.root_context.local_config.proxy_worker
         self.client_pool = ClientPool(
             partial(
                 tcp_client_session_factory,
                 timeout=client_timeout,
                 auto_decompress=False,  # transparently pass the response body
             ),
-            cleanup_interval_seconds=cleanup_interval,
+            cleanup_interval_seconds=worker_config.client_pool_cleanup_interval,
+            keep_inflight_sessions=worker_config.client_pool_keep_inflight_sessions,
         )
 
     @override

--- a/src/ai/backend/common/clients/http_client/client_pool.py
+++ b/src/ai/backend/common/clients/http_client/client_pool.py
@@ -51,6 +51,15 @@ def tcp_client_session_factory(
     )
 
 
+def _has_inflight_requests(session: aiohttp.ClientSession) -> bool:
+    """A connection stays acquired until its response body is fully read."""
+    connector = session.connector
+    if connector is None:
+        return False
+    # Private aiohttp attribute, verified on 3.13; absent means fall back to time-based eviction.
+    return bool(getattr(connector, "_acquired", None))
+
+
 @dataclass(slots=True)
 class _Client:
     session: aiohttp.ClientSession
@@ -72,13 +81,17 @@ class ClientKey:
 class ClientPool:
     _clients: MutableMapping[ClientKey, _Client]
     _cleanup_task: asyncio.Task[None]
+    _keep_inflight_sessions: bool
 
     def __init__(
         self,
         factory: ClientSessionFactory,
         cleanup_interval_seconds: float = 600,
+        *,
+        keep_inflight_sessions: bool = False,
     ) -> None:
         frame = inspect.stack()[1]
+        self._keep_inflight_sessions = keep_inflight_sessions
         self._creator_info = f"{frame.filename}:{frame.lineno}:{frame.function}()"
         self._cleanup_task = asyncio.create_task(
             self._cleanup_loop(cleanup_interval_seconds),
@@ -112,12 +125,16 @@ class ClientPool:
             await asyncio.sleep(cleanup_interval_seconds)
             now = time.perf_counter()
             for key, client in list(self._clients.items()):
-                if now - client.last_used > cleanup_interval_seconds:
-                    del self._clients[key]
-                    try:
-                        await client.session.close()
-                    except Exception as e:
-                        log.exception("Error closing client session: {}", e)
+                if now - client.last_used <= cleanup_interval_seconds:
+                    continue
+                if self._keep_inflight_sessions and _has_inflight_requests(client.session):
+                    client.last_used = now
+                    continue
+                del self._clients[key]
+                try:
+                    await client.session.close()
+                except Exception as e:
+                    log.exception("Error closing client session: {}", e)
 
     def load_client_session(self, key: ClientKey) -> aiohttp.ClientSession:
         session = self._clients.get(key, None)

--- a/tests/unit/common/clients/BUILD
+++ b/tests/unit/common/clients/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/common/clients/test_client_pool.py
+++ b/tests/unit/common/clients/test_client_pool.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator
+from functools import partial
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from ai.backend.common.clients.http_client.client_pool import (
+    ClientKey,
+    ClientPool,
+    tcp_client_session_factory,
+)
+
+CLEANUP_INTERVAL = 0.2
+STREAM_CHUNKS = 6
+CHUNK_DELAY = 0.1
+READ_DEADLINE = 5.0
+
+
+async def _slow_stream(request: web.Request) -> web.StreamResponse:
+    response = web.StreamResponse()
+    await response.prepare(request)
+    for index in range(STREAM_CHUNKS):
+        await response.write(f"chunk-{index}\n".encode())
+        await asyncio.sleep(CHUNK_DELAY)
+    await response.write_eof()
+    return response
+
+
+async def _read_stream(pool: ClientPool, upstream_url: str) -> list[bytes]:
+    session = pool.load_client_session(ClientKey(endpoint=upstream_url, domain="test"))
+    chunks: list[bytes] = []
+    with contextlib.suppress(TimeoutError, aiohttp.ClientError):
+        async with asyncio.timeout(READ_DEADLINE):
+            async with session.get("/stream") as response:
+                async for line in response.content:
+                    chunks.append(line)
+    return chunks
+
+
+async def _wait_closed(session: aiohttp.ClientSession) -> None:
+    async with asyncio.timeout(READ_DEADLINE):
+        while not session.closed:
+            await asyncio.sleep(CLEANUP_INTERVAL / 4)
+
+
+@pytest.fixture
+async def streaming_upstream_url() -> AsyncIterator[str]:
+    app = web.Application()
+    app.router.add_get("/stream", _slow_stream)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    try:
+        _, port = runner.addresses[0][:2]
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        await runner.cleanup()
+
+
+@pytest.fixture
+async def pool() -> AsyncIterator[ClientPool]:
+    client_pool = ClientPool(
+        partial(tcp_client_session_factory, ssl=False),
+        cleanup_interval_seconds=CLEANUP_INTERVAL,
+        keep_inflight_sessions=True,
+    )
+    try:
+        yield client_pool
+    finally:
+        await client_pool.close()
+
+
+@pytest.fixture
+async def legacy_pool() -> AsyncIterator[ClientPool]:
+    client_pool = ClientPool(
+        partial(tcp_client_session_factory, ssl=False),
+        cleanup_interval_seconds=CLEANUP_INTERVAL,
+    )
+    try:
+        yield client_pool
+    finally:
+        await client_pool.close()
+
+
+async def test_streaming_response_survives_a_cleanup_pass(
+    pool: ClientPool,
+    streaming_upstream_url: str,
+) -> None:
+    chunks = await _read_stream(pool, streaming_upstream_url)
+
+    assert len(chunks) == STREAM_CHUNKS
+    assert chunks[-1] == f"chunk-{STREAM_CHUNKS - 1}\n".encode()
+
+
+async def test_idle_session_is_still_evicted(
+    pool: ClientPool,
+    streaming_upstream_url: str,
+) -> None:
+    key = ClientKey(endpoint=streaming_upstream_url, domain="test")
+    session = pool.load_client_session(key)
+    async with session.get("/stream") as response:
+        await response.read()
+
+    await _wait_closed(session)
+
+    assert pool.load_client_session(key) is not session
+
+
+async def test_flag_off_keeps_time_based_eviction(
+    legacy_pool: ClientPool,
+    streaming_upstream_url: str,
+) -> None:
+    chunks = await _read_stream(legacy_pool, streaming_upstream_url)
+
+    assert len(chunks) < STREAM_CHUNKS


### PR DESCRIPTION
This is an auto-generated backport of #13425 to the 26.4 release.