### PR TITLE
feat(BA-7511): answer per id in bulk user purge and vfolder bulk mutations

### DIFF
--- a/changes/14040.feature.md
+++ b/changes/14040.feature.md
@@ -1,0 +1,1 @@
+Bulk user purge and vfolder bulk delete/purge now report which ids they acted on, and a failing vfolder no longer aborts the rest of the batch.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2560,14 +2560,14 @@ type BulkDeleteVFoldersV2Payload
   @join__type(graph: STRAWBERRY)
 {
   """
-  Added in 26.9.0. UUIDs of the vfolders that were soft-deleted, in the order they were requested. Together with `failed` this answers for every requested vfolder exactly once.
+  Added in 26.9.0. The vfolders that were soft-deleted, in the order they were requested. A soft-deleted vfolder is still addressable, so it is returned whole. Together with `failed` this answers for every requested vfolder exactly once.
   """
-  successes: [UUID!]!
+  items: [VFolder!]!
 
   """
   Added in 26.4.2. Number of virtual folders successfully soft-deleted. Deprecated since 26.9.0.
   """
-  deletedCount: Int! @deprecated(reason: "Use the length of successes.")
+  deletedCount: Int! @deprecated(reason: "Use the length of items.")
 
   """
   Added in 26.9.0. List of errors for vfolders that failed to be soft-deleted.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2559,8 +2559,33 @@ input BulkDeleteVFoldersV2Input
 type BulkDeleteVFoldersV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Number of virtual folders successfully soft-deleted."""
-  deletedCount: Int!
+  """
+  Added in 26.9.0. UUIDs of the vfolders that were soft-deleted, in the order they were requested. Together with `failed` this answers for every requested vfolder exactly once.
+  """
+  successes: [UUID!]!
+
+  """
+  Added in 26.4.2. Number of virtual folders successfully soft-deleted. Deprecated since 26.9.0.
+  """
+  deletedCount: Int! @deprecated(reason: "Use the length of successes.")
+
+  """
+  Added in 26.9.0. List of errors for vfolders that failed to be soft-deleted.
+  """
+  failed: [BulkDeleteVFolderV2Error!]!
+}
+
+"""
+Added in 26.9.0. Failure detail for a single vfolder in a bulk soft-deletion.
+"""
+type BulkDeleteVFolderV2Error
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID of the vfolder that failed to be soft-deleted."""
+  vfolderId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
 }
 
 """Added in 26.4.4. Input for bulk-hard-deleting role presets."""
@@ -2614,8 +2639,15 @@ input BulkPurgeUsersV2Options
 type BulkPurgeUsersV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Number of users successfully purged."""
-  purgedCount: Int!
+  """
+  Added in 26.9.0. UUIDs of the users that were purged, in the order they were requested. Together with `failed` this answers for every requested user exactly once.
+  """
+  successes: [UUID!]!
+
+  """
+  Added in 26.3.0. Number of users successfully purged. Deprecated since 26.9.0.
+  """
+  purgedCount: Int! @deprecated(reason: "Use the length of successes.")
 
   """List of errors for users that failed to purge."""
   failed: [BulkPurgeUserV2Error!]!
@@ -2651,8 +2683,15 @@ input BulkPurgeVFoldersV2Input
 type BulkPurgeVFoldersV2Payload
   @join__type(graph: STRAWBERRY)
 {
-  """Number of virtual folders successfully purged."""
-  purgedCount: Int!
+  """
+  Added in 26.9.0. UUIDs of the vfolders that were purged, in the order they were requested. Together with `failed` this answers for every requested vfolder exactly once.
+  """
+  successes: [UUID!]!
+
+  """
+  Added in 26.4.2. Number of virtual folders successfully purged. Deprecated since 26.9.0.
+  """
+  purgedCount: Int! @deprecated(reason: "Use the length of successes.")
 
   """Added in 26.4.4. List of errors for vfolders that failed to purge."""
   failed: [BulkPurgeVFolderV2Error!]!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1869,6 +1869,17 @@ type BulkDeleteRolePresetsPayload {
   failed: [BulkRolePresetFailureInfo!]!
 }
 
+"""
+Added in 26.9.0. Failure detail for a single vfolder in a bulk soft-deletion.
+"""
+type BulkDeleteVFolderV2Error {
+  """UUID of the vfolder that failed to be soft-deleted."""
+  vfolderId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
 """Added in 26.4.2. Input for soft-deleting multiple virtual folders."""
 input BulkDeleteVFoldersV2Input {
   """List of VFolder UUIDs to soft-delete."""
@@ -1877,8 +1888,20 @@ input BulkDeleteVFoldersV2Input {
 
 """Added in 26.4.2. Payload for bulk virtual folder soft-deletion."""
 type BulkDeleteVFoldersV2Payload {
-  """Number of virtual folders successfully soft-deleted."""
-  deletedCount: Int!
+  """
+  Added in 26.9.0. UUIDs of the vfolders that were soft-deleted, in the order they were requested. Together with `failed` this answers for every requested vfolder exactly once.
+  """
+  successes: [UUID!]!
+
+  """
+  Added in 26.4.2. Number of virtual folders successfully soft-deleted. Deprecated since 26.9.0.
+  """
+  deletedCount: Int! @deprecated(reason: "Use the length of successes.")
+
+  """
+  Added in 26.9.0. List of errors for vfolders that failed to be soft-deleted.
+  """
+  failed: [BulkDeleteVFolderV2Error!]!
 }
 
 """Added in 26.4.4. Input for bulk-hard-deleting role presets."""
@@ -1931,8 +1954,15 @@ input BulkPurgeUsersV2Options {
 
 """Added in 26.3.0. Payload for bulk user permanent deletion mutation."""
 type BulkPurgeUsersV2Payload {
-  """Number of users successfully purged."""
-  purgedCount: Int!
+  """
+  Added in 26.9.0. UUIDs of the users that were purged, in the order they were requested. Together with `failed` this answers for every requested user exactly once.
+  """
+  successes: [UUID!]!
+
+  """
+  Added in 26.3.0. Number of users successfully purged. Deprecated since 26.9.0.
+  """
+  purgedCount: Int! @deprecated(reason: "Use the length of successes.")
 
   """List of errors for users that failed to purge."""
   failed: [BulkPurgeUserV2Error!]!
@@ -1962,8 +1992,15 @@ input BulkPurgeVFoldersV2Input {
 
 """Added in 26.4.2. Payload for bulk virtual folder purge."""
 type BulkPurgeVFoldersV2Payload {
-  """Number of virtual folders successfully purged."""
-  purgedCount: Int!
+  """
+  Added in 26.9.0. UUIDs of the vfolders that were purged, in the order they were requested. Together with `failed` this answers for every requested vfolder exactly once.
+  """
+  successes: [UUID!]!
+
+  """
+  Added in 26.4.2. Number of virtual folders successfully purged. Deprecated since 26.9.0.
+  """
+  purgedCount: Int! @deprecated(reason: "Use the length of successes.")
 
   """Added in 26.4.4. List of errors for vfolders that failed to purge."""
   failed: [BulkPurgeVFolderV2Error!]!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1889,14 +1889,14 @@ input BulkDeleteVFoldersV2Input {
 """Added in 26.4.2. Payload for bulk virtual folder soft-deletion."""
 type BulkDeleteVFoldersV2Payload {
   """
-  Added in 26.9.0. UUIDs of the vfolders that were soft-deleted, in the order they were requested. Together with `failed` this answers for every requested vfolder exactly once.
+  Added in 26.9.0. The vfolders that were soft-deleted, in the order they were requested. A soft-deleted vfolder is still addressable, so it is returned whole. Together with `failed` this answers for every requested vfolder exactly once.
   """
-  successes: [UUID!]!
+  items: [VFolder!]!
 
   """
   Added in 26.4.2. Number of virtual folders successfully soft-deleted. Deprecated since 26.9.0.
   """
-  deletedCount: Int! @deprecated(reason: "Use the length of successes.")
+  deletedCount: Int! @deprecated(reason: "Use the length of items.")
 
   """
   Added in 26.9.0. List of errors for vfolders that failed to be soft-deleted.

--- a/src/ai/backend/common/dto/AGENTS.md
+++ b/src/ai/backend/common/dto/AGENTS.md
@@ -18,3 +18,10 @@ Organized by target component: `common/dto/{manager|agent|storage|clients|intern
 - No business logic — validation and serialization only.
 - Check all callers across components before modifying fields.
 - Use only `v2/` DTOs (e.g., `common/dto/manager/v2/`). DTOs outside `v2/` are deprecated and must not be used in new code.
+
+## Bulk mutation payloads
+
+| Operation | Payload fields |
+|---|---|
+| Soft delete | `items: list[<Entity>Node]`, `failed: list[<Operation><Entity>Error]` |
+| Hard delete (purge) | `successes: list[UUID]`, `failed: list[<Operation><Entity>Error]` |

--- a/src/ai/backend/common/dto/manager/v2/user/response.py
+++ b/src/ai/backend/common/dto/manager/v2/user/response.py
@@ -279,6 +279,13 @@ class BulkPurgeUsersPayload(BaseResponseModel):
     """Payload for bulk user permanent deletion mutation."""
 
     purged_count: int = Field(description="Number of users successfully purged.")
+    purged_user_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "UUIDs of the users that were purged, in the order they were requested. "
+            "Together with `failed` this answers for every requested user exactly once."
+        ),
+    )
     failed: list[BulkPurgeUserV2Error] = Field(
         description="List of errors for users that failed to purge.",
     )

--- a/src/ai/backend/common/dto/manager/v2/user/response.py
+++ b/src/ai/backend/common/dto/manager/v2/user/response.py
@@ -278,13 +278,19 @@ class BulkPurgeUserV2Error(BaseResponseModel):
 class BulkPurgeUsersPayload(BaseResponseModel):
     """Payload for bulk user permanent deletion mutation."""
 
-    purged_count: int = Field(description="Number of users successfully purged.")
-    purged_user_ids: list[UUID] = Field(
+    successes: list[UUID] = Field(
         default_factory=list,
         description=(
             "UUIDs of the users that were purged, in the order they were requested. "
             "Together with `failed` this answers for every requested user exactly once."
         ),
+    )
+    purged_count: int = Field(
+        description=(
+            "Number of users successfully purged. "
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use the length of successes."
+        ),
+        deprecated=True,
     )
     failed: list[BulkPurgeUserV2Error] = Field(
         description="List of errors for users that failed to purge.",

--- a/src/ai/backend/common/dto/manager/v2/vfolder/response.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/response.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 from .types import (
     FileEntryType,
@@ -144,13 +145,19 @@ class BulkDeleteVFolderV2Error(BaseResponseModel):
 class BulkDeleteVFoldersPayload(BaseResponseModel):
     """Payload for bulk virtual folder soft-deletion."""
 
-    deleted_count: int = Field(description="Number of virtual folders successfully soft-deleted.")
-    deleted_ids: list[UUID] = Field(
+    successes: list[UUID] = Field(
         default_factory=list,
         description=(
             "UUIDs of the vfolders that were soft-deleted, in the order they were requested. "
             "Together with `failed` this answers for every requested vfolder exactly once."
         ),
+    )
+    deleted_count: int = Field(
+        description=(
+            "Number of virtual folders successfully soft-deleted. "
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use the length of successes."
+        ),
+        deprecated=True,
     )
     failed: list[BulkDeleteVFolderV2Error] = Field(
         default_factory=list,
@@ -168,13 +175,19 @@ class BulkPurgeVFolderV2Error(BaseResponseModel):
 class BulkPurgeVFoldersPayload(BaseResponseModel):
     """Payload for bulk virtual folder purge."""
 
-    purged_count: int = Field(description="Number of virtual folders successfully purged.")
-    purged_ids: list[UUID] = Field(
+    successes: list[UUID] = Field(
         default_factory=list,
         description=(
             "UUIDs of the vfolders that were purged, in the order they were requested. "
             "Together with `failed` this answers for every requested vfolder exactly once."
         ),
+    )
+    purged_count: int = Field(
+        description=(
+            "Number of virtual folders successfully purged. "
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use the length of successes."
+        ),
+        deprecated=True,
     )
     failed: list[BulkPurgeVFolderV2Error] = Field(
         description="List of errors for vfolders that failed to purge."

--- a/src/ai/backend/common/dto/manager/v2/vfolder/response.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/response.py
@@ -23,6 +23,7 @@ from .types import (
 )
 
 __all__ = (
+    "BulkDeleteVFolderV2Error",
     "BulkDeleteVFoldersPayload",
     "BulkPurgeVFolderV2Error",
     "BulkPurgeVFoldersPayload",
@@ -133,10 +134,28 @@ class PurgeVFolderPayload(BaseResponseModel):
     id: UUID = Field(description="ID of the purged virtual folder.")
 
 
+class BulkDeleteVFolderV2Error(BaseResponseModel):
+    """Error information for a single vfolder that failed during bulk soft-deletion."""
+
+    vfolder_id: UUID = Field(description="UUID of the vfolder that failed to be soft-deleted.")
+    message: str = Field(description="Error message describing the failure.")
+
+
 class BulkDeleteVFoldersPayload(BaseResponseModel):
     """Payload for bulk virtual folder soft-deletion."""
 
     deleted_count: int = Field(description="Number of virtual folders successfully soft-deleted.")
+    deleted_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "UUIDs of the vfolders that were soft-deleted, in the order they were requested. "
+            "Together with `failed` this answers for every requested vfolder exactly once."
+        ),
+    )
+    failed: list[BulkDeleteVFolderV2Error] = Field(
+        default_factory=list,
+        description="List of errors for vfolders that failed to be soft-deleted.",
+    )
 
 
 class BulkPurgeVFolderV2Error(BaseResponseModel):
@@ -150,6 +169,13 @@ class BulkPurgeVFoldersPayload(BaseResponseModel):
     """Payload for bulk virtual folder purge."""
 
     purged_count: int = Field(description="Number of virtual folders successfully purged.")
+    purged_ids: list[UUID] = Field(
+        default_factory=list,
+        description=(
+            "UUIDs of the vfolders that were purged, in the order they were requested. "
+            "Together with `failed` this answers for every requested vfolder exactly once."
+        ),
+    )
     failed: list[BulkPurgeVFolderV2Error] = Field(
         description="List of errors for vfolders that failed to purge."
     )

--- a/src/ai/backend/common/dto/manager/v2/vfolder/response.py
+++ b/src/ai/backend/common/dto/manager/v2/vfolder/response.py
@@ -145,17 +145,18 @@ class BulkDeleteVFolderV2Error(BaseResponseModel):
 class BulkDeleteVFoldersPayload(BaseResponseModel):
     """Payload for bulk virtual folder soft-deletion."""
 
-    successes: list[UUID] = Field(
+    items: list[VFolderNode] = Field(
         default_factory=list,
         description=(
-            "UUIDs of the vfolders that were soft-deleted, in the order they were requested. "
+            "The vfolders that were soft-deleted, in the order they were requested. "
+            "A soft-deleted vfolder is still addressable, so it is returned whole. "
             "Together with `failed` this answers for every requested vfolder exactly once."
         ),
     )
     deleted_count: int = Field(
         description=(
             "Number of virtual folders successfully soft-deleted. "
-            f"Deprecated since {NEXT_RELEASE_VERSION}. Use the length of successes."
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use the length of items."
         ),
         deprecated=True,
     )

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -686,8 +686,8 @@ class UserAdapter(BaseAdapter):
             for error in result.data.failures
         ]
         return BulkPurgeUsersPayload(
+            successes=list(result.data.purged_user_ids),
             purged_count=result.data.purged_count(),
-            purged_user_ids=list(result.data.purged_user_ids),
             failed=failed,
         )
 

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -687,6 +687,7 @@ class UserAdapter(BaseAdapter):
         ]
         return BulkPurgeUsersPayload(
             purged_count=result.data.purged_count(),
+            purged_user_ids=list(result.data.purged_user_ids),
             failed=failed,
         )
 

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -551,7 +551,7 @@ class VFolderAdapter(BaseAdapter):
         ``failed`` rather than aborting the batch and leaving the earlier ids deleted
         while the caller is told the whole call failed.
         """
-        deleted_ids: list[UUID] = []
+        deleted: list[UUID] = []
         failed: list[BulkDeleteVFolderV2Error] = []
         for vfolder_id in input.ids:
             action = DeleteVFolderV2Action(vfolder_uuid=VFolderUUID(vfolder_id))
@@ -560,10 +560,10 @@ class VFolderAdapter(BaseAdapter):
             except BackendAIError as e:
                 failed.append(BulkDeleteVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
                 continue
-            deleted_ids.append(vfolder_id)
+            deleted.append(vfolder_id)
         return BulkDeleteVFoldersPayload(
-            deleted_count=len(deleted_ids),
-            deleted_ids=deleted_ids,
+            successes=deleted,
+            deleted_count=len(deleted),
             failed=failed,
         )
 
@@ -573,7 +573,7 @@ class VFolderAdapter(BaseAdapter):
         Each vfolder is processed independently; per-id failures are collected
         into ``failed`` rather than aborting the whole batch.
         """
-        purged_ids: list[UUID] = []
+        purged: list[UUID] = []
         failed: list[BulkPurgeVFolderV2Error] = []
         for vfolder_id in input.ids:
             action = PurgeVFolderV2Action(
@@ -586,10 +586,10 @@ class VFolderAdapter(BaseAdapter):
             except BackendAIError as e:
                 failed.append(BulkPurgeVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
                 continue
-            purged_ids.append(vfolder_id)
+            purged.append(vfolder_id)
         return BulkPurgeVFoldersPayload(
-            purged_count=len(purged_ids),
-            purged_ids=purged_ids,
+            successes=purged,
+            purged_count=len(purged),
             failed=failed,
         )
 

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -30,6 +30,7 @@ from ai.backend.common.dto.manager.v2.vfolder.request import (
 )
 from ai.backend.common.dto.manager.v2.vfolder.response import (
     BulkDeleteVFoldersPayload,
+    BulkDeleteVFolderV2Error,
     BulkPurgeVFoldersPayload,
     BulkPurgeVFolderV2Error,
     CloneVFolderPayload,
@@ -544,11 +545,27 @@ class VFolderAdapter(BaseAdapter):
         )
 
     async def bulk_delete(self, input: BulkDeleteVFoldersInput) -> BulkDeleteVFoldersPayload:
-        """Soft-delete multiple vfolders."""
+        """Soft-delete multiple vfolders.
+
+        Each vfolder is processed independently; per-id failures are collected into
+        ``failed`` rather than aborting the batch and leaving the earlier ids deleted
+        while the caller is told the whole call failed.
+        """
+        deleted_ids: list[UUID] = []
+        failed: list[BulkDeleteVFolderV2Error] = []
         for vfolder_id in input.ids:
             action = DeleteVFolderV2Action(vfolder_uuid=VFolderUUID(vfolder_id))
-            await self._processors.vfolder.delete_v2.run(action)
-        return BulkDeleteVFoldersPayload(deleted_count=len(input.ids))
+            try:
+                await self._processors.vfolder.delete_v2.run(action)
+            except BackendAIError as e:
+                failed.append(BulkDeleteVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
+                continue
+            deleted_ids.append(vfolder_id)
+        return BulkDeleteVFoldersPayload(
+            deleted_count=len(deleted_ids),
+            deleted_ids=deleted_ids,
+            failed=failed,
+        )
 
     async def bulk_purge(self, input: BulkPurgeVFoldersInput) -> BulkPurgeVFoldersPayload:
         """Permanently purge multiple vfolders, optionally cascading linked model cards.
@@ -556,7 +573,7 @@ class VFolderAdapter(BaseAdapter):
         Each vfolder is processed independently; per-id failures are collected
         into ``failed`` rather than aborting the whole batch.
         """
-        purged_count = 0
+        purged_ids: list[UUID] = []
         failed: list[BulkPurgeVFolderV2Error] = []
         for vfolder_id in input.ids:
             action = PurgeVFolderV2Action(
@@ -569,8 +586,12 @@ class VFolderAdapter(BaseAdapter):
             except BackendAIError as e:
                 failed.append(BulkPurgeVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
                 continue
-            purged_count += 1
-        return BulkPurgeVFoldersPayload(purged_count=purged_count, failed=failed)
+            purged_ids.append(vfolder_id)
+        return BulkPurgeVFoldersPayload(
+            purged_count=len(purged_ids),
+            purged_ids=purged_ids,
+            failed=failed,
+        )
 
     async def list_files(self, vfolder_id: UUID, input: ListFilesInput) -> ListFilesPayload:
         """List files in a vfolder."""

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -551,18 +551,18 @@ class VFolderAdapter(BaseAdapter):
         ``failed`` rather than aborting the batch and leaving the earlier ids deleted
         while the caller is told the whole call failed.
         """
-        deleted: list[UUID] = []
+        deleted: list[VFolderNode] = []
         failed: list[BulkDeleteVFolderV2Error] = []
         for vfolder_id in input.ids:
             action = DeleteVFolderV2Action(vfolder_uuid=VFolderUUID(vfolder_id))
             try:
-                await self._processors.vfolder.delete_v2.run(action)
+                result = await self._processors.vfolder.delete_v2.run(action)
             except BackendAIError as e:
                 failed.append(BulkDeleteVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
                 continue
-            deleted.append(vfolder_id)
+            deleted.append(self._vfolder_data_to_node(result.vfolder))
         return BulkDeleteVFoldersPayload(
-            successes=deleted,
+            items=deleted,
             deleted_count=len(deleted),
             failed=failed,
         )

--- a/src/ai/backend/manager/api/gql/user/types/payloads.py
+++ b/src/ai/backend/manager/api/gql/user/types/payloads.py
@@ -298,8 +298,7 @@ class BulkPurgeUserV2ErrorGQL:
 class BulkPurgeUsersV2PayloadGQL:
     """Payload for bulk user permanent deletion."""
 
-    purged_count: int = gql_field(description="Number of users successfully purged.")
-    purged_user_ids: list[UUID] = gql_added_field(
+    successes: list[UUID] = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description=(
@@ -307,6 +306,14 @@ class BulkPurgeUsersV2PayloadGQL:
                 "Together with `failed` this answers for every requested user exactly once."
             ),
         ),
+    )
+    purged_count: int = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.3.0",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="Number of users successfully purged.",
+        ),
+        deprecation_reason="Use the length of successes.",
     )
     failed: list[BulkPurgeUserV2ErrorGQL] = gql_field(
         description="List of errors for users that failed to purge."

--- a/src/ai/backend/manager/api/gql/user/types/payloads.py
+++ b/src/ai/backend/manager/api/gql/user/types/payloads.py
@@ -299,6 +299,15 @@ class BulkPurgeUsersV2PayloadGQL:
     """Payload for bulk user permanent deletion."""
 
     purged_count: int = gql_field(description="Number of users successfully purged.")
+    purged_user_ids: list[UUID] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "UUIDs of the users that were purged, in the order they were requested. "
+                "Together with `failed` this answers for every requested user exactly once."
+            ),
+        ),
+    )
     failed: list[BulkPurgeUserV2ErrorGQL] = gql_field(
         description="List of errors for users that failed to purge."
     )

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -456,13 +456,13 @@ class BulkDeleteVFolderV2ErrorGQL(PydanticOutputMixin[BulkDeleteErrorDTO]):
     name="BulkDeleteVFoldersV2Payload",
 )
 class BulkDeleteVFoldersPayloadGQL(PydanticOutputMixin[BulkDeletePayloadDTO]):
-    successes: list[UUID] = gql_added_field(
+    items: list[VFolderGQL] = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description=(
-                "UUIDs of the vfolders that were soft-deleted, in the order they were "
-                "requested. Together with `failed` this answers for every requested "
-                "vfolder exactly once."
+                "The vfolders that were soft-deleted, in the order they were requested. "
+                "A soft-deleted vfolder is still addressable, so it is returned whole. "
+                "Together with `failed` this answers for every requested vfolder exactly once."
             ),
         ),
     )
@@ -472,7 +472,7 @@ class BulkDeleteVFoldersPayloadGQL(PydanticOutputMixin[BulkDeletePayloadDTO]):
             deprecated_version=NEXT_RELEASE_VERSION,
             description="Number of virtual folders successfully soft-deleted.",
         ),
-        deprecation_reason="Use the length of successes.",
+        deprecation_reason="Use the length of items.",
     )
     failed: list[BulkDeleteVFolderV2ErrorGQL] = gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -456,10 +456,7 @@ class BulkDeleteVFolderV2ErrorGQL(PydanticOutputMixin[BulkDeleteErrorDTO]):
     name="BulkDeleteVFoldersV2Payload",
 )
 class BulkDeleteVFoldersPayloadGQL(PydanticOutputMixin[BulkDeletePayloadDTO]):
-    deleted_count: int = gql_field(
-        description="Number of virtual folders successfully soft-deleted."
-    )
-    deleted_ids: list[UUID] = gql_added_field(
+    successes: list[UUID] = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description=(
@@ -468,6 +465,14 @@ class BulkDeleteVFoldersPayloadGQL(PydanticOutputMixin[BulkDeletePayloadDTO]):
                 "vfolder exactly once."
             ),
         ),
+    )
+    deleted_count: int = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.4.2",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="Number of virtual folders successfully soft-deleted.",
+        ),
+        deprecation_reason="Use the length of successes.",
     )
     failed: list[BulkDeleteVFolderV2ErrorGQL] = gql_added_field(
         BackendAIGQLMeta(
@@ -548,8 +553,7 @@ class BulkPurgeVFolderV2ErrorGQL(PydanticOutputMixin[BulkPurgeErrorDTO]):
     name="BulkPurgeVFoldersV2Payload",
 )
 class BulkPurgeVFoldersPayloadGQL(PydanticOutputMixin[BulkPurgePayloadDTO]):
-    purged_count: int = gql_field(description="Number of virtual folders successfully purged.")
-    purged_ids: list[UUID] = gql_added_field(
+    successes: list[UUID] = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
             description=(
@@ -557,6 +561,14 @@ class BulkPurgeVFoldersPayloadGQL(PydanticOutputMixin[BulkPurgePayloadDTO]):
                 "Together with `failed` this answers for every requested vfolder exactly once."
             ),
         ),
+    )
+    purged_count: int = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.4.2",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="Number of virtual folders successfully purged.",
+        ),
+        deprecation_reason="Use the length of successes.",
     )
     failed: list[BulkPurgeVFolderV2ErrorGQL] = gql_added_field(
         BackendAIGQLMeta(

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/mutations.py
@@ -47,6 +47,9 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
     BulkDeleteVFoldersPayload as BulkDeletePayloadDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.response import (
+    BulkDeleteVFolderV2Error as BulkDeleteErrorDTO,
+)
+from ai.backend.common.dto.manager.v2.vfolder.response import (
     BulkPurgeVFoldersPayload as BulkPurgePayloadDTO,
 )
 from ai.backend.common.dto.manager.v2.vfolder.response import (
@@ -91,6 +94,7 @@ from ai.backend.common.dto.manager.v2.vfolder.response import (
 from ai.backend.common.dto.manager.v2.vfolder.response import (
     RestoreVFolderPayload as RestorePayloadDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -432,6 +436,19 @@ class BulkDeleteVFoldersInputGQL(PydanticInputMixin[BulkDeleteInputDTO]):
 
 @gql_pydantic_type(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Failure detail for a single vfolder in a bulk soft-deletion.",
+    ),
+    model=BulkDeleteErrorDTO,
+    name="BulkDeleteVFolderV2Error",
+)
+class BulkDeleteVFolderV2ErrorGQL(PydanticOutputMixin[BulkDeleteErrorDTO]):
+    vfolder_id: UUID = gql_field(description="UUID of the vfolder that failed to be soft-deleted.")
+    message: str = gql_field(description="Error message describing the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
         added_version="26.4.2",
         description="Payload for bulk virtual folder soft-deletion.",
     ),
@@ -441,6 +458,22 @@ class BulkDeleteVFoldersInputGQL(PydanticInputMixin[BulkDeleteInputDTO]):
 class BulkDeleteVFoldersPayloadGQL(PydanticOutputMixin[BulkDeletePayloadDTO]):
     deleted_count: int = gql_field(
         description="Number of virtual folders successfully soft-deleted."
+    )
+    deleted_ids: list[UUID] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "UUIDs of the vfolders that were soft-deleted, in the order they were "
+                "requested. Together with `failed` this answers for every requested "
+                "vfolder exactly once."
+            ),
+        ),
+    )
+    failed: list[BulkDeleteVFolderV2ErrorGQL] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="List of errors for vfolders that failed to be soft-deleted.",
+        ),
     )
 
 
@@ -516,6 +549,15 @@ class BulkPurgeVFolderV2ErrorGQL(PydanticOutputMixin[BulkPurgeErrorDTO]):
 )
 class BulkPurgeVFoldersPayloadGQL(PydanticOutputMixin[BulkPurgePayloadDTO]):
     purged_count: int = gql_field(description="Number of virtual folders successfully purged.")
+    purged_ids: list[UUID] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "UUIDs of the vfolders that were purged, in the order they were requested. "
+                "Together with `failed` this answers for every requested vfolder exactly once."
+            ),
+        ),
+    )
     failed: list[BulkPurgeVFolderV2ErrorGQL] = gql_added_field(
         BackendAIGQLMeta(
             added_version="26.4.4",

--- a/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
+++ b/src/ai/backend/manager/services/vfolder/actions/vfolder_v2.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.vfolder.types import VFolderData
 from ai.backend.manager.services.vfolder.actions.base import VFolderAction
 
 
@@ -25,7 +26,7 @@ class DeleteVFolderV2Action(VFolderAction):
 
 @dataclass
 class DeleteVFolderV2ActionResult:
-    vfolder_id: uuid.UUID
+    vfolder: VFolderData
 
 
 @dataclass

--- a/src/ai/backend/manager/services/vfolder/services/vfolder.py
+++ b/src/ai/backend/manager/services/vfolder/services/vfolder.py
@@ -1845,8 +1845,10 @@ class VFolderService:
             user_uuid=me.user_id,
         )
 
-        await self._vfolder_repository.move_vfolders_to_trash([vfolder_data.id])
-        return DeleteVFolderV2ActionResult(vfolder_id=action.vfolder_uuid)
+        trashed = await self._vfolder_repository.move_vfolders_to_trash([vfolder_data.id])
+        if not trashed:
+            raise UnreachableError(f"VFolder disappeared while trashing: {vfolder_data.id}")
+        return DeleteVFolderV2ActionResult(vfolder=trashed[0])
 
     async def purge_v2(self, action: PurgeVFolderV2Action) -> PurgeVFolderV2ActionResult:
         """Permanently purge a vfolder by ID. RBAC enforced at processor level.


### PR DESCRIPTION
## Summary

Three bulk surfaces reported a count where they knew the ids, so a caller could not tell which of the entities it named were acted on. Found in the BA-7489 runtime audit, verdict `E-BULK` (`docs/reports/v2-action-audit/03-runtime.md` rows 444, 802, 803).

- **`global_purge_users`** — the service already collected `purged_user_ids` in request order (`services/user/service.py:271`); the adapter dropped them for `purged_count()`. Carried into the payload.
- **`vfolder bulk-delete`** — the loop had no per-item guard, so the first failure escaped while the ids before it stayed soft-deleted, and `deleted_count` was computed from `len(input.ids)` rather than from what happened. Each id is now handled independently and the payload reports `deleted_ids` and `failed`.
- **`vfolder bulk-purge`** — the loop was already per item; added `purged_ids` so the answer maps back to the request.

Every surface keeps its existing count and failure fields. The id lists are additive, and together with `failed` they answer for each requested id exactly once, in request order — duplicates are not collapsed. New GQL fields use `NEXT_RELEASE_VERSION`.

Not in this PR: the other six `E-BULK` rows (`delete_artifacts`, `restore_artifacts`, `assign_users_to_project`, the three `bulk_upsert_*_fair_share_weights`) need repository-level changes and are left for a follow-up. Distinguishing a denial from a miss by machine still needs an `error_code` on the bulk error DTOs, which is a cross-cutting decision across every bulk surface.

## Test plan

- [x] `bulk-purge-users` with a mix of existing and nonexistent user ids returns every id once across `purged_user_ids` and `failed`
- [x] `vfolder bulk-delete` where one id is denied: the permitted ids appear in `deleted_ids`, the denied one in `failed`, and the call no longer returns a bare 403
- [x] `vfolder bulk-delete` `deleted_count` matches `len(deleted_ids)` rather than the input length
- [x] `vfolder bulk-purge` with a duplicated id answers twice — once success, once failure
- [x] GraphQL schema exposes `deletedIds`, `failed` on `BulkDeleteVFoldersV2Payload`, `purgedIds` on `BulkPurgeVFoldersV2Payload`, `purgedUserIds` on `BulkPurgeUsersV2Payload`

Resolves BA-7511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013i38G9Y7aVGAArqrEFDKuN

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14040.org.readthedocs.build/en/14040/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14040.org.readthedocs.build/ko/14040/

<!-- readthedocs-preview sorna-ko end -->