### PR TITLE
docs(BA-7519): propose entity relation operations and project membership

### DIFF
--- a/changes/14039.doc.md
+++ b/changes/14039.doc.md
@@ -1,0 +1,1 @@
+Add BEP-1075 (entity relation operations) and BEP-1076 (project membership), and correct BEP-1062 to match the virtual scope self-binding and invitation behavior in the code

--- a/proposals/BEP-1062-virtual-scope-rbac.md
+++ b/proposals/BEP-1062-virtual-scope-rbac.md
@@ -95,7 +95,7 @@ Lives in `repositories/permission_controller/db_source/db_source.py`. **But it i
 | ✅ | `resolve_effective_permissions_via_virtual_scope(keys)` — joins `entity → entity_memberships → scope_bindings → scope → permissions → roles → user_roles` in **one path, one hop**. Clips with `granted & scope_cap & entity_cap` (nullable = no ceiling), then OR-combines. One query per `(user_id, entity_type)` group |
 | ✅ | `check_permission_via_virtual_scope` / `check_bulk_permission_via_virtual_scope` — bitwise checks |
 | ✅ | (in use today) recursive scope-walk — `_build_scope_walk_cte(..., recursive=True)` traverses the scope hierarchy recursively |
-| ⚠️ | Resolution can only reach through a scope_binding. Ownership (an owner seeing its own entities) is also expressed via a **self scope_binding**, but nothing creates that binding today (3.(c)) |
+| ✅ | Resolution reaches a scope through a scope_binding. Ownership — an owner seeing its own entities — goes through a **self scope_binding**, written together with the VS node when an entity is provisioned (3.(c)) |
 | ➕ | Reverse lookups: `scope → readable entities`, `entity → authorizing scopes` (RBAC page, 3.(b)) |
 | ➕ | Wire into validators + remove the recursive scope-walk (3.(d), section 4) |
 
@@ -181,8 +181,8 @@ So the enrollment record (association) and the permission grant (`user_roles`) d
   as hierarchy/association/invitation. (Chosen over adding an owner-only special branch to the query.)
 - **Delete:** `delete_scope` drops the VS node, and FK `ON DELETE CASCADE` removes its bindings and memberships.
 - **Invariant:** every owner scope has a VS (`_resolve_virtual_scope_id` raises 500 otherwise).
-- **Where it wires:** VS writes are owned by the RBAC ops provider's grant method, and the domain/project/user/resource_group
-  operations use that provider/ops (2.3). No domain code touches the VS tables directly.
+- **Where it wires:** the entity write ops provision the VS node, the self entity_membership and the self scope_binding as
+  one step of creating any entity, and tear them down on removal. No domain code touches the VS tables directly.
 
 ### (d) Expressing hierarchy without recursion
 
@@ -200,7 +200,8 @@ Removing recursion is this BEP's goal, so domain→project→user inheritance is
 | **Invitation** (sharing) | grant a specific target access to a specific entity | `entity_memberships` on the **target's VS** | only what was granted (e.g. read\|write) |
 
 - Invitation is not a separate table or a direct-permission layer — it is **adding that entity as a member of the invitee's VS.**
-- The invitee sees entities in its own VS via the self-binding path, so once invited it can read the entity immediately.
+- Accepting adds that entity to the **invitee's own VS** carrying the offered `permission_cap`. The invitee reaches it
+  through their self-binding path, and what they may do there is their own permission clipped by that cap.
 - `permission_cap` enforces "only what was granted" — even if the target holds a stronger role in its own scope,
   it is clipped by `role permission & entity_cap`, so **permissions do not leak** (the cap replaces BEP-1048's escalation prevention).
 
@@ -228,6 +229,8 @@ Removing recursion is this BEP's goal, so domain→project→user inheritance is
 - auto (permission delegation) → owner VS membership + (for hierarchy/association) scope_binding.
 - ref (read-only reference / invitation) → invitee VS membership + `permission_cap` (3.(e)).
 - The `association_scopes_entities.relation_type` column and its branching are dropped after migration.
+- This is BEP-1048's delegation-versus-reference axis. It is **separate from the sharing context** — what an invitation
+  carries is the cap, not a relation kind.
 
 ### (i) Scope itself as an entity
 

--- a/proposals/BEP-1075-entity-relation-operations.md
+++ b/proposals/BEP-1075-entity-relation-operations.md
@@ -1,0 +1,229 @@
+---
+Author: HyeokJin Kim (hyeokjin@lablup.com)
+Status: Draft
+Created: 2026-08-26
+Created-Version: 26.8.0
+Target-Version:
+Implemented-Version:
+---
+
+# Entity Relation Operations
+
+## Related Issues
+
+- BA-7467 (how an action designates an entity)
+- BA-7468 · BA-7469 · BA-7470 (relocating the resource group, fair share and usage history specs)
+- BEP-1076 (Project Membership) — the contained case
+
+## Motivation
+
+Nothing decides what answers for the permission of an operation that links two entities.
+
+Handling a relation through the virtual scope makes the graph answer. Not handling it there
+means the operation has to answer for itself. Today each domain answers differently, so the
+same relation lands in the permission graph or not depending on which API created it.
+
+| Operation | Mapping row | Permission graph |
+|---|---|---|
+| Bind/unbind a resource group to a domain or project | writes | writes |
+| Bind/unbind a resource group to a keypair | writes | does not |
+| Edit a domain's or project's allowed resource groups | writes | writes |
+| Name resource groups while creating or editing a domain | writes | does not |
+
+**The virtual scope expresses ownership and nothing else.** A relation creates what business
+logic reads, and the permission of that operation is answered by the two scopes it names.
+
+## Current Design
+
+### Relation tables
+
+| Table | Links | Own data | Polymorphic side |
+|---|---|---|---|
+| `sgroups_for_domains` | resource group ↔ domain | none | no |
+| `sgroups_for_groups` | resource group ↔ project | none | no |
+| `sgroups_for_keypairs` | resource group ↔ keypair — the user is what it means to link | none | no |
+| `association_groups_users` | user ↔ project | none | no |
+| `user_roles` | user ↔ role | `granted_by` · `granted_at` | no |
+| `idle_checker_bindings` | idle checker ↔ scope | `enabled` | yes |
+| `association_container_registries_groups` | container registry ↔ project | none | no |
+
+No relation links three or more.
+
+`session_dependencies` is a field of the depending session: the interaction runs one way, so it
+is not a relation. `replica_groups` and `endpoint_tokens` are handled as deployment fields.
+
+### Business logic reads the relation tables
+
+`query_allowed_sgroups(domain_name, group, access_key)` reads the three tables as a union to
+decide which resource groups a session may run on. Session creation and scheduling call it.
+Project ↔ user searches read their relation table the same way.
+
+### The virtual scope expresses ownership
+
+A virtual scope edge carries one value, `permission_cap`, and the graph answers questions of the
+form (user, entity, permission). A relation misses on both counts.
+
+- The value to carry is not an amount of access — `enabled`, `granted_by`, or no value at all
+- The subject is not a user — a domain schedules on a resource group
+
+Owning something does not make an idle checker run or a role's permissions take effect. Ownership
+and behavior are different axes.
+
+## Proposed Design
+
+### A relation is a third position
+
+Neither entity nor field. An individual relation table is treated as neither of the two.
+
+| | Position |
+|---|---|
+| The value is an amount of access and the subject is a user | virtual scope edge — no table |
+| Any other link between two entities | **relation — its own table, its own operations** |
+| The other side is a value that does not hold the relation | field |
+
+### The action decides the permission, not ops
+
+The relation ops take a pair and write a row; they know nothing about permission. Who may run it
+is the action's, and the action's shape splits on **whether one side is contained in the other**.
+
+| | Example | Shape |
+|---|---|---|
+| Contained | project ⊃ user | `scope_targets` = the container alone, `entity_type` = what it contains |
+| Not contained | resource group ↔ domain | `scope_targets` = both, no `entity_type` |
+
+A resource group is a cluster resource several domains share, so neither side is inside the other.
+There the permission is asked of each named scope itself.
+
+```
+link · unlink  →  permission on the left scope  AND  permission on the right scope
+```
+
+With no `entity_type` there is no "permission on this type within this scope" to ask, so the only
+thing left to ask is the permission on the scope itself.
+
+The contained case is the scope shape as it already exists. Project membership is that case, and
+BEP-1076 covers it.
+
+### ops
+
+```
+create_relation (left, right, creator)
+delete_relation (left, right, updater)     writes the lifecycle column as a constant
+restore_relation(left, right, updater)     its reverse
+purge_relation  (left, right, purger)      removes the row
+```
+
+The middle two are wired only for relations that declare a lifecycle column. Whoever holds the
+permission on both scopes may turn a relation off and back on — turning it off is the same
+permission as unlinking.
+
+### The spec declares
+
+Conflict handling and the lifecycle differ per relation, so ops does not decide them.
+
+- With the unique constraint on the bare pair, a soft-deleted row occupies it — the create has to
+  revive it
+- With a partial index on (pair, alive), a new row is inserted and the history is kept
+
+Which one it is comes from the create spec, as `index_elements` and what to do on conflict.
+
+### The relation value is not exposed
+
+A relation row's id never leaves. A read does not return the relation; it returns the entities the
+relation reaches.
+
+Reads need no new machinery. They sit on the two axes a scope operation already has.
+
+| Axis | Value |
+|---|---|
+| `scope_targets()` | the domain — the permission is asked here |
+| `operation_scopes()` | the condition derived from the relation table |
+
+No edge per resource group is needed. Deriving permission from a relation turns into reference
+counting once the same entity is reached through several relations, and a permission written as a
+side effect of a business operation is invisible to the permission model.
+
+### Relation-based search
+
+Nine of the 48 `OperationScope` implementations already narrow their target through a relation
+table as a subquery.
+
+```python
+class DomainResourceGroupOperationScope(OperationScope):
+    def to_condition(self) -> QueryCondition:
+        return lambda: ResourceGroupRow.id.in_(
+            sa.select(ResourceGroupForDomainRow.resource_group_id)
+            .where(ResourceGroupForDomainRow.domain_id == self.domain_id)
+        )
+```
+
+Once a relation declares its table and its two reference columns, those nine come from that
+declaration instead of being written by hand.
+
+**Scope search as a whole does not collapse into one.** The other 39 carry the scope's id in a
+column of the target row (`SessionRow.group_id == project_id`) and go through no relation. What
+unifies is the nine that do.
+
+## Migration / Compatibility
+
+### What stays
+
+The relation tables stay. Business logic reads them directly, and the virtual scope cannot express
+what those reads decide.
+
+### What goes
+
+The permission graph edges the resource group relations wrote. Leaving them means only the
+relations made through that path stay inherited by the domain's administrators.
+
+### A relation is not carried as an updater field
+
+Two updaters carry a relation today and say so themselves.
+
+| Updater | Field | What it writes |
+|---|---|---|
+| `UserUpdater` | `group_ids` | the user's project memberships |
+| `ContainerRegistryUpdater` | `allowed_groups` | the registry's project associations |
+
+Neither field reaches `build_values()`; the repository writes those rows beside the update. This is
+the rule soft delete already follows — a value whose change drags other writes along does not
+belong on the general updater, because an edit path that can make the transition is an edit path
+that can make it wrong. Both fields move to the relation operations.
+
+### When a referenced entity is removed
+
+`purge_relation` takes both values to remove a row. There is no operation that knows one side and
+sweeps that entity's relations away.
+
+FK CASCADE is a guarantee about logic, not a statement of ownership. It may be kept, but it cannot
+be placed on a polymorphic reference.
+
+Removing a long-lived entity such as a domain will be handled by the lifecycle manager, and the
+relation rows it leaves are cleaned up there or by a retention sweep. A relation table has its own
+`RetentionCategory` entry.
+
+## Implementation Plan
+
+Decided once this BEP settles.
+
+## Open Questions
+
+- How to find relation rows whose reference is gone. The reference is polymorphic
+  (`entity_type`, `entity_id`), so an anti-join needs to know which table that type lives in.
+  `virtual_scopes` already indexes live entities by `(scope_type, scope_id)` and could be matched
+  against, but a row created before the virtual scope rollout may have no scope, which would read a
+  live entity's relation as a dangling one.
+- Whether to collapse the three `sgroups_for_*` into one polymorphic table — doing so makes
+  `query_allowed_sgroups` a single query and turns a new kind of scope into a value.
+- Whether to key the resource group ↔ keypair relation on the user — the access key was the wrong
+  choice at design time, and taking a user identifier and resolving the default access key in a
+  subquery puts it on the new ops with no column change.
+- What grants a domain administrator the permission to edit a resource group. It is not derived
+  from the relation, so it has to be stated as a role or a grant.
+
+## References
+
+- `src/ai/backend/manager/models/specs/KNOWLEDGE.md` — write spec selection criteria
+- `src/ai/backend/manager/actions/KNOWLEDGE.md` — the v2 action shapes
+- BEP-1008 · BEP-1012 (RBAC)
+- BEP-1076 (Project Membership)

--- a/proposals/BEP-1076-project-membership.md
+++ b/proposals/BEP-1076-project-membership.md
@@ -1,0 +1,170 @@
+---
+Author: HyeokJin Kim (hyeokjin@lablup.com)
+Status: Draft
+Created: 2026-08-26
+Created-Version: 26.8.0
+Target-Version:
+Implemented-Version:
+---
+
+# Project Membership
+
+## Related Issues
+
+- BEP-1075 (Entity Relation Operations) — the relation write primitive this uses
+- BA-7467 (how an action designates an entity)
+
+## Motivation
+
+Putting a user in a project does two things — it adds the relation and it grants a role. The two
+are fused today, and the operation cannot reach someone whose user id is unknown.
+
+- Joining always drags the scope's `auto_assign` roles along, so membership and role state cannot
+  be told apart
+- A user id is required, so someone without an account yet cannot be added
+
+Handing permission to another person already has two branches, immediate and by invitation.
+Project membership takes the same pair.
+
+## Current Design
+
+### Membership today
+
+| | Current |
+|---|---|
+| Table | `association_groups_users` — `DEPRECATED`, being moved to `association_scopes_entities` |
+| Role | `ScopeUserMember.assign_role_on()` grants the scope's `auto_assign` roles on every join |
+| Designation | a user id is required |
+
+`ScopeUserMember` states the fusion itself — *"membership always grants the scope's auto_assign
+roles (idempotently), so membership and role state cannot drift apart."*
+
+`UserUpdater.group_ids` carries the same membership through the edit path. It is not a column, so
+the write path syncs it beside `build_values()` (BEP-1075).
+
+### A domain is not this shape
+
+A user belongs to exactly one domain, held as `users.domain_id` with a foreign key. There is no
+domain ↔ user relation table, and the column is `NOT NULL`.
+
+| | Project | Domain |
+|---|---|---|
+| Storage | `association_groups_users` | `users.domain_id` column |
+| Cardinality | many to many | one to many |
+
+So a domain is not invited into. A user is created under a domain, and moving between domains is
+an edit of the user, not a membership operation. This proposal covers projects only.
+
+### The invitation that exists
+
+`entity_invitations` offers **access to an entity**.
+
+| Column | Value |
+|---|---|
+| `target_entity_type` · `target_entity_id` | polymorphic, no foreign key |
+| `permission_cap` | the ceiling applied on acceptance |
+| `invitee_email` | an email — names someone with no account yet |
+| `status` | unique only while `pending` |
+
+Project membership does not fit that shape: the value to carry is a role rather than a ceiling, and
+acceptance writes something else.
+
+## Proposed Design
+
+### Two branches
+
+| | When it takes effect | Designation | The other party's account |
+|---|---|---|---|
+| grant | immediately | user id | must exist |
+| invitation | on acceptance | email | need not exist |
+
+The same pair as handing out permission.
+
+### What each branch does
+
+```
+1. add the relation      project ↔ user
+2. grant the role        the named role if there is one, otherwise the project's auto_assign roles
+```
+
+Two writes in one transaction, not one fact — so the `ScopeUserMember` fusion comes apart.
+
+### The role is chosen from that project's roles
+
+Only a role enrolled in that project's scope may be named. Otherwise membership becomes a path for
+attaching an unrelated role.
+
+### Permission
+
+Putting a user inside a project means the scope is **one**.
+
+| Axis | Value |
+|---|---|
+| `scope_targets()` | the project |
+| `entity_type()` | `user` |
+
+Naming a role adds one more.
+
+| | What is asked |
+|---|---|
+| No role named (`auto_assign`) | the `user` permission at the project scope |
+| A role named | that, plus **the permission to grant that role** |
+
+Nobody may attach a role they could not grant.
+
+### Removal
+
+```
+remove the relation  +  take back the roles enrolled in that project from this user
+```
+
+**Nothing has to record which role came from this membership.** A role may only be chosen from that
+project's own, so holding a project-scoped role without being a member of that project is not a
+state that arises. What comes back is the intersection of "roles enrolled in that project" and the
+roles this user holds.
+
+The read already exists — `ScopedRoleOperationScope` selects the roles enrolled in one scope.
+
+Audit logs are for observing. What to take back is not read from audit rows: they are swept by
+retention and go away.
+
+### The invitation has its own table
+
+A different axis from `entity_invitations`.
+
+| | `entity_invitations` | Project invitation |
+|---|---|---|
+| What is offered | access to an entity | project membership |
+| Value carried | `permission_cap` | a role, or `auto_assign` |
+| Acceptance writes | one membership row | the relation and the role |
+
+The form matches: addressed by email, accepted or declined, unique only while pending.
+
+**After acceptance the invitation and the state part ways.** Deleting the invitation leaves the
+relation and the role in place. An invitation is an offer, not a permission — the same rule the
+permission invitation follows.
+
+## Migration / Compatibility
+
+- Undo the `ScopeUserMember` role fusion. Granting the role becomes the second step of the
+  membership operation
+- Take `group_ids` off `UserUpdater`. Enrolling in a project is its own operation
+- Stop moving `association_groups_users` into `association_scopes_entities`. Project membership is
+  a business relation, not a fact for the permission graph (BEP-1075)
+- The relation row is written through BEP-1075's relation primitive; the service composes it with
+  the role grant
+
+## Implementation Plan
+
+Decided once this BEP settles.
+
+## Open Questions
+
+- How the invitation table carries the role — one role id column, and how "none named
+  (`auto_assign`)" is told apart from it
+- Received invitations span two tables. Showing one list to a user needs somewhere to merge them
+- What happens when the role named at invitation time is gone by the time it is accepted
+- `UserUpdater.domain_name` stays an edit of the user, but it is a move: the identifier becomes
+  `domain_id` (resolved from a name by a lookup at the edge), and what else the move has to carry
+  — the graph membership, the projects of the old domain, the domain copied onto sessions and
+  vfolders — is not settled here

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -145,6 +145,8 @@ BEP numbers start from 1000.
 | [1072](BEP-1072-release-branching-and-backport.md) | Release Branch Isolation and Backport Automation | HyeokJin Kim | Draft |
 | [1073](BEP-1073-entity-labels.md) | Entity Labels | Sanghun Lee | Draft |
 | [1074](BEP-1074-container-secret-references.md) | Container Secret References | HyeokJin Kim | Draft |
+| [1075](BEP-1075-entity-relation-operations.md) | Entity Relation Operations | HyeokJin Kim | Draft |
+| [1076](BEP-1076-project-membership.md) | Project Membership | HyeokJin Kim | Draft |
 | _next_ | _(reserve your number here)_ | | |
 
 ## File Structure


### PR DESCRIPTION
## What

Three proposals, no code.

| BEP | Content |
|---|---|
| [1075 — Entity Relation Operations](https://github.com/lablup/backend.ai/blob/BA-7519/proposals/BEP-1075-entity-relation-operations.md) | A link between entities neither of which contains the other is `relation`-shaped; the contained case is `scope`-shaped. The virtual scope expresses ownership and nothing else. Ownership and behavior are different axes. Records that resource-group relations are handled inconsistently today. |
| [1076 — Project Membership](https://github.com/lablup/backend.ai/blob/BA-7519/proposals/BEP-1076-project-membership.md) | Project membership is a business relation, not a fact for the permission graph, so `association_groups_users` stays where it is. An invitation is an offer, not a permission, and has its own table. Nobody may attach a role they could not grant. |
| [1062 — Virtual Scope RBAC](https://github.com/lablup/backend.ai/blob/BA-7519/proposals/BEP-1062-virtual-scope-rbac.md) | Corrected to match the code. |

## BEP-1062 corrections

| Was | Now |
|---|---|
| ⚠️ nothing creates the self scope_binding | ✅ written together with the VS node when an entity is provisioned |
| VS writes owned by the RBAC ops provider's grant method | the entity write ops provision the VS node, the self entity_membership and the self scope_binding as one step |
| the invitee can read the entity immediately | accepting adds the entity to the invitee's own VS carrying the offered `permission_cap`, and what they may do is their own permission clipped by that cap |
| — | the auto/ref distinction is BEP-1048's delegation-versus-reference axis, separate from the sharing context |

## Open question

BEP-1062 still says user membership is written into the permission graph while BEP-1076 says it is not. Left as is until the membership placement is settled.

## Implementation

Tracked separately: BA-7517 (relation action shape) and BA-7518 (RBAC write concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)