### PR TITLE
fix(BA-7397): release glide client resources when creation fails

### DIFF
--- a/changes/14008.fix.md
+++ b/changes/14008.fix.md
@@ -1,0 +1,1 @@
+Release glide client resources when `GlideClient.create()` fails, so failed Valkey reconnects no longer leak sockets and connections.

--- a/src/ai/backend/common/clients/valkey_client/client.py
+++ b/src/ai/backend/common/clients/valkey_client/client.py
@@ -3,6 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Final, Self, override
 
@@ -51,6 +52,56 @@ _VALKEY_CONNECTION_ERRORS: tuple[type[Exception], ...] = (
 )
 
 Logger.init(LogLevel.OFF)  # Disable Glide logging by default
+
+
+_pending_glide_clients: ContextVar[list[GlideClient] | None] = ContextVar(
+    "_pending_glide_clients", default=None
+)
+
+
+class _TrackedGlideClient(GlideClient):
+    """
+    Register the instance that `GlideClient.create()` builds into the pending list, so
+    that `_create_glide_client()` can close it when creation fails partway through.
+    """
+
+    def __init__(self, config: GlideClientConfiguration) -> None:
+        super().__init__(config)
+        pending = _pending_glide_clients.get()
+        if pending is not None:
+            pending.append(self)
+
+
+async def _close_partial_glide_client(client: GlideClient) -> None:
+    """Release the UDS stream and reader task of a client that failed to be created."""
+    try:
+        await client.close(err_message="Valkey client creation failed.")
+    except Exception as e:
+        # The UDS stream may not exist yet when the failure happened early enough.
+        log.debug("Error while closing a partially created Valkey client: {}", e)
+    reader_task = getattr(client, "_reader_task", None)
+    if isinstance(reader_task, asyncio.Task) and not reader_task.done():
+        await cancel_and_wait(reader_task)
+
+
+async def _create_glide_client(config: GlideClientConfiguration) -> GlideClient:
+    """
+    Create a glide client, closing the partially built one when creation fails.
+
+    `GlideClient.create()` returns the instance only on success, leaking the UDS stream
+    and reader task on failure. Drop this and `_TrackedGlideClient` when valkey-glide
+    is upgraded to 2.5.2 or later, which replaces the UDS transport with FFI.
+    """
+    pending: list[GlideClient] = []
+    token = _pending_glide_clients.set(pending)
+    try:
+        return await _TrackedGlideClient.create(config)
+    except BaseException:
+        for partial_client in pending:
+            await _close_partial_glide_client(partial_client)
+        raise
+    finally:
+        _pending_glide_clients.reset(token)
 
 
 SSL_CERT_NONE = "none"
@@ -235,7 +286,7 @@ class ValkeyStandaloneClient(AbstractValkeyClient):
             ),
         )
 
-        glide_client = await GlideClient.create(config)
+        glide_client = await _create_glide_client(config)
         self._valkey_client = glide_client
 
         log.debug(
@@ -375,7 +426,7 @@ class ValkeySentinelClient(AbstractValkeyClient):
             ),
         )
 
-        glide_client = await GlideClient.create(config)
+        glide_client = await _create_glide_client(config)
         self._valkey_client = glide_client
 
         log.info(


### PR DESCRIPTION
## Summary

- `GlideClient.create()` returns the instance only on success. When it raises at `_set_connection_configurations()` — the failure mode seen in production — the UDS stream, the reader task, and the glide-core client it already built are left unreachable to the caller, so nothing can close them. The reader task keeps a strong reference to the abandoned instance, so it is never garbage collected either.
- Each failed reconnect therefore leaked 2 file descriptors and 1 asyncio task, and glide-core kept its Valkey connection open because the UDS stream was never closed. On the server this piled up as thousands of `cmd=NULL` entries in `CLIENT LIST`.
- `create()` exposes no handle to the half-built instance, so this captures it through a `GlideClient` subclass — `create()` calls `cls(config)` synchronously before its first `await`, so a ContextVar slot set by the caller is safe against interleaving. On failure the captured instance is closed, which shuts the UDS stream, terminates the reader loop, and lets glide-core drop its connection.

This is an upstream defect. valkey-glide 2.5.0 removed the UDS transport entirely (valkey-io/valkey-glide#5637), so the workaround should be dropped once the pin moves to 2.5.2 or later — the docstring says so. 2.5.2 is not yet published as a stable release, and 2.5.1 still carries a per-command payload leak (valkey-io/valkey-glide#6740), so 2.3.1 remains vulnerable in the meantime.

## Test plan

Verified against the local halfstack Valkey with `ClosingError` injected at `_set_connection_configurations()` — the exact failure point in the reported traceback — over 20 failed creates:

| | `close()` calls | leaked fds | leaked asyncio tasks |
|---|---|---|---|
| before (`GlideClient.create`) | 0/20 | 40 | 20 |
| after (`_create_glide_client`) | 20/20 | 0 | 0 |

- [x] Failed creation releases the UDS stream and reader task
- [x] Success path unchanged (identical fd/task counts before and after)
- [x] `pants fmt` / `fix` / `lint` / `check` pass

Resolves BA-7397
