### PR TITLE
fix(BA-7512): bind the halfstack GraphQL gateway to all interfaces (#14029)

### DIFF
--- a/changes/14029.fix.md
+++ b/changes/14029.fix.md
@@ -1,0 +1,1 @@
+Fix the halfstack GraphQL gateway binding only to loopback inside its container on WSL2, which made web login fail with "No healthy Manager endpoint is available"

--- a/docker-compose.halfstack-ha.yml
+++ b/docker-compose.halfstack-ha.yml
@@ -387,9 +387,8 @@ services:
       - half
     ports:
       - "4000:4000"
-    command: ["supergraph"]
+    command: ["supergraph", "--host", "0.0.0.0"]
     environment:
-      - HOST=0.0.0.0
       - PORT=4000
     volumes:
       - ./docs/manager/graphql-reference/supergraph.graphql:/gateway/supergraph.graphql:ro

--- a/docker-compose.halfstack-main.yml
+++ b/docker-compose.halfstack-main.yml
@@ -235,9 +235,8 @@ services:
       - half
     ports:
       - "4000:4000"
-    command: ["supergraph"]
+    command: ["supergraph", "--host", "0.0.0.0"]
     environment:
-      - HOST=0.0.0.0
       - PORT=4000
     configs:
       - source: supergraph_schema


### PR DESCRIPTION
This is an auto-generated backport of #14029 to the 26.8 release.