### PR TITLE
fix(BA-7487): drop zero-quantity resource slots at session enqueue (#13992)

### DIFF
--- a/changes/13992.fix.md
+++ b/changes/13992.fix.md
@@ -1,0 +1,1 @@
+Fix sessions requesting a zero-quantity resource slot (e.g. cuda.device: 0) staying PENDING forever when scheduled onto agents that don't serve that slot

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -261,18 +261,30 @@ class SessionAdapter(BaseAdapter):
                 bootstrap_script=input.bootstrap_script,
             )
 
+        parsed_entries = []
+        for e in input.resource_entries:
+            parsed_entries.append(
+                DataResourceSlotEntry(
+                    resource_type=ResourceSlotName(e.resource_type), quantity=e.quantity
+                )
+            )
+        requested_slots = DataResourceSlotEntry.inputs_to_resource_slot(parsed_entries)
+        resource_entries = []
+        for e in input.resource_entries:
+            if requested_slots.get(e.resource_type, Decimal(0)) == 0:
+                continue
+            resource_entries.append(
+                ResourceSlotEntry(
+                    resource_type=e.resource_type,
+                    quantity=e.quantity,
+                )
+            )
         action = EnqueueSessionAction(
             session_name=input.session_name,
             session_type=SessionTypes(input.session_type.value),
             image_id=input.image_id,
             resource=SessionResourceSpec(
-                entries=[
-                    ResourceSlotEntry(
-                        resource_type=e.resource_type,
-                        quantity=e.quantity,
-                    )
-                    for e in input.resource_entries
-                ],
+                entries=resource_entries,
                 resource_group=input.resource_group,
                 shmem=input.resource_opts.shmem.expr
                 if input.resource_opts and input.resource_opts.shmem


### PR DESCRIPTION
This is an auto-generated backport of #13992 to the 26.4 release.