### PR TITLE
fix(BA-7499): validate default_value against effective value_type on preset update (#13994)

### DIFF
--- a/changes/13994.fix.md
+++ b/changes/13994.fix.md
@@ -1,0 +1,1 @@
+Fix runtime variant preset update accepting a default_value that does not match its value_type

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/request.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Self
 from uuid import UUID
 
@@ -10,34 +9,12 @@ from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
+    VALUE_TYPE_VALIDATORS,
     PresetTarget,
     PresetValueType,
     RuntimeVariantPresetOrderField,
     UIOption,
 )
-
-_VALID_BOOL_VALUES = ("true", "false", "1", "0")
-
-
-def _validate_bool(v: str) -> bool:
-    if v.lower() not in _VALID_BOOL_VALUES:
-        raise ValueError(f"expected one of {_VALID_BOOL_VALUES}, got '{v}'")
-    return v.lower() in ("true", "1")
-
-
-def _validate_flag(v: str) -> bool:
-    if v.lower() not in _VALID_BOOL_VALUES:
-        raise ValueError(f"expected one of {_VALID_BOOL_VALUES}, got '{v}'")
-    return v.lower() in ("true", "1")
-
-
-VALUE_TYPE_VALIDATORS: dict[PresetValueType, Callable[[str], object]] = {
-    PresetValueType.STR: str,
-    PresetValueType.INT: int,
-    PresetValueType.FLOAT: float,
-    PresetValueType.BOOL: _validate_bool,
-    PresetValueType.FLAG: _validate_flag,
-}
 
 
 class CreateRuntimeVariantPresetInput(BaseRequestModel):
@@ -106,6 +83,21 @@ class UpdateRuntimeVariantPresetInput(BaseRequestModel):
             and self.preset_target != PresetTarget.ARGS
         ):
             raise ValueError("value_type 'flag' is only valid with preset_target 'args'.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_default_value(self) -> Self:
+        if self.value_type is None or self.default_value is SENTINEL or self.default_value is None:
+            return self
+        validator = VALUE_TYPE_VALIDATORS.get(self.value_type)
+        if validator is None:
+            return self
+        try:
+            validator(self.default_value)
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                f"default_value '{self.default_value}' is not a valid {self.value_type}: {e}"
+            ) from e
         return self
 
 

--- a/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/types.py
+++ b/src/ai/backend/common/dto/manager/v2/runtime_variant_preset/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from enum import StrEnum
 from typing import Self
 
@@ -25,6 +26,30 @@ class PresetValueType(StrEnum):
     FLOAT = "float"
     BOOL = "bool"
     FLAG = "flag"
+
+
+_VALID_BOOL_VALUES = ("true", "false", "1", "0")
+
+
+def _validate_bool(v: str) -> bool:
+    if v.lower() not in _VALID_BOOL_VALUES:
+        raise ValueError(f"expected one of {_VALID_BOOL_VALUES}, got '{v}'")
+    return v.lower() in ("true", "1")
+
+
+def _validate_flag(v: str) -> bool:
+    if v.lower() not in _VALID_BOOL_VALUES:
+        raise ValueError(f"expected one of {_VALID_BOOL_VALUES}, got '{v}'")
+    return v.lower() in ("true", "1")
+
+
+VALUE_TYPE_VALIDATORS: dict[PresetValueType, Callable[[str], object]] = {
+    PresetValueType.STR: str,
+    PresetValueType.INT: int,
+    PresetValueType.FLOAT: float,
+    PresetValueType.BOOL: _validate_bool,
+    PresetValueType.FLAG: _validate_flag,
+}
 
 
 class UIType(StrEnum):

--- a/src/ai/backend/manager/services/runtime_variant_preset/service.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/service.py
@@ -2,6 +2,7 @@ import logging
 from typing import cast
 
 from ai.backend.common.dto.manager.v2.runtime_variant_preset.types import (
+    VALUE_TYPE_VALIDATORS,
     PresetTarget,
     PresetValueType,
 )
@@ -65,8 +66,23 @@ class RuntimeVariantPresetService:
         ):
             raise InvalidAPIParameters("value_type 'flag' is only valid with preset_target 'args'.")
 
+<<<<<<< HEAD
         action.updater.pk_value = action.id
         data = await self._repository.update(action.updater)
+=======
+        if updater.default_value.is_update():
+            new_default_value = updater.default_value.value()
+            validator = VALUE_TYPE_VALIDATORS[effective_value_type]
+            try:
+                validator(new_default_value)
+            except (ValueError, TypeError) as e:
+                raise InvalidAPIParameters(
+                    f"default_value '{new_default_value}' is not a valid "
+                    f"{effective_value_type}: {e}"
+                ) from e
+
+        data = await self._ops_repository.update(updater)
+>>>>>>> f1e76551 (fix(BA-7499): validate default_value against effective value_type on preset update (#13994))
         return UpdateRuntimeVariantPresetActionResult(preset=data)
 
     async def delete(

--- a/src/ai/backend/manager/services/runtime_variant_preset/service.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/service.py
@@ -66,12 +66,8 @@ class RuntimeVariantPresetService:
         ):
             raise InvalidAPIParameters("value_type 'flag' is only valid with preset_target 'args'.")
 
-<<<<<<< HEAD
-        action.updater.pk_value = action.id
-        data = await self._repository.update(action.updater)
-=======
-        if updater.default_value.is_update():
-            new_default_value = updater.default_value.value()
+        if spec.default_value.is_update():
+            new_default_value = spec.default_value.value()
             validator = VALUE_TYPE_VALIDATORS[effective_value_type]
             try:
                 validator(new_default_value)
@@ -81,8 +77,8 @@ class RuntimeVariantPresetService:
                     f"{effective_value_type}: {e}"
                 ) from e
 
-        data = await self._ops_repository.update(updater)
->>>>>>> f1e76551 (fix(BA-7499): validate default_value against effective value_type on preset update (#13994))
+        action.updater.pk_value = action.id
+        data = await self._repository.update(action.updater)
         return UpdateRuntimeVariantPresetActionResult(preset=data)
 
     async def delete(

--- a/tests/unit/common/dto/manager/v2/runtime_variant_preset/test_request.py
+++ b/tests/unit/common/dto/manager/v2/runtime_variant_preset/test_request.py
@@ -56,6 +56,36 @@ class TestCreateRuntimeVariantPresetInputFlagValidation:
         assert result.preset_target == PresetTarget.ENV
 
 
+class TestCreateRuntimeVariantPresetInputDefaultValueValidation:
+    """Regression tests for value_type-aware default_value validation on create."""
+
+    @pytest.mark.parametrize(
+        "default_value",
+        [pytest.param("42", id="valid"), pytest.param(None, id="omitted")],
+    )
+    def test_default_value_is_valid(self, default_value: str | None) -> None:
+        result = CreateRuntimeVariantPresetInput(
+            runtime_variant_id=uuid4(),
+            name="test-preset",
+            preset_target=PresetTarget.ENV,
+            key="MY_VAR",
+            value_type=PresetValueType.INT,
+            default_value=default_value,
+        )
+        assert result.default_value == default_value
+
+    def test_default_value_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="not a valid"):
+            CreateRuntimeVariantPresetInput(
+                runtime_variant_id=uuid4(),
+                name="test-preset",
+                preset_target=PresetTarget.ENV,
+                key="MY_VAR",
+                value_type=PresetValueType.INT,
+                default_value="abc",
+            )
+
+
 class TestUpdateRuntimeVariantPresetInputFlagValidation:
     """Tests for flag + preset_target validation on UpdateRuntimeVariantPresetInput."""
 
@@ -87,3 +117,35 @@ class TestUpdateRuntimeVariantPresetInputFlagValidation:
             preset_target=PresetTarget.ARGS,
         )
         assert result.value_type == PresetValueType.FLAG
+
+
+class TestUpdateRuntimeVariantPresetInputDefaultValueValidation:
+    """Tests for value_type-aware default_value validation on UpdateRuntimeVariantPresetInput."""
+
+    @pytest.fixture
+    def preset_id(self) -> UUID:
+        return uuid4()
+
+    def test_default_value_is_rejected(self, preset_id: UUID) -> None:
+        with pytest.raises(ValidationError, match="not a valid"):
+            UpdateRuntimeVariantPresetInput(
+                id=preset_id, value_type=PresetValueType.INT, default_value="abc"
+            )
+
+    @pytest.mark.parametrize(
+        ("value_type", "default_value"),
+        [
+            pytest.param(PresetValueType.INT, "42", id="matching"),
+            pytest.param(None, "abc", id="value_type_missing"),
+            pytest.param(PresetValueType.INT, None, id="default_value_missing"),
+        ],
+    )
+    def test_default_value_is_valid(
+        self, preset_id: UUID, value_type: PresetValueType | None, default_value: str | None
+    ) -> None:
+        """DTO can only statically validate when both fields are present in the same
+        request; a partial update is left to the service, which has DB state."""
+        result = UpdateRuntimeVariantPresetInput(
+            id=preset_id, value_type=value_type, default_value=default_value
+        )
+        assert result.id == preset_id

--- a/tests/unit/manager/services/runtime_variant_preset/test_service.py
+++ b/tests/unit/manager/services/runtime_variant_preset/test_service.py
@@ -186,16 +186,8 @@ class TestRuntimeVariantPresetServiceUpdateDefaultValueValidation:
         return MagicMock(spec=RuntimeVariantPresetRepository)
 
     @pytest.fixture
-    def mock_ops_repository(self) -> MagicMock:
-        return MagicMock(spec=OpsRepository)
-
-    @pytest.fixture
-    def service(
-        self, mock_repository: MagicMock, mock_ops_repository: MagicMock
-    ) -> RuntimeVariantPresetService:
-        return RuntimeVariantPresetService(
-            repository=mock_repository, ops_repository=mock_ops_repository
-        )
+    def service(self, mock_repository: MagicMock) -> RuntimeVariantPresetService:
+        return RuntimeVariantPresetService(repository=mock_repository)
 
     @pytest.fixture
     def preset_id(self) -> uuid.UUID:
@@ -205,8 +197,8 @@ class TestRuntimeVariantPresetServiceUpdateDefaultValueValidation:
     def int_preset(self, preset_id: uuid.UUID) -> RuntimeVariantPresetData:
         """Existing preset with value_type=int."""
         return RuntimeVariantPresetData(
-            id=RuntimeVariantPresetID(preset_id),
-            runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+            id=preset_id,
+            runtime_variant_id=uuid.uuid4(),
             name="test",
             description=None,
             rank=0,
@@ -231,11 +223,11 @@ class TestRuntimeVariantPresetServiceUpdateDefaultValueValidation:
         int_preset: RuntimeVariantPresetData,
     ) -> None:
         mock_repository.get_by_id = AsyncMock(return_value=int_preset)
-        updater = RuntimeVariantPresetUpdater(
-            preset_id=RuntimeVariantPresetID(preset_id),
+        spec = RuntimeVariantPresetUpdaterSpec(
             default_value=TriState.update("abc"),
         )
-        action = UpdateRuntimeVariantPresetAction(updater=updater)
+        updater: Updater[RuntimeVariantPresetRow] = Updater(spec=spec, pk_value=preset_id)
+        action = UpdateRuntimeVariantPresetAction(id=preset_id, updater=updater)
 
         with pytest.raises(InvalidAPIParameters, match="not a valid"):
             await service.update(action)
@@ -244,14 +236,13 @@ class TestRuntimeVariantPresetServiceUpdateDefaultValueValidation:
         self,
         service: RuntimeVariantPresetService,
         mock_repository: MagicMock,
-        mock_ops_repository: MagicMock,
         preset_id: uuid.UUID,
         int_preset: RuntimeVariantPresetData,
     ) -> None:
         """default_value="abc" is invalid for the stored INT type but valid for the
-        incoming STR type — the effective (new) type must be used, not the stored one."""
+        incoming STR type - the effective (new) type must be used, not the stored one."""
         updated_data = RuntimeVariantPresetData(
-            id=RuntimeVariantPresetID(preset_id),
+            id=preset_id,
             runtime_variant_id=int_preset.runtime_variant_id,
             name="test",
             description=None,
@@ -269,13 +260,13 @@ class TestRuntimeVariantPresetServiceUpdateDefaultValueValidation:
             updated_at=datetime(2024, 1, 2, tzinfo=UTC),
         )
         mock_repository.get_by_id = AsyncMock(return_value=int_preset)
-        mock_ops_repository.update = AsyncMock(return_value=updated_data)
-        updater = RuntimeVariantPresetUpdater(
-            preset_id=RuntimeVariantPresetID(preset_id),
+        mock_repository.update = AsyncMock(return_value=updated_data)
+        spec = RuntimeVariantPresetUpdaterSpec(
             value_type=OptionalState.update(PresetValueType.STR),
             default_value=TriState.update("abc"),
         )
-        action = UpdateRuntimeVariantPresetAction(updater=updater)
+        updater: Updater[RuntimeVariantPresetRow] = Updater(spec=spec, pk_value=preset_id)
+        action = UpdateRuntimeVariantPresetAction(id=preset_id, updater=updater)
 
         result = await service.update(action)
         assert result.preset.default_value == "abc"

--- a/tests/unit/manager/services/runtime_variant_preset/test_service.py
+++ b/tests/unit/manager/services/runtime_variant_preset/test_service.py
@@ -28,7 +28,7 @@ from ai.backend.manager.services.runtime_variant_preset.actions.update import (
 from ai.backend.manager.services.runtime_variant_preset.service import (
     RuntimeVariantPresetService,
 )
-from ai.backend.manager.types import OptionalState
+from ai.backend.manager.types import OptionalState, TriState
 
 
 class TestRuntimeVariantPresetServiceUpdateValidation:
@@ -176,3 +176,106 @@ class TestRuntimeVariantPresetServiceUpdateValidation:
 
         with pytest.raises(InvalidAPIParameters, match="flag"):
             await service.update(action)
+
+
+class TestRuntimeVariantPresetServiceUpdateDefaultValueValidation:
+    """Tests for value_type-aware default_value validation in service update."""
+
+    @pytest.fixture
+    def mock_repository(self) -> MagicMock:
+        return MagicMock(spec=RuntimeVariantPresetRepository)
+
+    @pytest.fixture
+    def mock_ops_repository(self) -> MagicMock:
+        return MagicMock(spec=OpsRepository)
+
+    @pytest.fixture
+    def service(
+        self, mock_repository: MagicMock, mock_ops_repository: MagicMock
+    ) -> RuntimeVariantPresetService:
+        return RuntimeVariantPresetService(
+            repository=mock_repository, ops_repository=mock_ops_repository
+        )
+
+    @pytest.fixture
+    def preset_id(self) -> uuid.UUID:
+        return uuid.uuid4()
+
+    @pytest.fixture
+    def int_preset(self, preset_id: uuid.UUID) -> RuntimeVariantPresetData:
+        """Existing preset with value_type=int."""
+        return RuntimeVariantPresetData(
+            id=RuntimeVariantPresetID(preset_id),
+            runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
+            name="test",
+            description=None,
+            rank=0,
+            preset_target=PresetTarget.ENV,
+            value_type=PresetValueType.INT,
+            default_value="1",
+            key="MY_VAR",
+            required=False,
+            category=None,
+            ui_type=None,
+            display_name=None,
+            ui_option=None,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=None,
+        )
+
+    async def test_default_value_is_rejected(
+        self,
+        service: RuntimeVariantPresetService,
+        mock_repository: MagicMock,
+        preset_id: uuid.UUID,
+        int_preset: RuntimeVariantPresetData,
+    ) -> None:
+        mock_repository.get_by_id = AsyncMock(return_value=int_preset)
+        updater = RuntimeVariantPresetUpdater(
+            preset_id=RuntimeVariantPresetID(preset_id),
+            default_value=TriState.update("abc"),
+        )
+        action = UpdateRuntimeVariantPresetAction(updater=updater)
+
+        with pytest.raises(InvalidAPIParameters, match="not a valid"):
+            await service.update(action)
+
+    async def test_effective_value_type_is_valid(
+        self,
+        service: RuntimeVariantPresetService,
+        mock_repository: MagicMock,
+        mock_ops_repository: MagicMock,
+        preset_id: uuid.UUID,
+        int_preset: RuntimeVariantPresetData,
+    ) -> None:
+        """default_value="abc" is invalid for the stored INT type but valid for the
+        incoming STR type — the effective (new) type must be used, not the stored one."""
+        updated_data = RuntimeVariantPresetData(
+            id=RuntimeVariantPresetID(preset_id),
+            runtime_variant_id=int_preset.runtime_variant_id,
+            name="test",
+            description=None,
+            rank=0,
+            preset_target=PresetTarget.ENV,
+            value_type=PresetValueType.STR,
+            default_value="abc",
+            key="MY_VAR",
+            required=False,
+            category=None,
+            ui_type=None,
+            display_name=None,
+            ui_option=None,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 2, tzinfo=UTC),
+        )
+        mock_repository.get_by_id = AsyncMock(return_value=int_preset)
+        mock_ops_repository.update = AsyncMock(return_value=updated_data)
+        updater = RuntimeVariantPresetUpdater(
+            preset_id=RuntimeVariantPresetID(preset_id),
+            value_type=OptionalState.update(PresetValueType.STR),
+            default_value=TriState.update("abc"),
+        )
+        action = UpdateRuntimeVariantPresetAction(updater=updater)
+
+        result = await service.update(action)
+        assert result.preset.default_value == "abc"


### PR DESCRIPTION
This is an auto-generated backport of #13994 to the 26.8 release.