### PR TITLE
refactor(BA-7513): route plugin database access through the auth repository

### DIFF
--- a/changes/14030.enhance.md
+++ b/changes/14030.enhance.md
@@ -1,0 +1,1 @@
+Plugins now reach the database only through `AuthRepository`, so keypair authentication keeps working with `keypairs.secret_key` encrypted at rest.

--- a/src/ai/backend/manager/data/auth/types.py
+++ b/src/ai/backend/manager/data/auth/types.py
@@ -82,6 +82,33 @@ class AuthenticatedUser:
 
 
 @dataclass(frozen=True)
+class KeyPairSigningMaterial:
+    """The owner and decrypted secret key of a keypair, as a signature check needs them."""
+
+    user_id: UserID
+    secret_key: str
+
+
+@dataclass(frozen=True)
+class AuthorizingUser:
+    """The user record the authorize flow reads, and hands to its POST_AUTHORIZE plugins.
+
+    Wider than what the flow itself checks: ``totp_activated``, ``totp_key`` and
+    ``username`` are read by the two-factor plugins the flow dispatches to.
+    """
+
+    uuid: UserID
+    username: str
+    email: str
+    status: UserStatus
+    role: UserRole
+    resource_policy: str
+    password_changed_at: datetime | None
+    totp_activated: bool
+    totp_key: str | None
+
+
+@dataclass(frozen=True)
 class AuthenticatedKeypair:
     """The keypair the request authenticated with, limited to what request handling reads."""
 

--- a/src/ai/backend/manager/models/user/queriers.py
+++ b/src/ai/backend/manager/models/user/queriers.py
@@ -1,0 +1,48 @@
+"""Query specs for the users table."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.manager.data.auth.types import AuthorizingUser
+from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.user.row import UserRow
+
+__all__ = ("AuthorizingUserQuerier",)
+
+
+@dataclass
+class AuthorizingUserQuerier(DataQuerier[UserRow, AuthorizingUser]):
+    """Reads the user an authorize run is for, as that run and its plugins read it."""
+
+    user_id: UserID
+
+    @override
+    def row_class(self) -> type[UserRow]:
+        return UserRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return UserRow.uuid
+
+    @override
+    def entity_id_value(self) -> UserID:
+        return self.user_id
+
+    @override
+    def to_data(self, row: UserRow) -> AuthorizingUser:
+        return AuthorizingUser(
+            uuid=row.uuid,
+            username=row.username,
+            email=row.email,
+            status=row.status,
+            role=row.role,
+            resource_policy=row.resource_policy,
+            password_changed_at=row.password_changed_at,
+            totp_activated=row.totp_activated,
+            totp_key=row.totp_key,
+        )

--- a/src/ai/backend/manager/plugin/keypair/hook.py
+++ b/src/ai/backend/manager/plugin/keypair/hook.py
@@ -5,24 +5,21 @@ import hmac
 import logging
 import re
 from collections.abc import Mapping, Sequence
-from typing import Any, override
+from typing import Any, cast, override
 
-import sqlalchemy as sa
 import trafaret as t
 from aiohttp import web
 from dateutil.parser import parse as dateutil_parse
 
 from ai.backend.common.logging_utils import BraceStyleAdapter
 from ai.backend.common.plugin.hook import HookHandler, HookPlugin, Reject
+from ai.backend.common.types import AccessKey
 from ai.backend.common.utils import nmget
+from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.errors.auth import AuthorizationFailed, InvalidAuthParameters
-from ai.backend.manager.models.keypair.row import (
-    KEYPAIR_SECRET_KEY_CONTEXT,
-    KeyPairRow,
-    keypairs,
-)
-from ai.backend.manager.models.user import UserStatus, users
-from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.models.keypair.lookups import KeypairAccessKeyUserLookup
+from ai.backend.manager.models.user.queriers import AuthorizingUserQuerier
+from ai.backend.manager.repositories.auth.repository import AuthRepository
 
 from .utils import deserialize_stoken
 
@@ -124,8 +121,7 @@ class KeypairAuthHookPlugin(HookPlugin):
         params: Mapping[str, Any],
     ) -> Any:
         root_app = request.app["_root_app"]
-        db = root_app["_db"]
-        key_provider_pool: KeyProviderPool = root_app["_key_provider_pool"]
+        auth_repository = cast(AuthRepository, root_app["_auth_repository"])
         config_provider = root_app["_config_provider"]
         shared_config = await config_provider.legacy_etcd_config_loader.load()
         plugin_config = nmget(shared_config, "plugins.webapp.keypair_auth")
@@ -141,11 +137,12 @@ class KeypairAuthHookPlugin(HookPlugin):
             secret = plugin_config["secret"]
             try:
                 payload = deserialize_stoken(stoken, secret)
-                query = sa.select(KeyPairRow).where(KeyPairRow.access_key == payload.access_key)
-                async with db.begin_readonly_session() as db_session:
-                    keypair_row = await db_session.scalar(query)
-                    user_id = keypair_row.user
-
+                owner = await auth_repository.lookup(
+                    KeypairAccessKeyUserLookup(AccessKey(payload.access_key))
+                )
+                if owner is None:
+                    raise Reject("invalid authentication token")
+                user_id = owner
             except Exception:
                 try:
                     result = self.parse_token(stoken)
@@ -153,15 +150,9 @@ class KeypairAuthHookPlugin(HookPlugin):
                         raise Reject("invalid authentication token")
                     sign_method, access_key, signature = result
 
-                    async with db.begin() as conn:
-                        query = (
-                            sa.select(keypairs.c.user, keypairs.c.secret_key)
-                            .select_from(keypairs)
-                            .where(keypairs.c.access_key == access_key)
-                        )
-                        result = await conn.execute(query)
-                        keypair = result.fetchone()
-
+                    signing_material = await auth_repository.get_keypair_signing_material(
+                        access_key
+                    )
                     sign_params = {
                         "date": body.get("date"),
                         "endpoint": body.get("endpoint"),
@@ -169,14 +160,12 @@ class KeypairAuthHookPlugin(HookPlugin):
                     }
                     generated_token = await self.sign_token(
                         sign_method,
-                        await key_provider_pool.decrypt(
-                            keypair.secret_key, KEYPAIR_SECRET_KEY_CONTEXT
-                        ),
+                        signing_material.secret_key,
                         sign_params,
                     )
                     if generated_token != signature:
                         raise Reject("Invalid auth token")
-                    user_id = keypair.user
+                    user_id = signing_material.user_id
 
                 except Exception as e:
                     log.error("AUTHORIZE_KEYPAIR_HOOK: invalid auth token {}", _mask_token(stoken))
@@ -186,12 +175,9 @@ class KeypairAuthHookPlugin(HookPlugin):
         else:
             return None  # no-op for normal login
 
-        async with db.begin() as conn:
-            query = sa.select(users).select_from(users).where(users.c.uuid == user_id)
-            result = await conn.execute(query)
-            user = result.fetchone()
-            if not user:
-                raise Reject("No such user with access key")
-            if user.status != UserStatus.ACTIVE:
-                raise Reject("user is inactivated with access key")
-            return user
+        user = await auth_repository.query_user_data(AuthorizingUserQuerier(user_id))
+        if user is None:
+            raise Reject("No such user with access key")
+        if user.status != UserStatus.ACTIVE:
+            raise Reject("user is inactivated with access key")
+        return user

--- a/src/ai/backend/manager/plugin/keypair/webapp.py
+++ b/src/ai/backend/manager/plugin/keypair/webapp.py
@@ -1,11 +1,9 @@
 import json
 import logging
-import secrets
 from collections.abc import Mapping, Sequence
 from typing import Any, cast, override
 
 import aiohttp_cors
-import sqlalchemy as sa
 import yarl
 from aiohttp import web
 from pydantic import ValidationError
@@ -14,10 +12,8 @@ from ai.backend.common.logging_utils import BraceStyleAdapter
 from ai.backend.common.types import BackendAISchema
 from ai.backend.manager.api.rest.types import CORSOptions, WebMiddleware
 from ai.backend.manager.errors.auth import AuthorizationFailed, InvalidAuthParameters
-from ai.backend.manager.models.keypair.row import KEYPAIR_SECRET_KEY_CONTEXT, KeyPairRow
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.plugin.webapp import WebappPlugin
-from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.repositories.auth.repository import AuthRepository
 
 from .utils import (
     STokenData,
@@ -49,22 +45,10 @@ async def login(request: web.Request) -> web.Response:
         )
         raise InvalidAuthParameters("Invalid JSON data in request body.") from None
 
-    db = cast(ExtendedAsyncSAEngine, root_app["_db"])
-    key_provider_pool = cast(KeyProviderPool, root_app["_key_provider_pool"])
-    async with db.begin_readonly_session_read_committed() as db_session:
-        query = sa.select(KeyPairRow.secret_key, KeyPairRow.is_active).where(
-            KeyPairRow.access_key == json_data.access_key
-        )
-        keypair = (await db_session.execute(query)).first()
-
-    authenticated = False
-    if keypair is not None and keypair.secret_key is not None and keypair.is_active:
-        stored_secret_key = await key_provider_pool.decrypt(
-            keypair.secret_key, KEYPAIR_SECRET_KEY_CONTEXT
-        )
-        authenticated = secrets.compare_digest(
-            stored_secret_key.encode("utf-8"), json_data.secret_key.encode("utf-8")
-        )
+    auth_repository = cast(AuthRepository, root_app["_auth_repository"])
+    authenticated = await auth_repository.verify_keypair_secret(
+        json_data.access_key, json_data.secret_key
+    )
     if not authenticated:
         log.warning("login failed for access_key {}", json_data.access_key)
         raise AuthorizationFailed("Invalid credentials.")

--- a/src/ai/backend/manager/plugin/openid/hook.py
+++ b/src/ai/backend/manager/plugin/openid/hook.py
@@ -1,22 +1,24 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Mapping, Sequence
 from typing import (
     Any,
+    cast,
     override,
 )
 
 import jwt
 import jwt.exceptions
-import sqlalchemy as sa
 from aiohttp import web
 
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.plugin.hook import HookHandler, HookPlugin, Reject
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.auth.login_session_types import LoginSessionStatus
-from ai.backend.manager.models.login_session.row import LoginSessionRow
-from ai.backend.manager.models.user import UserStatus, users
+from ai.backend.manager.data.user.types import UserStatus
+from ai.backend.manager.models.user.queriers import AuthorizingUserQuerier
+from ai.backend.manager.repositories.auth.repository import AuthRepository
 
 from .config import OIDCHookConfig
 
@@ -60,7 +62,7 @@ class OIDCHookPlugin(HookPlugin):
         params: Mapping[str, Any],
     ) -> Any:
         root_app = request.app["_root_app"]
-        db = root_app["_db"]
+        auth_repository = cast(AuthRepository, root_app["_auth_repository"])
         secret = self._config.secret
 
         stoken = params.get("stoken") or params.get("sToken") or request.cookies.get("sToken")
@@ -71,38 +73,23 @@ class OIDCHookPlugin(HookPlugin):
             return None
         try:
             payload = jwt.decode(stoken, secret, algorithms=["HS256"])
-            user_uuid = payload["user"]
+            user_id = UserID(uuid.UUID(payload["user"]))
             email = payload["email"]
         except jwt.ExpiredSignatureError:
             raise Reject("Expired authentication token") from None
-        except (jwt.PyJWTError, KeyError):
+        except (jwt.PyJWTError, KeyError, ValueError):
             raise Reject("Invalid authentication token") from None
 
         log.debug("AUTHORIZE_HOOK(openid): auth token {}", stoken)
 
-        async with db.begin_readonly() as conn:
-            query = sa.select(users).select_from(users).where(users.c.uuid == user_uuid)
-            result = await conn.execute(query)
-            row = result.fetchone()
-            if not row:
-                raise Reject("user not found")
-            user = row._mapping
-            if user["status"] != UserStatus.ACTIVE:
-                raise Reject("user is inactivated")
+        user = await auth_repository.query_user_data(AuthorizingUserQuerier(user_id))
+        if user is None:
+            raise Reject("user not found")
+        if user.status != UserStatus.ACTIVE:
+            raise Reject("user is inactivated")
 
         if payload.get("force", False):
-            async with db.begin() as conn:
-                await conn.execute(
-                    sa.update(LoginSessionRow.__table__)
-                    .where(
-                        (LoginSessionRow.__table__.c.user_id == user_uuid)
-                        & (LoginSessionRow.__table__.c.status == LoginSessionStatus.ACTIVE)
-                    )
-                    .values(
-                        status=LoginSessionStatus.INVALIDATED,
-                        invalidated_at=sa.func.now(),
-                    )
-                )
+            await auth_repository.invalidate_active_login_sessions(user_id)
             log.info(
                 "AUTHORIZE_HOOK(openid): force-invalidated existing login sessions for {}",
                 email,

--- a/src/ai/backend/manager/plugin/openid/webapp.py
+++ b/src/ai/backend/manager/plugin/openid/webapp.py
@@ -9,13 +9,13 @@ from datetime import UTC, datetime, timedelta
 from typing import (
     Any,
     Final,
+    cast,
     override,
 )
 
 import aiohttp
 import aiohttp_cors
 import jwt
-import sqlalchemy as sa
 import yarl
 from aiohttp import web
 from authlib.common.security import generate_token  # pants: no-infer-dep
@@ -24,26 +24,18 @@ from authlib.jose import jwt as joseJWT  # pants: no-infer-dep
 from authlib.oidc.core import CodeIDToken  # pants: no-infer-dep
 
 from ai.backend.common.cron import LocalCron, PeriodicTask
-from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.domain import DomainName
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.types import CORSOptions, WebMiddleware
-from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.domain.lookups import DomainNameLookup
 from ai.backend.manager.models.hasher.types import PasswordInfo
-from ai.backend.manager.models.keypair.row import generate_keypair_data
-from ai.backend.manager.models.project import ProjectRow
-from ai.backend.manager.models.specs.pagination import NoPagination
-from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.models.project.lookups import ProjectNameInDomainLookup
+from ai.backend.manager.models.user import UserRole, UserStatus
 from ai.backend.manager.models.user.creators import UserCreator
-from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.user.lookups import UserEmailLookup
 from ai.backend.manager.plugin.webapp import WebappPlugin
-from ai.backend.manager.repositories.base.querier import BatchQuerier
-from ai.backend.manager.repositories.ops.rbac.provider import (
-    FullUserCreation,
-    RBACOpsProvider,
-)
-from ai.backend.manager.repositories.user.creators import UserScopeCreation
-from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.repositories.auth.repository import AuthRepository
 
 from .config import OIDCWebAppConfig
 from .valkey_client import ValkeyOpenIDClient
@@ -129,65 +121,46 @@ async def create_user_if_not_exists(
     openid_user_data: Mapping[str, Any],
     group_mapping: Mapping[str, Any],
     group_order: list[str],
-    db: ExtendedAsyncSAEngine,
+    auth_repository: AuthRepository,
     password_info: PasswordInfo,
-    key_provider_pool: KeyProviderPool,
-) -> UserRow:
-    """Provision an OpenID user through the RBAC member ops: the user scope, its
+) -> UserID:
+    """Provision an OpenID user through the auth repository: the user scope, its
     default keypair, and the domain/project (model-store included) enrollments."""
     user_info = generate_user_data(openid_user_data, group_mapping, group_order)
     user_data = user_info["user"]
-    async with RBACOpsProvider(db).write_ops() as w:
-        existing = await w.batch_query_in_global(
-            sa.select(UserRow).where(UserRow.email == user_data["email"]),
-            BatchQuerier(pagination=NoPagination()),
-        )
-        if existing.rows:
-            user: UserRow = existing.rows[0].UserRow
-            log.info("OPENID.WEBAPP: found existing user ({})", user.email)
-            return user
+    existing_id = await auth_repository.lookup(UserEmailLookup(user_data["email"]))
+    if existing_id is not None:
+        log.info("OPENID.WEBAPP: found existing user ({})", user_data["email"])
+        return existing_id
 
-        domain_result = await w.batch_query_in_global(
-            sa.select(DomainRow.id).where(DomainRow.name == user_data["domain_name"]),
-            BatchQuerier(pagination=NoPagination()),
-        )
-        if not domain_result.rows:
-            raise OpenIDError(f"Domain '{user_data['domain_name']}' does not exist")
-        domain_id = DomainID(domain_result.rows[0].id)
+    domain_name = DomainName(user_data["domain_name"])
+    domain_id = await auth_repository.lookup(DomainNameLookup(domain_name))
+    if domain_id is None:
+        raise OpenIDError(f"Domain '{domain_name}' does not exist")
+    project_id = await auth_repository.lookup(
+        ProjectNameInDomainLookup(domain_name, user_info["project"])
+    )
 
-        project_result = await w.batch_query_in_global(
-            sa.select(ProjectRow.id).where(
-                ProjectRow.domain_name == user_data["domain_name"],
-                ProjectRow.name == user_info["project"],
-            ),
-            BatchQuerier(pagination=NoPagination()),
-        )
-        project_ids = [ProjectID(row.id) for row in project_result.rows]
-
-        user_creator = UserCreator(
-            domain_id=domain_id,
-            email=user_data["email"],
-            username=user_data["username"],
-            password=password_info,
-            need_password_change=user_data["need_password_change"],
-            full_name=user_data["full_name"],
-            description=user_data["description"],
-            status=user_data["status"],
-            status_info=user_data["status_info"],
-            role=user_data["role"],
-            resource_policy=user_data["resource_policy"],
-        )
-        result = await w.create_full_user(
-            FullUserCreation(
-                creation=UserScopeCreation(spec=user_creator),
-                domain_id=domain_id,
-                project_ids=project_ids,
-                keypair_resource_policy=user_info["keypair_resource_policy"],
-                keypair_secrets=await generate_keypair_data(key_provider_pool),
-            )
-        )
-        log.info("OPENID.WEBAPP: new user created ({})", result.user_row.email)
-        return result.user_row
+    user_creator = UserCreator(
+        domain_id=domain_id,
+        email=user_data["email"],
+        username=user_data["username"],
+        password=password_info,
+        need_password_change=user_data["need_password_change"],
+        full_name=user_data["full_name"],
+        description=user_data["description"],
+        status=user_data["status"],
+        status_info=user_data["status_info"],
+        role=user_data["role"],
+        resource_policy=user_data["resource_policy"],
+    )
+    creation = await auth_repository.create_user_with_keypair(
+        user_creator,
+        [project_id] if project_id is not None else [],
+        keypair_resource_policy=user_info["keypair_resource_policy"],
+    )
+    log.info("OPENID.WEBAPP: new user created ({})", creation.user.email)
+    return UserID(creation.user.uuid)
 
 
 _JWKS_REFRESH_INTERVAL: Final[float] = 86400.0
@@ -316,7 +289,7 @@ class OIDCWebAppPlugin(WebappPlugin):
     async def redirect(self, request: web.Request) -> web.Response:
         root_app = request.app["_root_app"]
         config_provider = root_app["_config_provider"]
-        db = root_app["_db"]
+        auth_repository = cast(AuthRepository, root_app["_auth_repository"])
         openid_config = self._config.openid
         token_endpoint = request.app["openid.token_endpoint"]
         state = urllib.parse.parse_qs(request.query["state"])
@@ -361,18 +334,17 @@ class OIDCWebAppPlugin(WebappPlugin):
             rounds=config.auth.password_hash_rounds,
             salt_size=config.auth.password_hash_salt_size,
         )
-        user = await create_user_if_not_exists(
+        user_id = await create_user_if_not_exists(
             claims,
             openid_config.group_mapping,
             [x.strip() for x in openid_config.group_order.split(",")],
-            db,
+            auth_repository,
             password_info,
-            root_app["_key_provider_pool"],
         )
         force = state.get("force", ["false"])[0].lower() == "true"
         token_data = {
-            "user": str(user.uuid),
-            "email": user.email,
+            "user": str(user_id),
+            "email": claims["email"],
             "exp": datetime.now(UTC) + timedelta(seconds=60),
             "force": force,
         }

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import secrets
 import uuid as uuid_mod
 from collections.abc import Collection
 from dataclasses import dataclass
@@ -14,6 +15,8 @@ from sqlalchemy.dialects import postgresql as pgsql
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import BackendAIError, UserNotFound
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
@@ -23,7 +26,12 @@ from ai.backend.manager.data.auth.login_session_types import (
     LoginAttemptResult,
     LoginSessionStatus,
 )
-from ai.backend.manager.data.auth.types import GroupMembershipData, UserCreationData, UserData
+from ai.backend.manager.data.auth.types import (
+    GroupMembershipData,
+    KeyPairSigningMaterial,
+    UserCreationData,
+    UserData,
+)
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.errors.auth import (
     AuthorizationFailed,
@@ -35,8 +43,14 @@ from ai.backend.manager.errors.user import KeyPairNotFound, UserCreationBadReque
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.hasher.types import HashInfo, PasswordInfo
 from ai.backend.manager.models.keypair.queriers import DefaultKeypairQuerier
-from ai.backend.manager.models.keypair.row import generate_keypair_data, keypairs
+from ai.backend.manager.models.keypair.row import (
+    KEYPAIR_SECRET_KEY_CONTEXT,
+    generate_keypair_data,
+    keypairs,
+)
 from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
+from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.querier import DataQuerier
 from ai.backend.manager.models.user import (
     UserRole,
     UserRow,
@@ -49,6 +63,7 @@ from ai.backend.manager.models.user.creators import UserCreator
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_scope.queries import user_scope_membership_exists
 from ai.backend.manager.repositories.ops.rbac.provider import FullUserCreation, RBACOpsProvider
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.user.creators import UserScopeCreation
 from ai.backend.manager.secret.pool import KeyProviderPool
 
@@ -92,11 +107,18 @@ class AuthDBSource:
 
     _db: ExtendedAsyncSAEngine
     _rbac_ops_provider: RBACOpsProvider
+    _v2_ops: V2DBOpsProvider
     _key_provider_pool: KeyProviderPool
 
-    def __init__(self, db: ExtendedAsyncSAEngine, key_provider_pool: KeyProviderPool) -> None:
+    def __init__(
+        self,
+        db: ExtendedAsyncSAEngine,
+        v2_ops_provider: V2DBOpsProvider,
+        key_provider_pool: KeyProviderPool,
+    ) -> None:
         self._db = db
         self._rbac_ops_provider = RBACOpsProvider(db)
+        self._v2_ops = v2_ops_provider
         self._key_provider_pool = key_provider_pool
 
     @auth_db_source_resilience.apply()
@@ -138,7 +160,7 @@ class AuthDBSource:
         project_ids: Collection[ProjectID],
         *,
         keypair_resource_policy: str,
-        keypair_rate_limit: int,
+        keypair_rate_limit: int | None = None,
     ) -> UserCreationData:
         """Provision a signup user in one transaction: the row, its default keypair,
         and its domain/project (model-store included) scope enrollments."""
@@ -247,6 +269,50 @@ class AuthDBSource:
             query = keypairs.update().values(data).where(keypairs.c.access_key == access_key)
             await conn.execute(query)
 
+    @auth_db_source_resilience.apply()
+    async def verify_keypair_secret(self, access_key: str, secret_key: str) -> bool:
+        """Whether an active keypair holds the given secret key."""
+        async with self._db.begin_readonly() as conn:
+            row = (
+                await conn.execute(
+                    sa.select(keypairs.c.secret_key, keypairs.c.is_active).where(
+                        keypairs.c.access_key == access_key
+                    )
+                )
+            ).first()
+        if row is None or row.secret_key is None or not row.is_active:
+            return False
+        stored = await self._key_provider_pool.decrypt(row.secret_key, KEYPAIR_SECRET_KEY_CONTEXT)
+        return secrets.compare_digest(stored.encode("utf-8"), secret_key.encode("utf-8"))
+
+    @auth_db_source_resilience.apply()
+    async def fetch_keypair_signing_material(self, access_key: str) -> KeyPairSigningMaterial:
+        """Read the owner and the decrypted secret key of a keypair."""
+        async with self._db.begin_readonly() as conn:
+            row = (
+                await conn.execute(
+                    sa.select(keypairs.c.user, keypairs.c.secret_key).where(
+                        keypairs.c.access_key == access_key
+                    )
+                )
+            ).first()
+        if row is None or row.secret_key is None:
+            raise KeyPairNotFound(f"No keypair holds the access key {access_key}")
+        return KeyPairSigningMaterial(
+            user_id=row.user,
+            secret_key=await self._key_provider_pool.decrypt(
+                row.secret_key, KEYPAIR_SECRET_KEY_CONTEXT
+            ),
+        )
+
+    @auth_db_source_resilience.apply()
+    async def lookup[TEntityID: EntityIdentifier](
+        self, lookup: DataLookup[Any, TEntityID]
+    ) -> TEntityID | None:
+        """The id a key names, or None when it names nothing."""
+        async with self._v2_ops.read_ops() as r:
+            return await r.lookup_entity_id(lookup)
+
     def _user_row_to_data(self, row: UserRow | sa.Row[Any]) -> UserData:
         """Convert UserRow to UserData."""
         return UserData(
@@ -315,6 +381,12 @@ class AuthDBSource:
                 .select_from(users)
                 .where((users.c.email == email) & (users.c.domain_name == domain_name))
             )
+
+    @auth_db_source_resilience.apply()
+    async def query_user_data[TData](self, querier: DataQuerier[UserRow, TData]) -> TData | None:
+        """The user a querier names, or None when it names nothing."""
+        async with self._v2_ops.read_ops() as r:
+            return await r.query_data(querier)
 
     async def _check_password(
         self,
@@ -713,3 +785,14 @@ class AuthDBSource:
             )
             await conn.commit()
             return session_token
+
+    @auth_db_source_resilience.apply()
+    async def invalidate_active_login_sessions(self, user_id: UserID) -> None:
+        """Mark every active login session of a user invalidated."""
+        ls = LoginSessionRow.__table__
+        async with self._db.begin() as conn:
+            await conn.execute(
+                sa.update(ls)
+                .where((ls.c.user_id == user_id) & (ls.c.status == LoginSessionStatus.ACTIVE))
+                .values(status=LoginSessionStatus.INVALIDATED, invalidated_at=sa.func.now())
+            )

--- a/src/ai/backend/manager/repositories/auth/repositories.py
+++ b/src/ai/backend/manager/repositories/auth/repositories.py
@@ -11,4 +11,4 @@ class AuthRepositories:
 
     @classmethod
     def create(cls, args: RepositoryArgs) -> Self:
-        return cls(repository=AuthRepository(args.db, args.key_provider_pool))
+        return cls(repository=AuthRepository(args.db, args.v2_ops_provider, args.key_provider_pool))

--- a/src/ai/backend/manager/repositories/auth/repository.py
+++ b/src/ai/backend/manager/repositories/auth/repository.py
@@ -1,22 +1,28 @@
 from collections.abc import Collection
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.manager.data.auth.login_session_types import LoginAttemptResult
 from ai.backend.manager.data.auth.types import (
     GroupMembershipData,
+    KeyPairSigningMaterial,
     UserCreationData,
 )
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.models.hasher.types import PasswordInfo
-from ai.backend.manager.models.user import UserRole
+from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.user import UserRole, UserRow
 from ai.backend.manager.models.user.creators import UserCreator
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.auth.db_source.db_source import (
@@ -25,6 +31,7 @@ from ai.backend.manager.repositories.auth.db_source.db_source import (
     CredentialVerificationResult,
     LoginSessionCreationResult,
 )
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.secret.pool import KeyProviderPool
 
 auth_repository_resilience = Resilience(
@@ -37,8 +44,13 @@ auth_repository_resilience = Resilience(
 class AuthRepository:
     _db_source: AuthDBSource
 
-    def __init__(self, db: ExtendedAsyncSAEngine, key_provider_pool: KeyProviderPool) -> None:
-        self._db_source = AuthDBSource(db, key_provider_pool)
+    def __init__(
+        self,
+        db: ExtendedAsyncSAEngine,
+        v2_ops_provider: V2DBOpsProvider,
+        key_provider_pool: KeyProviderPool,
+    ) -> None:
+        self._db_source = AuthDBSource(db, v2_ops_provider, key_provider_pool)
 
     @auth_repository_resilience.apply()
     async def get_group_membership(self, group_id: UUID, user_id: UUID) -> GroupMembershipData:
@@ -60,7 +72,7 @@ class AuthRepository:
         project_ids: Collection[ProjectID],
         *,
         keypair_resource_policy: str,
-        keypair_rate_limit: int,
+        keypair_rate_limit: int | None = None,
     ) -> UserCreationData:
         return await self._db_source.insert_user_with_keypair(
             user_spec,
@@ -96,6 +108,23 @@ class AuthRepository:
         await self._db_source.modify_ssh_keypair(access_key, public_key, private_key)
 
     @auth_repository_resilience.apply()
+    async def verify_keypair_secret(self, access_key: str, secret_key: str) -> bool:
+        """Whether an active keypair holds the given secret key."""
+        return await self._db_source.verify_keypair_secret(access_key, secret_key)
+
+    @auth_repository_resilience.apply()
+    async def get_keypair_signing_material(self, access_key: str) -> KeyPairSigningMaterial:
+        """The owner and decrypted secret key of a keypair, for re-signing a request."""
+        return await self._db_source.fetch_keypair_signing_material(access_key)
+
+    @auth_repository_resilience.apply()
+    async def lookup[TEntityID: EntityIdentifier](
+        self, lookup: DataLookup[Any, TEntityID]
+    ) -> TEntityID | None:
+        """The id a key names, or None when it names nothing."""
+        return await self._db_source.lookup(lookup)
+
+    @auth_repository_resilience.apply()
     async def get_delegation_target_by_access_key(self, access_key: str) -> tuple[str, UserRole]:
         return await self._db_source.fetch_user_info_by_access_key(access_key)
 
@@ -106,6 +135,11 @@ class AuthRepository:
     @auth_repository_resilience.apply()
     async def get_user_uuid_by_email(self, email: str, domain_name: str) -> UUID | None:
         return await self._db_source.fetch_user_uuid_by_email(email, domain_name)
+
+    @auth_repository_resilience.apply()
+    async def query_user_data[TData](self, querier: DataQuerier[UserRow, TData]) -> TData | None:
+        """The user a querier names, or None when it names nothing."""
+        return await self._db_source.query_user_data(querier)
 
     @auth_repository_resilience.apply()
     async def verify_credential(
@@ -224,3 +258,7 @@ class AuthRepository:
         await self._db_source.record_login_history(
             user_id, domain_name, result, fail_reason, client_ip
         )
+
+    @auth_repository_resilience.apply()
+    async def invalidate_active_login_sessions(self, user_id: UserID) -> None:
+        await self._db_source.invalidate_active_login_sessions(user_id)

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -98,6 +98,7 @@ async def webapp_plugin_ctx(
     root_app["_etcd"] = r.bootstrap.etcd
     root_app["_valkey_stat"] = r.infrastructure.valkey.stat
     root_app["_key_provider_pool"] = r.bootstrap.key_provider_pool
+    root_app["_auth_repository"] = r.domain.repositories.auth.repository
     for plugin_name, plugin_instance in plugin_ctx.plugins.items():
         if pidx == 0:
             log.info("Loading webapp plugin: {0}", plugin_name)

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -1438,7 +1438,9 @@ def auth_processors(
 ) -> AuthProcessors:
     """Real AuthProcessors wired with real AuthService and AuthRepository."""
     repo = AuthRepository(
-        database_engine, KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN)
+        database_engine,
+        V2DBOpsProvider(database_engine),
+        KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
     )
     user_resource_policy_repository = UserResourcePolicyRepository(database_engine)
     user_repository = UserRepository(

--- a/tests/component/openid/conftest.py
+++ b/tests/component/openid/conftest.py
@@ -68,7 +68,9 @@ from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRo
 from ai.backend.manager.plugin.openid.hook import OIDCHookPlugin
 from ai.backend.manager.plugin.openid.valkey_client import ValkeyOpenIDClient
 from ai.backend.manager.plugin.openid.webapp import OIDCWebAppPlugin
+from ai.backend.manager.repositories.auth.repository import AuthRepository
 from ai.backend.manager.repositories.db.engine import connect_database
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.secret.pool import KeyProviderPool
 from ai.backend.testutils.bootstrap import (  # noqa: F401
     postgres_container,
@@ -553,12 +555,24 @@ def mock_config_provider(redis_container: Any) -> MagicMock:  # noqa: F811
 
 
 @pytest.fixture
+def auth_repository(seed_data: ExtendedAsyncSAEngine) -> AuthRepository:
+    """The only repository the OpenID plugin reaches the database through."""
+    return AuthRepository(
+        seed_data,
+        V2DBOpsProvider(seed_data),
+        KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
+    )
+
+
+@pytest.fixture
 def mock_root_app(
-    seed_data: ExtendedAsyncSAEngine, mock_config_provider: MagicMock
+    seed_data: ExtendedAsyncSAEngine,
+    mock_config_provider: MagicMock,
+    auth_repository: AuthRepository,
 ) -> dict[str, Any]:
     """
     Dict simulating root_app that plugin handlers access via
-    request.app["_root_app"]["_db"] / ["_config_provider"].
+    request.app["_root_app"]["_auth_repository"] / ["_config_provider"].
     """
     return {
         "_db": seed_data,  # seed_data yields database_engine
@@ -566,6 +580,7 @@ def mock_root_app(
         "_key_provider_pool": KeyProviderPool(
             providers=[], write_provider_type=KeyProviderType.PLAIN
         ),
+        "_auth_repository": auth_repository,
     }
 
 

--- a/tests/component/openid/conftest.py
+++ b/tests/component/openid/conftest.py
@@ -672,9 +672,11 @@ def make_stoken(plugin_config: dict[str, Any]) -> Callable[..., str]:
 
 
 @pytest.fixture
-def make_hook_request(seed_data: ExtendedAsyncSAEngine) -> Callable[..., MagicMock]:
+def make_hook_request(
+    seed_data: ExtendedAsyncSAEngine, auth_repository: AuthRepository
+) -> Callable[..., MagicMock]:
     """Callable(cookies) -> mock Request with _root_app wired to seed_data."""
-    root_app: dict[str, Any] = {"_db": seed_data}
+    root_app: dict[str, Any] = {"_db": seed_data, "_auth_repository": auth_repository}
 
     def _make(cookies: dict[str, str]) -> MagicMock:
         request = MagicMock()

--- a/tests/component/openid/test_hook.py
+++ b/tests/component/openid/test_hook.py
@@ -101,8 +101,8 @@ class TestOIDCHookPreAuth:
     ) -> None:
         raw_result: Any = await hook_plugin.pre_auth_hook(request_with_valid_stoken, {})
         assert raw_result is not None
-        assert raw_result["email"] == "alice@example.com"
-        assert raw_result["status"] == UserStatus.ACTIVE
+        assert raw_result.email == "alice@example.com"
+        assert raw_result.status == UserStatus.ACTIVE
 
     async def test_invalid_stoken_rejects(
         self, hook_plugin: OIDCHookPlugin, request_with_invalid_stoken: MagicMock
@@ -147,8 +147,8 @@ class TestOIDCHookPreAuth:
         params: dict[str, Any] = {"sToken": stoken}
         raw_result: Any = await hook_plugin.pre_auth_hook(request_without_stoken, params)
         assert raw_result is not None
-        assert raw_result["email"] == "alice@example.com"
-        assert raw_result["status"] == UserStatus.ACTIVE
+        assert raw_result.email == "alice@example.com"
+        assert raw_result.status == UserStatus.ACTIVE
 
     async def test_stoken_lowercase_key_in_params_authenticates(
         self,
@@ -161,7 +161,7 @@ class TestOIDCHookPreAuth:
         params: dict[str, Any] = {"stoken": stoken}
         raw_result: Any = await hook_plugin.pre_auth_hook(request_without_stoken, params)
         assert raw_result is not None
-        assert raw_result["email"] == "alice@example.com"
+        assert raw_result.email == "alice@example.com"
 
     async def test_expired_stoken_in_params_rejects(
         self,

--- a/tests/component/openid/test_webapp.py
+++ b/tests/component/openid/test_webapp.py
@@ -11,7 +11,6 @@ import pytest
 import sqlalchemy as sa
 from aiohttp import web
 
-from ai.backend.manager.data.secret.types import KeyProviderType
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
@@ -24,7 +23,7 @@ from ai.backend.manager.plugin.openid.webapp import (
     create_user_if_not_exists,
     generate_user_data,
 )
-from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.repositories.auth.repository import AuthRepository
 
 # ===========================================================================
 # TestGenerateUserData — pure function, no DB needed
@@ -107,27 +106,29 @@ class TestCreateUserIfNotExists:
     async def test_creates_new_user_with_keypair(
         self,
         seed_data: ExtendedAsyncSAEngine,
+        auth_repository: AuthRepository,
         openid_claims: dict[str, Any],
         group_mapping: dict[str, Any],
         password_info: PasswordInfo,
     ) -> None:
-        user = await create_user_if_not_exists(
+        user_id = await create_user_if_not_exists(
             openid_claims,
             group_mapping,
             ["backend-ai-users"],
-            seed_data,
+            auth_repository,
             password_info,
-            KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
         )
 
-        assert user.email == "newuser@example.com"
-        assert user.full_name == "New User"
-
-        # Verify keypair was created
         async with seed_data.begin_readonly_session() as sess:
+            user_row = await sess.scalar(sa.select(UserRow).where(UserRow.uuid == user_id))
+            assert user_row is not None
+            assert user_row.email == "newuser@example.com"
+            assert user_row.full_name == "New User"
+
+            # Verify keypair was created
             conn = await sess.connection()
             row = (
-                await conn.execute(sa.select(keypairs).where(keypairs.c.user == user.uuid))
+                await conn.execute(sa.select(keypairs).where(keypairs.c.user == user_id))
             ).fetchone()
             assert row is not None
             assert row.is_default is True
@@ -135,29 +136,27 @@ class TestCreateUserIfNotExists:
     async def test_returns_existing_user_without_duplicate(
         self,
         seed_data: ExtendedAsyncSAEngine,
+        auth_repository: AuthRepository,
         openid_claims: dict[str, Any],
         group_mapping: dict[str, Any],
         password_info: PasswordInfo,
     ) -> None:
-        user1 = await create_user_if_not_exists(
+        user_id1 = await create_user_if_not_exists(
             openid_claims,
             group_mapping,
             ["backend-ai-users"],
-            seed_data,
+            auth_repository,
             password_info,
-            KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
         )
-        user2 = await create_user_if_not_exists(
+        user_id2 = await create_user_if_not_exists(
             openid_claims,
             group_mapping,
             ["backend-ai-users"],
-            seed_data,
+            auth_repository,
             password_info,
-            KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
         )
 
-        assert user1.uuid == user2.uuid
-        assert user1.email == user2.email
+        assert user_id1 == user_id2
 
         # Verify only one keypair exists
         async with seed_data.begin_readonly_session() as sess:
@@ -166,7 +165,7 @@ class TestCreateUserIfNotExists:
                 await conn.execute(
                     sa.select(sa.func.count())
                     .select_from(keypairs)
-                    .where(keypairs.c.user == user1.uuid)
+                    .where(keypairs.c.user == user_id1)
                 )
             ).scalar()
             assert count == 1

--- a/tests/unit/manager/repositories/auth/test_auth_repository.py
+++ b/tests/unit/manager/repositories/auth/test_auth_repository.py
@@ -64,6 +64,7 @@ from ai.backend.manager.models.virtual_scope.entity_membership import EntityMemb
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.auth.repository import AuthRepository
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.secret.pool import KeyProviderPool
 from ai.backend.manager.secret.types import SecretValue
 from ai.backend.testutils.db import with_tables
@@ -147,6 +148,7 @@ class TestAuthRepository:
     async def auth_repository(self, db_with_cleanup: ExtendedAsyncSAEngine) -> AuthRepository:
         return AuthRepository(
             db=db_with_cleanup,
+            v2_ops_provider=V2DBOpsProvider(db_with_cleanup),
             key_provider_pool=KeyProviderPool(
                 providers=[], write_provider_type=KeyProviderType.PLAIN
             ),

--- a/tests/unit/manager/repositories/auth/test_login_session_force.py
+++ b/tests/unit/manager/repositories/auth/test_login_session_force.py
@@ -37,6 +37,7 @@ from ai.backend.manager.models.resource_policy import (
 from ai.backend.manager.models.user import UserRole, UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.auth.db_source.db_source import AuthDBSource
+from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.secret.pool import KeyProviderPool
 from ai.backend.manager.secret.types import SecretValue
 from ai.backend.testutils.db import with_tables
@@ -82,6 +83,7 @@ class TestLoginSessionForce:
     async def auth_db_source(self, db_with_cleanup: ExtendedAsyncSAEngine) -> AuthDBSource:
         return AuthDBSource(
             db_with_cleanup,
+            V2DBOpsProvider(db_with_cleanup),
             KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
         )
 


### PR DESCRIPTION
## Summary
- `keypairs.secret_key` is stored encrypted at rest, so a plugin that queries the table on its own reads ciphertext. `AuthRepository` is now the single entry point plugins reach the database through, and decryption happens inside it — no plugin code holds `KeyProviderPool`, `KEYPAIR_SECRET_KEY_CONTEXT`, or a SQLAlchemy query any more.
- `server.py` exposes `AuthRepository` alone on `root_app`, not the whole repository container. The repository takes v2 specs — `lookup(DataLookup)` and `query_user_data(DataQuerier[UserRow, …])` — so callers name a declared spec instead of building SQL, and the only hand-written methods left are the ones that decrypt or write several rows.
- The authorize hooks return the new `AuthorizingUser` DTO instead of a raw `sa.RowMapping`. It carries `totp_activated` / `totp_key` / `username`, which the POST_AUTHORIZE two-factor plugins read and no existing `data/` type had.

## Test plan
- [x] `tests/component/openid` passes (hook returns the DTO, `create_user_if_not_exists` returns `UserID`)
- [x] `tests/unit/manager/repositories/auth` passes with the new `V2DBOpsProvider` argument
- [x] Keypair sToken login and signature-based authorization both succeed against an encrypted `keypairs.secret_key`
- [x] Keypair authorization still succeeds against a legacy plaintext row
- [ ] OpenID first login provisions the user and its default keypair; a second login reuses them

Resolves BA-7513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJSXWXGpBjxa7dE6Y7Q1ox