### PR TITLE
feat(BA-7517): add the relation action shape

### DIFF
--- a/changes/14041.feature.md
+++ b/changes/14041.feature.md
@@ -1,0 +1,1 @@
+Add the relation action shape for operations that link two entities, or unlink them.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2017,8 +2017,10 @@ type AuditLogV2 implements Node
   """UUID of the action that generated this log."""
   actionId: UUID!
 
-  """Type of entity this log relates to."""
-  entityType: String!
+  """
+  Type of entity this log relates to. Null for an operation that names scopes and no entity kind, such as linking two entities.
+  """
+  entityType: String
 
   """Operation performed (create, update, delete, etc.)."""
   operation: String!

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1463,8 +1463,10 @@ type AuditLogV2 implements Node {
   """UUID of the action that generated this log."""
   actionId: UUID!
 
-  """Type of entity this log relates to."""
-  entityType: String!
+  """
+  Type of entity this log relates to. Null for an operation that names scopes and no entity kind, such as linking two entities.
+  """
+  entityType: String
 
   """Operation performed (create, update, delete, etc.)."""
   operation: String!

--- a/src/ai/backend/common/dto/manager/v2/audit_log/response.py
+++ b/src/ai/backend/common/dto/manager/v2/audit_log/response.py
@@ -23,7 +23,13 @@ class AuditLogNode(BaseResponseModel):
 
     id: UUID = Field(description="Audit log entry ID")
     action_id: UUID = Field(description="UUID of the action that generated this log")
-    entity_type: str = Field(description="Type of entity this log relates to")
+    entity_type: str | None = Field(
+        default=None,
+        description=(
+            "Type of entity this log relates to. Null for an operation that names "
+            "scopes and no entity kind, such as linking two entities."
+        ),
+    )
     operation: str = Field(description="Operation performed")
     entity_id: str | None = Field(default=None, description="ID of the affected entity")
     created_at: datetime = Field(description="Timestamp when the audit log was created")

--- a/src/ai/backend/manager/actions/AGENTS.md
+++ b/src/ai/backend/manager/actions/AGENTS.md
@@ -18,6 +18,30 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
 | `global` | none (system-wide) |
 | `lookup` / `bulk_lookup` | an external key into an internal id |
 | `single_field` / `bulk_field` | field rows |
+| `relation` | two entities, linked or unlinked |
+
+## Linking two entities
+
+- The shape splits on **whether one side is contained in the other**.
+
+| | Example | Shape |
+|---|---|---|
+| Contained | project ⊃ user | `scope`: `scope_targets` = the container, `entity_type` = what it contains |
+| Not contained | resource group ↔ domain | `relation`: `scope_targets` = both, no entity type |
+
+- A `relation` action declares no `entity_type`, because what it writes is not an entity.
+  With no type there is nothing to read at a scope, so the permission is asked of each
+  named scope itself and every one of them has to permit the run.
+- Its audit row names no entity and no kind; the scopes go to `audit_log_scopes`, which
+  is why `audit_logs.entity_type` is nullable. The catalog records the wiring with no
+  entity type at all, which `GLOBAL_ENTITY_TYPE` does not stand for — that names an
+  operation over every entity, and a relation targets none.
+- It is wired through `ConcernGroups.relation_group()`, not through an entity group:
+  a group is answered for by an entity type and a relation is answered for by none.
+- Which relation a run was about is read off those scopes, so the spec is a value on
+  the action and one wiring per operation serves every relation.
+- Putting a user in an organization is the contained case, and it grants roles as a
+  second write — see `proposals/BEP-1076-project-membership.md`.
 
 ## What an action takes
 

--- a/src/ai/backend/manager/actions/KNOWLEDGE.md
+++ b/src/ai/backend/manager/actions/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 ---
 name: action-framework-design
 type: design-rationale
-description: v2 action shapes and derived permissions, why a field row's operations are answered for by its owning entity, why a bulk field answers per row but records per entity, audit recording principles (writes always, reads on subscription, failures always, DENIED), lookup existence-leak handling, public read gate, ops-backed backing axis
+description: v2 action shapes and derived permissions, why a link between two entities names both scopes and no entity kind, why a field row's operations are answered for by its owning entity, why a bulk field answers per row but records per entity, audit recording principles (writes always, reads on subscription, failures always, DENIED), lookup existence-leak handling, public read gate, ops-backed backing axis
 scope: src/ai/backend/manager/actions
-keywords: [BaseSingleEntityAction, BaseScopeAction, BaseGlobalAction, BaseLookupAction, BaseBulkLookupAction, BaseSingleFieldAction, BaseBulkFieldAction, FieldOwnerLookup, PublicActionProcessor, AnonymousGlobalActionProcessor, anonymous_scope, anonymous_global, AuditLogPolicy, ProcessorRegistry, wired_actions, RESTORE, soft-delete]
+keywords: [BaseRelationAction, RelationActionProcessor, audit_log_scopes, BaseSingleEntityAction, BaseScopeAction, BaseGlobalAction, BaseLookupAction, BaseBulkLookupAction, BaseSingleFieldAction, BaseBulkFieldAction, FieldOwnerLookup, PublicActionProcessor, AnonymousGlobalActionProcessor, anonymous_scope, anonymous_global, AuditLogPolicy, ProcessorRegistry, wired_actions, RESTORE, soft-delete]
 sources:
   - src/ai/backend/manager/actions/v2
   - src/ai/backend/manager/actions/registry
@@ -74,6 +74,27 @@ which is why handlers call processors, not services.
 - Every field write is an `UPDATE`. Adding or removing a row is a change to that
   entity, and it is that entity's permission that answers for it; a separate permission
   bit would diverge from it.
+
+## A relation names two scopes and no kind
+
+- The shape a link takes follows from containment. A user is inside a project, so that is
+  the scope shape as it stands — one scope, and the type it contains. A resource group is
+  a cluster resource several domains share, so neither is inside the other and both are
+  named.
+- Naming both means asking both. With no entity type there is nothing to read at a scope,
+  so the question degenerates to the permission on the scope itself, which is the entity
+  question the bulk validator already asks. One denied scope refuses the run: the row is
+  about both, so there is no subset left to write.
+- Not the bulk shape, which runs the operation once per entity and answers per entity.
+  A link runs once and answers once.
+- The audit row names no entity and no kind — what was written stands between two
+  entities and is neither. The scopes go to `audit_log_scopes`, which is why
+  `audit_logs.entity_type` admits NULL. The reporter still emits one message per scope,
+  since every scope is an entity and each is reported as the one it is.
+- Deriving permission from a relation was rejected: the same entity reached through
+  several relations turns revocation into reference counting, and a permission written as
+  a side effect of a business operation cannot be explained from the roles and grants.
+- Rationale: `proposals/BEP-1075-entity-relation-operations.md`.
 
 ## A field bulk answers per row and records per entity
 

--- a/src/ai/backend/manager/actions/monitors/__init__.py
+++ b/src/ai/backend/manager/actions/monitors/__init__.py
@@ -5,6 +5,7 @@ from ai.backend.manager.actions.v2.bulk.monitor.base import BulkActionMonitor
 from ai.backend.manager.actions.v2.global_scope.monitor.base import GlobalActionMonitor
 from ai.backend.manager.actions.v2.lookup.bulk_monitor.base import BulkLookupActionMonitor
 from ai.backend.manager.actions.v2.lookup.monitor.base import LookupActionMonitor
+from ai.backend.manager.actions.v2.relation.monitor.base import RelationActionMonitor
 from ai.backend.manager.actions.v2.scope.monitor.base import ScopeActionMonitor
 from ai.backend.manager.actions.v2.single_entity.monitor.base import SingleEntityActionMonitor
 
@@ -23,6 +24,7 @@ class ActionMonitors:
     single_entity: list[SingleEntityActionMonitor] = field(default_factory=list)
     bulk: list[BulkActionMonitor] = field(default_factory=list)
     scope: list[ScopeActionMonitor] = field(default_factory=list)
+    relation: list[RelationActionMonitor] = field(default_factory=list)
     global_scope: list[GlobalActionMonitor] = field(default_factory=list)
     lookup: list[LookupActionMonitor] = field(default_factory=list)
     bulk_lookup: list[BulkLookupActionMonitor] = field(default_factory=list)

--- a/src/ai/backend/manager/actions/monitors/audit_log.py
+++ b/src/ai/backend/manager/actions/monitors/audit_log.py
@@ -45,6 +45,7 @@ class AuditLogMonitor(ActionMonitor):
             ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
         )
         creator = LegacyAuditLogCreator(
+            entity_type=EntityType(action.entity_type()),
             action_id=result.meta.action_id,
             operation=action.operation_type(),
             # Legacy actions declare no name; record the spec type until each
@@ -59,7 +60,7 @@ class AuditLogMonitor(ActionMonitor):
             duration=result.meta.duration,
             client_ip=client_ip,
         )
-        await self._repository.create_dangling_field(EntityType(action.entity_type()), creator)
+        await self._repository.create_dangling_field(creator)
 
     @override
     async def prepare(self, action: BaseAction, meta: BaseActionTriggerMeta) -> None:

--- a/src/ai/backend/manager/actions/registry/registry.py
+++ b/src/ai/backend/manager/actions/registry/registry.py
@@ -10,6 +10,7 @@ from ai.backend.manager.actions.registry.field import FieldGroup, LookupFieldGro
 from ai.backend.manager.actions.registry.group import (
     ProcessorGroup,
 )
+from ai.backend.manager.actions.registry.relation import RelationGroup
 from ai.backend.manager.actions.registry.types import (
     ConcernMeta,
     FieldGroupMeta,
@@ -48,6 +49,14 @@ class ConcernGroups[TData: EntityData]:
 
     def group(self, meta: GroupMeta) -> ProcessorGroup[TData]:
         return ProcessorGroup(self._deps, self._records, self._concern, meta)
+
+    def relation_group(self) -> RelationGroup:
+        """The relation operations of this area.
+
+        Reached from here rather than an entity group: a relation is answered for by the
+        two scopes it names and by no entity type, so there is no group meta to fix.
+        """
+        return RelationGroup(self._deps, self._records, self._concern)
 
     def dangling_field_group[TFieldData: FieldData](
         self, meta: FieldGroupMeta, data_cls: type[TFieldData]

--- a/src/ai/backend/manager/actions/registry/relation.py
+++ b/src/ai/backend/manager/actions/registry/relation.py
@@ -1,0 +1,72 @@
+"""The group a link between two entities is wired through.
+
+Apart from :class:`~.group.ProcessorGroup` because that group is answered for by an
+entity type and a relation is answered for by neither of the two it names. It takes no
+meta: there is nothing for one to carry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
+from ai.backend.manager.actions.registry.types import (
+    ProcessorDependencies,
+    WiredProcessor,
+)
+from ai.backend.manager.actions.types import ActionBacking, ActionGate, ActionKind
+from ai.backend.manager.actions.v2.relation.base import BaseRelationAction
+from ai.backend.manager.actions.v2.relation.monitor import RelationActionMonitor
+from ai.backend.manager.actions.v2.relation.processor import RelationActionProcessor
+from ai.backend.manager.actions.v2.relation.validator import RelationActionValidator
+
+__all__ = ("RelationGroup",)
+
+
+class RelationGroup:
+    """The relation operations of one area."""
+
+    _deps: ProcessorDependencies[Any]
+    _records: list[WiredProcessor]
+    _concern: str
+
+    def __init__(
+        self,
+        deps: ProcessorDependencies[Any],
+        records: list[WiredProcessor],
+        concern: str,
+    ) -> None:
+        self._deps = deps
+        self._records = records
+        self._concern = concern
+
+    def relation[TAction: BaseRelationAction, TResult](
+        self,
+        action_cls: type[TAction],
+        func: Callable[[TAction], Awaitable[TResult]],
+        *,
+        validators: Sequence[RelationActionValidator] = (),
+        monitors: Sequence[RelationActionMonitor] = (),
+    ) -> RelationActionProcessor[TAction, TResult]:
+        """A link between two entities, or its removal.
+
+        Recorded against no entity type: what it writes is neither of the two, and which
+        two it was about is on the run's scopes. The spec travels on the action, so one
+        wiring serves every relation.
+        """
+        self._records.append(
+            WiredProcessor(
+                concern=self._concern,
+                entity_type=None,
+                field_type=None,
+                action_cls=action_cls,
+                kind=ActionKind.RELATION,
+                gate=ActionGate.PERMISSION,
+                backing=ActionBacking.CUSTOM,
+            )
+        )
+        return RelationActionProcessor(
+            func,
+            monitors=(*self._deps.monitors.relation, *monitors),
+            validators=(*self._deps.validators.relation, *validators),
+        )

--- a/src/ai/backend/manager/actions/registry/types.py
+++ b/src/ai/backend/manager/actions/registry/types.py
@@ -118,7 +118,9 @@ class WiredProcessor:
     """
 
     concern: str
-    entity_type: EntityType
+    # ``None`` when the operation targets no entity at all, which only a relation does.
+    # Distinct from ``GLOBAL_ENTITY_TYPE``, which names an operation over every entity.
+    entity_type: EntityType | None
     # Set when the operation is over a field row, whose owner ``entity_type`` names.
     field_type: FieldType | None
     action_cls: type[Any]

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -26,6 +26,7 @@ class ActionKind(enum.StrEnum):
     SINGLE_ENTITY = "single_entity"
     BULK = "bulk"
     SCOPE = "scope"
+    RELATION = "relation"
     GLOBAL = "global"
     LOOKUP = "lookup"
     # Still on the legacy ``BaseAction`` base, which declares no shape.
@@ -40,6 +41,8 @@ class ActionKind(enum.StrEnum):
                 return "an action taking several entity ids and operating on each"
             case ActionKind.SCOPE:
                 return "an action reaching every entity under a scope at once"
+            case ActionKind.RELATION:
+                return "an action linking two entities, or unlinking them"
             case ActionKind.GLOBAL:
                 return "an action operating over everything, divided by no scope"
             case ActionKind.LOOKUP:

--- a/src/ai/backend/manager/actions/v2/lookup/bulk_monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/lookup/bulk_monitor/audit_log.py
@@ -73,6 +73,7 @@ class BulkLookupActionAuditLogMonitor(BulkLookupActionMonitor):
                 # The key named nothing, so only the key itself identifies the row.
                 missed.append(
                     MissedLookupAuditLogCreator(
+                        entity_type=meta.entity_type,
                         action_id=result.meta.action_id,
                         operation=meta.operation_type,
                         action_name=meta.action_name,
@@ -112,7 +113,7 @@ class BulkLookupActionAuditLogMonitor(BulkLookupActionMonitor):
         if resolved:
             await self._repository.atomic_create_fields(resolved)
         if missed:
-            await self._repository.atomic_create_dangling_fields(meta.entity_type, missed)
+            await self._repository.atomic_create_dangling_fields(missed)
 
     def _render_key(self, key: LookupKey) -> str:
         """Rendered as the single lookup's is, so both are filterable the same way."""

--- a/src/ai/backend/manager/actions/v2/lookup/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/lookup/monitor/audit_log.py
@@ -69,8 +69,8 @@ class LookupActionAuditLogMonitor(LookupActionMonitor):
         if meta.entity_id is None:
             # The key named nothing, so only the key itself identifies the row.
             await self._repository.create_dangling_field(
-                action.entity_type(),
                 MissedLookupAuditLogCreator(
+                    entity_type=action.entity_type(),
                     action_id=meta.action_id,
                     operation=action.operation_type(),
                     action_name=action.action_name(),

--- a/src/ai/backend/manager/actions/v2/relation/__init__.py
+++ b/src/ai/backend/manager/actions/v2/relation/__init__.py
@@ -1,0 +1,16 @@
+from .base import BaseRelationAction
+from .monitor import RelationActionMonitor
+from .processor import RelationActionProcessor
+from .result import RelationActionProcessResult, RelationActionResultMeta
+from .trigger import RelationActionTriggerMeta
+from .validator import RelationActionValidator
+
+__all__ = (
+    "BaseRelationAction",
+    "RelationActionMonitor",
+    "RelationActionProcessResult",
+    "RelationActionProcessor",
+    "RelationActionResultMeta",
+    "RelationActionTriggerMeta",
+    "RelationActionValidator",
+)

--- a/src/ai/backend/manager/actions/v2/relation/base.py
+++ b/src/ai/backend/manager/actions/v2/relation/base.py
@@ -1,0 +1,46 @@
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.manager.actions.types import ActionOperationType
+
+__all__ = ("BaseRelationAction",)
+
+
+class BaseRelationAction(ABC):
+    """Base for actions that link two entities, or unlink them.
+
+    Names the scopes it is about and no entity type. What it writes is a row standing
+    between two entities, which is neither of them, so there is no "permission on this
+    type within this scope" to ask — the permission is asked of each named scope itself.
+
+    Deliberately not a :class:`~..scope.base.BaseScopeAction`: that shape's check reads
+    the acted-on entity type at each scope, and a relation has none to read. Keeping the
+    roots apart means a relation cannot flow through the path that would ask the wrong
+    question.
+
+    Design rationale: `proposals/BEP-1075-entity-relation-operations.md`.
+    """
+
+    @classmethod
+    @abstractmethod
+    def operation_type(cls) -> ActionOperationType:
+        """Return the operation this action performs on the relation."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def action_name(cls) -> str:
+        """Return the name recorded on audit rows: a lowercase snake_case verb phrase,
+        declared rather than derived so a class rename cannot split the recorded
+        history. Naming rule: services/AGENTS.md."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        """Return the scopes this run links or unlinks.
+
+        Every one of them has to permit the run: you must be able to touch both to put
+        them in a relation.
+        """
+        raise NotImplementedError

--- a/src/ai/backend/manager/actions/v2/relation/monitor/__init__.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/__init__.py
@@ -1,0 +1,3 @@
+from .base import RelationActionMonitor
+
+__all__ = ("RelationActionMonitor",)

--- a/src/ai/backend/manager/actions/v2/relation/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/audit_log.py
@@ -5,29 +5,31 @@ from typing import override
 from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE
-from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.audit_policy import AuditLogPolicy
 from ai.backend.manager.actions.types import BLANK_ID
-from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
-from ai.backend.manager.actions.v2.global_scope.monitor.base import GlobalActionMonitor
-from ai.backend.manager.actions.v2.global_scope.result import GlobalActionProcessResult
+from ai.backend.manager.actions.v2.relation.monitor.base import RelationActionMonitor
+from ai.backend.manager.actions.v2.relation.result import RelationActionProcessResult
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
 from ai.backend.manager.data.audit_log.types import AuditLogData
 from ai.backend.manager.data.client_ip.masking import ClientIPMaskingTarget
-from ai.backend.manager.models.audit_log.creators import GlobalAuditLogCreator
+from ai.backend.manager.models.audit_log.creators import (
+    AuditLogScopeCreator,
+    RelationAuditLogCreator,
+)
 from ai.backend.manager.repositories.client_ip_masking.repository import (
     ClientIPMaskingRepository,
 )
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
-__all__ = ("GlobalActionAuditLogMonitor",)
+__all__ = ("RelationActionAuditLogMonitor",)
 
 
-class GlobalActionAuditLogMonitor(GlobalActionMonitor):
-    """Persists one audit-log row per global action run.
+class RelationActionAuditLogMonitor(RelationActionMonitor):
+    """Persists one audit-log row per link or unlink.
 
-    Every target column stays NULL; ``action_kind='global'`` is what marks the row
-    as a system-wide operation.
+    The row names no entity and no kind — what the run wrote stands between two entities
+    and is neither of them. Which two it was about is on ``audit_log_scopes``, the same
+    place a scope run's targets go.
     """
 
     _repository: OpsRepository[AuditLogData]
@@ -45,31 +47,38 @@ class GlobalActionAuditLogMonitor(GlobalActionMonitor):
         self._client_ip_masking = client_ip_masking
 
     @override
-    async def prepare(self, action: BaseGlobalAction, meta: BaseActionTriggerMeta) -> None:
+    async def prepare(self, meta: RelationActionTriggerMeta) -> None:
         pass
 
     @override
-    async def done(self, action: BaseGlobalAction, result: GlobalActionProcessResult) -> None:
-        meta = result.meta
-        if not self._policy.should_record(action.operation_type(), meta.status):
+    async def done(
+        self, meta: RelationActionTriggerMeta, result: RelationActionProcessResult
+    ) -> None:
+        if not self._policy.should_record(meta.operation_type, result.meta.status):
             return
         trigger = triggered_user()
         acting = current_user()
         client_ip = await self._client_ip_masking.mask(
             ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
         )
-        creator = GlobalAuditLogCreator(
-            entity_type=GLOBAL_ENTITY_TYPE,
+        creator = RelationAuditLogCreator(
+            entity_type=None,
             action_id=meta.action_id,
-            operation=action.operation_type(),
-            action_name=action.action_name(),
+            operation=meta.operation_type,
+            action_name=meta.action_name,
             created_at=meta.started_at,
-            description=meta.description,
-            status=meta.status,
+            description=result.meta.description,
+            status=result.meta.status,
             request_id=current_request_id() or BLANK_ID,
             triggered_by=str(trigger.user_id) if trigger else None,
             acted_as=acting.user_id if acting else None,
-            duration=meta.duration,
+            duration=result.meta.duration,
             client_ip=client_ip,
         )
-        await self._repository.create_dangling_field(creator)
+        await self._repository.atomic_create_dangling_fields_with_nested(
+            [creator],
+            [
+                AuditLogScopeCreator(scope_type=str(scope.scope_type), scope_id=scope.scope_id)
+                for scope in meta.scope_targets
+            ],
+        )

--- a/src/ai/backend/manager/actions/v2/relation/monitor/base.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/base.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+from ai.backend.manager.actions.v2.relation.result import RelationActionProcessResult
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+
+__all__ = ("RelationActionMonitor",)
+
+
+class RelationActionMonitor(ABC):
+    """Observes the lifecycle of a link or unlink.
+
+    ``prepare`` runs before the action function; ``done`` runs after it completes (or
+    fails), with the outcome carried in :class:`RelationActionProcessResult`.
+    """
+
+    async def prepare(self, meta: RelationActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the prepare method")
+
+    async def done(
+        self, meta: RelationActionTriggerMeta, result: RelationActionProcessResult
+    ) -> None:
+        raise NotImplementedError("Subclasses must implement the done method")

--- a/src/ai/backend/manager/actions/v2/relation/monitor/prometheus.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/prometheus.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.metrics.metric import ActionMetricObserver
+from ai.backend.manager.actions.v2.relation.monitor.base import RelationActionMonitor
+from ai.backend.manager.actions.v2.relation.result import RelationActionProcessResult
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+
+__all__ = ("RelationActionPrometheusMonitor",)
+
+
+class RelationActionPrometheusMonitor(RelationActionMonitor):
+    """Observes link and unlink outcomes into the Prometheus action metrics.
+
+    One observation per run and none per entity: the run writes one row, and the metric
+    names entities by kind, which a relation has none of.
+    """
+
+    _observer: ActionMetricObserver
+
+    def __init__(self) -> None:
+        self._observer = ActionMetricObserver.instance()
+
+    @override
+    async def prepare(self, meta: RelationActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(
+        self, meta: RelationActionTriggerMeta, result: RelationActionProcessResult
+    ) -> None:
+        self._observer.observe_action(
+            operation_type=meta.operation_type,
+            status=result.meta.status,
+            duration=result.meta.duration.total_seconds(),
+        )

--- a/src/ai/backend/manager/actions/v2/relation/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/reporter.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import override
+
+from ai.backend.common.contexts.request_id import current_request_id
+from ai.backend.common.contexts.user import current_user, triggered_user
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.types import BLANK_ID
+from ai.backend.manager.actions.v2.relation.monitor.base import RelationActionMonitor
+from ai.backend.manager.actions.v2.relation.result import RelationActionProcessResult
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+from ai.backend.manager.reporters.base import FinishedActionMessage, StartedActionMessage
+from ai.backend.manager.reporters.hub import ReporterHub
+
+__all__ = ("RelationActionReporterMonitor",)
+
+
+class RelationActionReporterMonitor(RelationActionMonitor):
+    """Reports the start and end of a link or unlink to the reporter hub.
+
+    A message carries one entity, so a run fans out into one message per named scope —
+    every scope is an entity, so each is reported as the one it is. The messages share
+    the ``action_id``.
+    """
+
+    _reporter_hub: ReporterHub
+
+    def __init__(self, reporter_hub: ReporterHub) -> None:
+        self._reporter_hub = reporter_hub
+
+    @override
+    async def prepare(self, meta: RelationActionTriggerMeta) -> None:
+        # triggered_by = the caller who triggered the request; acted_as = the effective
+        # (acting) subject. They differ only while a super admin is impersonating.
+        trigger = triggered_user()
+        acting = current_user()
+        request_id = current_request_id()
+        for scope in meta.scope_targets:
+            await self._reporter_hub.report_started(
+                StartedActionMessage(
+                    action_id=meta.action_id,
+                    action_type=meta.action_name,
+                    entity_id=scope.scope_id,
+                    entity_type=EntityType(scope.scope_type),
+                    request_id=request_id,
+                    triggered_by=str(trigger.user_id) if trigger else None,
+                    acted_as=acting.user_id if acting else None,
+                    operation_type=meta.operation_type,
+                    created_at=meta.started_at,
+                )
+            )
+
+    @override
+    async def done(
+        self, meta: RelationActionTriggerMeta, result: RelationActionProcessResult
+    ) -> None:
+        trigger = triggered_user()
+        acting = current_user()
+        request_id = current_request_id() or BLANK_ID
+        for scope in meta.scope_targets:
+            await self._reporter_hub.report_finished(
+                FinishedActionMessage(
+                    action_id=meta.action_id,
+                    action_type=meta.action_name,
+                    entity_id=scope.scope_id,
+                    request_id=request_id,
+                    triggered_by=str(trigger.user_id) if trigger else None,
+                    acted_as=acting.user_id if acting else None,
+                    entity_type=EntityType(scope.scope_type),
+                    operation_type=meta.operation_type,
+                    status=result.meta.status,
+                    description=result.meta.description,
+                    created_at=meta.started_at,
+                    ended_at=result.meta.ended_at,
+                    duration=result.meta.duration,
+                )
+            )

--- a/src/ai/backend/manager/actions/v2/relation/processor.py
+++ b/src/ai/backend/manager/actions/v2/relation/processor.py
@@ -1,0 +1,99 @@
+import logging
+import uuid
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.run_status import ActionRunStatus
+from ai.backend.manager.actions.v2.relation.base import BaseRelationAction
+from ai.backend.manager.actions.v2.relation.monitor import RelationActionMonitor
+from ai.backend.manager.actions.v2.relation.result import (
+    RelationActionProcessResult,
+    RelationActionResultMeta,
+)
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+from ai.backend.manager.actions.v2.relation.validator import RelationActionValidator
+
+__all__ = ("RelationActionProcessor",)
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class RelationActionProcessor[TAction: BaseRelationAction, TResult]:
+    """Validate, run monitors around, then link or unlink.
+
+    The same lifecycle every v2 shape runs. There is nothing to narrow — the row is
+    about both scopes — so a denial ends the run.
+    """
+
+    _func: Callable[[TAction], Awaitable[TResult]]
+    _monitors: Sequence[RelationActionMonitor]
+    _validators: Sequence[RelationActionValidator]
+
+    def __init__(
+        self,
+        func: Callable[[TAction], Awaitable[TResult]],
+        monitors: Sequence[RelationActionMonitor] | None = None,
+        validators: Sequence[RelationActionValidator] | None = None,
+    ) -> None:
+        self._func = func
+        self._monitors = monitors or []
+        self._validators = validators or []
+
+    async def _prepare_monitors(self, trigger_meta: RelationActionTriggerMeta) -> None:
+        for monitor in self._monitors:
+            try:
+                await monitor.prepare(trigger_meta)
+            except Exception as e:
+                log.warning("Error in monitor prepare method: {}", e)
+
+    async def _finalize_monitors(
+        self, trigger_meta: RelationActionTriggerMeta, meta: RelationActionResultMeta
+    ) -> None:
+        process_result = RelationActionProcessResult(meta=meta)
+        for monitor in reversed(self._monitors):
+            try:
+                await monitor.done(trigger_meta, process_result)
+            except Exception as e:
+                log.warning("Error in monitor done method: {}", e)
+
+    async def run(self, action: TAction) -> TResult:
+        started_at = datetime.now(UTC)
+        trigger_meta = RelationActionTriggerMeta(
+            action_id=uuid.uuid4(),
+            started_at=started_at,
+            scope_targets=action.scope_targets(),
+            operation_type=action.operation_type(),
+            action_name=action.action_name(),
+        )
+
+        run_status = ActionRunStatus.unknown()
+
+        # Validation runs inside the monitor lifecycle so a rejected action is
+        # recorded too; monitors that only wrapped execution missed every denial.
+        await self._prepare_monitors(trigger_meta)
+        try:
+            try:
+                for validator in self._validators:
+                    await validator.validate(trigger_meta)
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=True)
+                raise
+            try:
+                result = await self._func(action)
+            except BaseException as e:
+                run_status = ActionRunStatus.of_failure(e, during_validation=False)
+                raise
+            else:
+                run_status = ActionRunStatus.success()
+                return result
+        finally:
+            ended_at = datetime.now(UTC)
+            meta = RelationActionResultMeta(
+                status=run_status.status,
+                description=run_status.description,
+                ended_at=ended_at,
+                duration=ended_at - started_at,
+                error_code=run_status.error_code,
+            )
+            await self._finalize_monitors(trigger_meta, meta)

--- a/src/ai/backend/manager/actions/v2/relation/result.py
+++ b/src/ai/backend/manager/actions/v2/relation/result.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from ai.backend.common.exception import ErrorCode
+from ai.backend.manager.actions.types import OperationStatus
+
+__all__ = (
+    "RelationActionResultMeta",
+    "RelationActionProcessResult",
+)
+
+
+@dataclass
+class RelationActionResultMeta:
+    """How a relation action run turned out.
+
+    One outcome for the run: the operation writes one row and the scopes it was about
+    are the trigger meta's.
+    """
+
+    status: OperationStatus
+    description: str
+    ended_at: datetime
+    duration: timedelta
+    error_code: ErrorCode | None
+
+
+@dataclass
+class RelationActionProcessResult:
+    meta: RelationActionResultMeta

--- a/src/ai/backend/manager/actions/v2/relation/trigger.py
+++ b/src/ai/backend/manager/actions/v2/relation/trigger.py
@@ -1,0 +1,20 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from ai.backend.common.data.entity.action import ActionID
+from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.manager.actions.types import ActionOperationType
+
+__all__ = ("RelationActionTriggerMeta",)
+
+
+@dataclass(frozen=True)
+class RelationActionTriggerMeta:
+    """What a run of this shape is, handed to its validators and monitors."""
+
+    action_id: ActionID
+    started_at: datetime
+    scope_targets: Sequence[ScopeRef]
+    operation_type: ActionOperationType
+    action_name: str

--- a/src/ai/backend/manager/actions/v2/relation/validator/__init__.py
+++ b/src/ai/backend/manager/actions/v2/relation/validator/__init__.py
@@ -1,0 +1,3 @@
+from .base import RelationActionValidator
+
+__all__ = ("RelationActionValidator",)

--- a/src/ai/backend/manager/actions/v2/relation/validator/base.py
+++ b/src/ai/backend/manager/actions/v2/relation/validator/base.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+
+__all__ = ("RelationActionValidator",)
+
+
+class RelationActionValidator(ABC):
+    """Validates a link or unlink before it runs.
+
+    Raises rather than answering per scope: the operation writes one row about both, so
+    a scope the caller may not reach leaves nothing to run.
+    """
+
+    @abstractmethod
+    async def validate(self, meta: RelationActionTriggerMeta) -> None:
+        raise NotImplementedError("Subclasses must implement the validate method")

--- a/src/ai/backend/manager/actions/v2/relation/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/relation/validator/rbac.py
@@ -1,0 +1,64 @@
+from typing import override
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.types import EntityIdentifier, RuntimeEntityID
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+from ai.backend.manager.actions.v2.relation.validator.base import RelationActionValidator
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.permission.virtual_scope import EntityPermissionCheckKey
+from ai.backend.manager.errors.permission import NotEnoughPermission
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+__all__ = ("VirtualScopeRelationActionRBACValidator",)
+
+
+class VirtualScopeRelationActionRBACValidator(RelationActionValidator):
+    """The operation's permission asked of every scope the run names, as an entity.
+
+    Asked of the scope itself rather than of a type within it: the action declares no
+    entity type, because what it writes is not an entity. One scope lacking the
+    permission refuses the whole run — you must be able to touch both to relate them.
+    """
+
+    _repository: PermissionControllerRepository
+    _config_provider: ManagerConfigProvider
+
+    def __init__(
+        self,
+        repository: PermissionControllerRepository,
+        config_provider: ManagerConfigProvider,
+    ) -> None:
+        self._repository = repository
+        self._config_provider = config_provider
+
+    @override
+    async def validate(self, meta: RelationActionTriggerMeta) -> None:
+        if not self._config_provider.config.manager.rbac.enforcement_enabled:
+            return
+
+        user = current_user()
+        if user is None:
+            raise UnreachableError("User context is not available")
+        if user.is_superadmin:
+            return
+
+        entities: list[EntityIdentifier] = [
+            RuntimeEntityID(scope.scope_type, scope.scope_id) for scope in meta.scope_targets
+        ]
+        keys = [
+            EntityPermissionCheckKey(user_id=UserID(user.user_id), entity=entity)
+            for entity in entities
+        ]
+        permission = meta.operation_type.to_permission()
+        permission_map = await self._repository.check_bulk_permission_via_virtual_scope(
+            keys, permission
+        )
+        denied = [key.entity for key in keys if not permission_map.get(key, False)]
+        if denied:
+            raise NotEnoughPermission(
+                f"User {user.user_id} lacks permission {permission!r} on scopes {denied}"
+            )

--- a/src/ai/backend/manager/actions/v2/scope/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/scope/monitor/audit_log.py
@@ -79,7 +79,6 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
             return
         # Nothing was touched, but the run still has to leave a trace.
         await self._repository.atomic_create_dangling_fields_with_nested(
-            action.entity_type(),
             [self._build_empty_spec(action, result, client_ip)],
             nested,
         )
@@ -98,7 +97,9 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
         result: ScopeActionProcessResult,
         client_ip: str | None,
     ) -> EmptyScopeAuditLogCreator:
-        return EmptyScopeAuditLogCreator(**self._fields(action, result, client_ip))
+        return EmptyScopeAuditLogCreator(
+            entity_type=action.entity_type(), **self._fields(action, result, client_ip)
+        )
 
     def _fields(
         self,

--- a/src/ai/backend/manager/actions/v2/validators.py
+++ b/src/ai/backend/manager/actions/v2/validators.py
@@ -6,6 +6,7 @@ from ai.backend.manager.actions.v2.bulk.validator.base import (
 )
 from ai.backend.manager.actions.v2.global_scope.validator.base import GlobalActionValidator
 from ai.backend.manager.actions.v2.lookup.validator.base import LookupActionValidator
+from ai.backend.manager.actions.v2.relation.validator.base import RelationActionValidator
 from ai.backend.manager.actions.v2.scope.validator.base import ScopeActionValidator
 from ai.backend.manager.actions.v2.single_entity.validator.base import SingleEntityActionValidator
 
@@ -20,5 +21,6 @@ class ActionValidators:
     partial_bulk: list[PartialBulkActionValidator] = field(default_factory=list)
     atomic_bulk: list[AtomicBulkActionValidator] = field(default_factory=list)
     scope: list[ScopeActionValidator] = field(default_factory=list)
+    relation: list[RelationActionValidator] = field(default_factory=list)
     global_scope: list[GlobalActionValidator] = field(default_factory=list)
     lookup: list[LookupActionValidator] = field(default_factory=list)

--- a/src/ai/backend/manager/api/adapters/entity/types.py
+++ b/src/ai/backend/manager/api/adapters/entity/types.py
@@ -14,8 +14,8 @@ class WiredEntityTypes:
     """Every entity type the processor wiring names, read once at startup.
 
     An entity type is declared where its operations are wired rather than in an enum,
-    so what a caller may name is whatever the wiring covers. `global` is wiring only
-    and names no entity, so it is left out.
+    so what a caller may name is whatever the wiring covers. Two kinds are left out:
+    `global`, which is wiring only, and a relation, which names no entity at all.
     """
 
     _types: frozenset[EntityType]
@@ -25,7 +25,7 @@ class WiredEntityTypes:
         self._types = frozenset(
             wiring.entity_type
             for wiring in registry.wired_processors()
-            if wiring.entity_type != GLOBAL_ENTITY_TYPE
+            if wiring.entity_type is not None and wiring.entity_type != GLOBAL_ENTITY_TYPE
         )
         self._sorted = tuple(sorted(self._types))
 

--- a/src/ai/backend/manager/api/gql/audit_log/types/node.py
+++ b/src/ai/backend/manager/api/gql/audit_log/types/node.py
@@ -52,7 +52,12 @@ class AuditLogV2GQL(PydanticNodeMixin[AuditLogNode]):
     id: NodeID[str] = gql_field(description="Unique identifier of the audit log entry (UUID).")
 
     action_id: UUID = gql_field(description="UUID of the action that generated this log.")
-    entity_type: str = gql_field(description="Type of entity this log relates to.")
+    entity_type: str | None = gql_field(
+        description=(
+            "Type of entity this log relates to. Null for an operation that names "
+            "scopes and no entity kind, such as linking two entities."
+        )
+    )
     operation: str = gql_field(description="Operation performed (create, update, delete, etc.).")
     entity_id: str | None = gql_field(description="ID of the affected entity, if applicable.")
     created_at: datetime = gql_field(description="Timestamp when the audit log was created.")

--- a/src/ai/backend/manager/cli/ops.py
+++ b/src/ai/backend/manager/cli/ops.py
@@ -47,6 +47,9 @@ _FIELD_BLOCK_COLUMNS: Final[tuple[str, ...]] = tuple(
 _ENTITY_COLUMNS: Final[tuple[str, ...]] = ("concern", "entity_type", "field_type", "operations")
 # Stands for a column a wiring leaves unset, so every line has the same shape.
 _ABSENT: Final[str] = "-"
+# An operation targeting no entity at all, which only a relation does. Distinct from
+# `global`, which names an operation over every entity.
+_NO_ENTITY: Final[str] = "(none)"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -67,7 +70,7 @@ class CatalogEntry:
     def from_wiring(cls, wiring: WiredProcessor) -> CatalogEntry:
         return cls(
             concern=str(wiring.concern),
-            entity_type=str(wiring.entity_type),
+            entity_type=str(wiring.entity_type) if wiring.entity_type is not None else _NO_ENTITY,
             field_type=str(wiring.field_type) if wiring.field_type is not None else _ABSENT,
             operation=str(wiring.action_cls.operation_type()),
             action_name=wiring.action_cls.action_name(),

--- a/src/ai/backend/manager/data/audit_log/types.py
+++ b/src/ai/backend/manager/data/audit_log/types.py
@@ -22,7 +22,7 @@ class AuditLogData(FieldData):
     action_id: ActionID
     action_kind: ActionKind | None
     action_name: str
-    entity_type: str
+    entity_type: str | None
     operation: str
     created_at: datetime
     description: str

--- a/src/ai/backend/manager/models/alembic/versions/c8e4b1a09d37_make_audit_log_entity_type_nullable.py
+++ b/src/ai/backend/manager/models/alembic/versions/c8e4b1a09d37_make_audit_log_entity_type_nullable.py
@@ -1,0 +1,33 @@
+"""make audit_logs.entity_type nullable
+
+A relation operation names two scopes and no entity type: what it writes is a row
+linking two entities, which is neither of them. The audit row it leaves therefore has
+scopes but no entity kind, and the column has to admit that.
+
+Existing rows all carry a kind, so nothing is migrated.
+
+Revision ID: c8e4b1a09d37
+Revises: 3f7a2c1e9b04
+Create Date: 2026-08-26
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8e4b1a09d37"
+down_revision = "3f7a2c1e9b04"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("audit_logs", "entity_type", existing_type=sa.String(), nullable=True)
+
+
+def downgrade() -> None:
+    # A row written by a relation operation has no kind to restore, so the column can
+    # only go back to NOT NULL once those rows are gone.
+    op.execute("DELETE FROM audit_logs WHERE entity_type IS NULL")
+    op.alter_column("audit_logs", "entity_type", existing_type=sa.String(), nullable=False)

--- a/src/ai/backend/manager/models/audit_log/creators.py
+++ b/src/ai/backend/manager/models/audit_log/creators.py
@@ -33,6 +33,7 @@ __all__ = (
     "LookupAuditLogCreator",
     "MissedLookupAuditLogCreator",
     "EmptyScopeAuditLogCreator",
+    "RelationAuditLogCreator",
     "GlobalAuditLogCreator",
     "LegacyAuditLogCreator",
     "AuditLogScopeCreator",
@@ -76,7 +77,7 @@ class BaseAuditLogFields:
     def _build_row(
         self,
         *,
-        entity_type: str,
+        entity_type: str | None,
         entity_id: EntityID | str | None = None,
         lookup_kind: str | None = None,
         lookup_key: str | None = None,
@@ -118,11 +119,17 @@ class OwnedAuditLogCreator(
 
 @dataclass
 class DanglingAuditLogCreator(BaseAuditLogFields, DanglingFieldCreator[AuditLogRow, AuditLogData]):
-    """A record of an operation that named no entity, so the row has a kind and no id."""
+    """A record of an operation that named no entity, so the row has no id.
+
+    ``entity_type`` is the kind it was about, or ``None`` where the operation named no
+    kind either — a relation stands between two entities and is neither of them.
+    """
+
+    entity_type: EntityType | None
 
     @override
-    def build_row(self, entity_type: EntityType) -> AuditLogRow:
-        return self._build_row(entity_type=entity_type, entity_id=None)
+    def build_row(self) -> AuditLogRow:
+        return self._build_row(entity_type=self.entity_type, entity_id=None)
 
 
 @dataclass
@@ -190,9 +197,9 @@ class MissedLookupAuditLogCreator(DanglingAuditLogCreator):
         return ActionKind.LOOKUP
 
     @override
-    def build_row(self, entity_type: EntityType) -> AuditLogRow:
+    def build_row(self) -> AuditLogRow:
         return self._build_row(
-            entity_type=entity_type,
+            entity_type=self.entity_type,
             entity_id=None,
             lookup_kind=self.lookup_kind,
             lookup_key=self.lookup_key,
@@ -207,6 +214,20 @@ class EmptyScopeAuditLogCreator(DanglingAuditLogCreator):
     @override
     def action_kind(cls) -> ActionKind:
         return ActionKind.SCOPE
+
+
+@dataclass
+class RelationAuditLogCreator(DanglingAuditLogCreator):
+    """A run that linked or unlinked two entities.
+
+    Names no entity kind: what it wrote stands between two entities and is neither of
+    them. The scopes it was about go to ``audit_log_scopes``.
+    """
+
+    @classmethod
+    @override
+    def action_kind(cls) -> ActionKind:
+        return ActionKind.RELATION
 
 
 @dataclass

--- a/src/ai/backend/manager/models/audit_log/row.py
+++ b/src/ai/backend/manager/models/audit_log/row.py
@@ -41,7 +41,10 @@ class AuditLogRow(Base):
         "action_kind", StrEnumType(ActionKind), nullable=True
     )
 
-    entity_type: Mapped[str] = mapped_column("entity_type", sa.String, index=True, nullable=False)
+    # NULL for a relation operation: it names two scopes and no entity kind.
+    entity_type: Mapped[str | None] = mapped_column(
+        "entity_type", sa.String, index=True, nullable=True
+    )
     operation: Mapped[str] = mapped_column("operation", sa.String, index=True, nullable=False)
 
     # Declared by v2 actions; legacy rows carry the "entity_type:operation" spec type.

--- a/src/ai/backend/manager/models/specs/AGENTS.md
+++ b/src/ai/backend/manager/models/specs/AGENTS.md
@@ -14,6 +14,23 @@ write specs below, plus the read/update declarations (`querier.py`, `lookup.py`,
 `purger.py`). `repositories/base/` keeps legacy-compatible views for the transition
 only; do not declare a new spec there.
 
+## A relation is neither an entity nor a field
+
+- A row linking two entities belongs to neither: both own it. It is not a field row,
+  which has exactly one owner, and it is not an entity, which has a node in the graph.
+- Its specs are `RelationCreator` / `RelationLifecycleUpdater` / `RelationPurger`
+  (`relation.py`), and they name the pair rather than a row id — a relation row's id
+  never leaves the layer that wrote it.
+- The create declares its own conflict handling. Whether a soft-deleted row occupies the
+  pair is the table's unique constraint's business, so `build_conflict_values()` says
+  what to do: `None` leaves the row alone, a mapping revives it.
+- Only a relation carrying a lifecycle column declares the lifecycle updaters. One class
+  per direction, each returning a constant, as the entity soft delete does.
+- Do NOT carry a relation as a field on a `DataUpdater`. A value whose change drags
+  other writes along does not belong on the general edit path — the same rule soft
+  delete follows.
+- Rationale: `proposals/BEP-1075-entity-relation-operations.md`.
+
 ## What a spec splits on depends on the operation
 
 A row in the graph is an entity or a field, and which one it is comes from the table

--- a/src/ai/backend/manager/models/specs/KNOWLEDGE.md
+++ b/src/ai/backend/manager/models/specs/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 ---
 name: write-spec-design
 type: design-rationale
-description: write-spec selection criteria (Entity/Global/Field/Sidecar), why the roots share no common ABC, what a sidecar row is and why it belongs to neither position, why the role-managed root is not an EntityCreator subtype, why a global entity is provisioned in the graph, how a field row's owner is read, the distinction between member_of and cap-based sharing, open entity-type strings
+description: write-spec selection criteria (Entity/Global/Field/Sidecar/Relation), why a row two entities own belongs to neither position and declares its own conflict handling, why the roots share no common ABC, what a sidecar row is and why it belongs to neither position, why the role-managed root is not an EntityCreator subtype, why a global entity is provisioned in the graph, how a field row's owner is read, the distinction between member_of and cap-based sharing, open entity-type strings
 scope: src/ai/backend/manager/models/specs
-keywords: [EntityCreator, GlobalEntityCreator, FieldCreator, RoleManagedEntityCreator, SidecarCreator, FieldOwnerLookup, RoleTemplateSource, member_of, entity_id, virtual-scope, preset-role, DataUpdater, soft-delete]
+keywords: [RelationCreator, RelationPurger, RelationLifecycleUpdater, EntityCreator, GlobalEntityCreator, FieldCreator, RoleManagedEntityCreator, SidecarCreator, FieldOwnerLookup, RoleTemplateSource, member_of, entity_id, virtual-scope, preset-role, DataUpdater, soft-delete]
 sources:
   - src/ai/backend/manager/models/specs/creator.py
   - src/ai/backend/manager/models/specs/lookup.py
@@ -38,6 +38,24 @@ execution path.
 | Global | An entity that goes under no other entity | Entity behavior minus `member_of` — the node is provisioned the same way |
 | Field | A row another entity owns (even with its own get/delete API) | create requires `owner_id`; purge is a plain delete |
 | Sidecar | A row outside the graph — an audit record, an event log | create inserts and nothing else; the entity it names is read by, not belonged to |
+
+## A relation belongs to both, so it belongs to neither position
+
+- The write specs split on ownership, and both positions assume it is zero or one: an
+  entity owns itself, a field is owned by exactly one entity. A row linking two entities
+  is owned by both, which neither position can say.
+- Ownership is read off the schema, not off the call site: what deletes the row when it
+  goes is what owns it. A polymorphic reference carries no foreign key, so ownership
+  there is a fact about the code that cleans up rather than about a constraint.
+- The relation roots therefore name the pair, never a row id. Nothing outside the layer
+  that wrote the row holds that id, and a read answers with the entities the relation
+  reaches rather than the row between them.
+- Conflict handling is the spec's because it is the table's. A unique constraint on the
+  bare pair means a soft-deleted row still occupies it, so an insert that did nothing
+  would leave the relation switched off; a partial index on (pair, alive) admits a new
+  row and keeps the history. One rule cannot serve both, so `build_conflict_values()`
+  declares which.
+- Full rationale: `proposals/BEP-1075-entity-relation-operations.md`.
 
 ## A sidecar belongs to neither position
 

--- a/src/ai/backend/manager/models/specs/creator.py
+++ b/src/ai/backend/manager/models/specs/creator.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
-    EntityType,
     FieldData,
     FieldIdentifier,
 )
@@ -173,14 +172,16 @@ class FieldCreator[TOwnerID: EntityIdentifier, TRow: Base, TData: FieldData](
 class DanglingFieldCreator[TRow: Base, TData: FieldData](FieldRowCreator[TRow, TData], ABC):
     """Insert spec of a field row written without an owner to build under.
 
-    The row names an entity type and no id: the operation being recorded named a kind but
-    no row, or named nothing at all. The type is on the creator, since there is no owner
-    to read it from. Reachable only by a read that names no owner either.
+    No owner names it, so what the row says about the entity it concerns is the spec's
+    own value like every other column — the kind it is about where there is one, nothing
+    where there is not. An operation that names scopes and no entity type is the latter.
+
+    Reachable only by a read that names no owner either.
     """
 
     @abstractmethod
-    def build_row(self, entity_type: EntityType) -> TRow:
-        """Build the row under a kind alone, since no owner names it."""
+    def build_row(self) -> TRow:
+        """Build the row, which no owner names."""
         raise NotImplementedError
 
 

--- a/src/ai/backend/manager/models/specs/relation.py
+++ b/src/ai/backend/manager/models/specs/relation.py
@@ -1,0 +1,117 @@
+"""Relation specs of the v2 lineage: rows that link two entities.
+
+A relation belongs to neither of the entities it links — both own it — so it is neither
+an entity nor a field. The roots below are unrelated to the entity and field roots for
+the same reason those are unrelated to each other: a relation must not flow through a
+path that would provision or tear down a graph node it never had.
+
+Design rationale: `proposals/BEP-1075-entity-relation-operations.md`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import Any
+
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.models.base import Base
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.specs.types import ConflictCheck, IntegrityErrorCheck
+
+
+class RelationCreator[TRow: Base](ABC):
+    """Insert spec of a row linking two entities.
+
+    Takes both ids rather than an owner: the pair is what names the row, and the caller
+    holds the pair and not the row's id.
+
+    Answers no ``data``. A relation is not returned to a caller — what a read answers
+    with is the entities the relation reaches, never the relation.
+    """
+
+    @abstractmethod
+    def row_class(self) -> type[TRow]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_row(self, left: EntityIdentifier, right: EntityIdentifier) -> TRow:
+        """Build the row linking the two entities."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def index_elements(self) -> list[str]:
+        """The column names conflict detection keys on.
+
+        Whether a soft-deleted row occupies the pair is a property of the table's own
+        unique constraint, so what conflicts is declared here rather than assumed.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_conflict_values(self) -> dict[str, Any] | None:
+        """What to write when the pair is already taken.
+
+        ``None`` leaves the existing row alone. A mapping revives it — which is what a
+        table whose unique constraint covers the bare pair needs, since a soft-deleted
+        row still occupies it and an insert that did nothing would leave the relation
+        switched off.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        raise NotImplementedError
+
+
+class RelationLifecycleUpdater[TRow: Base](ABC):
+    """Update spec that switches one relation off or back on.
+
+    ``build_values`` returns a constant, as the entity soft delete's updaters do: a
+    transition value taken as an argument is a value that can be passed wrong. A
+    relation declares one class per direction, and which of the two an operation is
+    comes from the ops method it is handed to.
+
+    Only relations carrying a lifecycle column declare these. A relation without one is
+    linked and purged, and has nothing to switch.
+    """
+
+    @abstractmethod
+    def row_class(self) -> type[TRow]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def conditions(
+        self, left: EntityIdentifier, right: EntityIdentifier
+    ) -> Sequence[QueryCondition]:
+        """Return the conditions naming the pair's row, AND combined."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_values(self) -> dict[str, Any]:
+        """Return the constant the lifecycle column is written with."""
+        raise NotImplementedError
+
+
+class RelationPurger[TRow: Base](ABC):
+    """Delete spec of the row linking two entities.
+
+    Names the row by the pair, never by its own id: a relation row holds nothing in the
+    graph, and nothing outside it holds that id.
+    """
+
+    @abstractmethod
+    def row_class(self) -> type[TRow]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def conditions(
+        self, left: EntityIdentifier, right: EntityIdentifier
+    ) -> Sequence[QueryCondition]:
+        """Return the conditions naming the pair's row, AND combined."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        """Return rows that must not exist before the link is removed (empty if none)."""
+        raise NotImplementedError

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -12,7 +12,6 @@ from typing import Any
 from ai.backend.common.data.entity.types import (
     EntityData,
     EntityIdentifier,
-    EntityType,
     FieldData,
     FieldIdentifier,
     RuntimeEntityID,
@@ -306,10 +305,10 @@ class OpsRepository[TData]:
             return await w.atomic_create_field_entities(owner_id, creators)
 
     async def create_dangling_field[TFieldData: FieldData](
-        self, entity_type: EntityType, creator: DanglingFieldCreator[Any, TFieldData]
+        self, creator: DanglingFieldCreator[Any, TFieldData]
     ) -> TFieldData:
         async with self._ops.write_ops() as w:
-            return await w.create_dangling_field(entity_type, creator)
+            return await w.create_dangling_field(creator)
 
     async def atomic_create_fields[TOwnerID: EntityIdentifier, TFieldData: FieldData](
         self, creations: Sequence[FieldToCreate[TOwnerID, Any, TFieldData]]
@@ -332,24 +331,21 @@ class OpsRepository[TData]:
             return await w.atomic_create_fields_with_nested(creations, nested_creators)
 
     async def atomic_create_dangling_fields[TFieldData: FieldData](
-        self, entity_type: EntityType, creators: Sequence[DanglingFieldCreator[Any, TFieldData]]
+        self, creators: Sequence[DanglingFieldCreator[Any, TFieldData]]
     ) -> list[TFieldData]:
         async with self._ops.write_ops() as w:
-            return await w.atomic_create_dangling_fields(entity_type, creators)
+            return await w.atomic_create_dangling_fields(creators)
 
     async def atomic_create_dangling_fields_with_nested[
         TFieldData: FieldData,
         TNestedData: FieldData,
     ](
         self,
-        entity_type: EntityType,
         creators: Sequence[DanglingFieldCreator[Any, TFieldData]],
         field_creators: Sequence[NestedFieldCreator[Any, Any, TNestedData]],
     ) -> list[TFieldData]:
         async with self._ops.write_ops() as w:
-            return await w.atomic_create_dangling_fields_with_nested(
-                entity_type, creators, field_creators
-            )
+            return await w.atomic_create_dangling_fields_with_nested(creators, field_creators)
 
     async def purge_entity(self, purger: EntityPurger[Any, TData]) -> TData:
         """Hard-delete one entity row, tearing its scope down with it."""

--- a/src/ai/backend/manager/repositories/ops/v2/dangling_field_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/dangling_field_write.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from ai.backend.common.data.entity.types import EntityType, FieldData
+from ai.backend.common.data.entity.types import FieldData
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.creator import DanglingFieldCreator, NestedFieldCreator
 from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
@@ -19,20 +19,20 @@ class V2DanglingFieldWriteOps(V2WriteOpsBase):
     """Sidecar writes, bound to a single session."""
 
     async def create_dangling_field[TRow: Base, TData: FieldData](
-        self, entity_type: EntityType, creator: DanglingFieldCreator[TRow, TData]
+        self, creator: DanglingFieldCreator[TRow, TData]
     ) -> TData:
         """Insert one row that names a kind and no owner."""
-        row = creator.build_row(entity_type)
+        row = creator.build_row()
         await self._insert_row(row, creator.integrity_error_checks())
         return creator.to_data(row)
 
     async def atomic_create_dangling_fields[TRow: Base, TData: FieldData](
-        self, entity_type: EntityType, creators: Sequence[DanglingFieldCreator[TRow, TData]]
+        self, creators: Sequence[DanglingFieldCreator[TRow, TData]]
     ) -> list[TData]:
         """Insert such rows atomically in a single flush."""
         if not creators:
             return []
-        rows = [creator.build_row(entity_type) for creator in creators]
+        rows = [creator.build_row() for creator in creators]
         # First creator's checks: all specs share the same creator subclass.
         await self._insert_rows(rows, creators[0].integrity_error_checks())
         return [creator.to_data(row) for creator, row in zip(creators, rows, strict=True)]
@@ -44,7 +44,6 @@ class V2DanglingFieldWriteOps(V2WriteOpsBase):
         TFieldData: FieldData,
     ](
         self,
-        entity_type: EntityType,
         creators: Sequence[DanglingFieldCreator[TRow, TData]],
         field_creators: Sequence[NestedFieldCreator[Any, TFieldRow, TFieldData]],
     ) -> list[TData]:
@@ -56,7 +55,7 @@ class V2DanglingFieldWriteOps(V2WriteOpsBase):
         """
         if not creators:
             return []
-        rows = [creator.build_row(entity_type) for creator in creators]
+        rows = [creator.build_row() for creator in creators]
         await self._insert_rows(rows, creators[0].integrity_error_checks())
         if field_creators:
             owner_ids = [creator.field_id(row) for creator, row in zip(creators, rows, strict=True)]

--- a/tests/unit/manager/actions/test_processor.py
+++ b/tests/unit/manager/actions/test_processor.py
@@ -266,7 +266,7 @@ class TestAuditLogMonitorActorIdentities:
     def _recorded_spec(self, mock_audit_log_repository: MagicMock) -> LegacyAuditLogCreator:
         mock_audit_log_repository.create_dangling_field.assert_called_once()
         spec: LegacyAuditLogCreator = (
-            mock_audit_log_repository.create_dangling_field.call_args.args[1]
+            mock_audit_log_repository.create_dangling_field.call_args.args[0]
         )
         return spec
 

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -96,6 +96,7 @@ from ai.backend.manager.actions.v2.field.bulk_base import BaseBulkFieldAction
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction
 from ai.backend.manager.actions.v2.lookup.bulk_base import BaseBulkLookupAction
+from ai.backend.manager.actions.v2.relation.base import BaseRelationAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
 from ai.backend.manager.actions.v2.validators import ActionValidators
@@ -194,6 +195,7 @@ _V2_ACTION_BASES: tuple[type[Any], ...] = (
     BaseSingleEntityAction,
     BaseBulkAction,
     BaseScopeAction,
+    BaseRelationAction,
     BaseGlobalAction,
     BaseLookupAction,
     BaseBulkLookupAction,

--- a/tests/unit/manager/actions/test_relation_processor.py
+++ b/tests/unit/manager/actions/test_relation_processor.py
@@ -1,0 +1,222 @@
+"""``actions/v2/relation``: a link is answered for by both ends and names no kind.
+
+A relation row stands between two entities and is neither of them, so the action carries
+no entity type. With no type there is no "permission on this type within this scope" to
+ask, and the only thing left is the permission on each named scope itself — which is why
+the shape is separate from the scope one rather than a variant of it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.common.exception import PermissionDeniedError
+from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
+from ai.backend.manager.actions.v2.relation.base import BaseRelationAction
+from ai.backend.manager.actions.v2.relation.monitor.base import RelationActionMonitor
+from ai.backend.manager.actions.v2.relation.processor import RelationActionProcessor
+from ai.backend.manager.actions.v2.relation.result import RelationActionProcessResult
+from ai.backend.manager.actions.v2.relation.trigger import RelationActionTriggerMeta
+from ai.backend.manager.actions.v2.relation.validator.base import RelationActionValidator
+from ai.backend.manager.actions.v2.relation.validator.rbac import (
+    VirtualScopeRelationActionRBACValidator,
+)
+from ai.backend.manager.errors.permission import NotEnoughPermission
+
+_RESOURCE_GROUP = ScopeType(EntityType("resource_group"))
+_DOMAIN = ScopeType(EntityType("domain"))
+
+_RG_ID = uuid.uuid5(uuid.NAMESPACE_OID, "rg")
+_DOMAIN_ID = uuid.uuid5(uuid.NAMESPACE_OID, "domain")
+
+
+@dataclass
+class _LinkAction(BaseRelationAction):
+    scopes: list[ScopeRef]
+
+    @override
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return self.scopes
+
+    @classmethod
+    @override
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.CREATE
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "link_resource_group_to_domain"
+
+
+def _action(*scopes: ScopeRef) -> _LinkAction:
+    return _LinkAction(scopes=list(scopes))
+
+
+def _rg() -> ScopeRef:
+    return ScopeRef(scope_type=_RESOURCE_GROUP, scope_id=_RG_ID)
+
+
+def _domain() -> ScopeRef:
+    return ScopeRef(scope_type=_DOMAIN, scope_id=_DOMAIN_ID)
+
+
+class _RecordingMonitor(RelationActionMonitor):
+    def __init__(self) -> None:
+        self.done_calls: list[tuple[RelationActionTriggerMeta, RelationActionProcessResult]] = []
+
+    @override
+    async def prepare(self, meta: RelationActionTriggerMeta) -> None:
+        return
+
+    @override
+    async def done(
+        self, meta: RelationActionTriggerMeta, result: RelationActionProcessResult
+    ) -> None:
+        self.done_calls.append((meta, result))
+
+
+class _DenyingValidator(RelationActionValidator):
+    @override
+    async def validate(self, meta: RelationActionTriggerMeta) -> None:
+        raise PermissionDeniedError("denied")
+
+
+class TestRelationActionProcessor:
+    async def test_the_run_names_both_ends(self) -> None:
+        monitor = _RecordingMonitor()
+
+        async def run(_: _LinkAction) -> str:
+            return "linked"
+
+        assert (
+            await RelationActionProcessor[_LinkAction, str](run, monitors=[monitor]).run(
+                _action(_rg(), _domain())
+            )
+            == "linked"
+        )
+
+        (meta, result) = monitor.done_calls[0]
+        assert [(s.scope_type, s.scope_id) for s in meta.scope_targets] == [
+            (_RESOURCE_GROUP, _RG_ID),
+            (_DOMAIN, _DOMAIN_ID),
+        ]
+        assert result.meta.status is OperationStatus.SUCCESS
+
+    async def test_the_action_carries_no_entity_type(self) -> None:
+        # The absence is the point: with a type the check would read it at each scope,
+        # and a relation has none to read.
+        assert not hasattr(_LinkAction, "entity_type")
+
+    async def test_a_denial_stops_the_run_and_is_recorded(self) -> None:
+        monitor = _RecordingMonitor()
+        ran = False
+
+        async def run(_: _LinkAction) -> None:
+            nonlocal ran
+            ran = True
+
+        processor = RelationActionProcessor[_LinkAction, None](
+            run, monitors=[monitor], validators=[_DenyingValidator()]
+        )
+        with pytest.raises(PermissionDeniedError):
+            await processor.run(_action(_rg(), _domain()))
+
+        assert not ran
+        (meta, result) = monitor.done_calls[0]
+        assert result.meta.status is OperationStatus.DENIED
+        assert len(meta.scope_targets) == 2
+
+    async def test_a_monitor_failure_does_not_fail_the_run(self) -> None:
+        class _BrokenMonitor(RelationActionMonitor):
+            @override
+            async def prepare(self, meta: RelationActionTriggerMeta) -> None:
+                raise RuntimeError("monitor down")
+
+            @override
+            async def done(
+                self, meta: RelationActionTriggerMeta, result: RelationActionProcessResult
+            ) -> None:
+                raise RuntimeError("monitor down")
+
+        async def run(_: _LinkAction) -> str:
+            return "linked"
+
+        processor = RelationActionProcessor[_LinkAction, str](run, monitors=[_BrokenMonitor()])
+        assert await processor.run(_action(_rg(), _domain())) == "linked"
+
+
+class TestEveryEndMustPermitTheRun:
+    def _validator(self, permitted: set[uuid.UUID]) -> VirtualScopeRelationActionRBACValidator:
+        repository = MagicMock()
+
+        async def check(keys: list[Any], permission: Any) -> dict[Any, bool]:
+            return {key: key.entity in permitted for key in keys}
+
+        repository.check_bulk_permission_via_virtual_scope = check
+        config_provider = MagicMock()
+        config_provider.config.manager.rbac.enforcement_enabled = True
+        return VirtualScopeRelationActionRBACValidator(repository, config_provider)
+
+    def _meta(self, action: _LinkAction) -> RelationActionTriggerMeta:
+        return RelationActionTriggerMeta(
+            action_id=uuid.uuid4(),
+            started_at=MagicMock(),
+            scope_targets=action.scope_targets(),
+            operation_type=action.operation_type(),
+            action_name=action.action_name(),
+        )
+
+    @pytest.fixture
+    def user(self) -> UserData:
+        return UserData(
+            user_id=uuid.uuid4(),
+            is_authorized=True,
+            is_admin=False,
+            is_superadmin=False,
+            role=UserRole.USER,
+            domain_name="default",
+            domain_id=MagicMock(),
+        )
+
+    async def test_both_ends_permitted_passes(self, user: UserData) -> None:
+        validator = self._validator({_RG_ID, _DOMAIN_ID})
+        with with_user(user):
+            await validator.validate(self._meta(_action(_rg(), _domain())))
+
+    async def test_one_end_alone_is_not_enough(self, user: UserData) -> None:
+        # The hole a single-scope shape leaves: it would ask about the domain and never
+        # about the resource group.
+        validator = self._validator({_DOMAIN_ID})
+        with with_user(user):
+            with pytest.raises(NotEnoughPermission):
+                await validator.validate(self._meta(_action(_rg(), _domain())))
+
+    async def test_the_other_end_alone_is_not_enough(self, user: UserData) -> None:
+        validator = self._validator({_RG_ID})
+        with with_user(user):
+            with pytest.raises(NotEnoughPermission):
+                await validator.validate(self._meta(_action(_rg(), _domain())))
+
+    async def test_a_superadmin_bypasses_the_check(self) -> None:
+        superadmin = UserData(
+            user_id=uuid.uuid4(),
+            is_authorized=True,
+            is_admin=True,
+            is_superadmin=True,
+            role=UserRole.SUPERADMIN,
+            domain_name="default",
+            domain_id=MagicMock(),
+        )
+        validator = self._validator(set())
+        with with_user(superadmin):
+            await validator.validate(self._meta(_action(_rg(), _domain())))

--- a/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
+++ b/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
@@ -769,7 +769,7 @@ class _Sidecar(DanglingFieldCreator[EntityLifecycleTestRow, _SidecarData]):
         return ()
 
     @override
-    def build_row(self, entity_type: EntityType) -> EntityLifecycleTestRow:
+    def build_row(self) -> EntityLifecycleTestRow:
         return EntityLifecycleTestRow(name=self.name)
 
     @override
@@ -781,9 +781,7 @@ class TestSidecarCreate:
     async def test_create_provisions_no_scope_and_joins_nothing(
         self, database: ExtendedAsyncSAEngine, repository: OpsRepository[_EntityData]
     ) -> None:
-        data = await repository.create_dangling_field(
-            EntityType("test_dangling"), _Sidecar(name="a")
-        )
+        data = await repository.create_dangling_field(_Sidecar(name="a"))
 
         assert await _virtual_scope_id(database, data.id) is None
         assert not await _self_membership_exists(database, data.id)
@@ -791,13 +789,10 @@ class TestSidecarCreate:
     async def test_atomic_create_writes_every_row(
         self, database: ExtendedAsyncSAEngine, repository: OpsRepository[_EntityData]
     ) -> None:
-        items = await repository.atomic_create_dangling_fields(
-            EntityType("test_dangling"),
-            [
-                _Sidecar(name="a"),
-                _Sidecar(name="b"),
-            ],
-        )
+        items = await repository.atomic_create_dangling_fields([
+            _Sidecar(name="a"),
+            _Sidecar(name="b"),
+        ])
 
         assert [item.name for item in items] == ["a", "b"]
         assert await _row_count(database) == 2
@@ -806,9 +801,10 @@ class TestSidecarCreate:
         self, database: ExtendedAsyncSAEngine, repository: OpsRepository[_EntityData]
     ) -> None:
         with pytest.raises(RepositoryIntegrityError):
-            await repository.atomic_create_dangling_fields(
-                EntityType("test_dangling"), [_Sidecar(name="a"), _Sidecar(name="a")]
-            )
+            await repository.atomic_create_dangling_fields([
+                _Sidecar(name="a"),
+                _Sidecar(name="a"),
+            ])
 
         assert await _row_count(database) == 0
 


### PR DESCRIPTION
## Summary

- Adds the `relation` action shape for an operation linking two entities, or unlinking
  them. A row standing between two entities belongs to neither, so it fits neither
  existing shape: `scope` names a container and the type it holds, `single_entity` names
  one row. `actions/v2/relation` declares no entity type — with no type there is nothing
  to read at a scope, so the permission is asked of each named scope itself and one
  denied scope refuses the whole run.
- Adds the matching write specs (`models/specs/relation.py`): `RelationCreator` /
  `RelationLifecycleUpdater` / `RelationPurger`. They name the pair rather than a row id,
  because nothing outside the layer that wrote the row holds that id.
- Makes `audit_logs.entity_type` nullable (migration `c8e4b1a09d37`). A relation's audit
  row names no kind; which two entities it was about goes to `audit_log_scopes`, the same
  place a scope run's targets go. Those rows stay reachable through the existing
  scope-shaped read arm, from either entity.
- Moves the kind onto the dangling creator. It was injected by the executor when it is
  the spec's own value like every other column, and a dangling row is not tied to an
  entity at all — `entity_id` was already `None` there. `build_row()` now takes nothing.

Nothing is wired to the shape yet: `RelationGroup.relation()` takes a handler callable
and no operation calls it in this PR.

## Breaking change

`AuditLogV2.entityType` goes from `String!` to `String` in GraphQL. Clients that assume
the field is non-null need checking — the WebUI in particular.

## Test plan

- [x] `pants fmt/fix/lint --changed-since=origin/main`
- [x] `pants check --changed-since=HEAD~1`
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=direct`
- [x] New `tests/unit/manager/actions/test_relation_processor.py` covers the lifecycle,
      the per-scope permission check and the one-denied-scope refusal
- [ ] Apply `c8e4b1a09d37` against a populated database and confirm the downgrade path

Design: `proposals/BEP-1075-entity-relation-operations.md`, which lands separately —
docstrings and `AGENTS.md` in this PR already point at it.

Resolves BA-7517
