### PR TITLE
fix(BA-7400): detect an agent worker that dies outside the shutdown path

### DIFF
--- a/changes/14003.fix.md
+++ b/changes/14003.fix.md
@@ -1,0 +1,1 @@
+Restart the agent when its worker process dies unexpectedly, instead of leaving the supervisor running with the service manager reporting the unit as active, and record a crash dump for native faults that leave no Python traceback.

--- a/configs/systemd/backendai-agent.service
+++ b/configs/systemd/backendai-agent.service
@@ -7,6 +7,7 @@ After=network.target remote-fs.target backendai-manager.service
 Type=simple
 ExecStart=/home/ubuntu/backend.ai/backend.ai ag start-server --debug
 WorkingDirectory=/home/ubuntu/backend.ai
+Environment=RUST_BACKTRACE=1
 User=ubuntu
 Group=ubuntu
 TimeoutStopSec=5

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -15,6 +15,7 @@ from collections.abc import (
     AsyncIterator,
     Callable,
     Coroutine,
+    Generator,
     Iterable,
     Mapping,
     Sequence,
@@ -27,6 +28,7 @@ from pprint import pformat, pprint
 from typing import (
     Any,
     ClassVar,
+    Final,
     Literal,
     cast,
     override,
@@ -100,6 +102,8 @@ from ai.backend.common.metrics.http import (
 from ai.backend.common.metrics.metric import CommonMetricRegistry
 from ai.backend.common.metrics.profiler import Profiler, PyroscopeArgs
 from ai.backend.common.networking import force_threaded_dns_resolver
+from ai.backend.common.process.child_exit import ChildExitMonitor, ChildStatus
+from ai.backend.common.process.crashdump import enable_crash_dump
 from ai.backend.common.service_discovery.etcd_discovery.service_discovery import (
     ETCDServiceDiscovery,
     ETCDServiceDiscoveryArgs,
@@ -153,6 +157,9 @@ from .types import (
 from .utils import get_subnet_ip
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+_CRASH_DUMP_DIR_NAME: Final[str] = "crash-dumps"
+_NUM_WORKERS: Final[int] = 1
 
 
 def collect_error(meth: Callable[..., Any]) -> Callable[..., Any]:
@@ -1248,6 +1255,10 @@ async def server_main_logwrapper(
     setproctitle(f"backend.ai: agent worker-{pidx}")
     local_cfg: AgentUnifiedConfig = _args[0]
     log_endpoint = _args[1]
+    child_statuses: Sequence[ChildStatus] = _args[2]
+    child_status = child_statuses[pidx]
+    child_status.publish_pid()
+    enable_crash_dump(local_cfg.agent_common.var_base_path / _CRASH_DUMP_DIR_NAME, f"worker-{pidx}")
     logger = Logger(
         local_cfg.logging,
         is_master=False,
@@ -1261,6 +1272,7 @@ async def server_main_logwrapper(
         with logger:
             async with server_main(loop, pidx, _args):
                 yield
+            child_status.mark_clean_shutdown()
     except Exception:
         traceback.print_exc(file=sys.stderr)
 
@@ -1756,8 +1768,28 @@ def main(
             with logger:
                 ns = server_config.etcd.namespace
                 setproctitle(f"backend.ai: agent {ns}")
+                enable_crash_dump(
+                    server_config.agent_common.var_base_path / _CRASH_DUMP_DIR_NAME,
+                    "supervisor",
+                )
                 log.info("Backend.AI Agent {0}", VERSION)
                 log.info("runtime: {0}", utils.env_info())
+
+                # Built here rather than at module scope: these allocate shared memory
+                # and a semaphore, which no other `ag` subcommand has any use for.
+                child_statuses = tuple(ChildStatus() for _ in range(_NUM_WORKERS))
+                child_exit_monitor = ChildExitMonitor(child_statuses)
+
+                @aiotools.main_context
+                def server_main_ctx() -> Generator[None, signal.Signals, None]:
+                    """Tear the supervisor down when a worker dies outside the shutdown
+                    path, so that the service manager sees a failed unit instead of a
+                    supervisor with no worker."""
+                    child_exit_monitor.start()
+                    try:
+                        yield
+                    finally:
+                        child_exit_monitor.disarm()
 
                 log_config = logging.getLogger("ai.backend.agent.config")
                 if log_level == LogLevel.DEBUG:
@@ -1773,12 +1805,14 @@ def main(
                         runner = asyncio.run
                 aiotools.start_server(
                     server_main_logwrapper,
-                    num_workers=1,
-                    args=(server_config, log_endpoint),
+                    main_ctxmgr=server_main_ctx,
+                    num_workers=_NUM_WORKERS,
+                    args=(server_config, log_endpoint, child_statuses),
                     wait_timeout=5.0,
                     runner=runner,
                 )
                 log.info("exit.")
+                child_exit_monitor.raise_system_exit()
         finally:
             if server_config.agent_common.pid_file.is_file():
                 # check is_file() to prevent deleting /dev/null!

--- a/src/ai/backend/common/process/child_exit.py
+++ b/src/ai/backend/common/process/child_exit.py
@@ -1,0 +1,149 @@
+"""Detection of child processes that die without going through the shutdown path."""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+import os
+import signal
+import threading
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from multiprocessing.sharedctypes import Synchronized
+from multiprocessing.synchronize import Event as MPEvent
+from typing import Final
+
+from ai.backend.logging.utils import BraceStyleAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+_POLL_INTERVAL: Final[float] = 0.05
+_UNPUBLISHED_PID: Final[int] = 0
+
+
+@dataclass(frozen=True)
+class ChildExit:
+    pid: int
+    si_code: int
+    si_status: int
+
+    def describe(self) -> str:
+        match self.si_code:
+            case os.CLD_KILLED | os.CLD_DUMPED:
+                return f"was killed by {signal.Signals(self.si_status).name}"
+            case os.CLD_EXITED:
+                return f"exited with code {self.si_status}"
+            case _:
+                return f"exited with si_code={self.si_code}, si_status={self.si_status}"
+
+
+@dataclass(frozen=True)
+class ChildCheck:
+    """Whether the child has ended, and how it ended while the exit status is still
+    available. aiotools may have reaped the status already, leaving only the fact."""
+
+    ended: bool
+    child_exit: ChildExit | None = None
+
+
+@dataclass(frozen=True)
+class ChildStatus:
+    """One child's process ID and whether it reached the end of its shutdown path.
+    Both live in shared memory because the child writes them and the supervisor reads
+    them. Create one per child and hand it to that child through the worker arguments."""
+
+    pid: Synchronized[int] = field(
+        default_factory=lambda: mp.Value("i", _UNPUBLISHED_PID),
+    )
+    clean_shutdown: MPEvent = field(default_factory=mp.Event)
+
+    def publish_pid(self) -> None:
+        """Call once the child process has started."""
+        self.pid.value = os.getpid()
+
+    def mark_clean_shutdown(self) -> None:
+        """Call once the child has finished its shutdown routines."""
+        self.clean_shutdown.set()
+
+
+class ChildExitMonitor:
+    """Turn a child that stopped without being asked to into a non-zero exit code, and
+    shut the supervisor down if nothing else does. `aiotools.start_server()` keeps the
+    parent alive when a worker dies, so the service manager sees a healthy unit that no
+    longer serves anything."""
+
+    _statuses: Final[Sequence[ChildStatus]]
+    _armed: Final[threading.Event]
+    _thread: threading.Thread | None
+
+    def __init__(self, statuses: Sequence[ChildStatus]) -> None:
+        self._statuses = statuses
+        self._armed = threading.Event()
+        self._thread = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._armed.set()
+        self._thread = threading.Thread(
+            target=self._observe, name="child-exit-monitor", daemon=True
+        )
+        self._thread.start()
+
+    def raise_system_exit(self) -> None:
+        """Fail the process unless every child ran its shutdown routines. Call this once
+        the server has stopped: a zero exit code tells a service manager that the stop
+        was intended, so `Restart=on-failure` would not fire."""
+        if all(status.clean_shutdown.is_set() for status in self._statuses):
+            return
+        raise SystemExit(1)
+
+    def disarm(self) -> None:
+        """Stop watching, so an expected shutdown does not draw a redundant signal."""
+        self._armed.clear()
+
+    def _observe(self) -> None:
+        # Watching for a child's presence rather than reaping its exit status: aiotools
+        # reaps through its own pidfd reader, and a second reaper would race it for the
+        # single status the kernel keeps. Presence cannot be consumed by anyone else, and
+        # whether the stop was intended is answered by the flag the child sets, not here.
+        while self._armed.is_set():
+            time.sleep(_POLL_INTERVAL)
+            for status in self._statuses:
+                pid = status.pid.value
+                if pid == _UNPUBLISHED_PID:
+                    continue
+                check = self._check_ended(pid)
+                if not check.ended or status.clean_shutdown.is_set():
+                    continue
+                self._request_shutdown(pid, check.child_exit)
+                return
+
+    def _check_ended(self, pid: int) -> ChildCheck:
+        """`WNOWAIT` keeps this check from consuming the exit status, so that aiotools
+        can still reap the child itself."""
+        try:
+            info = os.waitid(os.P_PID, pid, os.WEXITED | os.WNOWAIT | os.WNOHANG)
+        except ChildProcessError:
+            return ChildCheck(ended=True)
+        except OSError as e:
+            log.warning("stopped watching the child process {}: {}", pid, e)
+            return ChildCheck(ended=False)
+        if info is None:
+            return ChildCheck(ended=False)
+        return ChildCheck(
+            ended=True,
+            child_exit=ChildExit(info.si_pid, info.si_code, info.si_status),
+        )
+
+    def _request_shutdown(self, pid: int, child_exit: ChildExit | None) -> None:
+        log.error(
+            "The child process {} {} without being asked to stop. Shutting down the "
+            "supervisor so that the service manager can restart it.",
+            pid,
+            child_exit.describe() if child_exit is not None else "terminated",
+        )
+        # Go through the stop signal the supervisor already handles, so that the
+        # remaining shutdown routines still run.
+        os.kill(os.getpid(), signal.SIGINT)

--- a/src/ai/backend/common/process/crashdump.py
+++ b/src/ai/backend/common/process/crashdump.py
@@ -1,0 +1,38 @@
+"""Crash dumps for native faults that never reach Python exception handling."""
+
+from __future__ import annotations
+
+import faulthandler
+import logging
+import os
+from pathlib import Path
+from typing import IO, Final
+
+from ai.backend.logging.utils import BraceStyleAdapter
+
+log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+# faulthandler writes through a raw file descriptor, so the file object must outlive the call.
+_dump_file: IO[str] | None = None
+# Tracked separately because a forked worker inherits the file of its supervisor.
+_dump_pid: int | None = None
+
+
+def enable_crash_dump(dump_dir: Path, tag: str) -> None:
+    """Dump a Python traceback of every thread into `dump_dir` when the process
+    receives SIGABRT, SIGSEGV, SIGBUS, SIGFPE, or SIGILL.
+    Aborts from native extensions (e.g. a Rust panic at the FFI boundary) land here."""
+    global _dump_file, _dump_pid
+    pid = os.getpid()
+    if _dump_pid == pid:
+        return
+    dump_path = dump_dir / f"crash-{tag}-{pid}.log"
+    try:
+        dump_dir.mkdir(parents=True, exist_ok=True)
+        _dump_file = dump_path.open("a", buffering=1)
+    except OSError as e:
+        log.warning("could not open the crash dump file {}: {}", dump_path, e)
+        return
+    _dump_pid = pid
+    faulthandler.enable(file=_dump_file, all_threads=True)
+    log.debug("crash dumps enabled at {}", dump_path)


### PR DESCRIPTION
## Summary

- `aiotools.start_server()` does not respawn workers. When the agent worker died, the supervisor stayed alive, so `systemctl status` kept reporting `active (running)`, `Restart=on-failure` never fired, and the node left the cluster silently — only the manager-side LOST state showed it. Reproduced locally: the supervisor also spins at ~98% CPU afterwards, because the worker-to-parent interrupt pipe stays readable at EOF and `handle_child_interrupt()` ignores EOF without removing the reader.
- A new supervisor-side monitor (`common/process/child_exit.py`) watches for a child that exits by signal or with a non-zero code and tears the supervisor down, so the service manager sees a failed unit. It uses `WNOWAIT`, so aiotools keeps its right to reap the child.
- The agent now enables `faulthandler` in both the supervisor and the worker (`common/process/crashdump.py`), writing to `<var-base-path>/crash-dumps/`. The field crash was a SIGABRT from a native extension, which leaves no Python traceback and no journal entry — that is why it could not be diagnosed.

## Details

| Change | File |
|---|---|
| `ChildExit`, `ChildExitMonitor` | `common/process/child_exit.py` (new) |
| `enable_crash_dump()` | `common/process/crashdump.py` (new) |
| Monitor wired through a main context manager; `SystemExit(1)` on an abnormal worker exit | `agent/server.py` |
| Crash dumps enabled for the supervisor and the worker | `agent/server.py` |
| `Environment=RUST_BACKTRACE=1` | `configs/systemd/backendai-agent.service` |

The non-zero exit code is required: under click's standalone mode the `return 0` in `main()` never reaches the exit status, and a clean exit would keep `Restart=on-failure` from firing.

Scope is limited to the agent. `aiotools.start_server()` is used by seven components, but `manager`, `storage` and `web` run with `num_workers > 1`, where "one worker died, restart the whole unit" means something different. The two helpers live in `common/` so those components can adopt them separately.

## Test plan

Verified against a real `aiotools.start_server()` using the shipped modules:

- [x] Worker `os.abort()` (SIGABRT) — supervisor reports `killed by SIGABRT`, exits **1** within ~1.4s, no CPU spin
- [x] Worker killed externally by SIGKILL (OOM-killer analogue) — supervisor exits **1**
- [x] SIGTERM to the supervisor (`systemctl stop`) — worker shuts down gracefully, supervisor exits **0**, no false positive
- [x] SIGINT to the supervisor — supervisor exits **0**, no false positive
- [x] Crash dump contains `Fatal Python error: Aborted` plus a Python traceback for every thread
- [x] Grandchild deaths are invisible to `waitid(P_ALL)`, so a subprocess of the worker cannot trigger a restart
- [x] Confirm `waitid(P_ALL, WNOWAIT)` behaviour on Linux (verified on macOS only)
- [x] Confirm on a Linux node that a crash dump is produced for a real worker abort

## Known limitations

- On Linux with pidfd, aiotools registers `loop.add_reader(pidfd, _do_wait)` which reaps without `WNOWAIT`. If that callback wins the race, the monitor never observes the exit and behaviour degrades to today's — it can only miss, never mis-fire. In the reported incident the child was left as a zombie, so that callback demonstrably did not run. Making it race-free needs `Type=notify` + `WatchdogSec`, which would also cover a hung worker; `common/sd_notify.py` already has the client for it and currently has no users.
- A worker that crashes on every start now produces a restart loop. `RestartSec=10` keeps systemd's default `StartLimitIntervalSec=10s`/`StartLimitBurst=5` from ever tripping. Left as is; capping it needs a `StartLimitIntervalSec=600` decision on the unit.
- The agent's own core dumps are still off. `debug.coredump` is container-only (`agent/docker/agent.py` mounts it into kernel containers), so an empty `coredumps/` says nothing about the agent process. `faulthandler` covers the Python side; enabling `LimitCORE` fleet-wide risks filling disks with GB-scale static-python cores.

Resolves BA-7400