### PR TITLE
fix(BA-7514): merge partial model_definition updates onto stored deployment revision presets

### DIFF
--- a/changes/14075.fix.md
+++ b/changes/14075.fix.md
@@ -1,0 +1,1 @@
+Fix updating a deployment revision preset's model_definition to no longer crash when a service block omits shell, preserving the existing value instead

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.config import DEFAULT_SHELL, ModelDefinition, PreStartAction
+from ai.backend.common.config import DEFAULT_SHELL, PreStartAction
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import (
     EnvironmentVariableEntryInput,
@@ -15,6 +15,7 @@ from ai.backend.common.dto.manager.v2.common import (
 )
 from ai.backend.common.dto.manager.v2.deployment.request import (
     DeploymentStrategyInput,
+    ModelDefinitionInput,
     PresetValueInput,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.types import (
@@ -151,7 +152,7 @@ class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
     description: str | Sentinel | None = Field(default=SENTINEL)
     rank: int | None = Field(default=None, ge=0)
     image_id: ImageID | Sentinel | None = Field(default=SENTINEL)
-    model_definition: ModelDefinition | Sentinel | None = Field(default=SENTINEL)
+    model_definition: ModelDefinitionInput | Sentinel | None = Field(default=SENTINEL)
     resource_slots: list[ResourceSlotEntryInput] | None = Field(default=None)
     resource_opts: list[ResourceOptsEntryDTO] | None = Field(default=None)
     cluster_mode: str | None = Field(default=None, max_length=16)

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -7,13 +7,17 @@ from ai.backend.common.api_handlers import SENTINEL, Sentinel
 from ai.backend.common.config import (
     ModelConfig,
     ModelDefinition,
+    ModelDefinitionDraft,
     ModelHealthCheck,
     ModelMetadata,
     ModelServiceConfig,
     PreStartAction,
 )
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
-from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    DeploymentStrategyInput,
+    ModelDefinitionInput,
+)
 from ai.backend.common.dto.manager.v2.deployment.types import (
     ModelConfigInfoDTO,
     ModelDefinitionInfoDTO,
@@ -229,6 +233,9 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         )
 
     async def get(self, preset_id: UUID) -> DeploymentRevisionPresetNode:
+        return self._data_to_node(await self._get_preset_data(preset_id))
+
+    async def _get_preset_data(self, preset_id: UUID) -> DeploymentRevisionPresetData:
         conditions: list[QueryCondition] = [lambda: DeploymentRevisionPresetRow.id == preset_id]
         querier = self._build_querier(
             conditions=conditions,
@@ -241,7 +248,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         )
         if not result.items:
             raise DeploymentRevisionPresetNotFound()
-        return self._data_to_node(result.items[0])
+        return result.items[0]
 
     async def create(
         self,
@@ -307,8 +314,8 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             if input.preset_values is not None
             else OptionalState.nop()
         )
-        model_def_state: TriState[ModelDefinition] = self._convert_model_definition_state(
-            input.model_definition
+        model_def_state: TriState[ModelDefinition] = await self._resolve_model_definition_state(
+            input.id, input.model_definition
         )
 
         spec = DeploymentRevisionPresetUpdaterSpec(
@@ -558,15 +565,22 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             for pv in preset_values
         ]
 
-    @staticmethod
-    def _convert_model_definition_state(
-        value: ModelDefinition | Sentinel | None,
+    async def _resolve_model_definition_state(
+        self,
+        preset_id: UUID,
+        value: ModelDefinitionInput | Sentinel | None,
     ) -> TriState[ModelDefinition]:
+        """Merge a partial model_definition update onto the preset's stored value."""
         if value is SENTINEL:
             return TriState.nop()
         if value is None:
             return TriState.nullify()
-        return TriState.update(value)
+        existing = await self._get_preset_data(preset_id)
+        base_draft = ModelDefinitionDraft()
+        if existing.model_definition is not None:
+            base_draft = ModelDefinitionDraft.model_validate(existing.model_definition)
+        merged = base_draft.merge(value.to_draft())
+        return TriState.update(merged.to_resolved())
 
     @staticmethod
     def _convert_tri_state(value: Any) -> TriState[Any]:

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -314,7 +314,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             if input.preset_values is not None
             else OptionalState.nop()
         )
-        model_def_state: TriState[ModelDefinition] = await self._resolve_model_definition_state(
+        model_def_state: TriState[ModelDefinition] = await self._merge_model_definition_update(
             input.id, input.model_definition
         )
 
@@ -565,7 +565,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             for pv in preset_values
         ]
 
-    async def _resolve_model_definition_state(
+    async def _merge_model_definition_update(
         self,
         preset_id: UUID,
         value: ModelDefinitionInput | Sentinel | None,

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -25,7 +25,12 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.dto.manager.query import UUIDFilter
 from ai.backend.common.dto.manager.v2.common import ResourceSlotEntryInput
-from ai.backend.common.dto.manager.v2.deployment.request import DeploymentStrategyInput
+from ai.backend.common.dto.manager.v2.deployment.request import (
+    DeploymentStrategyInput,
+    ModelConfigInput,
+    ModelDefinitionInput,
+    ModelServiceConfigInput,
+)
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     CreateDeploymentRevisionPresetInput,
     DeploymentRevisionPresetFilter,
@@ -86,6 +91,44 @@ async def other_runtime_variant_id(
     """Create a second runtime variant to move a preset into."""
     async with _runtime_variant(db_engine) as variant_id:
         yield variant_id
+
+
+@pytest.fixture()
+async def preset_with_model_definition_id(
+    admin_v2_registry: V2ClientRegistry,
+    runtime_variant_id: RuntimeVariantID,
+) -> AsyncIterator[uuid.UUID]:
+    """Create a preset with a fully populated model_definition (custom shell)."""
+    create_result = await admin_v2_registry.deployment_revision_preset.create(
+        CreateDeploymentRevisionPresetInput(
+            runtime_variant_id=runtime_variant_id,
+            name="partial-update-preset",
+            image_id=ImageID(uuid.uuid4()),
+            model_definition=PresetModelDefinitionInput(
+                models=[
+                    PresetModelConfigInput(
+                        name="llama",
+                        model_path="/models/llama",
+                        service=PresetModelServiceConfigInput(
+                            port=8080,
+                            start_command=["python", "server.py"],
+                            shell="/bin/zsh",
+                        ),
+                    ),
+                ],
+            ),
+            resource_slots=[ResourceSlotEntryInput(resource_type="cpu", quantity="1")],
+            cluster_mode="single-node",
+            cluster_size=1,
+            replica_count=1,
+            deployment_strategy=DeploymentStrategyInput(type=DeploymentStrategy.ROLLING),
+        )
+    )
+    preset_id = create_result.preset.id
+    try:
+        yield preset_id
+    finally:
+        await admin_v2_registry.deployment_revision_preset.delete(preset_id)
 
 
 class TestDeploymentRevisionPresetCRUD:
@@ -260,6 +303,67 @@ class TestDeploymentRevisionPresetCRUD:
 
         get_result = await admin_v2_registry.deployment_revision_preset.get(preset_id)
         assert get_result.runtime_variant_id == other_runtime_variant_id
+
+    async def test_update_model_definition_partial(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        preset_with_model_definition_id: uuid.UUID,
+    ) -> None:
+        preset_id = preset_with_model_definition_id
+
+        # Omitting service.shell must not crash and must preserve the stored
+        # shell (and name/model_path) -- the update is merged onto the
+        # preset's existing model_definition, not a plain replace.
+        update_result = await admin_v2_registry.deployment_revision_preset.update(
+            preset_id,
+            UpdateDeploymentRevisionPresetInput(
+                id=preset_id,
+                model_definition=ModelDefinitionInput(
+                    models=[
+                        ModelConfigInput(
+                            service=ModelServiceConfigInput(
+                                start_command=["python", "server_v2.py"],
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        )
+        assert update_result.preset.model_definition is not None
+        updated_config = update_result.preset.model_definition.models[0]
+        assert updated_config.name == "llama"
+        assert updated_config.model_path == "/models/llama"
+        service = updated_config.service
+        assert service is not None
+        assert service.shell == "/bin/zsh"
+        assert service.start_command == ["python", "server_v2.py"]
+
+        # Explicitly setting shell applies the new value.
+        update_result = await admin_v2_registry.deployment_revision_preset.update(
+            preset_id,
+            UpdateDeploymentRevisionPresetInput(
+                id=preset_id,
+                model_definition=ModelDefinitionInput(
+                    models=[
+                        ModelConfigInput(service=ModelServiceConfigInput(shell="/bin/bash")),
+                    ],
+                ),
+            ),
+        )
+        assert update_result.preset.model_definition is not None
+        service = update_result.preset.model_definition.models[0].service
+        assert service is not None
+        assert service.shell == "/bin/bash"
+
+        # Omitting model_definition entirely leaves the stored value untouched.
+        update_result = await admin_v2_registry.deployment_revision_preset.update(
+            preset_id,
+            UpdateDeploymentRevisionPresetInput(id=preset_id, description="unrelated change"),
+        )
+        assert update_result.preset.model_definition is not None
+        service = update_result.preset.model_definition.models[0].service
+        assert service is not None
+        assert service.shell == "/bin/bash"
 
     async def test_delete(
         self,


### PR DESCRIPTION
Backport: none

## Summary
- Updating a deployment revision preset's `model_definition` with a `service` block that omits `shell` crashed with a pydantic `ValidationError` instead of applying the update, because the update DTO validated the partial payload against the strict, fully-populated `ModelDefinition` type.
- Point `UpdateDeploymentRevisionPresetInput.model_definition` at the loose `ModelDefinitionInput` the GQL layer already produces (no schema change), and merge the partial patch onto the preset's existing stored value in the adapter (`ModelDefinitionDraft.merge`) so omitted fields keep their previous value instead of crashing or being silently reset.

## Test plan
- [x] `pants fmt/fix/lint/check/test` on changed files and affected repository/sokovan tests
- [x] Live-verified via `./bai admin deployment revision-preset` against local halfstack:
  - Omitting `service.shell` on update no longer crashes; existing shell value is preserved
  - Explicitly setting `shell` applies the new value (both directions: bash→zsh and zsh→bash)
  - Omitting `model_definition` entirely leaves the stored value untouched

Resolves BA-7514