### PR TITLE
test: align user soft-delete test with keypairs staying active

### DIFF
--- a/changes/14011.test.md
+++ b/changes/14011.test.md
@@ -1,0 +1,1 @@
+Fix the user soft-delete component test to expect keypairs to stay active.

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -281,7 +281,7 @@ class TestUserDeleteCrud:
         user_factory: UserFactory,
         db_engine: SAEngine,
     ) -> None:
-        """S-1: Admin soft deletes ACTIVE user → success=True, DB status=DELETED, keypairs deactivated."""
+        """S-1: Admin soft deletes ACTIVE user → success=True, DB status=DELETED, keypairs untouched."""
         created = await user_factory()
 
         result = await admin_registry.user.delete(DeleteUserRequest(user_id=created.user.id))
@@ -297,15 +297,14 @@ class TestUserDeleteCrud:
             user_status = user_row.scalar()
             assert user_status == UserStatus.DELETED
 
-            # Verify all keypairs deactivated
+            # Keypairs stay active: the auth status gate keeps a deleted user out,
+            # so restore does not have to re-activate them.
             kp_row = await conn.execute(
                 sa.select(keypairs.c.is_active).where(keypairs.c.user == str(created.user.id))
             )
             kp_actives = kp_row.scalars().all()
             assert len(kp_actives) > 0, "Should have at least one keypair"
-            assert all(not active for active in kp_actives), (
-                "All keypairs should be deactivated after soft delete"
-            )
+            assert all(kp_actives), "Keypairs should stay active after soft delete"
 
     async def test_s2_soft_delete_inactive_user(
         self,


### PR DESCRIPTION
## Summary
- `tests/component/user/test_user_crud.py::TestUserDeleteCrud::test_s1_soft_delete_active_user` failed on `main`: it still asserted that soft-deleting a user deactivates the user's keypairs.
- #13955 (BA-7452) deliberately dropped that keypair update — a deleted account is kept out by the auth middleware's user-status gate, so restore does not have to re-activate keypairs — but did not update this component test.
- Flipped the assertion to check keypairs stay active, and updated the docstring/comment to state the contract.

## Test plan
- [x] `pants test tests/component/user/test_user_crud.py::TestUserDeleteCrud`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqZZYBXHmyr4VmKwZ8C7yL