### PR TITLE
refactor(BA-7498): move the permissions table off the legacy type enums

### DIFF
--- a/changes/13988.enhance.md
+++ b/changes/13988.enhance.md
@@ -1,0 +1,1 @@
+Resolve permission checks over entity types outside the legacy RBAC enum instead of always denying them.

--- a/src/ai/backend/common/dto/manager/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/rbac/response.py
@@ -11,11 +11,13 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.data.permission.types import ScopeType
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.permission.types import ScopeType as LegacyScopeType
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.types import BackendAISchema
 
-from .types import EntityType, OperationType, RoleSource, RoleStatus
+from .types import EntityType as LegacyEntityType
+from .types import OperationType, RoleSource, RoleStatus
 
 __all__ = (
     "AssignRoleResponse",
@@ -131,7 +133,7 @@ class ObjectPermissionDTO(BackendAISchema):
 
     id: UUID = Field(description="Object permission ID")
     role_id: UUID = Field(description="Role ID")
-    entity_type: EntityType = Field(description="Entity type")
+    entity_type: LegacyEntityType = Field(description="Entity type")
     entity_id: str = Field(description="Entity ID")
     operation: OperationType = Field(description="Operation type")
 
@@ -163,13 +165,13 @@ class DeleteObjectPermissionResponse(BaseResponseModel):
 class GetScopeTypesResponse(BaseResponseModel):
     """Response for getting available scope types."""
 
-    items: list[ScopeType] = Field(description="List of available scope types")
+    items: list[LegacyScopeType] = Field(description="List of available scope types")
 
 
 class ScopeDTO(BackendAISchema):
     """DTO for scope data."""
 
-    scope_type: ScopeType = Field(description="Scope type")
+    scope_type: LegacyScopeType = Field(description="Scope type")
     scope_id: str = Field(description="Scope ID (domain name, project UUID, or user UUID)")
     name: str = Field(description="Scope display name")
 
@@ -184,13 +186,13 @@ class SearchScopesResponse(BaseResponseModel):
 class GetEntityTypesResponse(BaseResponseModel):
     """Response for getting available entity types."""
 
-    items: list[EntityType] = Field(description="List of available entity types")
+    items: list[LegacyEntityType] = Field(description="List of available entity types")
 
 
 class EntityDTO(BackendAISchema):
     """DTO for entity data."""
 
-    entity_type: EntityType = Field(description="Entity type")
+    entity_type: LegacyEntityType = Field(description="Entity type")
     entity_id: str = Field(description="Entity ID")
 
 

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.permission.types import OperationType as InternalOperationType
 from ai.backend.common.data.permission.types import RBACElementType
@@ -941,9 +942,9 @@ class RBACAdapter(BaseAdapter):
         creator: Creator[PermissionRow] = Creator(
             spec=PermissionCreatorSpec(
                 role_id=input.role_id,
-                scope_type=scope_type,
+                scope_type=ScopeType(EntityType(scope_type)),
                 scope_id=input.scope_id,
-                entity_type=RBACElementType(input.entity_type),
+                entity_type=EntityType(RBACElementType(input.entity_type)),
                 operation=InternalOperationType(input.operation),
             )
         )
@@ -960,7 +961,7 @@ class RBACAdapter(BaseAdapter):
             self._validate_scope_id(RBACElementType(input.scope_type), input.scope_id)
         spec = PermissionUpdaterSpec(
             scope_type=(
-                OptionalState.update(RBACElementType(input.scope_type))
+                OptionalState.update(ScopeType(EntityType(RBACElementType(input.scope_type))))
                 if input.scope_type is not None
                 else OptionalState.nop()
             ),
@@ -970,7 +971,7 @@ class RBACAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
             entity_type=(
-                OptionalState.update(RBACElementType(input.entity_type))
+                OptionalState.update(EntityType(RBACElementType(input.entity_type)))
                 if input.entity_type is not None
                 else OptionalState.nop()
             ),
@@ -1072,9 +1073,9 @@ class RBACAdapter(BaseAdapter):
             failed=[
                 BulkAddRolePermissionFailureInfo(
                     role_id=f.role_id,
-                    scope_type=f.scope_type.value,
+                    scope_type=f.scope_type,
                     scope_id=f.scope_id,
-                    entity_type=f.entity_type.value,
+                    entity_type=f.entity_type,
                     operation=f.operation.value,
                     message=f.message,
                 )
@@ -1130,9 +1131,9 @@ class RBACAdapter(BaseAdapter):
             failed=[
                 ReplaceRolePermissionFailureInfo(
                     role_id=f.role_id,
-                    scope_type=f.scope_type.value,
+                    scope_type=f.scope_type,
                     scope_id=f.scope_id,
-                    entity_type=f.entity_type.value,
+                    entity_type=f.entity_type,
                     operation=f.operation.value,
                     message=f.message,
                 )
@@ -1145,9 +1146,9 @@ class RBACAdapter(BaseAdapter):
         self._validate_scope_id(scope_type, entry.scope_id)
         return PermissionCreatorSpec(
             role_id=entry.role_id,
-            scope_type=scope_type,
+            scope_type=ScopeType(EntityType(scope_type)),
             scope_id=entry.scope_id,
-            entity_type=RBACElementType(entry.entity_type),
+            entity_type=EntityType(RBACElementType(entry.entity_type)),
             operation=InternalOperationType(entry.operation),
         )
 
@@ -1852,9 +1853,9 @@ class RBACAdapter(BaseAdapter):
         return PermissionNode(
             id=data.id,
             role_id=data.role_id,
-            scope_type=RBACElementTypeDTO(data.scope_type.to_element().value),
+            scope_type=RBACElementTypeDTO(data.scope_type),
             scope_id=data.scope_id,
-            entity_type=RBACElementTypeDTO(data.entity_type.to_element().value),
+            entity_type=RBACElementTypeDTO(data.entity_type),
             operation=OperationTypeDTO(data.operation.value),
             created_at=data.created_at,
         )

--- a/src/ai/backend/manager/api/rest/rbac/permission_adapter.py
+++ b/src/ai/backend/manager/api/rest/rbac/permission_adapter.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import uuid
 
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.dto.manager.rbac import (
     CreatePermissionRequest,
     PermissionDTO,
@@ -43,9 +44,9 @@ class PermissionAdapter:
         creator = Creator(
             spec=PermissionCreatorSpec(
                 role_id=request.role_id,
-                scope_type=request.scope_type.to_element(),
+                scope_type=ScopeType(EntityType(request.scope_type)),
                 scope_id=request.scope_id,
-                entity_type=request.entity_type.to_element(),
+                entity_type=EntityType(request.entity_type),
                 operation=request.operation,
             )
         )

--- a/src/ai/backend/manager/data/permission/permission.py
+++ b/src/ai/backend/manager/data/permission/permission.py
@@ -24,7 +24,7 @@ class PermissionCreator:
 class PermissionData:
     id: uuid.UUID
     role_id: uuid.UUID
-    scope_type: ScopeType
+    scope_type: EntityType
     scope_id: str
     entity_type: EntityType
     operation: OperationType

--- a/src/ai/backend/manager/data/permission/permission.py
+++ b/src/ai/backend/manager/data/permission/permission.py
@@ -4,10 +4,10 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.manager.data.common.types import SearchResult
 
-from .id import ScopeId
-from .types import EntityType, OperationType, Permission, ScopeType
+from .types import OperationType, Permission
 
 
 @dataclass
@@ -43,10 +43,6 @@ class ScopedPermissionCreateInput:
     scope_id: str
     entity_type: EntityType
     operation: OperationType
-
-    def to_scope_id(self) -> ScopeId:
-        """Convert to ScopeId."""
-        return ScopeId(scope_type=self.scope_type, scope_id=self.scope_id)
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -4,6 +4,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.manager.data.common.types import SearchResult
 
 from .id import ObjectId, ScopeId
@@ -14,11 +15,12 @@ from .object_permission import (
 from .permission import PermissionData, ScopedPermissionCreateInput
 from .status import RoleStatus
 from .types import (
-    EntityType,
+    EntityType as LegacyEntityType,
+)
+from .types import (
     OperationType,
     RBACElementType,
     RoleSource,
-    ScopeType,
 )
 
 
@@ -75,7 +77,7 @@ class RoleDetailData:
 @dataclass(frozen=True)
 class ScopePermissionCheckInput:
     user_id: uuid.UUID
-    target_entity_type: EntityType
+    target_entity_type: LegacyEntityType
     target_scope_id: ScopeId
     operation: OperationType
 

--- a/src/ai/backend/manager/models/rbac_models/permission/permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.role import RoleID
-from ai.backend.common.data.entity.types import EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.data.permission.permission import PermissionCreator, PermissionData
 from ai.backend.manager.data.permission.types import (
     OperationType,
@@ -52,7 +52,7 @@ class PermissionRow(CreatedAtMixin, Base):
         sa.ForeignKey("roles.id", ondelete="CASCADE"),
         nullable=False,
     )
-    scope_type: Mapped[ScopeType] = mapped_column(
+    scope_type: Mapped[EntityType] = mapped_column(
         "scope_type", sa.String(length=32), nullable=False
     )
     scope_id: Mapped[str] = mapped_column("scope_id", sa.String(64), nullable=False)

--- a/src/ai/backend/manager/models/rbac_models/permission/permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission.py
@@ -7,12 +7,11 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.role import RoleID
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.manager.data.permission.permission import PermissionCreator, PermissionData
 from ai.backend.manager.data.permission.types import (
-    EntityType,
     OperationType,
     Permission,
-    ScopeType,
 )
 from ai.backend.manager.models.base import (
     GUID,
@@ -54,11 +53,11 @@ class PermissionRow(CreatedAtMixin, Base):
         nullable=False,
     )
     scope_type: Mapped[ScopeType] = mapped_column(
-        "scope_type", StrEnumType(ScopeType, length=32), nullable=False
+        "scope_type", sa.String(length=32), nullable=False
     )
     scope_id: Mapped[str] = mapped_column("scope_id", sa.String(64), nullable=False)
     entity_type: Mapped[EntityType] = mapped_column(
-        "entity_type", StrEnumType(EntityType, length=32), nullable=False
+        "entity_type", sa.String(length=32), nullable=False
     )
     operation: Mapped[OperationType] = mapped_column(
         "operation", StrEnumType(OperationType, length=32), nullable=False

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -855,9 +855,9 @@ class RBACWriteOps(WriteOps):
         permissions = [
             PermissionCreatorSpec(
                 role_id=row.id,
-                scope_type=self._scope_element_type(spec.scope),
+                scope_type=ScopeType(EntityType(self._scope_element_type(spec.scope))),
                 scope_id=str(spec.scope.scope_id),
-                entity_type=entity_type,
+                entity_type=EntityType(entity_type),
                 operation=operation,
             )
             for spec, row in zip(specs, roles.rows, strict=True)

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityRef, ScopeRef
+from ai.backend.common.data.entity.types import EntityRef, EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.virtual_scope import VirtualScopeID
 from ai.backend.common.data.permission.types import RBACElementType
@@ -63,18 +63,18 @@ class PermissionCreatorSpec(CreatorSpec[PermissionRow]):
     """CreatorSpec for permissions."""
 
     role_id: uuid.UUID
-    scope_type: RBACElementType
+    scope_type: ScopeType
     scope_id: str
-    entity_type: RBACElementType
+    entity_type: EntityType
     operation: OperationType
 
     @override
     def build_row(self) -> PermissionRow:
         return PermissionRow(
             role_id=self.role_id,
-            scope_type=self.scope_type.to_scope_type(),
+            scope_type=self.scope_type,
             scope_id=self.scope_id,
-            entity_type=self.entity_type.to_entity_type(),
+            entity_type=self.entity_type,
             operation=self.operation,
             permission=Permission.from_operation(self.operation),
         )

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -439,9 +439,9 @@ class PermissionDBSource:
                 perm_creator = Creator(
                     spec=PermissionCreatorSpec(
                         role_id=input_data.role_id,
-                        scope_type=RBACElementType(scoped_perm_input.scope_type.value),
+                        scope_type=scoped_perm_input.scope_type,
                         scope_id=scoped_perm_input.scope_id,
-                        entity_type=RBACElementType(scoped_perm_input.entity_type.value),
+                        entity_type=scoped_perm_input.entity_type,
                         operation=scoped_perm_input.operation,
                     )
                 )
@@ -1344,11 +1344,7 @@ class PermissionDBSource:
                         # scope_bindings.scope_id is a native UUID; permissions.scope_id
                         # stores its canonical string form. Cast to compare.
                         perm.c.scope_id == sa.cast(sb.c.scope_id, sa.String),
-                        # permissions.entity_type is an enum-backed column; bind the open
-                        # string type as a plain VARCHAR so unknown types match nothing
-                        # instead of failing enum coercion.
-                        perm.c.entity_type
-                        == sa.literal(group_key.subject_entity_type, sa.String()),
+                        perm.c.entity_type == group_key.subject_entity_type,
                     ),
                 )
                 .join(roles, roles.c.id == perm.c.role_id)

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -46,9 +46,7 @@ from ai.backend.manager.data.permission.role import (
     UserRoleRevocationInput,
 )
 from ai.backend.manager.data.permission.types import (
-    EntityType,
     ScopeListResult,
-    ScopeType,
 )
 from ai.backend.manager.data.permission.virtual_scope import (
     EntityPermissionCheckKey,
@@ -183,9 +181,9 @@ class PermissionControllerRepository:
         failures = [
             BulkRolePermissionAddFailure(
                 role_id=(spec := cast(PermissionCreatorSpec, error.spec)).role_id,
-                scope_type=ScopeType(spec.scope_type.value),
+                scope_type=spec.scope_type,
                 scope_id=spec.scope_id,
-                entity_type=EntityType(spec.entity_type.value),
+                entity_type=spec.entity_type,
                 operation=spec.operation,
                 message=str(error.exception),
             )
@@ -224,9 +222,9 @@ class PermissionControllerRepository:
         failures = [
             BulkRolePermissionAddFailure(
                 role_id=(spec := cast(PermissionCreatorSpec, error.spec)).role_id,
-                scope_type=ScopeType(spec.scope_type.value),
+                scope_type=spec.scope_type,
                 scope_id=spec.scope_id,
-                entity_type=EntityType(spec.entity_type.value),
+                entity_type=spec.entity_type,
                 operation=spec.operation,
                 message=str(error.exception),
             )

--- a/src/ai/backend/manager/repositories/permission_controller/role_manager.py
+++ b/src/ai/backend/manager/repositories/permission_controller/role_manager.py
@@ -9,6 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.data.entity.role_preset import RolePresetID
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
@@ -19,12 +20,16 @@ from ai.backend.manager.data.permission.role import (
 )
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
-    EntityType,
+    EntityType as LegacyEntityType,
+)
+from ai.backend.manager.data.permission.types import (
     OperationType,
     Permission,
     RBACElementRef,
     RoleSource,
-    ScopeType,
+)
+from ai.backend.manager.data.permission.types import (
+    ScopeType as LegacyScopeType,
 )
 from ai.backend.manager.errors.repository import RepositoryIntegrityError
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
@@ -75,7 +80,7 @@ class UserSystemRoleSpec:
     user_id: uuid.UUID
 
     def scope_id(self) -> ScopeId:
-        return ScopeId(scope_type=ScopeType.USER, scope_id=str(self.user_id))
+        return ScopeId(scope_type=LegacyScopeType.USER, scope_id=str(self.user_id))
 
     def role_name(self) -> str:
         return f"user-{str(self.user_id)[:8]}"
@@ -83,7 +88,7 @@ class UserSystemRoleSpec:
     def entity_operations(self) -> Mapping[RBACElementType, Iterable[OperationType]]:
         resource_entity_permissions = {
             entity.to_element(): OperationType.owner_operations()
-            for entity in EntityType.owner_accessible_entity_types_in_user()
+            for entity in LegacyEntityType.owner_accessible_entity_types_in_user()
         }
         user_permissions = OperationType.owner_operations() - {OperationType.CREATE}
         return {RBACElementType.USER: user_permissions, **resource_entity_permissions}
@@ -138,9 +143,9 @@ class RoleManager:
             for operation in operations:
                 creator = PermissionCreator(
                     role_id=role_id,
-                    scope_type=data.scope_id().scope_type,
+                    scope_type=ScopeType(EntityType(data.scope_id().scope_type)),
                     scope_id=data.scope_id().scope_id,
-                    entity_type=element_type.to_entity_type(),
+                    entity_type=EntityType(element_type),
                     operation=operation,
                     permission=Permission.from_operation(operation),
                 )
@@ -232,9 +237,9 @@ class RoleManager:
             PermissionRow.from_input(
                 PermissionCreator(
                     role_id=role_id,
-                    scope_type=scope_id.scope_type,
+                    scope_type=ScopeType(EntityType(scope_id.scope_type)),
                     scope_id=scope_id.scope_id,
-                    entity_type=preset_permission.entity_type,
+                    entity_type=EntityType(preset_permission.entity_type),
                     operation=preset_permission.operation,
                     permission=Permission.from_operation(preset_permission.operation),
                 )
@@ -253,7 +258,7 @@ class RoleManager:
         and assigns the auto_assign ones to the user, who is the sole member of its
         own user scope. Returns all created roles.
         """
-        scope_id = ScopeId(scope_type=ScopeType.USER, scope_id=str(user_id))
+        scope_id = ScopeId(scope_type=LegacyScopeType.USER, scope_id=str(user_id))
         created_roles = await self.create_preset_roles(db_session, scope_id)
         for role in created_roles:
             if not role.auto_assign:
@@ -281,7 +286,7 @@ class RoleManager:
                 .where(
                     AssociationScopesEntitiesRow.scope_type == scope_id.scope_type,
                     AssociationScopesEntitiesRow.scope_id == scope_id.scope_id,
-                    AssociationScopesEntitiesRow.entity_type == EntityType.ROLE,
+                    AssociationScopesEntitiesRow.entity_type == LegacyEntityType.ROLE,
                     RoleRow.auto_assign.is_(True),
                     RoleRow.status == RoleStatus.ACTIVE,
                 )

--- a/src/ai/backend/manager/repositories/permission_controller/updaters.py
+++ b/src/ai/backend/manager/repositories/permission_controller/updaters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     OperationType,
@@ -45,9 +45,9 @@ class RoleUpdaterSpec(UpdaterSpec[RoleRow]):
 class PermissionUpdaterSpec(UpdaterSpec[PermissionRow]):
     """UpdaterSpec for permission updates."""
 
-    scope_type: OptionalState[RBACElementType] = field(default_factory=OptionalState.nop)
+    scope_type: OptionalState[ScopeType] = field(default_factory=OptionalState.nop)
     scope_id: OptionalState[str] = field(default_factory=OptionalState.nop)
-    entity_type: OptionalState[RBACElementType] = field(default_factory=OptionalState.nop)
+    entity_type: OptionalState[EntityType] = field(default_factory=OptionalState.nop)
     operation: OptionalState[OperationType] = field(default_factory=OptionalState.nop)
 
     @property
@@ -58,8 +58,8 @@ class PermissionUpdaterSpec(UpdaterSpec[PermissionRow]):
     @override
     def build_values(self) -> dict[str, Any]:
         to_update: dict[str, Any] = {}
-        self.scope_type.map(lambda v: v.to_scope_type()).update_dict(to_update, "scope_type")
+        self.scope_type.update_dict(to_update, "scope_type")
         self.scope_id.update_dict(to_update, "scope_id")
-        self.entity_type.map(lambda v: v.to_entity_type()).update_dict(to_update, "entity_type")
+        self.entity_type.update_dict(to_update, "entity_type")
         self.operation.update_dict(to_update, "operation")
         return to_update

--- a/tests/component/rbac/test_rbac_permission.py
+++ b/tests/component/rbac/test_rbac_permission.py
@@ -5,10 +5,13 @@ from typing import Any
 
 import pytest
 
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.permission.types import (
     OperationType,
     RBACElementType,
-    ScopeType,
+)
+from ai.backend.common.data.permission.types import (
+    ScopeType as LegacyScopeType,
 )
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.permission import PermissionData
@@ -19,7 +22,7 @@ from ai.backend.manager.data.permission.role import (
     UserRoleAssignmentInput,
     UserRoleRevocationInput,
 )
-from ai.backend.manager.data.permission.types import EntityType
+from ai.backend.manager.data.permission.types import EntityType as LegacyEntityType
 from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.repository import (
     UniqueConstraintViolationError,
@@ -67,9 +70,9 @@ class TestPermissionCreate:
         creator = Creator(
             spec=PermissionCreatorSpec(
                 role_id=target_role.role.id,
-                scope_type=RBACElementType.DOMAIN,
+                scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                 scope_id=domain_fixture.domain_name,
-                entity_type=RBACElementType.SESSION,
+                entity_type=EntityType(RBACElementType.SESSION),
                 operation=OperationType.READ,
             )
         )
@@ -79,8 +82,8 @@ class TestPermissionCreate:
 
         assert isinstance(result.data, PermissionData)
         assert result.data.role_id == target_role.role.id
-        assert result.data.scope_type == ScopeType.DOMAIN
-        assert result.data.entity_type == EntityType.SESSION
+        assert result.data.scope_type == LegacyScopeType.DOMAIN.value
+        assert result.data.entity_type == LegacyEntityType.SESSION.value
         assert result.data.operation == OperationType.READ
 
         # Cleanup
@@ -125,15 +128,15 @@ class TestPermissionCreate:
                     creator=Creator(
                         spec=PermissionCreatorSpec(
                             role_id=target_role.role.id,
-                            scope_type=scope_type,
+                            scope_type=ScopeType(EntityType(scope_type)),
                             scope_id=scope_id,
-                            entity_type=entity_type,
+                            entity_type=EntityType(entity_type),
                             operation=operation,
                         )
                     )
                 )
             )
-            assert result.data.entity_type == entity_type.to_entity_type()
+            assert result.data.entity_type == entity_type.value
             assert result.data.operation == operation
             assert result.data.role_id == target_role.role.id
             created_ids.append(result.data.id)
@@ -155,9 +158,9 @@ class TestPermissionCreate:
         """F-BIZ-4: Create duplicate permission → unique constraint error."""
         spec = PermissionCreatorSpec(
             role_id=target_role.role.id,
-            scope_type=RBACElementType.DOMAIN,
+            scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
             scope_id=domain_fixture.domain_name,
-            entity_type=RBACElementType.VFOLDER,
+            entity_type=EntityType(RBACElementType.VFOLDER),
             operation=OperationType.READ,
         )
 
@@ -194,9 +197,9 @@ class TestPermissionDelete:
                 creator=Creator(
                     spec=PermissionCreatorSpec(
                         role_id=target_role.role.id,
-                        scope_type=RBACElementType.DOMAIN,
+                        scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                         scope_id=domain_fixture.domain_name,
-                        entity_type=RBACElementType.SESSION,
+                        entity_type=EntityType(RBACElementType.SESSION),
                         operation=OperationType.HARD_DELETE,
                     )
                 )
@@ -223,9 +226,9 @@ class TestPermissionDelete:
                 creator=Creator(
                     spec=PermissionCreatorSpec(
                         role_id=target_role.role.id,
-                        scope_type=RBACElementType.DOMAIN,
+                        scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                         scope_id=domain_fixture.domain_name,
-                        entity_type=RBACElementType.IMAGE,
+                        entity_type=EntityType(RBACElementType.IMAGE),
                         operation=OperationType.SOFT_DELETE,
                     )
                 )
@@ -270,7 +273,7 @@ class TestCheckPermissionOfEntity:
             SingleEntityPermissionCheckInput(
                 user_id=uuid.uuid4(),  # random user with no roles
                 target_object_id=ObjectId(
-                    entity_type=EntityType.SESSION, entity_id=str(uuid.uuid4())
+                    entity_type=LegacyEntityType.SESSION, entity_id=str(uuid.uuid4())
                 ),
                 operation=OperationType.READ,
             )
@@ -299,9 +302,9 @@ class TestCheckPermissionInScope:
                 creator=Creator(
                     spec=PermissionCreatorSpec(
                         role_id=role_id,
-                        scope_type=RBACElementType.DOMAIN,
+                        scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                         scope_id=domain_fixture.domain_name,
-                        entity_type=RBACElementType.SESSION,
+                        entity_type=EntityType(RBACElementType.SESSION),
                         operation=OperationType.READ,
                     )
                 )
@@ -316,9 +319,9 @@ class TestCheckPermissionInScope:
             has_perm = await permission_repo.check_permission_in_scope(
                 ScopePermissionCheckInput(
                     user_id=user_id,
-                    target_entity_type=EntityType.SESSION,
+                    target_entity_type=LegacyEntityType.SESSION,
                     target_scope_id=ScopeId(
-                        scope_type=ScopeType.DOMAIN, scope_id=domain_fixture.domain_name
+                        scope_type=LegacyScopeType.DOMAIN, scope_id=domain_fixture.domain_name
                     ),
                     operation=OperationType.READ,
                 )
@@ -343,9 +346,9 @@ class TestCheckPermissionInScope:
         has_perm = await permission_repo.check_permission_in_scope(
             ScopePermissionCheckInput(
                 user_id=uuid.uuid4(),  # random user with no roles
-                target_entity_type=EntityType.SESSION,
+                target_entity_type=LegacyEntityType.SESSION,
                 target_scope_id=ScopeId(
-                    scope_type=ScopeType.DOMAIN, scope_id=domain_fixture.domain_name
+                    scope_type=LegacyScopeType.DOMAIN, scope_id=domain_fixture.domain_name
                 ),
                 operation=OperationType.READ,
             )

--- a/tests/unit/manager/repositories/base/rbac/test_granter.py
+++ b/tests/unit/manager/repositories/base/rbac/test_granter.py
@@ -174,9 +174,9 @@ class TestGranterBasic:
             assert operations == {OperationType.READ, OperationType.UPDATE}
             for perm in perms:
                 assert perm.role_id == ctx.role_id
-                assert perm.scope_type == ScopeType.VFOLDER
+                assert perm.scope_type == ScopeType.VFOLDER.value
                 assert perm.scope_id == ctx.entity_id.entity_id
-                assert perm.entity_type == EntityType.VFOLDER
+                assert perm.entity_type == EntityType.VFOLDER.value
 
     async def test_granter_with_empty_role_ids(
         self,

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -16,6 +16,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE, RolePresetID
 from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
@@ -76,6 +77,8 @@ _ORM_CLUSTER = (
 )
 
 _TARGET_ENTITY_TYPE = EntityType("vfolder")
+# Wired, but not a member of the legacy RBAC enum the permissions table used to carry.
+_UNMAPPED_ENTITY_TYPE = ROLE_PRESET_ENTITY_TYPE
 
 
 @dataclass
@@ -463,6 +466,95 @@ class TestCheckPermissionViaVirtualScope:
             key, Permission.READ
         )
         assert result is False
+
+    async def _build_unmapped_chain(
+        self,
+        db: ExtendedAsyncSAEngine,
+        ids: VSChainFixture,
+    ) -> None:
+        """The chain of :meth:`_build_chain`, over an entity type the legacy enum
+        does not name."""
+        async with db.begin_session() as db_sess:
+            db_sess.add(
+                VirtualScopeRow(
+                    id=ids.virtual_scope_id,
+                    scope_type=ScopeType(EntityType("project")),
+                    scope_id=ids.owner_scope_id,
+                )
+            )
+            await db_sess.flush()
+            db_sess.add(
+                ScopeBindingRow(
+                    virtual_scope_id=ids.virtual_scope_id,
+                    scope_type=ScopeType(EntityType("project")),
+                    scope_id=ids.bound_scope_id,
+                )
+            )
+            db_sess.add(
+                EntityMembershipRow(
+                    virtual_scope_id=ids.virtual_scope_id,
+                    entity_type=_UNMAPPED_ENTITY_TYPE,
+                    entity_id=ids.entity_id,
+                )
+            )
+            db_sess.add(
+                PermissionRow(
+                    role_id=ids.role_id,
+                    scope_type=ScopeType(EntityType("project")),
+                    scope_id=str(ids.bound_scope_id),
+                    entity_type=_UNMAPPED_ENTITY_TYPE,
+                    operation=OperationType.READ,
+                    permission=Permission.READ,
+                )
+            )
+            await db_sess.flush()
+
+    async def test_grant_over_unmapped_entity_type_resolves(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        db_source: PermissionDBSource,
+        fixture_ids: VSChainFixture,
+    ) -> None:
+        """A grant whose entity type the legacy enum does not name is authored and
+        resolves through the chain, instead of being unwritable and falling closed."""
+        await self._create_user_and_role(db_with_rbac_tables, fixture_ids, RoleStatus.ACTIVE)
+        await self._build_unmapped_chain(db_with_rbac_tables, fixture_ids)
+
+        key = EntityPermissionCheckKey(
+            user_id=fixture_ids.user_id,
+            entity=RolePresetID(fixture_ids.entity_id),
+        )
+        resolved = await db_source.resolve_effective_permissions_via_virtual_scope([key])
+        assert resolved[key] == Permission.READ
+
+    async def test_stored_unmapped_entity_type_reads_back(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        fixture_ids: VSChainFixture,
+    ) -> None:
+        """A stored entity type the legacy enum does not name survives an ORM read."""
+        await self._create_user_and_role(db_with_rbac_tables, fixture_ids, RoleStatus.ACTIVE)
+        async with db_with_rbac_tables.begin_session() as db_sess:
+            await db_sess.execute(
+                sa.text(
+                    "INSERT INTO permissions"
+                    " (role_id, scope_type, scope_id, entity_type, operation, permission)"
+                    " VALUES"
+                    " (:role_id, :scope_type, :scope_id, :entity_type, :operation, :permission)"
+                ),
+                {
+                    "role_id": fixture_ids.role_id,
+                    "scope_type": str(ScopeType(EntityType("project"))),
+                    "scope_id": str(fixture_ids.bound_scope_id),
+                    "entity_type": str(_UNMAPPED_ENTITY_TYPE),
+                    "operation": OperationType.READ.value,
+                    "permission": int(Permission.READ),
+                },
+            )
+
+        async with db_with_rbac_tables.begin_readonly_session() as db_sess:
+            row = (await db_sess.scalars(sa.select(PermissionRow))).one()
+        assert row.entity_type == _UNMAPPED_ENTITY_TYPE
 
 
 class TestScopeMemberEnrollmentCascade:

--- a/tests/unit/manager/repositories/permission_controller/test_create_preset_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_create_preset_roles.py
@@ -203,11 +203,12 @@ class TestCreatePresetRoles:
                 )
             )
             for row in permission_rows:
-                assert row.scope_type == ScopeType.DOMAIN
+                assert row.scope_type == ScopeType.DOMAIN.value
                 assert row.scope_id == domain_id
-            assert {(row.entity_type, row.operation) for row in permission_rows} == set(
-                domain_preset.permissions
-            )
+            assert {(row.entity_type, row.operation) for row in permission_rows} == {
+                (entity_type.value, operation)
+                for entity_type, operation in domain_preset.permissions
+            }
 
     async def test_auto_assign_is_inherited_from_preset(
         self,

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -12,12 +12,11 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.manager.data.permission.types import (
-    EntityType,
     OperationType,
     Permission,
-    ScopeType,
 )
 from ai.backend.manager.errors.permission import RoleNotFound
 
@@ -77,9 +76,9 @@ def _spec(
 ) -> PermissionCreatorSpec:
     return PermissionCreatorSpec(
         role_id=role_id,
-        scope_type=scope_type,
+        scope_type=ScopeType(EntityType(scope_type)),
         scope_id=scope_id,
-        entity_type=entity_type,
+        entity_type=EntityType(entity_type),
         operation=operation,
     )
 
@@ -117,9 +116,9 @@ class TestBulkRolePermissions:
                 session.add(
                     PermissionRow(
                         role_id=role_id,
-                        scope_type=ScopeType(seed_permission.scope_type.value),
+                        scope_type=seed_permission.scope_type,
                         scope_id=seed_permission.scope_id,
-                        entity_type=EntityType(seed_permission.entity_type.value),
+                        entity_type=seed_permission.entity_type,
                         operation=seed_permission.operation,
                         permission=Permission.from_operation(seed_permission.operation),
                     )
@@ -138,9 +137,9 @@ class TestBulkRolePermissions:
                 PermissionRow(
                     id=permission_id,
                     role_id=spec.role_id,
-                    scope_type=ScopeType(spec.scope_type.value),
+                    scope_type=spec.scope_type,
                     scope_id=spec.scope_id,
-                    entity_type=EntityType(spec.entity_type.value),
+                    entity_type=spec.entity_type,
                     operation=spec.operation,
                     permission=Permission.from_operation(spec.operation),
                 )
@@ -201,9 +200,9 @@ class TestBulkRolePermissions:
         result = await perm_db_source.bulk_add_role_permissions(creator)
         assert result.success_count() == len(ALL_OWNER_OPS)
         assert not result.has_failures()
-        assert await self._list_operations(db_with_cleanup, role_id, EntityType.SESSION) == set(
-            ALL_OWNER_OPS
-        )
+        assert await self._list_operations(
+            db_with_cleanup, role_id, EntityType(RBACElementType.SESSION)
+        ) == set(ALL_OWNER_OPS)
 
     async def test_bulk_add_duplicate_rows_are_recorded_as_failures(
         self,
@@ -217,9 +216,9 @@ class TestBulkRolePermissions:
         second = await perm_db_source.bulk_add_role_permissions(creator)
         assert second.success_count() == 0
         assert len(second.errors) == len(ALL_OWNER_OPS)
-        assert await self._count_permissions(db_with_cleanup, role_id, EntityType.SESSION) == len(
-            ALL_OWNER_OPS
-        )
+        assert await self._count_permissions(
+            db_with_cleanup, role_id, EntityType(RBACElementType.SESSION)
+        ) == len(ALL_OWNER_OPS)
 
     async def test_bulk_add_with_empty_creator_is_noop(
         self,
@@ -310,9 +309,9 @@ class TestBulkRolePermissions:
         )
         assert result.success_count() == len(new_specs)
         assert await self._count_permissions(db_with_cleanup, role_id) == len(new_specs)
-        assert await self._list_operations(db_with_cleanup, role_id, EntityType.SESSION) == set(
-            ALL_OWNER_OPS
-        )
+        assert await self._list_operations(
+            db_with_cleanup, role_id, EntityType(RBACElementType.SESSION)
+        ) == set(ALL_OWNER_OPS)
 
     async def test_replace_with_empty_creator_clears_role(
         self,

--- a/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
@@ -150,7 +150,7 @@ class TestSearchPermissions:
 
         assert result.total_count == 2
         for item in result.items:
-            assert item.entity_type == EntityType.VFOLDER
+            assert item.entity_type == EntityType.VFOLDER.value
 
     async def test_search_permissions_ordered_by_entity_type(
         self,
@@ -166,4 +166,4 @@ class TestSearchPermissions:
         result = await repository.search_permissions(querier)
 
         entity_types = [item.entity_type for item in result.items]
-        assert entity_types == sorted(entity_types, key=lambda et: et.value)
+        assert entity_types == sorted(entity_types)

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -12,14 +12,19 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.permission.types import (
-    EntityType,
+    EntityType as LegacyEntityType,
+)
+from ai.backend.common.data.permission.types import (
     OperationType,
     Permission,
     RBACElementType,
     RelationType,
     RoleSource,
-    ScopeType,
+)
+from ai.backend.common.data.permission.types import (
+    ScopeType as LegacyScopeType,
 )
 from ai.backend.manager.actions.action import RBAC_ACTION_REGISTRY
 from ai.backend.manager.actions.action.rbac import RBACActionName
@@ -185,7 +190,7 @@ class TestCreateRole:
         mock_repository.create_role.return_value = role_data
 
         obj_perm = ObjectPermissionCreateInputBeforeRoleCreation(
-            entity_type=EntityType.USER,
+            entity_type=LegacyEntityType.USER,
             entity_id="user-1",
             operation=OperationType.READ,
             status=PermissionStatus.ACTIVE,
@@ -279,7 +284,7 @@ class TestGetRoleDetail:
         obj_perm = ObjectPermissionData(
             id=uuid.uuid4(),
             role_id=role_id,
-            object_id=ObjectId(entity_type=EntityType.USER, entity_id="user-1"),
+            object_id=ObjectId(entity_type=LegacyEntityType.USER, entity_id="user-1"),
             operation=OperationType.READ,
         )
         detail = _make_role_detail_data(role_id=role_id, object_permissions=[obj_perm])
@@ -684,9 +689,9 @@ class TestCreatePermission:
         perm_data = PermissionData(
             id=uuid.uuid4(),
             role_id=uuid.uuid4(),
-            scope_type=ScopeType.DOMAIN,
+            scope_type=ScopeType(EntityType(LegacyScopeType.DOMAIN)),
             scope_id="test-domain",
-            entity_type=EntityType.USER,
+            entity_type=EntityType(LegacyEntityType.USER),
             operation=OperationType.READ,
             permission=Permission.READ,
             created_at=datetime.now(UTC),
@@ -698,7 +703,7 @@ class TestCreatePermission:
         result = await service.create_permission(action)
 
         mock_repository.create_permission.assert_called_once_with(creator)
-        assert result.data.scope_type == ScopeType.DOMAIN
+        assert result.data.scope_type == LegacyScopeType.DOMAIN.value
 
     async def test_create_permission_global_scope(
         self,
@@ -708,9 +713,9 @@ class TestCreatePermission:
         perm_data = PermissionData(
             id=uuid.uuid4(),
             role_id=uuid.uuid4(),
-            scope_type=ScopeType.GLOBAL,
+            scope_type=ScopeType(EntityType(LegacyScopeType.GLOBAL)),
             scope_id="global",
-            entity_type=EntityType.USER,
+            entity_type=EntityType(LegacyEntityType.USER),
             operation=OperationType.CREATE,
             permission=Permission.CREATE,
             created_at=datetime.now(UTC),
@@ -720,7 +725,7 @@ class TestCreatePermission:
         action = CreatePermissionAction(creator=MagicMock())
         result = await service.create_permission(action)
 
-        assert result.data.scope_type == ScopeType.GLOBAL
+        assert result.data.scope_type == LegacyScopeType.GLOBAL.value
 
 
 class TestDeletePermission:
@@ -748,9 +753,9 @@ class TestDeletePermission:
         perm_data = PermissionData(
             id=uuid.uuid4(),
             role_id=uuid.uuid4(),
-            scope_type=ScopeType.DOMAIN,
+            scope_type=ScopeType(EntityType(LegacyScopeType.DOMAIN)),
             scope_id="test-domain",
-            entity_type=EntityType.USER,
+            entity_type=EntityType(LegacyEntityType.USER),
             operation=OperationType.READ,
             permission=Permission.READ,
             created_at=datetime.now(UTC),
@@ -790,9 +795,9 @@ class TestSearchPermissions:
         perm = PermissionData(
             id=uuid.uuid4(),
             role_id=uuid.uuid4(),
-            scope_type=ScopeType.DOMAIN,
+            scope_type=ScopeType(EntityType(LegacyScopeType.DOMAIN)),
             scope_id="test-domain",
-            entity_type=EntityType.USER,
+            entity_type=EntityType(LegacyEntityType.USER),
             operation=OperationType.READ,
             permission=Permission.READ,
             created_at=datetime.now(UTC),
@@ -922,7 +927,7 @@ class TestSearchEntities:
         service: PermissionControllerService,
         mock_repository: MagicMock,
     ) -> None:
-        entity_data = EntityData(entity_type=EntityType.USER, entity_id="user-1")
+        entity_data = EntityData(entity_type=LegacyEntityType.USER, entity_id="user-1")
         mock_result = SearchResult(
             items=[entity_data],
             total_count=1,
@@ -937,7 +942,7 @@ class TestSearchEntities:
 
         mock_repository.search_entities.assert_called_once_with(querier)
         assert result.result.total_count == 1
-        assert result.result.items[0].entity_type == EntityType.USER
+        assert result.result.items[0].entity_type == LegacyEntityType.USER
 
     async def test_search_entities_pagination(
         self,
@@ -983,8 +988,8 @@ class TestSearchElementAssociations:
     ) -> None:
         assoc = AssociationScopesEntitiesData(
             id=uuid.uuid4(),
-            scope_id=ScopeId(scope_type=ScopeType.DOMAIN, scope_id="test-domain"),
-            object_id=ObjectId(entity_type=EntityType.USER, entity_id="user-1"),
+            scope_id=ScopeId(scope_type=LegacyScopeType.DOMAIN, scope_id="test-domain"),
+            object_id=ObjectId(entity_type=LegacyEntityType.USER, entity_id="user-1"),
             relation_type=RelationType.AUTO,
             permission_cap=Permission.full(),
             registered_at=datetime.now(tz=UTC),


### PR DESCRIPTION
## Summary

- `permissions.entity_type` and `permissions.scope_type` move from `StrEnumType` over the closed `common.data.permission.types` enums to `sa.String(32)` with the open `common.data.entity.types` ones, matching how `entity_memberships` and `scope_bindings` already declare theirs. This closes the seam the virtual-scope chain spanned: the chain query bridged it by binding the open string as a plain VARCHAR, which was fail-closed — an entity type absent from the legacy enum matched no permission row — and writing was blocked from the other side, since the column bound through `value.value`. That bridge is gone.
- **No alembic migration.** `StrEnumType.impl` is `sa.VARCHAR`, so the DDL was already `VARCHAR(32)`; the live columns are `character varying(32)` with no CHECK constraints, and the original create used `sa.VARCHAR(length=32)`. Stored values were already plain strings, so no data migration either. Alembic autogenerate against a live database reports 0 diffs both before and after the change.
- `PermissionCreatorSpec` / `PermissionUpdaterSpec` carry the open types, dropping the `to_entity_type()` / `to_scope_type()` bridge from the permission write path; callers convert at their own boundary. `PermissionDTO.entity_type` widens with them, since a response holding an out-of-enum value would otherwise fail serialization.

### Scope decisions

- **`association_scopes_entities` stays on the legacy enums.** It is the association table the virtual-scope chain replaces rather than a member of it — the chain query joins `entity_memberships`, `scope_bindings`, `permissions`, `roles`, `user_roles` only — and its whole read/write surface is keyed on the closed `RBACElementType`, so widening the column alone would change no behavior.
- **Request DTOs keep their closed enums.** Responses widen because reads would otherwise break, but `CreatePermissionRequest` and the GraphQL `PermissionNode` keep validating against their enum and the adapters convert. Widening those would drop REST input validation and change the GraphQL supergraph.
- **Known remaining limit:** the preset and system-role seeding path is still keyed on `RBACElementType` and `RolePermissionPresetRow.entity_type`, both still closed. The `permissions` table itself is open now, but grants for entity types missing from those two vocabularies still cannot be authored. Confirming that every affected operation resolves a real permission needs that path opened as well.

## Test plan

- [x] `pants fmt` / `fix` / `lint` / `check` pass on the changed files
- [x] All 30 RBAC unit targets pass, including the virtual-scope chain suites (`test_check_permission_via_virtual_scope`, `test_resolve_effective_permissions`, `test_check_bulk_permission_with_scope_chain`)
- [x] `tests/component/rbac/test_rbac_permission.py` passes
- [x] Regression tests added over `role_preset`, a wired entity type absent from the legacy enum: `test_grant_over_unmapped_entity_type_resolves` authors a grant on it and resolves it through the virtual-scope chain, and `test_stored_unmapped_entity_type_reads_back` stores it directly and reads the row back through the ORM. Verified by A/B — reverting `src/` to `main` and rerunning the same two tests gives `2 failed`, with `AttributeError: 'EntityType' object has no attribute 'value'` on the write and `ValueError: 'role_preset' is not a valid EntityType` on the read, both at `models/base.py:327`; on this branch they give `2 passed`.
- [x] Verify the RBAC admin surfaces against a running server, admin and non-admin

Resolves BA-7498

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBFw11xQvmhWuP2qfrkmjU
