### PR TITLE
chore(BA-7501): resolve resource preset by name across scaling groups

### DIFF
--- a/changes/13997.misc.md
+++ b/changes/13997.misc.md
@@ -1,0 +1,1 @@
+Resolve resource preset by name across scaling groups instead of only global presets

--- a/src/ai/backend/manager/models/resource_preset/lookups.py
+++ b/src/ai/backend/manager/models/resource_preset/lookups.py
@@ -14,7 +14,8 @@ from ai.backend.manager.models.specs.lookup import DataLookup
 
 @dataclass
 class ResourcePresetNameLookup(DataLookup[ResourcePresetRow, ResourcePresetID]):
-    """Reads the preset a name refers to, within a resource group or outside one."""
+    """Reads the preset a name refers to, within a resource group, or across all of them
+    when none is given."""
 
     name: str
     resource_group_name: str | None = None
@@ -25,12 +26,12 @@ class ResourcePresetNameLookup(DataLookup[ResourcePresetRow, ResourcePresetID]):
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:
-        return [
-            lambda: ResourcePresetRow.name == self.name,
-            lambda: ResourcePresetRow.scaling_group_name.is_(None)
-            if self.resource_group_name is None
-            else ResourcePresetRow.scaling_group_name == self.resource_group_name,
-        ]
+        conditions: list[QueryCondition] = [lambda: ResourcePresetRow.name == self.name]
+        if self.resource_group_name is not None:
+            conditions.append(
+                lambda: ResourcePresetRow.scaling_group_name == self.resource_group_name
+            )
+        return conditions
 
     @override
     def to_entity_id(self, row: ResourcePresetRow) -> ResourcePresetID:


### PR DESCRIPTION
## Summary
- `delete_resource_preset` / `modify_resource_preset` resolve `name` through `ResourcePresetNameLookup`, which never received a `scaling_group_name`, so it always filtered on `scaling_group_name IS NULL`.
- A preset created inside a specific resource group could never be found by name alone, so name-only delete/update calls failed with "Entity not found".
- Fix: when `resource_group_name` is `None`, drop the scaling-group condition entirely (search across all groups) instead of forcing a NULL match; when it's given, filter on it as before.

## Test plan
- [x] `pants fmt/lint/check --changed-since=HEAD~1`
- [x] Created a preset scoped to the `default` resource group via GQL, then deleted it with the deprecated `delete_resource_preset(name: ...)` mutation (no scaling group arg) — previously failed with "Entity not found", now succeeds and the preset disappears from `resource-preset search`.

Resolves BA-7501