### PR TITLE
fix(BA-7510): source known resource slots from the slot-type registry (#14025)

### DIFF
--- a/changes/14025.fix.md
+++ b/changes/14025.fix.md
@@ -1,0 +1,1 @@
+Fix `GET /resource/presets` returning 500 on a preset-list cache hit

--- a/src/ai/backend/common/types.py
+++ b/src/ai/backend/common/types.py
@@ -1236,7 +1236,23 @@ class ResourceSlot(UserDict[str, Decimal]):
         )
 
     def normalize_slots(self, *, ignore_unknown: bool) -> ResourceSlot:
-        known_slots = current_resource_slots.get()
+        """
+        Normalize using the known slots in the ``current_resource_slots`` ContextVar.
+        Callers must have set it; use :meth:`normalize_slots_by_known_slots` otherwise.
+        """
+        return self.normalize_slots_by_known_slots(
+            current_resource_slots.get(), ignore_unknown=ignore_unknown
+        )
+
+    def normalize_slots_by_known_slots(
+        self,
+        known_slots: Mapping[SlotName, SlotTypes],
+        *,
+        ignore_unknown: bool,
+    ) -> ResourceSlot:
+        """
+        Drop keys outside ``known_slots`` and fill unset known slots with zero.
+        """
         unset_slots = known_slots.keys() - self.data.keys()
         if not ignore_unknown and (unknown_slots := self.data.keys() - known_slots.keys()):
             raise ValueError(f"Unknown slots: {', '.join(map(repr, unknown_slots))}")

--- a/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
@@ -193,6 +193,17 @@ class ResourcePresetDBSource:
 
         return presets
 
+    async def known_slot_types(self) -> Mapping[SlotName, SlotTypes]:
+        """
+        The system-wide registry of enabled resource slot types.
+        """
+        async with self._db.begin_readonly_session_read_committed() as session:
+            stmt = sa.select(ResourceSlotTypeRow.slot_name, ResourceSlotTypeRow.slot_type).where(
+                ResourceSlotTypeRow.enabled.is_(True)
+            )
+            rows = (await session.execute(stmt)).all()
+        return {SlotName(row.slot_name): SlotTypes(row.slot_type) for row in rows}
+
     async def search_presets(
         self,
         querier: BatchQuerier,
@@ -651,7 +662,9 @@ class ResourcePresetDBSource:
         for preset_data in preset_data_list:
             allocatable = False
             preset_slots = resource_slot_to_quantities(
-                preset_data.resource_slots.normalize_slots(ignore_unknown=True)
+                preset_data.resource_slots.normalize_slots_by_known_slots(
+                    known_slot_types, ignore_unknown=True
+                )
             )
             for agent_slot in agent_slots:
                 if quantities_ge(agent_slot, preset_slots) and quantities_ge(

--- a/src/ai/backend/manager/repositories/resource_preset/repository.py
+++ b/src/ai/backend/manager/repositories/resource_preset/repository.py
@@ -14,7 +14,7 @@ from ai.backend.common.metrics.metric import DomainType, LayerType
 from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPolicy
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
-from ai.backend.common.types import AccessKey, SlotQuantity
+from ai.backend.common.types import AccessKey, SlotName, SlotQuantity, SlotTypes
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.resource_preset.types import (
@@ -178,14 +178,25 @@ class ResourcePresetRepository:
                 return presets
 
         # Fallback to DB
+<<<<<<< HEAD
         await self._config_provider.legacy_etcd_config_loader.get_resource_slots()
         presets = await self._db_source.list_presets(scaling_group_name)
+=======
+        presets = await self._db_source.list_presets(resource_group_name)
+>>>>>>> 46de869e (fix(BA-7510): source known resource slots from the slot-type registry (#14025))
 
         # Cache the result
         with suppress_with_log([Exception], message="Failed to cache preset list"):
             await self._cache_source.set_preset_list(presets, scaling_group_name)
 
         return presets
+
+    @resource_preset_repository_resilience.apply()
+    async def known_slot_types(self) -> Mapping[SlotName, SlotTypes]:
+        """
+        The system-wide registry of enabled resource slot types.
+        """
+        return await self._db_source.known_slot_types()
 
     @resource_preset_repository_resilience.apply()
     async def search_presets(
@@ -208,10 +219,6 @@ class ResourcePresetRepository:
         """
         Check resource presets availability and resource limits.
         """
-        # Get configuration values
-        known_slot_types = (
-            await self._config_provider.legacy_etcd_config_loader.get_resource_slots()
-        )
         # Try to get from cache first
         with suppress_with_log([Exception], message="Failed to get check presets data from cache"):
             cached_data = await self._cache_source.get_check_presets_data(
@@ -229,6 +236,7 @@ class ResourcePresetRepository:
             domain_name,
         )
 
+        known_slot_types = await self._db_source.known_slot_types()
         group_resource_visibility = await self._config_provider.legacy_etcd_config_loader.get_raw(
             "config/api/resources/group_resource_visibility"
         )

--- a/src/ai/backend/manager/repositories/resource_preset/repository.py
+++ b/src/ai/backend/manager/repositories/resource_preset/repository.py
@@ -178,12 +178,7 @@ class ResourcePresetRepository:
                 return presets
 
         # Fallback to DB
-<<<<<<< HEAD
-        await self._config_provider.legacy_etcd_config_loader.get_resource_slots()
         presets = await self._db_source.list_presets(scaling_group_name)
-=======
-        presets = await self._db_source.list_presets(resource_group_name)
->>>>>>> 46de869e (fix(BA-7510): source known resource slots from the slot-type registry (#14025))
 
         # Cache the result
         with suppress_with_log([Exception], message="Failed to cache preset list"):

--- a/src/ai/backend/manager/services/resource_allocation/service.py
+++ b/src/ai/backend/manager/services/resource_allocation/service.py
@@ -146,11 +146,14 @@ class ResourceAllocationService:
         preset_data_list = await self._resource_preset_repository.list_presets(
             action.scaling_group,
         )
+        known_slot_types = await self._resource_preset_repository.known_slot_types()
 
         presets: list[PresetAvailabilityData] = []
         for preset_data in preset_data_list:
             preset_slots = resource_slot_to_quantities(
-                preset_data.resource_slots.normalize_slots(ignore_unknown=True)
+                preset_data.resource_slots.normalize_slots_by_known_slots(
+                    known_slot_types, ignore_unknown=True
+                )
             )
             allocatable = quantities_ge(allocation.assignable, preset_slots)
             # Also check max_per_node if resource group data is available

--- a/src/ai/backend/manager/services/resource_preset/service.py
+++ b/src/ai/backend/manager/services/resource_preset/service.py
@@ -99,11 +99,20 @@ class ResourcePresetService:
         return DeleteResourcePresetActionResult(resource_preset=preset_data)
 
     async def list_presets(self, action: ListResourcePresetsAction) -> ListResourcePresetsResult:
+<<<<<<< HEAD
         preset_data_list = await self._resource_preset_repository.list_presets(action.scaling_group)
+=======
+        preset_data_list = await self._resource_preset_repository.list_presets(
+            action.resource_group
+        )
+        known_slot_types = await self._resource_preset_repository.known_slot_types()
+>>>>>>> 46de869e (fix(BA-7510): source known resource slots from the slot-type registry (#14025))
 
         presets = []
         for preset_data in preset_data_list:
-            preset_slots = preset_data.resource_slots.normalize_slots(ignore_unknown=True)
+            preset_slots = preset_data.resource_slots.normalize_slots_by_known_slots(
+                known_slot_types, ignore_unknown=True
+            )
             presets.append({
                 "id": str(preset_data.id),
                 "name": preset_data.name,
@@ -140,11 +149,15 @@ class ResourcePresetService:
             scaling_group=action.scaling_group,
         )
 
+        known_slot_types = await self._resource_preset_repository.known_slot_types()
+
         # Convert repository result to action result
         # Process presets to JSON format
         presets: list[Mapping[str, Any]] = []
         for preset_data in result.presets:
-            preset_slots = preset_data.preset.resource_slots.normalize_slots(ignore_unknown=True)
+            preset_slots = preset_data.preset.resource_slots.normalize_slots_by_known_slots(
+                known_slot_types, ignore_unknown=True
+            )
             presets.append({
                 "id": str(preset_data.preset.id),
                 "name": preset_data.preset.name,

--- a/src/ai/backend/manager/services/resource_preset/service.py
+++ b/src/ai/backend/manager/services/resource_preset/service.py
@@ -99,14 +99,8 @@ class ResourcePresetService:
         return DeleteResourcePresetActionResult(resource_preset=preset_data)
 
     async def list_presets(self, action: ListResourcePresetsAction) -> ListResourcePresetsResult:
-<<<<<<< HEAD
         preset_data_list = await self._resource_preset_repository.list_presets(action.scaling_group)
-=======
-        preset_data_list = await self._resource_preset_repository.list_presets(
-            action.resource_group
-        )
         known_slot_types = await self._resource_preset_repository.known_slot_types()
->>>>>>> 46de869e (fix(BA-7510): source known resource slots from the slot-type registry (#14025))
 
         presets = []
         for preset_data in preset_data_list:

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -71,7 +71,6 @@ from ai.backend.common.types import (
     SlotName,
     SlotTypes,
     VFolderHostPermissionMap,
-    current_resource_slots,
 )
 from ai.backend.logging import LocalLogger, LogLevel
 from ai.backend.logging.config import ConsoleConfig, LogDriver, LoggingConfig
@@ -125,8 +124,13 @@ from ai.backend.manager.models.resource_policy import (
     UserResourcePolicyRow,
     keypair_resource_policies,
 )
+<<<<<<< HEAD
 from ai.backend.manager.models.scaling_group import scaling_groups, sgroups_for_domains
 from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts
+=======
+from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
+from ai.backend.manager.models.resource_slot.types import NumberFormat
+>>>>>>> 46de869e (fix(BA-7510): source known resource slots from the slot-type registry (#14025))
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.session_template import session_templates
 from ai.backend.manager.models.user import users
@@ -503,6 +507,29 @@ def database(
             obj=cli_ctx,
         )
         cli_schema_oneshot.invoke(click_ctx)
+
+    # `schema oneshot` creates the tables but applies no migration, so the seed
+    # rows the migrations carry are missing. Installs load them from the fixture
+    # files; do the same for the registry the manager reads at runtime.
+    async def seed_resource_slot_types() -> None:
+        fixture_path = (
+            Path(os.environ["BACKEND_BUILD_ROOT"])
+            / "fixtures"
+            / "manager"
+            / "example-resource-slot-types.json"
+        )
+        rows = [
+            {**row, "number_format": NumberFormat(**row["number_format"])}
+            for row in json.loads(fixture_path.read_text())["resource_slot_types"]
+        ]
+        engine = create_async_engine(str(test_db_url), connect_args=pgsql_connect_opts)
+        async with engine.begin() as conn:
+            await conn.execute(
+                pg_insert(ResourceSlotTypeRow.__table__).values(rows).on_conflict_do_nothing()
+            )
+        await engine.dispose()
+
+    asyncio.run(seed_resource_slot_types())
 
 
 # ---------------------------------------------------------------------------
@@ -969,13 +996,6 @@ class _TestConfigProvider(ManagerConfigProvider):
         mock_etcd_loader.register_myself = AsyncMock()
         mock_etcd_loader.deregister_myself = AsyncMock()
         self._legacy_etcd_config_loader = mock_etcd_loader
-        # Set the current_resource_slots ContextVar so that ResourceSlot
-        # operations (e.g. normalize_slots) work without hitting etcd.
-        _slots = {
-            SlotName("cpu"): SlotTypes("count"),
-            SlotName("mem"): SlotTypes("bytes"),
-        }
-        current_resource_slots.set(_slots)
 
 
 @pytest.fixture()

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -124,13 +124,10 @@ from ai.backend.manager.models.resource_policy import (
     UserResourcePolicyRow,
     keypair_resource_policies,
 )
-<<<<<<< HEAD
-from ai.backend.manager.models.scaling_group import scaling_groups, sgroups_for_domains
-from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts
-=======
 from ai.backend.manager.models.resource_slot.row import ResourceSlotTypeRow
 from ai.backend.manager.models.resource_slot.types import NumberFormat
->>>>>>> 46de869e (fix(BA-7510): source known resource slots from the slot-type registry (#14025))
+from ai.backend.manager.models.scaling_group import scaling_groups, sgroups_for_domains
+from ai.backend.manager.models.scaling_group.row import ScalingGroupOpts
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.session_template import session_templates
 from ai.backend.manager.models.user import users

--- a/tests/unit/manager/services/resource_preset/test_resource_preset.py
+++ b/tests/unit/manager/services/resource_preset/test_resource_preset.py
@@ -20,7 +20,6 @@ from ai.backend.common.types import (
     SlotName,
     SlotQuantity,
     SlotTypes,
-    current_resource_slots,
 )
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.resource_preset.types import ResourcePresetData
@@ -66,7 +65,6 @@ class TestResourcePresetServiceCompatibility:
     @pytest.fixture
     def mock_dependencies(self) -> dict[str, Any]:
         """Create mocked dependencies for testing."""
-        # Set up current_resource_slots context variable
         resource_slots = {
             SlotName("cpu"): SlotTypes("count"),
             SlotName("mem"): SlotTypes("bytes"),
@@ -76,12 +74,12 @@ class TestResourcePresetServiceCompatibility:
             SlotName("npu"): SlotTypes("count"),
             SlotName("tpu"): SlotTypes("count"),
         }
-        current_resource_slots.set(resource_slots)
 
         db_engine = MagicMock(spec=ExtendedAsyncSAEngine)
         agent_registry = MagicMock(spec=AgentRegistry)
         config_provider = MagicMock(spec=ManagerConfigProvider)
         resource_preset_repository = MagicMock(spec=ResourcePresetRepository)
+        resource_preset_repository.known_slot_types = AsyncMock(return_value=resource_slots)
 
         # Mock config provider methods
         config_provider.legacy_etcd_config_loader.get_resource_slots = AsyncMock(


### PR DESCRIPTION
This is an auto-generated backport of #14025 to the 26.4 release.