### PR TITLE
fix(BA-7487): drop zero-quantity resource slots at session enqueue

### DIFF
--- a/changes/13992.fix.md
+++ b/changes/13992.fix.md
@@ -1,0 +1,1 @@
+Fix sessions requesting a zero-quantity resource slot (e.g. cuda.device: 0) staying PENDING forever when scheduled onto agents that don't serve that slot

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -301,19 +301,23 @@ class SessionAdapter(BaseAdapter):
                 bootstrap_script=input.bootstrap_script,
             )
 
+        resource_entries = []
+        for e in input.resource_entries:
+            if Decimal(e.quantity) == 0:
+                continue
+            resource_entries.append(
+                ResourceSlotEntry(
+                    resource_type=e.resource_type,
+                    quantity=e.quantity,
+                )
+            )
         action = EnqueueSessionAction(
             project_id=ProjectID(group_id),
             session_name=input.session_name,
             session_type=SessionTypes(input.session_type.value),
             image_id=input.image_id,
             resource=SessionResourceSpec(
-                entries=[
-                    ResourceSlotEntry(
-                        resource_type=e.resource_type,
-                        quantity=e.quantity,
-                    )
-                    for e in input.resource_entries
-                ],
+                entries=resource_entries,
                 resource_group=input.resource_group,
                 resource_group_id=input.resource_group_id,
                 shmem=input.resource_opts.shmem.expr

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -301,9 +301,17 @@ class SessionAdapter(BaseAdapter):
                 bootstrap_script=input.bootstrap_script,
             )
 
+        parsed_entries = []
+        for e in input.resource_entries:
+            parsed_entries.append(
+                DataResourceSlotEntry(
+                    resource_type=ResourceSlotName(e.resource_type), quantity=e.quantity
+                )
+            )
+        requested_slots = DataResourceSlotEntry.inputs_to_resource_slot(parsed_entries)
         resource_entries = []
         for e in input.resource_entries:
-            if Decimal(e.quantity) == 0:
+            if requested_slots.get(e.resource_type, Decimal(0)) == 0:
                 continue
             resource_entries.append(
                 ResourceSlotEntry(


### PR DESCRIPTION
## Summary
- Sokovan's capacity gate matches an agent's `resource_allocations` rows by slot presence, so a zero-quantity slot absent from the agent (e.g. `cuda.device: 0` sent by the WebUI image-install flow) was rejected as a real shortage and the session stayed PENDING forever, retried every scheduling cycle.
- Filter out zero-quantity resource entries in `SessionAdapter.enqueue()` before building `EnqueueSessionAction`, so a zero-quantity slot never becomes a `resource_allocations` row in the first place. Both the REST v2 handler and the GraphQL resolver funnel through this same adapter method.
- Quantity strings can carry unit suffixes (e.g. `"1g"` for mem), so the zero check reuses `ResourceSlotEntry.inputs_to_resource_slot` (the same tolerant parser used downstream) instead of a bare `Decimal(quantity)`.

## Test plan
- [x] `pants test tests/unit/manager/api/adapters/test_session_adapter.py`
- [x] `pants fmt/lint/check` on the changed file
- [ ] Manual repro: enqueue a session with `{"cpu": "1", "mem": "1g", "cuda.device": "0"}` into a CPU-only resource group and confirm it schedules instead of staying PENDING

Resolves BA-7487