### PR TITLE
feat(BA-7309): sign requests against X-Forwarded-Prefix path

### DIFF
--- a/changes/14006.feature.md
+++ b/changes/14006.feature.md
@@ -1,0 +1,1 @@
+Support X-Forwarded-Prefix so signature verification covers the path actually routed behind a prefix-mounted reverse proxy

--- a/configs/manager/sample.toml
+++ b/configs/manager/sample.toml
@@ -192,11 +192,12 @@
   # the client IP is resolved by walking the X-Forwarded-For chain inwards from
   # the peer of the connection and taking the first address that is not one of
   # these proxies, so any number of proxy hops is supported. The X-Forwarded-URL
-  # header, which overrides the host and path used for HMAC signature
-  # verification, is honored only when the request comes directly from one of
-  # these proxies. If empty (default), the manager falls back to manual
-  # X-Forwarded-For parsing and accepts X-Forwarded-URL from any client, which
-  # is deprecated.
+  # and X-Forwarded-Prefix headers, which override the host and path used for
+  # HMAC signature verification, are honored only when the request comes
+  # directly from one of these proxies; X-Forwarded-Prefix is ignored entirely
+  # when this list is empty. If empty (default), the manager falls back to
+  # manual X-Forwarded-For parsing and accepts X-Forwarded-URL from any client,
+  # which is deprecated.
   # Added in 26.4.2
   trusted-proxies = ["10.0.0.0/8", "172.16.0.0/12"]
   # Event loop implementation to use for async operations. 'asyncio' is the

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -446,14 +446,6 @@ def _resolve_forwarded_url(request: web.Request) -> str | None:
     return upstream_url
 
 
-@functools.cache
-def _warn_forwarded_url_path_deprecated() -> None:
-    log.warning(
-        "Deriving the signed path from the X-Forwarded-URL header is deprecated; "
-        "configure the reverse proxy to send X-Forwarded-Prefix instead."
-    )
-
-
 def _resolve_forwarded_prefix(request: web.Request) -> str | None:
     """Return the ``X-Forwarded-Prefix`` value only when its origin may be trusted.
 
@@ -522,7 +514,6 @@ async def sign_request(sign_method: str, request: web.Request, secret_key: str) 
             path = prefix + request.raw_path
         elif upstream_url:
             path = urlparse(upstream_url).path
-            _warn_forwarded_url_path_deprecated()
 
         sign_bytes = "{0}\n{1}\n{2}\nhost:{3}\ncontent-type:{4}\nx-{name}-version:{5}\n{6}".format(
             request.method,

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -520,8 +520,6 @@ async def sign_request(sign_method: str, request: web.Request, secret_key: str) 
         prefix = _resolve_forwarded_prefix(request)
         if prefix is not None:
             path = prefix + request.raw_path
-            if upstream_url:
-                _warn_forwarded_url_path_deprecated()
         elif upstream_url:
             path = urlparse(upstream_url).path
             _warn_forwarded_url_path_deprecated()

--- a/src/ai/backend/manager/api/rest/middleware/auth.py
+++ b/src/ai/backend/manager/api/rest/middleware/auth.py
@@ -77,6 +77,7 @@ log: Final = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 TRUSTED_PROXY_NETWORKS_KEY: Final = "_trusted_proxy_networks"
 FORWARDED_URL_HEADER: Final = "X-Forwarded-URL"
+FORWARDED_PREFIX_HEADER: Final = "X-Forwarded-Prefix"
 
 _whois_timezone_info: Final = {
     "A": 1 * 3600,
@@ -445,6 +446,31 @@ def _resolve_forwarded_url(request: web.Request) -> str | None:
     return upstream_url
 
 
+@functools.cache
+def _warn_forwarded_url_path_deprecated() -> None:
+    log.warning(
+        "Deriving the signed path from the X-Forwarded-URL header is deprecated; "
+        "configure the reverse proxy to send X-Forwarded-Prefix instead."
+    )
+
+
+def _resolve_forwarded_prefix(request: web.Request) -> str | None:
+    """Return the ``X-Forwarded-Prefix`` value only when its origin may be trusted.
+
+    Unlike ``X-Forwarded-URL``, there is no untrusted-origin fallback for this header.
+    """
+    raw_prefix = request.headers.get(FORWARDED_PREFIX_HEADER)
+    if raw_prefix is None:
+        return None
+    if not is_from_trusted_proxy(request):
+        log.debug(
+            "ignored the X-Forwarded-Prefix header sent from an untrusted peer (peer:{})",
+            _peer_address(request),
+        )
+        return None
+    return raw_prefix.rstrip("/")
+
+
 def check_date(request: web.Request) -> bool:
     raw_date = request.headers.get("Date")
     if not raw_date:
@@ -487,10 +513,18 @@ async def sign_request(sign_method: str, request: web.Request, secret_key: str) 
         body_hash = hashlib.new(hash_type, body).hexdigest()
         path = request.raw_path
         host = request.host
-        if upstream_url := _resolve_forwarded_url(request):
-            parsed_url = urlparse(upstream_url)
-            path = parsed_url.path
-            host = parsed_url.netloc
+        upstream_url = _resolve_forwarded_url(request)
+        if upstream_url:
+            host = urlparse(upstream_url).netloc
+
+        prefix = _resolve_forwarded_prefix(request)
+        if prefix is not None:
+            path = prefix + request.raw_path
+            if upstream_url:
+                _warn_forwarded_url_path_deprecated()
+        elif upstream_url:
+            path = urlparse(upstream_url).path
+            _warn_forwarded_url_path_deprecated()
 
         sign_bytes = "{0}\n{1}\n{2}\nhost:{3}\ncontent-type:{4}\nx-{name}-version:{5}\n{6}".format(
             request.method,

--- a/src/ai/backend/manager/config/unified.py
+++ b/src/ai/backend/manager/config/unified.py
@@ -921,9 +921,10 @@ class ManagerConfig(BaseConfigSchema):
                 "When configured, the client IP is resolved by walking the X-Forwarded-For chain "
                 "inwards from the peer of the connection and taking the first address that is not "
                 "one of these proxies, so any number of proxy hops is supported. "
-                "The X-Forwarded-URL header, which overrides the host and path used for HMAC "
-                "signature verification, is honored only when the request comes directly from one "
-                "of these proxies. "
+                "The X-Forwarded-URL and X-Forwarded-Prefix headers, which override the host and "
+                "path used for HMAC signature verification, are honored only when the request "
+                "comes directly from one of these proxies; X-Forwarded-Prefix is ignored entirely "
+                "when this list is empty. "
                 "If empty (default), the manager falls back to manual X-Forwarded-For parsing and "
                 "accepts X-Forwarded-URL from any client, which is deprecated."
             ),

--- a/tests/unit/manager/api/test_auth_trusted_proxy.py
+++ b/tests/unit/manager/api/test_auth_trusted_proxy.py
@@ -196,19 +196,32 @@ async def test_no_warning_when_forwarded_url_is_absent(
 
 class TestSignRequestForwardedPrefix:
     @pytest.mark.parametrize(
-        ("peer", "expected_path"),
+        ("peer", "trusted_proxies", "expected_path"),
         [
             pytest.param(
-                TRUSTED_PROXY, FORWARDED_PREFIX + DEFAULT_PATH, id="honored_from_trusted_peer"
+                TRUSTED_PROXY,
+                ["10.0.0.0/8"],
+                FORWARDED_PREFIX + DEFAULT_PATH,
+                id="honored_from_trusted_peer",
             ),
-            pytest.param(UNTRUSTED_PEER, DEFAULT_PATH, id="ignored_from_untrusted_peer"),
+            pytest.param(
+                UNTRUSTED_PEER, ["10.0.0.0/8"], DEFAULT_PATH, id="ignored_from_untrusted_peer"
+            ),
+            pytest.param(
+                TRUSTED_PROXY,
+                [],
+                DEFAULT_PATH,
+                id="ignored_without_trusted_proxies_configured",
+            ),
         ],
     )
-    async def test_is_honored_based_on_trust(self, peer: str, expected_path: str) -> None:
+    async def test_is_honored_based_on_trust(
+        self, peer: str, trusted_proxies: list[str], expected_path: str
+    ) -> None:
         prefixed = _make_request(
-            forwarded_prefix=FORWARDED_PREFIX, peer=peer, trusted_proxies=["10.0.0.0/8"]
+            forwarded_prefix=FORWARDED_PREFIX, peer=peer, trusted_proxies=trusted_proxies
         )
-        literal = _make_request(raw_path=expected_path, peer=peer, trusted_proxies=["10.0.0.0/8"])
+        literal = _make_request(raw_path=expected_path, peer=peer, trusted_proxies=trusted_proxies)
 
         assert await sign_request(SIGN_METHOD, prefixed, SECRET_KEY) == await sign_request(
             SIGN_METHOD, literal, SECRET_KEY

--- a/tests/unit/manager/api/test_auth_trusted_proxy.py
+++ b/tests/unit/manager/api/test_auth_trusted_proxy.py
@@ -11,6 +11,7 @@ from dateutil.tz import tzutc
 from ai.backend.common.exception import InvalidIpAddressValue
 from ai.backend.manager.api.rest.middleware import auth as auth_module
 from ai.backend.manager.api.rest.middleware.auth import (
+    FORWARDED_PREFIX_HEADER,
     FORWARDED_URL_HEADER,
     TRUSTED_PROXY_NETWORKS_KEY,
     extract_client_ip,
@@ -24,6 +25,7 @@ SECRET_KEY = "fake-secret-key"
 DEFAULT_HOST = "10.214.150.180:8081"
 DEFAULT_PATH = "/admin/gql"
 FORWARDED_URL = "https://example.invalid/proxied/admin/gql"
+FORWARDED_PREFIX = "/bai"
 TRUSTED_PROXY = "10.0.0.1"
 UNTRUSTED_PEER = "203.0.113.7"
 
@@ -33,6 +35,7 @@ def _make_request(
     host: str = DEFAULT_HOST,
     raw_path: str = DEFAULT_PATH,
     forwarded_url: str | None = None,
+    forwarded_prefix: str | None = None,
     forwarded_for: str | None = None,
     peer: str | None = TRUSTED_PROXY,
     trusted_proxies: list[str] | None = None,
@@ -42,6 +45,8 @@ def _make_request(
     headers = {"X-BackendAI-Version": "v8.20240915"}
     if forwarded_url is not None:
         headers[FORWARDED_URL_HEADER] = forwarded_url
+    if forwarded_prefix is not None:
+        headers[FORWARDED_PREFIX_HEADER] = forwarded_prefix
     if forwarded_for is not None:
         headers["X-Forwarded-For"] = forwarded_for
 
@@ -69,6 +74,7 @@ def _make_request(
 @pytest.fixture(autouse=True)
 def reset_deprecation_warning() -> None:
     auth_module._warn_forwarded_url_without_trusted_proxies.cache_clear()
+    auth_module._warn_forwarded_url_path_deprecated.cache_clear()
 
 
 def test_parse_trusted_proxy_networks_accepts_bare_addresses_cidrs_and_wildcards() -> None:
@@ -186,6 +192,68 @@ async def test_no_warning_when_forwarded_url_is_absent(
     assert not [
         record for record in caplog.records if "manager.trusted-proxies" in record.getMessage()
     ]
+
+
+class TestSignRequestForwardedPrefix:
+    @pytest.mark.parametrize(
+        ("peer", "expected_path"),
+        [
+            pytest.param(
+                TRUSTED_PROXY, FORWARDED_PREFIX + DEFAULT_PATH, id="honored_from_trusted_peer"
+            ),
+            pytest.param(UNTRUSTED_PEER, DEFAULT_PATH, id="ignored_from_untrusted_peer"),
+        ],
+    )
+    async def test_is_honored_based_on_trust(self, peer: str, expected_path: str) -> None:
+        prefixed = _make_request(
+            forwarded_prefix=FORWARDED_PREFIX, peer=peer, trusted_proxies=["10.0.0.0/8"]
+        )
+        literal = _make_request(raw_path=expected_path, peer=peer, trusted_proxies=["10.0.0.0/8"])
+
+        assert await sign_request(SIGN_METHOD, prefixed, SECRET_KEY) == await sign_request(
+            SIGN_METHOD, literal, SECRET_KEY
+        )
+
+    @pytest.mark.parametrize(
+        ("raw_prefix", "expected_path"),
+        [
+            pytest.param(
+                FORWARDED_PREFIX + "/",
+                FORWARDED_PREFIX + DEFAULT_PATH,
+                id="trailing_slash_stripped",
+            ),
+            pytest.param("", DEFAULT_PATH, id="empty_prefix_is_no_prefix"),
+        ],
+    )
+    async def test_normalizes_prefix_value(self, raw_prefix: str, expected_path: str) -> None:
+        given = _make_request(
+            forwarded_prefix=raw_prefix, peer=TRUSTED_PROXY, trusted_proxies=["10.0.0.0/8"]
+        )
+        literal = _make_request(
+            raw_path=expected_path, peer=TRUSTED_PROXY, trusted_proxies=["10.0.0.0/8"]
+        )
+
+        assert await sign_request(SIGN_METHOD, given, SECRET_KEY) == await sign_request(
+            SIGN_METHOD, literal, SECRET_KEY
+        )
+
+    async def test_takes_priority_over_forwarded_url_path(self) -> None:
+        both = _make_request(
+            forwarded_prefix=FORWARDED_PREFIX,
+            forwarded_url=FORWARDED_URL,
+            peer=TRUSTED_PROXY,
+            trusted_proxies=["10.0.0.0/8"],
+        )
+        upstream_host_with_prefixed_path = _make_request(
+            host="example.invalid",
+            raw_path=FORWARDED_PREFIX + DEFAULT_PATH,
+            peer=TRUSTED_PROXY,
+            trusted_proxies=["10.0.0.0/8"],
+        )
+
+        assert await sign_request(SIGN_METHOD, both, SECRET_KEY) == await sign_request(
+            SIGN_METHOD, upstream_host_with_prefixed_path, SECRET_KEY
+        )
 
 
 class TestExtractClientIP:

--- a/tests/unit/manager/api/test_auth_trusted_proxy.py
+++ b/tests/unit/manager/api/test_auth_trusted_proxy.py
@@ -74,7 +74,6 @@ def _make_request(
 @pytest.fixture(autouse=True)
 def reset_deprecation_warning() -> None:
     auth_module._warn_forwarded_url_without_trusted_proxies.cache_clear()
-    auth_module._warn_forwarded_url_path_deprecated.cache_clear()
 
 
 def test_parse_trusted_proxy_networks_accepts_bare_addresses_cidrs_and_wildcards() -> None:


### PR DESCRIPTION
## Summary
- Add `X-Forwarded-Prefix` support to `sign_request()` so the HMAC signature covers the path the manager actually routes, even when it's mounted under a prefix behind a reverse proxy (e.g. `/bai/admin/gql`).
- Honored only from a configured trusted proxy (`manager.trusted-proxies`), with no untrusted-origin fallback — unlike `X-Forwarded-URL`, this header has no legacy consumers to preserve.
- When path is still derived from `X-Forwarded-URL` (prefix absent, or both headers present), log a one-time deprecation warning pointing at `X-Forwarded-Prefix`.

## Test plan
- [x] `pants fmt/lint/check/test` on the changed files
- [x] `tests/unit/manager/api/test_auth_trusted_proxy.py` — trusted/untrusted prefix, trailing-slash/empty-prefix normalization, priority over `X-Forwarded-URL`'s path

Resolves BA-7309