### PR TITLE
feat(BA-7511): answer per id in project user assignment and artifact bulk delete/restore

### DIFF
--- a/changes/14044.feature.md
+++ b/changes/14044.feature.md
@@ -1,0 +1,1 @@
+Project user assignment and artifact bulk delete/restore now answer for every id the caller named, saying why each one that did not go through was left out, and a repeated user id no longer fails the whole assignment.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2406,6 +2406,19 @@ type BulkAddRolePermissionsPayload
 }
 
 """
+Added in 26.9.0. Failure detail for a single artifact in a bulk delete or restore.
+"""
+type BulkArtifactV2Error
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID of the artifact that could not be reached."""
+  artifactId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
 Added in 26.3.0. Error information for a failed user in bulk role assignment.
 """
 type BulkAssignRoleError
@@ -5660,8 +5673,20 @@ Added in 25.15.0. Response payload for artifact deletion operations. Contains th
 type DeleteArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
-  """List of soft-deleted artifacts."""
-  artifacts: [Artifact!]!
+  """
+  Added in 26.9.0. Artifacts that were soft-deleted, in the order they were requested. Together with `failed` this answers for every requested artifact exactly once.
+  """
+  successes: [Artifact!]!
+
+  """
+  Added in 26.9.0. List of errors for artifacts that could not be soft-deleted.
+  """
+  failed: [BulkArtifactV2Error!]!
+
+  """
+  Added in 25.15.0. List of soft-deleted artifacts. Deprecated since 26.9.0.
+  """
+  artifacts: [Artifact!]! @deprecated(reason: "Use successes.")
 }
 
 """Added in 25.16.0. Input for deleting an auto-scaling rule"""
@@ -18530,8 +18555,18 @@ Added in 25.15.0. Response payload for artifact restoration operations. Contains
 type RestoreArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
-  """List of restored artifacts."""
-  artifacts: [Artifact!]!
+  """
+  Added in 26.9.0. Artifacts that were restored, in the order they were requested. Together with `failed` this answers for every requested artifact exactly once.
+  """
+  successes: [Artifact!]!
+
+  """
+  Added in 26.9.0. List of errors for artifacts that could not be restored.
+  """
+  failed: [BulkArtifactV2Error!]!
+
+  """Added in 25.15.0. List of restored artifacts. Deprecated since 26.9.0."""
+  artifacts: [Artifact!]! @deprecated(reason: "Use successes.")
 }
 
 """Added in 26.9.0. Payload for domain restore mutation."""

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1752,6 +1752,17 @@ type BulkAddRolePermissionsPayload {
 }
 
 """
+Added in 26.9.0. Failure detail for a single artifact in a bulk delete or restore.
+"""
+type BulkArtifactV2Error {
+  """UUID of the artifact that could not be reached."""
+  artifactId: UUID!
+
+  """Error message describing the failure."""
+  message: String!
+}
+
+"""
 Added in 26.3.0. Error information for a failed user in bulk role assignment.
 """
 type BulkAssignRoleError {
@@ -3941,8 +3952,20 @@ input DeleteArtifactsInput {
 Added in 25.15.0. Response payload for artifact deletion operations. Contains the artifacts that were soft-deleted. These can be restored later.
 """
 type DeleteArtifactsPayload {
-  """List of soft-deleted artifacts."""
-  artifacts: [Artifact!]!
+  """
+  Added in 26.9.0. Artifacts that were soft-deleted, in the order they were requested. Together with `failed` this answers for every requested artifact exactly once.
+  """
+  successes: [Artifact!]!
+
+  """
+  Added in 26.9.0. List of errors for artifacts that could not be soft-deleted.
+  """
+  failed: [BulkArtifactV2Error!]!
+
+  """
+  Added in 25.15.0. List of soft-deleted artifacts. Deprecated since 26.9.0.
+  """
+  artifacts: [Artifact!]! @deprecated(reason: "Use successes.")
 }
 
 """Added in 25.16.0. Input for deleting an auto-scaling rule"""
@@ -13170,8 +13193,18 @@ input RestoreArtifactsInput {
 Added in 25.15.0. Response payload for artifact restoration operations. Contains the artifacts that were restored from soft-deleted state.
 """
 type RestoreArtifactsPayload {
-  """List of restored artifacts."""
-  artifacts: [Artifact!]!
+  """
+  Added in 26.9.0. Artifacts that were restored, in the order they were requested. Together with `failed` this answers for every requested artifact exactly once.
+  """
+  successes: [Artifact!]!
+
+  """
+  Added in 26.9.0. List of errors for artifacts that could not be restored.
+  """
+  failed: [BulkArtifactV2Error!]!
+
+  """Added in 25.15.0. List of restored artifacts. Deprecated since 26.9.0."""
+  artifacts: [Artifact!]! @deprecated(reason: "Use successes.")
 }
 
 """Added in 26.9.0. Payload for domain restore mutation."""

--- a/src/ai/backend/common/dto/manager/v2/artifact/response.py
+++ b/src/ai/backend/common/dto/manager/v2/artifact/response.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 from .types import (
     ArtifactAvailability,
@@ -30,6 +31,7 @@ __all__ = (
     "ArtifactRevisionImportTaskInfo",
     "ArtifactRevisionImportTaskInfoGQL",
     "ArtifactRevisionNode",
+    "BulkArtifactV2Error",
     "ArtifactStatusChangedGQLPayload",
     "ArtifactVerificationGQLResultDTO",
     "ArtifactVerifierGQLResultDTO",
@@ -168,10 +170,34 @@ class AdminSearchArtifactRevisionsPayload(BaseResponseModel):
     has_previous_page: bool
 
 
+class BulkArtifactV2Error(BaseResponseModel):
+    """Error information for a single artifact that a bulk write could not reach."""
+
+    artifact_id: UUID = Field(description="UUID of the artifact that could not be reached.")
+    message: str = Field(description="Error message describing the failure.")
+
+
 class DeleteArtifactsPayload(BaseResponseModel):
     """Payload for artifact deletion result."""
 
-    artifacts: list[ArtifactNode] = Field(description="List of deleted artifact nodes.")
+    successes: list[ArtifactNode] = Field(
+        default_factory=list,
+        description=(
+            "Artifacts that were soft-deleted, in the order they were requested. Together "
+            "with `failed` this answers for every requested artifact exactly once."
+        ),
+    )
+    failed: list[BulkArtifactV2Error] = Field(
+        default_factory=list,
+        description="List of errors for artifacts that could not be soft-deleted.",
+    )
+    artifacts: list[ArtifactNode] = Field(
+        description=(
+            "List of deleted artifact nodes. "
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use successes."
+        ),
+        deprecated=True,
+    )
 
 
 class GetRevisionReadmePayload(BaseResponseModel):
@@ -370,10 +396,43 @@ class ScanArtifactModelsGQLPayload(BaseResponseModel):
 class DeleteArtifactsGQLPayload(BaseResponseModel):
     """GQL payload for artifact deletion operations."""
 
-    artifacts: list[ArtifactNode] = Field(description="List of soft-deleted artifacts.")
+    successes: list[ArtifactNode] = Field(
+        default_factory=list,
+        description=(
+            "Artifacts that were soft-deleted, in the order they were requested. Together "
+            "with `failed` this answers for every requested artifact exactly once."
+        ),
+    )
+    failed: list[BulkArtifactV2Error] = Field(
+        default_factory=list,
+        description="List of errors for artifacts that could not be soft-deleted.",
+    )
+    artifacts: list[ArtifactNode] = Field(
+        description=(
+            "List of soft-deleted artifacts. "
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use successes."
+        ),
+        deprecated=True,
+    )
 
 
 class RestoreArtifactsGQLPayload(BaseResponseModel):
     """GQL payload for artifact restoration operations."""
 
-    artifacts: list[ArtifactNode] = Field(description="List of restored artifacts.")
+    successes: list[ArtifactNode] = Field(
+        default_factory=list,
+        description=(
+            "Artifacts that were restored, in the order they were requested. Together with "
+            "`failed` this answers for every requested artifact exactly once."
+        ),
+    )
+    failed: list[BulkArtifactV2Error] = Field(
+        default_factory=list,
+        description="List of errors for artifacts that could not be restored.",
+    )
+    artifacts: list[ArtifactNode] = Field(
+        description=(
+            f"List of restored artifacts. Deprecated since {NEXT_RELEASE_VERSION}. Use successes."
+        ),
+        deprecated=True,
+    )

--- a/src/ai/backend/common/dto/manager/v2/group/__init__.py
+++ b/src/ai/backend/common/dto/manager/v2/group/__init__.py
@@ -16,6 +16,7 @@ from ai.backend.common.dto.manager.v2.group.request import (
 )
 from ai.backend.common.dto.manager.v2.group.response import (
     AdminSearchGroupsPayload,
+    AssignUserError,
     AssignUsersToProjectPayload,
     DeleteProjectPayload,
     ProjectBasicInfo,
@@ -62,6 +63,7 @@ __all__ = (
     "UnassignUsersFromProjectInput",
     # Response DTOs
     "AdminSearchGroupsPayload",
+    "AssignUserError",
     "AssignUsersToProjectPayload",
     "ProjectBasicInfo",
     "ProjectOrganizationInfo",

--- a/src/ai/backend/common/dto/manager/v2/group/response.py
+++ b/src/ai/backend/common/dto/manager/v2/group/response.py
@@ -14,10 +14,12 @@ from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.dto.manager.v2.group.types import ProjectType
 from ai.backend.common.dto.manager.v2.user.response import UserNode
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import BackendAISchema
 
 __all__ = (
     "AdminSearchGroupsPayload",
+    "AssignUserError",
     "AssignUsersToProjectPayload",
     "DeleteProjectPayload",
     "ProjectBasicInfo",
@@ -174,10 +176,34 @@ class PurgeProjectPayload(BaseResponseModel):
     )
 
 
+class AssignUserError(BaseResponseModel):
+    """Error information for a single user that could not be assigned."""
+
+    user_id: UUID = Field(description="UUID of the user that failed to be assigned.")
+    message: str = Field(description="Error message describing the failure reason.")
+
+
 class AssignUsersToProjectPayload(BaseResponseModel):
     """Payload for assign users to project response."""
 
-    items: list[UserNode] = Field(description="List of users actually assigned.")
+    successes: list[UserNode] = Field(
+        default_factory=list,
+        description=(
+            "Users that were assigned, in the order they were requested. Together with "
+            "`failed` this answers for every requested user exactly once."
+        ),
+    )
+    failed: list[AssignUserError] = Field(
+        default_factory=list,
+        description="List of errors for users that could not be assigned.",
+    )
+    items: list[UserNode] = Field(
+        description=(
+            "List of users actually assigned. "
+            f"Deprecated since {NEXT_RELEASE_VERSION}. Use successes."
+        ),
+        deprecated=True,
+    )
 
 
 class AdminSearchGroupsPayload(BaseResponseModel):

--- a/src/ai/backend/manager/api/adapters/artifact/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact/adapter.py
@@ -33,7 +33,9 @@ from ai.backend.common.dto.manager.v2.artifact.response import (
     AdminSearchArtifactsPayload,
     ArtifactNode,
     ArtifactRevisionNode,
+    BulkArtifactV2Error,
     DeleteArtifactsPayload,
+    RestoreArtifactsGQLPayload,
     UpdateArtifactPayload,
 )
 from ai.backend.common.dto.manager.v2.artifact.types import (
@@ -291,8 +293,17 @@ class ArtifactAdapter(BaseAdapter):
         action_result = await self._processors.artifact.delete_artifacts.run(
             DeleteArtifactsAction(artifact_ids=input.artifact_ids)
         )
+        deleted = [self._data_to_dto(item) for item in action_result.artifacts]
         return DeleteArtifactsPayload(
-            artifacts=[self._data_to_dto(item) for item in action_result.artifacts]
+            successes=deleted,
+            failed=[self._missing_artifact(item) for item in action_result.missing],
+            artifacts=deleted,
+        )
+
+    def _missing_artifact(self, artifact_id: UUID) -> BulkArtifactV2Error:
+        """An id that named no artifact row."""
+        return BulkArtifactV2Error(
+            artifact_id=artifact_id, message="No artifact matches the given id."
         )
 
     async def get_revision(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
@@ -417,14 +428,19 @@ class ArtifactAdapter(BaseAdapter):
         )
         return self._revision_data_to_dto(action_result.result)
 
-    async def restore(self, artifact_ids: list[UUID]) -> list[ArtifactNode]:
+    async def restore(self, artifact_ids: list[UUID]) -> RestoreArtifactsGQLPayload:
         """Restore previously deleted artifacts."""
         action_result: RestoreArtifactsActionResult = (
             await self._processors.artifact.restore_artifacts.run(
                 RestoreArtifactsAction(artifact_ids=artifact_ids)
             )
         )
-        return [self._data_to_dto(item) for item in action_result.artifacts]
+        restored = [self._data_to_dto(item) for item in action_result.artifacts]
+        return RestoreArtifactsGQLPayload(
+            successes=restored,
+            failed=[self._missing_artifact(item) for item in action_result.missing],
+            artifacts=restored,
+        )
 
     async def cancel_import(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
         """Cancel an in-progress artifact import and revert to SCANNED status."""

--- a/src/ai/backend/manager/api/adapters/project/adapter.py
+++ b/src/ai/backend/manager/api/adapters/project/adapter.py
@@ -25,6 +25,7 @@ from ai.backend.common.dto.manager.v2.group.request import (
 )
 from ai.backend.common.dto.manager.v2.group.response import (
     AdminSearchGroupsPayload,
+    AssignUserError,
     AssignUsersToProjectPayload,
     DeleteProjectPayload,
     ProjectBasicInfo,
@@ -355,8 +356,11 @@ class ProjectAdapter(BaseAdapter):
                 project_id=ProjectID(project_id), user_ids=input.user_ids, role_id=input.role_id
             )
         )
+        assigned = await self._user_nodes(result.assigned_users)
         return AssignUsersToProjectPayload(
-            items=await self._user_nodes(result.assigned_users),
+            successes=assigned,
+            failed=[AssignUserError(user_id=f.user_id, message=f.reason) for f in result.failures],
+            items=assigned,
         )
 
     async def _user_nodes(self, users: Sequence[UserData]) -> list[UserNode]:

--- a/src/ai/backend/manager/api/gql/artifact/resolver.py
+++ b/src/ai/backend/manager/api/gql/artifact/resolver.py
@@ -50,6 +50,7 @@ from .types import (
     ArtifactRevisionOrderBy,
     ArtifactStatusChangedInput,
     ArtifactStatusChangedPayload,
+    BulkArtifactV2ErrorGQL,
     CancelArtifactInput,
     CancelImportArtifactPayload,
     CleanupArtifactRevisionsInput,
@@ -500,7 +501,11 @@ async def delete_artifacts(
             Artifact.from_pydantic(to_artifact_gql_node(item, registry_url, source_url))
         )
 
-    return DeleteArtifactsPayload(artifacts=artifacts)
+    return DeleteArtifactsPayload(
+        successes=artifacts,
+        failed=[BulkArtifactV2ErrorGQL.from_pydantic(item) for item in payload.failed],
+        artifacts=artifacts,
+    )
 
 
 @gql_mutation(
@@ -512,14 +517,14 @@ async def delete_artifacts(
 async def restore_artifacts(
     input: RestoreArtifactsInput, info: Info[StrawberryGQLContext]
 ) -> RestoreArtifactsPayload | None:
-    artifact_node_list = await info.context.adapters.artifact.restore(
+    payload = await info.context.adapters.artifact.restore(
         artifact_ids=[UUID(id) for id in input.artifact_ids],
     )
 
     data_loaders = info.context.data_loaders
 
     artifacts = []
-    for item in artifact_node_list:
+    for item in payload.artifacts:
         registry_url = await get_registry_url(data_loaders, item.registry_id, item.registry_type)
         source_url = await get_registry_url(
             data_loaders, item.source_registry_id, item.source_registry_type
@@ -528,7 +533,11 @@ async def restore_artifacts(
             Artifact.from_pydantic(to_artifact_gql_node(item, registry_url, source_url))
         )
 
-    return RestoreArtifactsPayload(artifacts=artifacts)
+    return RestoreArtifactsPayload(
+        successes=artifacts,
+        failed=[BulkArtifactV2ErrorGQL.from_pydantic(item) for item in payload.failed],
+        artifacts=artifacts,
+    )
 
 
 @gql_mutation(

--- a/src/ai/backend/manager/api/gql/artifact/types.py
+++ b/src/ai/backend/manager/api/gql/artifact/types.py
@@ -94,6 +94,10 @@ from ai.backend.common.dto.manager.v2.artifact.response import (
     SourceInfoDTO,
     UpdateArtifactGQLPayload,
 )
+from ai.backend.common.dto.manager.v2.artifact.response import (
+    BulkArtifactV2Error as BulkArtifactV2ErrorDTO,
+)
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.base import (
     ByteSize,
     IntFilter,
@@ -1005,13 +1009,51 @@ class ScanArtifactModelsPayload(PydanticOutputMixin[ScanArtifactModelsGQLPayload
 
 @gql_pydantic_type(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Failure detail for a single artifact in a bulk delete or restore.",
+    ),
+    model=BulkArtifactV2ErrorDTO,
+    name="BulkArtifactV2Error",
+)
+class BulkArtifactV2ErrorGQL(PydanticOutputMixin[BulkArtifactV2ErrorDTO]):
+    artifact_id: uuid.UUID = gql_field(
+        description="UUID of the artifact that could not be reached."
+    )
+    message: str = gql_field(description="Error message describing the failure.")
+
+
+@gql_pydantic_type(
+    BackendAIGQLMeta(
         added_version="25.15.0",
         description="Response payload for artifact deletion operations. Contains the artifacts that were soft-deleted. These can be restored later.",
     ),
     model=DeleteArtifactsGQLPayload,
 )
 class DeleteArtifactsPayload(PydanticOutputMixin[DeleteArtifactsGQLPayload]):
-    artifacts: list[Artifact]
+    successes: list[Artifact] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Artifacts that were soft-deleted, in the order they were requested. "
+                "Together with `failed` this answers for every requested artifact "
+                "exactly once."
+            ),
+        ),
+    )
+    failed: list[BulkArtifactV2ErrorGQL] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="List of errors for artifacts that could not be soft-deleted.",
+        ),
+    )
+    artifacts: list[Artifact] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="25.15.0",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="List of soft-deleted artifacts.",
+        ),
+        deprecation_reason="Use successes.",
+    )
 
 
 @gql_pydantic_type(
@@ -1022,4 +1064,26 @@ class DeleteArtifactsPayload(PydanticOutputMixin[DeleteArtifactsGQLPayload]):
     model=RestoreArtifactsGQLPayload,
 )
 class RestoreArtifactsPayload(PydanticOutputMixin[RestoreArtifactsGQLPayload]):
-    artifacts: list[Artifact]
+    successes: list[Artifact] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "Artifacts that were restored, in the order they were requested. Together "
+                "with `failed` this answers for every requested artifact exactly once."
+            ),
+        ),
+    )
+    failed: list[BulkArtifactV2ErrorGQL] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="List of errors for artifacts that could not be restored.",
+        ),
+    )
+    artifacts: list[Artifact] = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="25.15.0",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="List of restored artifacts.",
+        ),
+        deprecation_reason="Use successes.",
+    )

--- a/src/ai/backend/manager/api/rest/v2/artifact/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/artifact/handler.py
@@ -18,7 +18,6 @@ from ai.backend.common.dto.manager.v2.artifact.response import (
     CancelImportTaskPayload,
     CleanupRevisionsPayload,
     RejectRevisionPayload,
-    RestoreArtifactsGQLPayload,
 )
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.api.rest.v2.path_params import ArtifactIdPathParam, RevisionIdPathParam
@@ -73,8 +72,7 @@ class V2ArtifactHandler:
         body: BodyParam[RestoreArtifactsInput],
     ) -> APIResponse:
         """Restore previously deleted artifacts."""
-        artifacts = await self._adapter.restore(body.parsed.artifact_ids)
-        result = RestoreArtifactsGQLPayload(artifacts=artifacts)
+        result = await self._adapter.restore(body.parsed.artifact_ids)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def get_revision(

--- a/src/ai/backend/manager/data/artifact/types.py
+++ b/src/ai/backend/manager/data/artifact/types.py
@@ -129,6 +129,18 @@ class ArtifactRevisionReadme:
 
 
 @dataclass
+class BulkArtifactResult:
+    """Which of the named artifacts the write reached, and which named no row.
+
+    ``successes`` follows the order the caller named them, so a repeated id appears
+    at each position it was named at.
+    """
+
+    successes: list[ArtifactData]
+    missing: list[ArtifactID]
+
+
+@dataclass
 class ArtifactDataWithRevisions(ArtifactData):
     revisions: list[ArtifactRevisionData]
 

--- a/src/ai/backend/manager/data/project/types.py
+++ b/src/ai/backend/manager/data/project/types.py
@@ -164,6 +164,22 @@ class ProjectModifier(PartialModifier):
 
 
 @dataclass
+class AssignUserFailure:
+    """Why one requested user could not be enrolled in the project."""
+
+    user_id: uuid.UUID
+    reason: str
+
+
+@dataclass
+class AssignUsersResult:
+    """Who was enrolled and, for everyone else the caller named, why not."""
+
+    assigned_users: list[UserData]
+    failures: list[AssignUserFailure]
+
+
+@dataclass
 class UnassignUserFailure:
     user_id: uuid.UUID
     reason: str

--- a/src/ai/backend/manager/repositories/artifact/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/artifact/db_source/db_source.py
@@ -1,5 +1,5 @@
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager as actxmgr
 from typing import Any, cast
 
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from ai.backend.common.data.artifact.types import VerificationStepResult
+from ai.backend.common.data.entity.artifact import ArtifactID
 from ai.backend.common.data.storage.types import ArtifactStorageType
 from ai.backend.manager.data.artifact.types import (
     ArtifactAvailability,
@@ -16,6 +17,7 @@ from ai.backend.manager.data.artifact.types import (
     ArtifactRemoteStatus,
     ArtifactRevisionData,
     ArtifactStatus,
+    BulkArtifactResult,
 )
 from ai.backend.manager.data.association.types import AssociationArtifactsStoragesData
 from ai.backend.manager.errors.artifact import (
@@ -259,7 +261,13 @@ class ArtifactDBSource:
             await db_sess.execute(stmt)
             return artifact_revision_id
 
-    async def delete_artifacts(self, artifact_ids: list[uuid.UUID]) -> list[ArtifactData]:
+    async def delete_artifacts(self, artifact_ids: list[uuid.UUID]) -> BulkArtifactResult:
+        """Soft-delete the named artifacts and answer for every id that was named.
+
+        An id matching no row is reported as missing rather than dropped: the read
+        back is by id, so nothing else would say the caller named something that is
+        not there.
+        """
         async with self._db.begin_session() as db_sess:
             # Update availability to DELETED for the given artifact IDs (only for ALIVE artifacts)
             await db_sess.execute(
@@ -277,10 +285,13 @@ class ArtifactDBSource:
             result = await db_sess.execute(
                 sa.select(ArtifactRow).where(ArtifactRow.id.in_(artifact_ids))
             )
-            rows = list(result.scalars().all())
-            return [row.to_dataclass() for row in rows]
+            return self._answer_for_each(artifact_ids, list(result.scalars().all()))
 
-    async def restore_artifacts(self, artifact_ids: list[uuid.UUID]) -> list[ArtifactData]:
+    async def restore_artifacts(self, artifact_ids: list[uuid.UUID]) -> BulkArtifactResult:
+        """Restore the named artifacts and answer for every id that was named.
+
+        An id matching no row is reported as missing, as :meth:`delete_artifacts` does.
+        """
         async with self._db.begin_session() as db_sess:
             # Update availability to ALIVE for the given artifact IDs (only for DELETED artifacts)
             await db_sess.execute(
@@ -298,8 +309,23 @@ class ArtifactDBSource:
             result = await db_sess.execute(
                 sa.select(ArtifactRow).where(ArtifactRow.id.in_(artifact_ids))
             )
-            rows = list(result.scalars().all())
-            return [row.to_dataclass() for row in rows]
+            return self._answer_for_each(artifact_ids, list(result.scalars().all()))
+
+    def _answer_for_each(
+        self, artifact_ids: Sequence[uuid.UUID], rows: Sequence[ArtifactRow]
+    ) -> BulkArtifactResult:
+        """Put the rows that were read back against the ids the caller named."""
+        by_id = {row.id: row for row in rows}
+        successes: list[ArtifactData] = []
+        missing: list[ArtifactID] = []
+        for raw_id in artifact_ids:
+            artifact_id = ArtifactID(raw_id)
+            row = by_id.get(artifact_id)
+            if row is None:
+                missing.append(artifact_id)
+            else:
+                successes.append(row.to_dataclass())
+        return BulkArtifactResult(successes=successes, missing=missing)
 
     async def update_artifact_revision_bytesize(
         self, artifact_revision_id: uuid.UUID, size: int

--- a/src/ai/backend/manager/repositories/artifact/repository.py
+++ b/src/ai/backend/manager/repositories/artifact/repository.py
@@ -19,6 +19,7 @@ from ai.backend.manager.data.artifact.types import (
     ArtifactStatus,
     ArtifactType,
     ArtifactWithRevisionsListResult,
+    BulkArtifactResult,
 )
 from ai.backend.manager.data.association.types import AssociationArtifactsStoragesData
 from ai.backend.manager.errors.artifact import ArtifactNotFoundError
@@ -351,11 +352,11 @@ class ArtifactRepository:
         )
 
     @artifact_repository_resilience.apply()
-    async def delete_artifacts(self, artifact_ids: list[uuid.UUID]) -> list[ArtifactData]:
+    async def delete_artifacts(self, artifact_ids: list[uuid.UUID]) -> BulkArtifactResult:
         return await self._db_source.delete_artifacts(artifact_ids)
 
     @artifact_repository_resilience.apply()
-    async def restore_artifacts(self, artifact_ids: list[uuid.UUID]) -> list[ArtifactData]:
+    async def restore_artifacts(self, artifact_ids: list[uuid.UUID]) -> BulkArtifactResult:
         return await self._db_source.restore_artifacts(artifact_ids)
 
     @artifact_repository_resilience.apply()

--- a/src/ai/backend/manager/repositories/project/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/project/db_source/db_source.py
@@ -28,6 +28,8 @@ from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.project.types import (
+    AssignUserFailure,
+    AssignUsersResult,
     ProjectData,
     UnassignUserFailure,
     UnassignUsersResult,
@@ -509,7 +511,7 @@ class ProjectDBSource:
 
     async def assign_users_to_project(
         self, project_id: ProjectID, user_ids: list[UserID], role_id: UUID
-    ) -> list[UserData]:
+    ) -> AssignUsersResult:
         """Assign users to a project with domain validation via the RBAC member ops.
 
         Validates that the role exists, filters to users in the project's domain
@@ -518,10 +520,12 @@ class ProjectDBSource:
         specified role. Membership grants the project's ``auto_assign`` roles on
         top of that role.
 
-        Returns the list of newly assigned users.
+        Answers for every id the caller named, in that order: a user that could not
+        be enrolled says why rather than dropping out of the answer, and a repeated
+        id is enrolled once and reported as a duplicate at its later positions.
         """
         if not user_ids:
-            return []
+            return AssignUsersResult(assigned_users=[], failures=[])
 
         async with self._rbac_ops_provider.write_ops() as w:
             # TODO: https://github.com/lablup/backend.ai/issues/10687
@@ -529,22 +533,96 @@ class ProjectDBSource:
             if role is None:
                 raise InvalidAPIParameters(f"Role not found: {role_id}")
 
-            new_user_rows = await self._users_addable_to_project(w, project_id, user_ids)
-            if not new_user_rows:
-                return []
+            unique_ids = list(dict.fromkeys(user_ids))
+            domains = await self._domains_of_users(w, unique_ids)
+            members = await self._project_member_ids(w, project_id, unique_ids)
+            new_user_rows = await self._users_addable_to_project(w, project_id, unique_ids)
+            addable = {row.uuid: row for row in new_user_rows}
 
-            await w.add_bulk_members(
-                EntityMembersAddition(
-                    scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
-                    members=[ScopeUserMember(user_id=UserID(row.uuid)) for row in new_user_rows],
+            if new_user_rows:
+                await w.add_bulk_members(
+                    EntityMembersAddition(
+                        scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
+                        members=[
+                            ScopeUserMember(user_id=UserID(row.uuid)) for row in new_user_rows
+                        ],
+                    )
                 )
-            )
-            user_role_specs = [
-                UserRoleCreatorSpec(user_id=row.uuid, role_id=role_id) for row in new_user_rows
-            ]
-            await w.bulk_create(BulkCreator(specs=user_role_specs))
+                user_role_specs = [
+                    UserRoleCreatorSpec(user_id=row.uuid, role_id=role_id) for row in new_user_rows
+                ]
+                await w.bulk_create(BulkCreator(specs=user_role_specs))
 
-            return [row.to_data() for row in new_user_rows]
+            project_domain = await self._domain_of_project(w, project_id)
+            assigned_users: list[UserData] = []
+            failures: list[AssignUserFailure] = []
+            answered: set[UUID] = set()
+            for user_id in user_ids:
+                if user_id in answered:
+                    failures.append(
+                        AssignUserFailure(
+                            user_id=user_id, reason="Duplicate user id in the request."
+                        )
+                    )
+                    continue
+                answered.add(user_id)
+                row = addable.get(user_id)
+                if row is not None:
+                    assigned_users.append(row.to_data())
+                elif user_id not in domains:
+                    failures.append(
+                        AssignUserFailure(user_id=user_id, reason="User does not exist.")
+                    )
+                elif domains[user_id] != project_domain:
+                    failures.append(
+                        AssignUserFailure(
+                            user_id=user_id,
+                            reason="User does not belong to the project's domain.",
+                        )
+                    )
+                elif user_id in members:
+                    failures.append(
+                        AssignUserFailure(
+                            user_id=user_id, reason="User is already assigned to this project."
+                        )
+                    )
+                else:
+                    failures.append(
+                        AssignUserFailure(user_id=user_id, reason="User could not be assigned.")
+                    )
+            return AssignUsersResult(assigned_users=assigned_users, failures=failures)
+
+    async def _domain_of_project(self, w: RBACWriteOps, project_id: ProjectID) -> str | None:
+        """The domain the project belongs to, ``None`` if it names no project."""
+        result = await w.batch_query_in_global(
+            sa.select(ProjectRow.domain_name).where(ProjectRow.id == project_id),
+            BatchQuerier(pagination=NoPagination()),
+        )
+        rows = list(result.rows)
+        return rows[0].domain_name if rows else None
+
+    async def _domains_of_users(
+        self, w: RBACWriteOps, user_ids: Sequence[UserID]
+    ) -> dict[UUID, str]:
+        """The domain of each id that names a user; an id naming none is absent."""
+        result = await w.batch_query_in_global(
+            sa.select(UserRow.uuid, UserRow.domain_name).where(UserRow.uuid.in_(user_ids)),
+            BatchQuerier(pagination=NoPagination()),
+        )
+        return {row.uuid: row.domain_name for row in result.rows}
+
+    async def _project_member_ids(
+        self, w: RBACWriteOps, project_id: ProjectID, user_ids: Sequence[UserID]
+    ) -> set[UUID]:
+        """Which of the named users already belong to the project."""
+        result = await w.batch_query_in_global(
+            sa.select(UserRow.uuid).where(
+                UserRow.uuid.in_(user_ids)
+                & user_scope_membership_exists(PROJECT_SCOPE_TYPE, project_id, UserRow.uuid)
+            ),
+            BatchQuerier(pagination=NoPagination()),
+        )
+        return {row.uuid for row in result.rows}
 
     async def unassign_users_from_project(
         self, unbinder: UserProjectEntityUnbinder

--- a/src/ai/backend/manager/repositories/project/repository.py
+++ b/src/ai/backend/manager/repositories/project/repository.py
@@ -19,8 +19,11 @@ from ai.backend.common.types import ResourceSlot
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
 from ai.backend.manager.config.provider import ManagerConfigProvider
-from ai.backend.manager.data.project.types import ProjectData, UnassignUsersResult
-from ai.backend.manager.data.user.types import UserData
+from ai.backend.manager.data.project.types import (
+    AssignUsersResult,
+    ProjectData,
+    UnassignUsersResult,
+)
 from ai.backend.manager.errors.resource import (
     InvalidUserUpdateMode,
     ProjectNotFound,
@@ -139,10 +142,11 @@ class ProjectRepository:
     @project_repository_resilience.apply()
     async def assign_users_to_project(
         self, project_id: UUID, user_ids: list[UUID], role_id: UUID
-    ) -> list[UserData]:
+    ) -> AssignUsersResult:
         """Assign users to a project with domain validation and RBAC scope binding.
 
-        Returns the list of newly assigned users.
+        Answers for every id the caller named: who was enrolled, and why each of the
+        others was not.
         """
         return await self._db_source.assign_users_to_project(
             ProjectID(project_id), [UserID(uid) for uid in user_ids], role_id

--- a/src/ai/backend/manager/services/artifact/actions/delete_multi.py
+++ b/src/ai/backend/manager/services/artifact/actions/delete_multi.py
@@ -2,6 +2,7 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.data.entity.artifact import ArtifactID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.artifact.types import ArtifactData
 from ai.backend.manager.services.artifact.actions.base import ArtifactAction
@@ -25,3 +26,4 @@ class DeleteArtifactsAction(ArtifactAction):
 @dataclass
 class DeleteArtifactsActionResult:
     artifacts: list[ArtifactData]
+    missing: list[ArtifactID]

--- a/src/ai/backend/manager/services/artifact/actions/restore_multi.py
+++ b/src/ai/backend/manager/services/artifact/actions/restore_multi.py
@@ -2,6 +2,7 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.data.entity.artifact import ArtifactID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.artifact.types import ArtifactData
 from ai.backend.manager.services.artifact.actions.base import ArtifactAction
@@ -25,3 +26,4 @@ class RestoreArtifactsAction(ArtifactAction):
 @dataclass
 class RestoreArtifactsActionResult:
     artifacts: list[ArtifactData]
+    missing: list[ArtifactID]

--- a/src/ai/backend/manager/services/artifact/service.py
+++ b/src/ai/backend/manager/services/artifact/service.py
@@ -474,14 +474,14 @@ class ArtifactService:
         return RetrieveModelActionResult(result=scanned_models[0])
 
     async def delete_artifacts(self, action: DeleteArtifactsAction) -> DeleteArtifactsActionResult:
-        deleted_artifacts = await self._artifact_repository.delete_artifacts(action.artifact_ids)
-        return DeleteArtifactsActionResult(artifacts=deleted_artifacts)
+        result = await self._artifact_repository.delete_artifacts(action.artifact_ids)
+        return DeleteArtifactsActionResult(artifacts=result.successes, missing=result.missing)
 
     async def restore_artifacts(
         self, action: RestoreArtifactsAction
     ) -> RestoreArtifactsActionResult:
-        restored_artifacts = await self._artifact_repository.restore_artifacts(action.artifact_ids)
-        return RestoreArtifactsActionResult(artifacts=restored_artifacts)
+        result = await self._artifact_repository.restore_artifacts(action.artifact_ids)
+        return RestoreArtifactsActionResult(artifacts=result.successes, missing=result.missing)
 
     async def _resolve_artifact_registry_meta(
         self, _artifact_type: ArtifactType | None, registry_id_or_none: uuid.UUID | None

--- a/src/ai/backend/manager/services/project/actions/assign_users_to_project.py
+++ b/src/ai/backend/manager/services/project/actions/assign_users_to_project.py
@@ -6,6 +6,7 @@ from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
+from ai.backend.manager.data.project.types import AssignUserFailure
 from ai.backend.manager.data.user.types import UserData
 
 
@@ -36,3 +37,4 @@ class AssignUsersToProjectAction(BaseSingleEntityAction):
 class AssignUsersToProjectActionResult:
     project_id: ProjectID
     assigned_users: list[UserData]
+    failures: list[AssignUserFailure]

--- a/src/ai/backend/manager/services/project/service.py
+++ b/src/ai/backend/manager/services/project/service.py
@@ -174,11 +174,13 @@ class ProjectService:
     async def assign_users_to_project(
         self, action: AssignUsersToProjectAction
     ) -> AssignUsersToProjectActionResult:
-        assigned_users = await self._group_repository.assign_users_to_project(
+        result = await self._group_repository.assign_users_to_project(
             action.project_id, action.user_ids, action.role_id
         )
         return AssignUsersToProjectActionResult(
-            project_id=action.project_id, assigned_users=assigned_users
+            project_id=action.project_id,
+            assigned_users=result.assigned_users,
+            failures=result.failures,
         )
 
     async def create_dotfile(

--- a/tests/unit/manager/repositories/artifact/test_artifact_repository.py
+++ b/tests/unit/manager/repositories/artifact/test_artifact_repository.py
@@ -336,10 +336,11 @@ class TestArtifactRepository:
         sample_artifact_id: uuid.UUID,
     ) -> None:
         """Test deleting artifact (soft delete)"""
-        deleted_artifacts = await artifact_repository.delete_artifacts([sample_artifact_id])
+        result = await artifact_repository.delete_artifacts([sample_artifact_id])
 
-        assert len(deleted_artifacts) == 1
-        assert deleted_artifacts[0].availability == ArtifactAvailability.DELETED
+        assert len(result.successes) == 1
+        assert result.successes[0].availability == ArtifactAvailability.DELETED
+        assert result.missing == []
 
         # Verify artifact is marked as deleted
         artifact = await artifact_repository.get_artifact_by_id(sample_artifact_id)
@@ -355,10 +356,11 @@ class TestArtifactRepository:
         await artifact_repository.delete_artifacts([sample_artifact_id])
 
         # Then restore it
-        restored_artifacts = await artifact_repository.restore_artifacts([sample_artifact_id])
+        result = await artifact_repository.restore_artifacts([sample_artifact_id])
 
-        assert len(restored_artifacts) == 1
-        assert restored_artifacts[0].availability == ArtifactAvailability.ALIVE
+        assert len(result.successes) == 1
+        assert result.successes[0].availability == ArtifactAvailability.ALIVE
+        assert result.missing == []
 
     # =========================================================================
     # Tests - Search with filtering

--- a/tests/unit/manager/repositories/group/test_assign_users_to_project.py
+++ b/tests/unit/manager/repositories/group/test_assign_users_to_project.py
@@ -318,9 +318,10 @@ class TestAssignUsersToProject:
             test_project, [same_domain_user_1, same_domain_user_2], test_role
         )
 
-        assert len(result) == 2
-        result_uuids = {u.uuid for u in result}
+        assert len(result.assigned_users) == 2
+        result_uuids = {u.uuid for u in result.assigned_users}
         assert result_uuids == {same_domain_user_1, same_domain_user_2}
+        assert result.failures == []
 
         # Verify ASE rows created (PROJECT scope, USER entity)
         async with db_with_cleanup.begin_readonly_session() as session:
@@ -341,7 +342,8 @@ class TestAssignUsersToProject:
     ) -> None:
         """Empty user_ids list returns empty result without DB access."""
         result = await group_db_source.assign_users_to_project(test_project, [], test_role)
-        assert result == []
+        assert result.assigned_users == []
+        assert result.failures == []
 
     async def test_assign_filters_already_assigned_users(
         self,
@@ -352,17 +354,18 @@ class TestAssignUsersToProject:
         same_domain_user_1: UserID,
         same_domain_user_2: UserID,
     ) -> None:
-        """Already-assigned users are excluded; only new users are returned."""
+        """An already-assigned user is answered as a failure, not dropped."""
         # Pre-assign user_1
         await group_db_source.assign_users_to_project(test_project, [same_domain_user_1], test_role)
 
-        # Assign both — only user_2 should be returned
+        # Assign both — user_2 goes through and user_1 is answered as already assigned
         result = await group_db_source.assign_users_to_project(
             test_project, [same_domain_user_1, same_domain_user_2], test_role
         )
 
-        assert len(result) == 1
-        assert result[0].uuid == same_domain_user_2
+        assert [u.uuid for u in result.assigned_users] == [same_domain_user_2]
+        assert [f.user_id for f in result.failures] == [same_domain_user_1]
+        assert result.failures[0].reason == "User is already assigned to this project."
 
         # Verify total 2 ASE associations
         async with db_with_cleanup.begin_readonly_session() as session:
@@ -383,13 +386,14 @@ class TestAssignUsersToProject:
         same_domain_user_1: UserID,
         cross_domain_user: UserID,
     ) -> None:
-        """Users from a different domain are silently excluded."""
+        """A user from another domain is answered as a failure, not dropped."""
         result = await group_db_source.assign_users_to_project(
             test_project, [same_domain_user_1, cross_domain_user], test_role
         )
 
-        assert len(result) == 1
-        assert result[0].uuid == same_domain_user_1
+        assert [u.uuid for u in result.assigned_users] == [same_domain_user_1]
+        assert [f.user_id for f in result.failures] == [cross_domain_user]
+        assert result.failures[0].reason == "User does not belong to the project's domain."
 
     async def test_assign_filters_nonexistent_users(
         self,
@@ -397,10 +401,12 @@ class TestAssignUsersToProject:
         test_project: ProjectID,
         test_role: uuid.UUID,
     ) -> None:
-        """Non-existent user UUIDs are silently excluded."""
+        """A UUID naming no user is answered as a failure, not dropped."""
         fake_user = UserID(uuid.uuid4())
         result = await group_db_source.assign_users_to_project(test_project, [fake_user], test_role)
-        assert result == []
+        assert result.assigned_users == []
+        assert [f.user_id for f in result.failures] == [fake_user]
+        assert result.failures[0].reason == "User does not exist."
 
     async def test_assign_all_invalid_returns_empty(
         self,
@@ -409,13 +415,14 @@ class TestAssignUsersToProject:
         test_role: uuid.UUID,
         cross_domain_user: UserID,
     ) -> None:
-        """When all users are invalid (wrong domain, nonexistent), return empty."""
+        """When every named user is invalid, each is still answered in request order."""
         fake_user = UserID(uuid.uuid4())
 
         result = await group_db_source.assign_users_to_project(
             test_project, [cross_domain_user, fake_user], test_role
         )
-        assert result == []
+        assert result.assigned_users == []
+        assert [f.user_id for f in result.failures] == [cross_domain_user, fake_user]
 
     async def test_assign_creates_user_role_rows(
         self,

--- a/tests/unit/manager/services/artifact/test_artifact_service.py
+++ b/tests/unit/manager/services/artifact/test_artifact_service.py
@@ -28,6 +28,7 @@ from ai.backend.manager.data.artifact.types import (
     ArtifactStatus,
     ArtifactType,
     ArtifactWithRevisionsListResult,
+    BulkArtifactResult,
     DelegateeTarget,
 )
 from ai.backend.manager.data.artifact_registries.types import ArtifactRegistryData
@@ -336,7 +337,9 @@ class TestArtifactService:
             readonly=sample_artifact_data.readonly,
             extra=sample_artifact_data.extra,
         )
-        mock_artifact_repository.delete_artifacts = AsyncMock(return_value=[deleted_artifact])
+        mock_artifact_repository.delete_artifacts = AsyncMock(
+            return_value=BulkArtifactResult(successes=[deleted_artifact], missing=[])
+        )
 
         action = DeleteArtifactsAction(artifact_ids=[sample_artifact_data.id])
         result = await artifact_service.delete_artifacts(action)
@@ -352,7 +355,9 @@ class TestArtifactService:
         sample_artifact_data: ArtifactData,
     ) -> None:
         """Test restoring deleted artifacts"""
-        mock_artifact_repository.restore_artifacts = AsyncMock(return_value=[sample_artifact_data])
+        mock_artifact_repository.restore_artifacts = AsyncMock(
+            return_value=BulkArtifactResult(successes=[sample_artifact_data], missing=[])
+        )
 
         action = RestoreArtifactsAction(artifact_ids=[sample_artifact_data.id])
         result = await artifact_service.restore_artifacts(action)


### PR DESCRIPTION
## Summary

Three bulk surfaces dropped the ids they could not act on, so a caller could not tell what happened to what it asked for. Found in the BA-7489 runtime audit, verdict `E-BULK` (`docs/reports/v2-action-audit/03-runtime.md` rows 193, 197, 426).

**`assign_users_to_project`** — `_users_addable_to_project` filtered out every id it could not enrol and the call returned only the rest, so a nonexistent user, a cross-domain user and an already-assigned user were indistinguishable and none appeared in the response or the audit row. A repeated id passed the filter twice and turned the whole call into a 409 on the user-role insert. The write now dedupes before it runs, and the answer is built against the ids the caller named, in that order, each carrying its reason — the shape `unassign_users_from_project` in the same file already had.

**`delete_artifacts` / `restore_artifacts`** — both updated by `id.in_()` and read back by `id.in_()`, so an id matching no row left no trace: two nonexistent ids got `200 {"artifacts": []}` plus a success audit row, and the rows that were found came back in the read's own order. Both now put the rows they read back against the ids the caller named. These two are super-admin gated, so a miss is the only failure they can report.

Payload fields follow `BulkDeleteModelCardsV2Payload`: `successes` and `failed`. The fields they replace (`items` on the assign payload, `artifacts` on the three artifact payloads) are kept, still populated, and marked deprecated.

Not in this PR: the three `bulk_upsert_*_fair_share_weights` rows, which need `execute_bulk_upserter` to report per key and a decision on how domain/project existence should be checked. `#14040` covers `global_purge_users` and the two vfolder adapter loops.

## Test plan

- [ ] Assign a mix of `[valid, cross-domain, nonexistent, already-member, duplicate-of-first]` — five answers in that order across `successes` and `failed`, each with its own reason, and no 409
- [ ] Assign only invalid ids — `successes` empty, every id answered in `failed` (previously an empty response)
- [ ] `artifact delete` with a mix of existing and nonexistent ids — existing ones in `successes` in request order, nonexistent ones in `failed`
- [ ] `artifact restore` likewise, over both REST `POST /artifacts/restore` and `restoreArtifacts`
- [ ] Existing callers reading `items` / `artifacts` still get the same values
- [ ] `pants test tests/unit/manager/repositories/group/test_assign_users_to_project.py tests/unit/manager/repositories/artifact tests/unit/manager/services/artifact`

Relates to BA-7511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013i38G9Y7aVGAArqrEFDKuN

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14044.org.readthedocs.build/en/14044/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14044.org.readthedocs.build/ko/14044/

<!-- readthedocs-preview sorna-ko end -->