### PR TITLE
docs: document same-release fix policy for PR title and news fragment

### DIFF
--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -79,7 +79,7 @@ pants lint --changed-since=origin/{base_branch}
    - **Title**: Conventional commit style with JIRA key as scope
      - Format: `type(BA-XXXX): description`
      - Example: `fix(BA-1234): resolve session cleanup race condition`
-     - Fixing code introduced earlier in this same, still-unreleased cycle, and it never reached a maintained release branch? Use `chore`, not `fix` — see backport table below and `changes/README.md` § Same-release fixes
+     - Fixing code introduced earlier in this unreleased cycle that never reached a maintained branch? Use `chore`, not `fix` — see step 3 below
    - **Body**: Use this template:
 
    ```markdown
@@ -126,7 +126,7 @@ pants lint --changed-since=origin/{base_branch}
    - Map from PR content:
      - New functionality → `feature`
      - Bug fix → `fix`
-     - Fix to code introduced earlier in this same, still-unreleased cycle, never shipped on a maintained release branch → `misc`, not `fix` (see `changes/README.md` § Same-release fixes; PR title uses `chore`, not `fix`)
+     - Fix to code introduced earlier in this unreleased cycle that never reached a maintained branch → `misc`, not `fix` (see `changes/README.md` § Same-release fixes)
      - Performance/refactoring → `enhance`
      - Breaking API change → `breaking`
      - Test-only change → `test`

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -79,7 +79,7 @@ pants lint --changed-since=origin/{base_branch}
    - **Title**: Conventional commit style with JIRA key as scope
      - Format: `type(BA-XXXX): description`
      - Example: `fix(BA-1234): resolve session cleanup race condition`
-     - Fixing code introduced earlier in this same, still-unreleased cycle? Use `chore`, not `fix` — see backport table below and `changes/README.md` § Same-release fixes
+     - Fixing code introduced earlier in this same, still-unreleased cycle, and it never reached a maintained release branch? Use `chore`, not `fix` — see backport table below and `changes/README.md` § Same-release fixes
    - **Body**: Use this template:
 
    ```markdown
@@ -126,7 +126,7 @@ pants lint --changed-since=origin/{base_branch}
    - Map from PR content:
      - New functionality → `feature`
      - Bug fix → `fix`
-     - Fix to code introduced earlier in this same, still-unreleased cycle → `misc`, not `fix` (see `changes/README.md` § Same-release fixes; PR title uses `chore`, not `fix`)
+     - Fix to code introduced earlier in this same, still-unreleased cycle, never shipped on a maintained release branch → `misc`, not `fix` (see `changes/README.md` § Same-release fixes; PR title uses `chore`, not `fix`)
      - Performance/refactoring → `enhance`
      - Breaking API change → `breaking`
      - Test-only change → `test`

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -79,6 +79,7 @@ pants lint --changed-since=origin/{base_branch}
    - **Title**: Conventional commit style with JIRA key as scope
      - Format: `type(BA-XXXX): description`
      - Example: `fix(BA-1234): resolve session cleanup race condition`
+     - Fixing code introduced earlier in this same, still-unreleased cycle? Use `chore`, not `fix` — see backport table below and `changes/README.md` § Same-release fixes
    - **Body**: Use this template:
 
    ```markdown
@@ -105,6 +106,7 @@ pants lint --changed-since=origin/{base_branch}
    | `fix:` PR that must NOT be backported | Add `Backport: none` to the PR body |
    | Non-`fix:` PR that stays on `main` | Nothing |
    | A target realized only after the merge | Comment `/backport <version>` on the merged PR |
+   | PR fixes code introduced earlier in this same, still-unreleased cycle (never shipped on a maintained release branch) | Use `chore:`, not `fix:` — see `changes/README.md` § Same-release fixes |
 
    - Valid versions are exactly the entries of `.github/maintained-versions.yml` — read that file
      rather than guessing. A trailer naming anything else fails the backport job and backports
@@ -124,6 +126,7 @@ pants lint --changed-since=origin/{base_branch}
    - Map from PR content:
      - New functionality → `feature`
      - Bug fix → `fix`
+     - Fix to code introduced earlier in this same, still-unreleased cycle → `misc`, not `fix` (see `changes/README.md` § Same-release fixes; PR title uses `chore`, not `fix`)
      - Performance/refactoring → `enhance`
      - Breaking API change → `breaking`
      - Test-only change → `test`

--- a/.claude/skills/submit/SKILL.md
+++ b/.claude/skills/submit/SKILL.md
@@ -79,7 +79,7 @@ pants lint --changed-since=origin/{base_branch}
    - **Title**: Conventional commit style with JIRA key as scope
      - Format: `type(BA-XXXX): description`
      - Example: `fix(BA-1234): resolve session cleanup race condition`
-     - Fixing code introduced earlier in this unreleased cycle that never reached a maintained branch? Use `chore`, not `fix` — see step 3 below
+     - See `changes/KNOWLEDGE.md` for the category-to-prefix/changelog-type mapping, including same-release fixes (`chore`, not `fix`)
    - **Body**: Use this template:
 
    ```markdown
@@ -106,7 +106,6 @@ pants lint --changed-since=origin/{base_branch}
    | `fix:` PR that must NOT be backported | Add `Backport: none` to the PR body |
    | Non-`fix:` PR that stays on `main` | Nothing |
    | A target realized only after the merge | Comment `/backport <version>` on the merged PR |
-   | PR fixes code introduced earlier in this same, still-unreleased cycle (never shipped on a maintained release branch) | Use `chore:`, not `fix:` — see `changes/README.md` § Same-release fixes |
 
    - Valid versions are exactly the entries of `.github/maintained-versions.yml` — read that file
      rather than guessing. A trailer naming anything else fails the backport job and backports
@@ -122,29 +121,7 @@ pants lint --changed-since=origin/{base_branch}
 
 ### Phase 5: Changelog (News Fragment)
 
-1. **Determine changelog type** (if not provided)
-   - Map from PR content:
-     - New functionality → `feature`
-     - Bug fix → `fix`
-     - Fix to code introduced earlier in this unreleased cycle that never reached a maintained branch → `misc`, not `fix` (see `changes/README.md` § Same-release fixes)
-     - Performance/refactoring → `enhance`
-     - Breaking API change → `breaking`
-     - Test-only change → `test`
-     - Documentation → `doc`
-     - Dependency update → `deps`
-
-   Valid types (from `pyproject.toml`):
-   | Type | Category |
-   |------|----------|
-   | `breaking` | Breaking Changes |
-   | `feature` | Features |
-   | `enhance` | Improvements |
-   | `deprecation` | Deprecations |
-   | `fix` | Fixes |
-   | `doc` | Documentation Updates |
-   | `deps` | External Dependency Updates |
-   | `misc` | Miscellaneous |
-   | `test` | Test Updates |
+1. **Determine changelog type** (if not provided) — see `changes/KNOWLEDGE.md` for valid types and the category mapping
 
 2. **Generate changelog message** (if not provided)
    - Single-line English sentence

--- a/changes/14007.doc.md
+++ b/changes/14007.doc.md
@@ -1,0 +1,1 @@
+Document the policy of using `chore`/`misc` instead of `fix` for changes to code introduced earlier in the same unreleased release cycle

--- a/changes/KNOWLEDGE.md
+++ b/changes/KNOWLEDGE.md
@@ -1,0 +1,43 @@
+---
+name: changes-pr-title-changelog-mapping
+type: decision-table
+description: category-to-PR-title-prefix/changelog-type mapping, the rule for marking same-release-cycle bug fixes as chore/misc instead of fix, and why
+scope: changes
+keywords: [fix, chore, misc, backport, towncrier, changelog, PR title, maintained-versions]
+sources:
+  - changes/README.md
+  - .github/maintained-versions.yml
+generated:
+  by: claude-code/sonnet-5
+  at: 2026-09-04
+status: draft
+---
+
+# changes/ — Knowledge
+
+> Rules: `changes/README.md` (filename convention, writing style)
+
+## Why this directory exists
+
+A PR title and its news fragment (`changes/<PR-number>.<type>.md`) live in different places but share the same classification. This document holds that classification, and the exception it creates because `fix:` triggers an automatic backport (same-release fixes).
+
+## Category-to-PR-title-prefix/changelog-type mapping
+
+| Category | PR title prefix | Changelog type | Note |
+|---|---|---|---|
+| New functionality | `feat` | `feature` | |
+| Bug fix — already on a maintained release branch | `fix` | `fix` | Auto-backports to every maintained version |
+| Bug fix — code introduced this same, still-unreleased cycle | `chore` | `misc` | Never shipped, so not a backport target |
+| Performance/refactoring | `refactor`/`perf` | `enhance` | |
+| Breaking API change | keeps the underlying commit type (`feat`/`refactor`/...) | `breaking` | No dedicated prefix — the type stays as-is, only the changelog classifies it as breaking |
+| Test-only change | `test` | `test` | |
+| Documentation | `doc` | `doc` | |
+| Dependency update | `deps` | `deps` | |
+| Deprecating existing functionality | keeps the underlying commit type (`chore`/`feat`/...) | `deprecation` | No dedicated prefix |
+
+## Why a same-release fix isn't `fix`
+
+- A `fix:` PR backports automatically to every maintained version listed in `.github/maintained-versions.yml`.
+- That only makes sense when the bug already exists on a maintained branch.
+- If the buggy code exists only on `main` — introduced earlier in this same, unreleased cycle — tagging it `fix` backports code that was never released.
+- So the PR title uses `chore` and the news fragment uses `misc`.

--- a/changes/README.md
+++ b/changes/README.md
@@ -52,6 +52,15 @@ For example, when changed both `client.func` and `client.cli` with the same sign
 
 Note: maintainers may modify the PR title without notice during reviews.
 
+### Same-release fixes: `chore`/`misc`, not `fix`
+
+A `fix:` pull request backports automatically to every maintained version listed in `.github/maintained-versions.yml`.
+That only makes sense when the bug being fixed already shipped in a released version.
+
+When a PR fixes code that was introduced earlier in the same, still-unreleased cycle — the buggy code exists only on `main` and has never reached a maintained release branch — it is not a user-facing bug fix from the release notes' point of view.
+Use `chore` as the PR title prefix and `misc` as the news fragment type instead of `fix`.
+Tagging it `fix` would trigger a backport of code that was never released.
+
 ## Most macroscopic: Release highlights
 
 The release highlights included in our news letters and the technical blog have more abstract and high-level user-centric descriptions.

--- a/changes/README.md
+++ b/changes/README.md
@@ -52,14 +52,7 @@ For example, when changed both `client.func` and `client.cli` with the same sign
 
 Note: maintainers may modify the PR title without notice during reviews.
 
-### Same-release fixes: `chore`/`misc`, not `fix`
-
-A `fix:` pull request backports automatically to every maintained version listed in `.github/maintained-versions.yml`.
-That only makes sense when the bug being fixed already exists on a maintained release branch.
-
-When a PR fixes code that was introduced earlier in the same, still-unreleased cycle — the buggy code exists only on `main` and has never reached a maintained release branch — it is not a user-facing bug fix from the release notes' point of view.
-Use `chore` as the PR title prefix and `misc` as the news fragment type instead of `fix`.
-Tagging it `fix` would trigger a backport of code that was never released.
+See `changes/KNOWLEDGE.md` for the category-to-PR-title-prefix/changelog-type mapping, including the same-release fix rule (`chore`/`misc`, not `fix`).
 
 ## Most macroscopic: Release highlights
 

--- a/changes/README.md
+++ b/changes/README.md
@@ -55,7 +55,7 @@ Note: maintainers may modify the PR title without notice during reviews.
 ### Same-release fixes: `chore`/`misc`, not `fix`
 
 A `fix:` pull request backports automatically to every maintained version listed in `.github/maintained-versions.yml`.
-That only makes sense when the bug being fixed already shipped in a released version.
+That only makes sense when the bug being fixed already exists on a maintained release branch.
 
 When a PR fixes code that was introduced earlier in the same, still-unreleased cycle — the buggy code exists only on `main` and has never reached a maintained release branch — it is not a user-facing bug fix from the release notes' point of view.
 Use `chore` as the PR title prefix and `misc` as the news fragment type instead of `fix`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ filename = "CHANGELOG.md"
 directory = "changes/"
 title_format = ""  # embedded inside the template
 template = "changes/template.md"
+ignore = ["KNOWLEDGE.md"]
 start_string = "<!-- towncrier release notes start -->\n"
 issue_format = "([#{issue}](https://github.com/lablup/backend.ai/issues/{issue}))"
 underlines = ["", "", ""]

--- a/scripts/assign-pr-number.py
+++ b/scripts/assign-pr-number.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import tomlkit
 
-exempted_files = ["README.md", "template.md"]
+exempted_files = ["README.md", "template.md", "KNOWLEDGE.md"]
 
 
 def read_news_types() -> set[str]:


### PR DESCRIPTION
## Summary
- Add a "Same-release fixes: `chore`/`misc`, not `fix`" section to `changes/README.md` explaining when to use `chore`/`misc` instead of `fix` — namely when the code being fixed was introduced earlier in the same, still-unreleased cycle and never shipped on a maintained release branch, so a `fix:` backport would be meaningless.
- Update `.claude/skills/submit/SKILL.md` (PR title generation, backport decision table, changelog-type mapping) to reference this rule.

## Test plan
- [ ] N/A — documentation only