### PR TITLE
fix(BA-7487): restore the session enqueue adapter on 26.4

### DIFF
--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1403,6 +1403,20 @@ class ResourceSlotEntry(BackendAISchema):
         """
         return ResourceSlot({e.resource_type: Decimal(e.quantity) for e in entries})
 
+    @classmethod
+    def inputs_to_resource_slot(cls, entries: Sequence[ResourceSlotEntry]) -> ResourceSlot:
+        """Collapse a user-supplied entry list into the legacy ``ResourceSlot``.
+
+        Unlike :meth:`to_resource_slot`, quantities are parsed with the tolerance
+        ``ResourceSlot.from_user_input`` gives, so ``"4g"`` is accepted.
+        """
+        try:
+            return ResourceSlot.from_user_input(
+                {e.resource_type: e.quantity for e in entries}, None
+            )
+        except ValueError as e:
+            raise InvalidResourceSlotQuantity(extra_msg=str(e)) from e
+
 
 class ResourceSlotState(enum.StrEnum):
     OCCUPIED = "occupied"

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -77,6 +77,7 @@ from ai.backend.common.types import (
     SessionId,
     SessionTypes,
 )
+from ai.backend.common.types import ResourceSlotEntry as DataResourceSlotEntry
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus, KernelStatusInMatchSpec
@@ -264,9 +265,7 @@ class SessionAdapter(BaseAdapter):
         parsed_entries = []
         for e in input.resource_entries:
             parsed_entries.append(
-                DataResourceSlotEntry(
-                    resource_type=ResourceSlotName(e.resource_type), quantity=e.quantity
-                )
+                DataResourceSlotEntry(resource_type=e.resource_type, quantity=e.quantity)
             )
         requested_slots = DataResourceSlotEntry.inputs_to_resource_slot(parsed_entries)
         resource_entries = []


### PR DESCRIPTION
## Summary

`26.4` HEAD does not typecheck. The backport of #13992 ([`65adadd1b6`](https://github.com/lablup/backend.ai/commit/65adadd1b6e5146c41aa476bd52d51bd829a6af6), PR #14005) carried the zero-quantity filter into `api/adapters/session/adapter.py` but none of the names it depends on — on `main` those imports already existed at the top of the file, so the cherry-pick hunk did not include them.

```
src/ai/backend/manager/api/adapters/session/adapter.py:267: error: Name "DataResourceSlotEntry" is not defined
src/ai/backend/manager/api/adapters/session/adapter.py:268: error: Name "ResourceSlotName" is not defined
src/ai/backend/manager/api/adapters/session/adapter.py:271: error: Name "DataResourceSlotEntry" is not defined
```

Beyond the missing imports, the gap is real API surface:

| symbol | main | 26.4 before this PR |
|---|---|---|
| `ResourceSlotName` | `common.data.entity.resource_slot` | module does not exist |
| `DataResourceSlotEntry` | alias of `common.types.ResourceSlotEntry` | no alias |
| `ResourceSlotEntry.inputs_to_resource_slot` | present | absent — only `to_resource_slot` |

This is not just a typecheck failure: the enqueue path would raise `NameError` at runtime for every v2 session create.

## Changes

- `adapter.py`: alias `common.types.ResourceSlotEntry` as `DataResourceSlotEntry`, and drop the `ResourceSlotName(...)` wrapper — `resource_type` is a plain `str` on this branch.
- `common/types.py`: add `inputs_to_resource_slot` **beside** the existing `to_resource_slot` rather than renaming it. `main` renamed the method, but seven call sites on this branch still use the `Decimal`-parsing form. The new one parses via `ResourceSlot.from_user_input`, so a human-readable `"4g"` stays a 4xx `InvalidResourceSlotQuantity` instead of an unhandled 500 from `decimal.InvalidOperation`.

## Test plan

- [x] `pants check src/ai/backend/manager/api/adapters/session/adapter.py src/ai/backend/common/types.py` — was 3 errors, now clean
- [x] `pants lint` on both files
- [x] `pants test tests/unit/manager/api/adapters/test_session_adapter.py tests/unit/common/dto/test_session_v2_dto.py`

No news fragment: this repairs an already-shipped change on the release branch rather than introducing a user-facing one.

Found while fixing the BA-7505 backport (#14018), whose `typecheck` job is red for this reason and unrelated to its own diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqZZYBXHmyr4VmKwZ8C7yL