### PR TITLE
fix(BA-7544): apply the fair share order fields the enums advertise (#14076)

### DIFF
--- a/changes/14076.fix.md
+++ b/changes/14076.fix.md
@@ -1,0 +1,1 @@
+Order fair shares by the project name, project active state, user name and user email that the order-field enums advertise; these were accepted but silently ignored since 26.4.0.

--- a/src/ai/backend/manager/api/adapters/fair_share/adapter.py
+++ b/src/ai/backend/manager/api/adapters/fair_share/adapter.py
@@ -538,8 +538,7 @@ class FairShareAdapter(BaseAdapter):
 
     # ------------------------------------------------------------------ filter helpers (domain)
 
-    @staticmethod
-    def _convert_domain_filter(filter: DomainFairShareFilter) -> list[QueryCondition]:
+    def _convert_domain_filter(self, filter: DomainFairShareFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter.resource_group is not None:
             cond = filter.resource_group.build_query_condition(
@@ -567,23 +566,22 @@ class FairShareAdapter(BaseAdapter):
             )
         if filter.AND:
             for sub_filter in filter.AND:
-                conditions.extend(FairShareAdapter._convert_domain_filter(sub_filter))
+                conditions.extend(self._convert_domain_filter(sub_filter))
         if filter.OR:
             or_conditions: list[QueryCondition] = []
             for sub_filter in filter.OR:
-                or_conditions.extend(FairShareAdapter._convert_domain_filter(sub_filter))
+                or_conditions.extend(self._convert_domain_filter(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if filter.NOT:
             not_conditions: list[QueryCondition] = []
             for sub_filter in filter.NOT:
-                not_conditions.extend(FairShareAdapter._convert_domain_filter(sub_filter))
+                not_conditions.extend(self._convert_domain_filter(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
-    @staticmethod
-    def _convert_domain_filter_rg(filter: DomainFairShareFilter) -> list[QueryCondition]:
+    def _convert_domain_filter_rg(self, filter: DomainFairShareFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter.resource_group is not None:
             cond = filter.resource_group.build_query_condition(
@@ -611,57 +609,54 @@ class FairShareAdapter(BaseAdapter):
             )
         if filter.AND:
             for sub_filter in filter.AND:
-                conditions.extend(FairShareAdapter._convert_domain_filter_rg(sub_filter))
+                conditions.extend(self._convert_domain_filter_rg(sub_filter))
         if filter.OR:
             or_conditions: list[QueryCondition] = []
             for sub_filter in filter.OR:
-                or_conditions.extend(FairShareAdapter._convert_domain_filter_rg(sub_filter))
+                or_conditions.extend(self._convert_domain_filter_rg(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if filter.NOT:
             not_conditions: list[QueryCondition] = []
             for sub_filter in filter.NOT:
-                not_conditions.extend(FairShareAdapter._convert_domain_filter_rg(sub_filter))
+                not_conditions.extend(self._convert_domain_filter_rg(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
-    @staticmethod
-    def _convert_domain_orders(orders: list[DomainFairShareOrder]) -> list[QueryOrder]:
-        result: list[QueryOrder] = []
-        for o in orders:
-            ascending = o.direction == OrderDirection.ASC
-            match o.field:
-                case DomainFairShareOrderField.FAIR_SHARE_FACTOR:
-                    result.append(DomainFairShareOrders.by_fair_share_factor(ascending=ascending))
-                case DomainFairShareOrderField.DOMAIN_NAME:
-                    result.append(DomainFairShareOrders.by_domain_name(ascending=ascending))
-                case DomainFairShareOrderField.CREATED_AT:
-                    result.append(DomainFairShareOrders.by_created_at(ascending=ascending))
-                case DomainFairShareOrderField.DOMAIN_IS_ACTIVE:
-                    result.append(DomainFairShareOrders.by_domain_is_active(ascending=ascending))
-        return result
+    def _convert_domain_orders(self, orders: list[DomainFairShareOrder]) -> list[QueryOrder]:
+        return [self._convert_domain_order(o) for o in orders]
 
-    @staticmethod
-    def _convert_domain_orders_rg(orders: list[DomainFairShareOrder]) -> list[QueryOrder]:
-        result: list[QueryOrder] = []
-        for o in orders:
-            ascending = o.direction == OrderDirection.ASC
-            match o.field:
-                case DomainFairShareOrderField.FAIR_SHARE_FACTOR:
-                    result.append(RGDomainFairShareOrders.by_fair_share_factor(ascending=ascending))
-                case DomainFairShareOrderField.DOMAIN_NAME:
-                    result.append(RGDomainFairShareOrders.by_domain_name(ascending=ascending))
-                case DomainFairShareOrderField.CREATED_AT:
-                    result.append(RGDomainFairShareOrders.by_created_at(ascending=ascending))
-                case DomainFairShareOrderField.DOMAIN_IS_ACTIVE:
-                    result.append(DomainFairShareOrders.by_domain_is_active(ascending=ascending))
-        return result
+    def _convert_domain_order(self, order: DomainFairShareOrder) -> QueryOrder:
+        ascending = order.direction == OrderDirection.ASC
+        match order.field:
+            case DomainFairShareOrderField.FAIR_SHARE_FACTOR:
+                return DomainFairShareOrders.by_fair_share_factor(ascending=ascending)
+            case DomainFairShareOrderField.DOMAIN_NAME:
+                return DomainFairShareOrders.by_domain_name(ascending=ascending)
+            case DomainFairShareOrderField.CREATED_AT:
+                return DomainFairShareOrders.by_created_at(ascending=ascending)
+            case DomainFairShareOrderField.DOMAIN_IS_ACTIVE:
+                return DomainFairShareOrders.by_domain_is_active(ascending=ascending)
+
+    def _convert_domain_orders_rg(self, orders: list[DomainFairShareOrder]) -> list[QueryOrder]:
+        return [self._convert_domain_order_rg(o) for o in orders]
+
+    def _convert_domain_order_rg(self, order: DomainFairShareOrder) -> QueryOrder:
+        ascending = order.direction == OrderDirection.ASC
+        match order.field:
+            case DomainFairShareOrderField.FAIR_SHARE_FACTOR:
+                return RGDomainFairShareOrders.by_fair_share_factor(ascending=ascending)
+            case DomainFairShareOrderField.DOMAIN_NAME:
+                return RGDomainFairShareOrders.by_domain_name(ascending=ascending)
+            case DomainFairShareOrderField.CREATED_AT:
+                return RGDomainFairShareOrders.by_created_at(ascending=ascending)
+            case DomainFairShareOrderField.DOMAIN_IS_ACTIVE:
+                return RGDomainFairShareOrders.by_domain_is_active(ascending=ascending)
 
     # ------------------------------------------------------------------ filter helpers (project)
 
-    @staticmethod
-    def _convert_project_filter(filter: ProjectFairShareFilter) -> list[QueryCondition]:
+    def _convert_project_filter(self, filter: ProjectFairShareFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter.resource_group is not None:
             cond = filter.resource_group.build_query_condition(
@@ -696,23 +691,22 @@ class FairShareAdapter(BaseAdapter):
             )
         if filter.AND:
             for sub_filter in filter.AND:
-                conditions.extend(FairShareAdapter._convert_project_filter(sub_filter))
+                conditions.extend(self._convert_project_filter(sub_filter))
         if filter.OR:
             or_conditions: list[QueryCondition] = []
             for sub_filter in filter.OR:
-                or_conditions.extend(FairShareAdapter._convert_project_filter(sub_filter))
+                or_conditions.extend(self._convert_project_filter(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if filter.NOT:
             not_conditions: list[QueryCondition] = []
             for sub_filter in filter.NOT:
-                not_conditions.extend(FairShareAdapter._convert_project_filter(sub_filter))
+                not_conditions.extend(self._convert_project_filter(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
-    @staticmethod
-    def _convert_project_filter_rg(filter: ProjectFairShareFilter) -> list[QueryCondition]:
+    def _convert_project_filter_rg(self, filter: ProjectFairShareFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter.resource_group is not None:
             cond = filter.resource_group.build_query_condition(
@@ -747,51 +741,54 @@ class FairShareAdapter(BaseAdapter):
             )
         if filter.AND:
             for sub_filter in filter.AND:
-                conditions.extend(FairShareAdapter._convert_project_filter_rg(sub_filter))
+                conditions.extend(self._convert_project_filter_rg(sub_filter))
         if filter.OR:
             or_conditions: list[QueryCondition] = []
             for sub_filter in filter.OR:
-                or_conditions.extend(FairShareAdapter._convert_project_filter_rg(sub_filter))
+                or_conditions.extend(self._convert_project_filter_rg(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if filter.NOT:
             not_conditions: list[QueryCondition] = []
             for sub_filter in filter.NOT:
-                not_conditions.extend(FairShareAdapter._convert_project_filter_rg(sub_filter))
+                not_conditions.extend(self._convert_project_filter_rg(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
-    @staticmethod
-    def _convert_project_orders(orders: list[ProjectFairShareOrder]) -> list[QueryOrder]:
-        result: list[QueryOrder] = []
-        for o in orders:
-            ascending = o.direction == OrderDirection.ASC
-            match o.field:
-                case ProjectFairShareOrderField.FAIR_SHARE_FACTOR:
-                    result.append(ProjectFairShareOrders.by_fair_share_factor(ascending=ascending))
-                case ProjectFairShareOrderField.CREATED_AT:
-                    result.append(ProjectFairShareOrders.by_created_at(ascending=ascending))
-        return result
+    def _convert_project_orders(self, orders: list[ProjectFairShareOrder]) -> list[QueryOrder]:
+        return [self._convert_project_order(o) for o in orders]
 
-    @staticmethod
-    def _convert_project_orders_rg(orders: list[ProjectFairShareOrder]) -> list[QueryOrder]:
-        result: list[QueryOrder] = []
-        for o in orders:
-            ascending = o.direction == OrderDirection.ASC
-            match o.field:
-                case ProjectFairShareOrderField.FAIR_SHARE_FACTOR:
-                    result.append(
-                        RGProjectFairShareOrders.by_fair_share_factor(ascending=ascending)
-                    )
-                case ProjectFairShareOrderField.CREATED_AT:
-                    result.append(RGProjectFairShareOrders.by_created_at(ascending=ascending))
-        return result
+    def _convert_project_order(self, order: ProjectFairShareOrder) -> QueryOrder:
+        ascending = order.direction == OrderDirection.ASC
+        match order.field:
+            case ProjectFairShareOrderField.FAIR_SHARE_FACTOR:
+                return ProjectFairShareOrders.by_fair_share_factor(ascending=ascending)
+            case ProjectFairShareOrderField.CREATED_AT:
+                return ProjectFairShareOrders.by_created_at(ascending=ascending)
+            case ProjectFairShareOrderField.PROJECT_NAME:
+                return ProjectFairShareOrders.by_project_name(ascending=ascending)
+            case ProjectFairShareOrderField.PROJECT_IS_ACTIVE:
+                return ProjectFairShareOrders.by_project_is_active(ascending=ascending)
+
+    def _convert_project_orders_rg(self, orders: list[ProjectFairShareOrder]) -> list[QueryOrder]:
+        return [self._convert_project_order_rg(o) for o in orders]
+
+    def _convert_project_order_rg(self, order: ProjectFairShareOrder) -> QueryOrder:
+        ascending = order.direction == OrderDirection.ASC
+        match order.field:
+            case ProjectFairShareOrderField.FAIR_SHARE_FACTOR:
+                return RGProjectFairShareOrders.by_fair_share_factor(ascending=ascending)
+            case ProjectFairShareOrderField.CREATED_AT:
+                return RGProjectFairShareOrders.by_created_at(ascending=ascending)
+            case ProjectFairShareOrderField.PROJECT_NAME:
+                return RGProjectFairShareOrders.by_project_name(ascending=ascending)
+            case ProjectFairShareOrderField.PROJECT_IS_ACTIVE:
+                return RGProjectFairShareOrders.by_project_is_active(ascending=ascending)
 
     # ------------------------------------------------------------------ filter helpers (user)
 
-    @staticmethod
-    def _convert_user_filter(filter: UserFairShareFilter) -> list[QueryCondition]:
+    def _convert_user_filter(self, filter: UserFairShareFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter.resource_group is not None:
             cond = filter.resource_group.build_query_condition(
@@ -831,23 +828,22 @@ class FairShareAdapter(BaseAdapter):
             conditions.append(UserFairShareConditions.by_user_is_active(filter.user.is_active))
         if filter.AND:
             for sub_filter in filter.AND:
-                conditions.extend(FairShareAdapter._convert_user_filter(sub_filter))
+                conditions.extend(self._convert_user_filter(sub_filter))
         if filter.OR:
             or_conditions: list[QueryCondition] = []
             for sub_filter in filter.OR:
-                or_conditions.extend(FairShareAdapter._convert_user_filter(sub_filter))
+                or_conditions.extend(self._convert_user_filter(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if filter.NOT:
             not_conditions: list[QueryCondition] = []
             for sub_filter in filter.NOT:
-                not_conditions.extend(FairShareAdapter._convert_user_filter(sub_filter))
+                not_conditions.extend(self._convert_user_filter(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
-    @staticmethod
-    def _convert_user_filter_rg(filter: UserFairShareFilter) -> list[QueryCondition]:
+    def _convert_user_filter_rg(self, filter: UserFairShareFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
         if filter.resource_group is not None:
             cond = filter.resource_group.build_query_condition(
@@ -887,44 +883,50 @@ class FairShareAdapter(BaseAdapter):
             conditions.append(UserFairShareConditions.by_user_is_active(filter.user.is_active))
         if filter.AND:
             for sub_filter in filter.AND:
-                conditions.extend(FairShareAdapter._convert_user_filter_rg(sub_filter))
+                conditions.extend(self._convert_user_filter_rg(sub_filter))
         if filter.OR:
             or_conditions: list[QueryCondition] = []
             for sub_filter in filter.OR:
-                or_conditions.extend(FairShareAdapter._convert_user_filter_rg(sub_filter))
+                or_conditions.extend(self._convert_user_filter_rg(sub_filter))
             if or_conditions:
                 conditions.append(combine_conditions_or(or_conditions))
         if filter.NOT:
             not_conditions: list[QueryCondition] = []
             for sub_filter in filter.NOT:
-                not_conditions.extend(FairShareAdapter._convert_user_filter_rg(sub_filter))
+                not_conditions.extend(self._convert_user_filter_rg(sub_filter))
             if not_conditions:
                 conditions.append(negate_conditions(not_conditions))
         return conditions
 
-    @staticmethod
-    def _convert_user_orders(orders: list[UserFairShareOrder]) -> list[QueryOrder]:
-        result: list[QueryOrder] = []
-        for o in orders:
-            ascending = o.direction == OrderDirection.ASC
-            match o.field:
-                case UserFairShareOrderField.FAIR_SHARE_FACTOR:
-                    result.append(UserFairShareOrders.by_fair_share_factor(ascending=ascending))
-                case UserFairShareOrderField.CREATED_AT:
-                    result.append(UserFairShareOrders.by_created_at(ascending=ascending))
-        return result
+    def _convert_user_orders(self, orders: list[UserFairShareOrder]) -> list[QueryOrder]:
+        return [self._convert_user_order(o) for o in orders]
 
-    @staticmethod
-    def _convert_user_orders_rg(orders: list[UserFairShareOrder]) -> list[QueryOrder]:
-        result: list[QueryOrder] = []
-        for o in orders:
-            ascending = o.direction == OrderDirection.ASC
-            match o.field:
-                case UserFairShareOrderField.FAIR_SHARE_FACTOR:
-                    result.append(RGUserFairShareOrders.by_fair_share_factor(ascending=ascending))
-                case UserFairShareOrderField.CREATED_AT:
-                    result.append(RGUserFairShareOrders.by_created_at(ascending=ascending))
-        return result
+    def _convert_user_order(self, order: UserFairShareOrder) -> QueryOrder:
+        ascending = order.direction == OrderDirection.ASC
+        match order.field:
+            case UserFairShareOrderField.FAIR_SHARE_FACTOR:
+                return UserFairShareOrders.by_fair_share_factor(ascending=ascending)
+            case UserFairShareOrderField.CREATED_AT:
+                return UserFairShareOrders.by_created_at(ascending=ascending)
+            case UserFairShareOrderField.USER_USERNAME:
+                return UserFairShareOrders.by_user_username(ascending=ascending)
+            case UserFairShareOrderField.USER_EMAIL:
+                return UserFairShareOrders.by_user_email(ascending=ascending)
+
+    def _convert_user_orders_rg(self, orders: list[UserFairShareOrder]) -> list[QueryOrder]:
+        return [self._convert_user_order_rg(o) for o in orders]
+
+    def _convert_user_order_rg(self, order: UserFairShareOrder) -> QueryOrder:
+        ascending = order.direction == OrderDirection.ASC
+        match order.field:
+            case UserFairShareOrderField.FAIR_SHARE_FACTOR:
+                return RGUserFairShareOrders.by_fair_share_factor(ascending=ascending)
+            case UserFairShareOrderField.CREATED_AT:
+                return RGUserFairShareOrders.by_created_at(ascending=ascending)
+            case UserFairShareOrderField.USER_USERNAME:
+                return RGUserFairShareOrders.by_user_username(ascending=ascending)
+            case UserFairShareOrderField.USER_EMAIL:
+                return RGUserFairShareOrders.by_user_email(ascending=ascending)
 
     # ------------------------------------------------------------------ data → DTO converters
 

--- a/src/ai/backend/manager/models/fair_share/orders.py
+++ b/src/ai/backend/manager/models/fair_share/orders.py
@@ -98,6 +98,11 @@ class RGDomainFairShareOrders:
         return col.asc() if ascending else col.desc()
 
     @staticmethod
+    def by_domain_is_active(ascending: bool = True) -> QueryOrder:
+        col = DomainRow.is_active
+        return col.asc() if ascending else col.desc()
+
+    @staticmethod
     def by_fair_share_factor(ascending: bool = False) -> QueryOrder:
         col = DomainFairShareRow.fair_share_factor
         return col.asc() if ascending else col.desc()
@@ -111,8 +116,19 @@ class RGDomainFairShareOrders:
 class RGProjectFairShareOrders:
     """Query orders for rg-scoped project fair share queries.
 
-    Uses ProjectFairShareRow (LEFT JOIN'd) for fair-share-specific ordering.
+    Uses ProjectRow (base table) columns for reliable sorting,
+    and ProjectFairShareRow (LEFT JOIN'd) for fair-share-specific ordering.
     """
+
+    @staticmethod
+    def by_project_name(ascending: bool = True) -> QueryOrder:
+        col = ProjectRow.name
+        return col.asc() if ascending else col.desc()
+
+    @staticmethod
+    def by_project_is_active(ascending: bool = True) -> QueryOrder:
+        col = ProjectRow.is_active
+        return col.asc() if ascending else col.desc()
 
     @staticmethod
     def by_fair_share_factor(ascending: bool = False) -> QueryOrder:
@@ -128,8 +144,19 @@ class RGProjectFairShareOrders:
 class RGUserFairShareOrders:
     """Query orders for rg-scoped user fair share queries.
 
-    Uses UserFairShareRow (LEFT JOIN'd) for fair-share-specific ordering.
+    Uses UserRow (base table) columns for reliable sorting,
+    and UserFairShareRow (LEFT JOIN'd) for fair-share-specific ordering.
     """
+
+    @staticmethod
+    def by_user_username(ascending: bool = True) -> QueryOrder:
+        col = UserRow.username
+        return col.asc() if ascending else col.desc()
+
+    @staticmethod
+    def by_user_email(ascending: bool = True) -> QueryOrder:
+        col = UserRow.email
+        return col.asc() if ascending else col.desc()
 
     @staticmethod
     def by_fair_share_factor(ascending: bool = False) -> QueryOrder:

--- a/tests/unit/manager/api/adapters/test_fair_share_adapter.py
+++ b/tests/unit/manager/api/adapters/test_fair_share_adapter.py
@@ -1,0 +1,211 @@
+"""Tests for FairShareAdapter order-field conversion."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.dto.manager.v2.common import OrderDirection
+from ai.backend.common.dto.manager.v2.fair_share.request import (
+    DomainFairShareOrder,
+    ProjectFairShareOrder,
+    UserFairShareOrder,
+)
+from ai.backend.common.dto.manager.v2.fair_share.types import (
+    DomainFairShareOrderField,
+    ProjectFairShareOrderField,
+    UserFairShareOrderField,
+)
+from ai.backend.manager.api.adapters.fair_share.adapter import FairShareAdapter
+from ai.backend.manager.models.clauses import QueryOrder
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.fair_share.row import (
+    DomainFairShareRow,
+    ProjectFairShareRow,
+    UserFairShareRow,
+)
+from ai.backend.manager.models.project import ProjectRow
+from ai.backend.manager.models.user import UserRow
+
+_DIRECTIONS = [(OrderDirection.ASC, True), (OrderDirection.DESC, False)]
+
+# (order field, column the field must sort on)
+_DOMAIN_CASES: list[tuple[DomainFairShareOrderField, InstrumentedAttribute[Any]]] = [
+    (DomainFairShareOrderField.FAIR_SHARE_FACTOR, DomainFairShareRow.fair_share_factor),
+    (DomainFairShareOrderField.CREATED_AT, DomainFairShareRow.created_at),
+    (DomainFairShareOrderField.DOMAIN_NAME, DomainFairShareRow.domain_name),
+    (DomainFairShareOrderField.DOMAIN_IS_ACTIVE, DomainRow.is_active),
+]
+_DOMAIN_RG_CASES: list[tuple[DomainFairShareOrderField, InstrumentedAttribute[Any]]] = [
+    (DomainFairShareOrderField.FAIR_SHARE_FACTOR, DomainFairShareRow.fair_share_factor),
+    (DomainFairShareOrderField.CREATED_AT, DomainFairShareRow.created_at),
+    (DomainFairShareOrderField.DOMAIN_NAME, DomainRow.name),
+    (DomainFairShareOrderField.DOMAIN_IS_ACTIVE, DomainRow.is_active),
+]
+_PROJECT_CASES: list[tuple[ProjectFairShareOrderField, InstrumentedAttribute[Any]]] = [
+    (ProjectFairShareOrderField.FAIR_SHARE_FACTOR, ProjectFairShareRow.fair_share_factor),
+    (ProjectFairShareOrderField.CREATED_AT, ProjectFairShareRow.created_at),
+    (ProjectFairShareOrderField.PROJECT_NAME, ProjectRow.name),
+    (ProjectFairShareOrderField.PROJECT_IS_ACTIVE, ProjectRow.is_active),
+]
+_USER_CASES: list[tuple[UserFairShareOrderField, InstrumentedAttribute[Any]]] = [
+    (UserFairShareOrderField.FAIR_SHARE_FACTOR, UserFairShareRow.fair_share_factor),
+    (UserFairShareOrderField.CREATED_AT, UserFairShareRow.created_at),
+    (UserFairShareOrderField.USER_USERNAME, UserRow.username),
+    (UserFairShareOrderField.USER_EMAIL, UserRow.email),
+]
+
+
+@pytest.fixture
+def adapter() -> FairShareAdapter:
+    return FairShareAdapter(MagicMock())
+
+
+def _assert_sorts_on(
+    order: QueryOrder, column: InstrumentedAttribute[Any], ascending: bool
+) -> None:
+    expected = column.asc() if ascending else column.desc()
+    assert order.compare(expected)
+
+
+class TestDomainOrderConversion:
+    """Every DomainFairShareOrderField maps to its column, on both surfaces."""
+
+    @pytest.mark.parametrize("direction, ascending", _DIRECTIONS)
+    @pytest.mark.parametrize("field, column", _DOMAIN_CASES)
+    def test_global_field_sorts_on_column(
+        self,
+        adapter: FairShareAdapter,
+        field: DomainFairShareOrderField,
+        column: InstrumentedAttribute[Any],
+        direction: OrderDirection,
+        ascending: bool,
+    ) -> None:
+        order = adapter._convert_domain_order(
+            DomainFairShareOrder(field=field, direction=direction)
+        )
+        _assert_sorts_on(order, column, ascending)
+
+    @pytest.mark.parametrize("direction, ascending", _DIRECTIONS)
+    @pytest.mark.parametrize("field, column", _DOMAIN_RG_CASES)
+    def test_rg_field_sorts_on_column(
+        self,
+        adapter: FairShareAdapter,
+        field: DomainFairShareOrderField,
+        column: InstrumentedAttribute[Any],
+        direction: OrderDirection,
+        ascending: bool,
+    ) -> None:
+        order = adapter._convert_domain_order_rg(
+            DomainFairShareOrder(field=field, direction=direction)
+        )
+        _assert_sorts_on(order, column, ascending)
+
+    def test_cases_cover_every_field(self) -> None:
+        assert {field for field, _ in _DOMAIN_CASES} == set(DomainFairShareOrderField)
+        assert {field for field, _ in _DOMAIN_RG_CASES} == set(DomainFairShareOrderField)
+
+
+class TestProjectOrderConversion:
+    """Every ProjectFairShareOrderField maps to its column, on both surfaces."""
+
+    @pytest.mark.parametrize("direction, ascending", _DIRECTIONS)
+    @pytest.mark.parametrize("field, column", _PROJECT_CASES)
+    def test_global_field_sorts_on_column(
+        self,
+        adapter: FairShareAdapter,
+        field: ProjectFairShareOrderField,
+        column: InstrumentedAttribute[Any],
+        direction: OrderDirection,
+        ascending: bool,
+    ) -> None:
+        order = adapter._convert_project_order(
+            ProjectFairShareOrder(field=field, direction=direction)
+        )
+        _assert_sorts_on(order, column, ascending)
+
+    @pytest.mark.parametrize("direction, ascending", _DIRECTIONS)
+    @pytest.mark.parametrize("field, column", _PROJECT_CASES)
+    def test_rg_field_sorts_on_column(
+        self,
+        adapter: FairShareAdapter,
+        field: ProjectFairShareOrderField,
+        column: InstrumentedAttribute[Any],
+        direction: OrderDirection,
+        ascending: bool,
+    ) -> None:
+        order = adapter._convert_project_order_rg(
+            ProjectFairShareOrder(field=field, direction=direction)
+        )
+        _assert_sorts_on(order, column, ascending)
+
+    def test_cases_cover_every_field(self) -> None:
+        assert {field for field, _ in _PROJECT_CASES} == set(ProjectFairShareOrderField)
+
+
+class TestUserOrderConversion:
+    """Every UserFairShareOrderField maps to its column, on both surfaces."""
+
+    @pytest.mark.parametrize("direction, ascending", _DIRECTIONS)
+    @pytest.mark.parametrize("field, column", _USER_CASES)
+    def test_global_field_sorts_on_column(
+        self,
+        adapter: FairShareAdapter,
+        field: UserFairShareOrderField,
+        column: InstrumentedAttribute[Any],
+        direction: OrderDirection,
+        ascending: bool,
+    ) -> None:
+        order = adapter._convert_user_order(UserFairShareOrder(field=field, direction=direction))
+        _assert_sorts_on(order, column, ascending)
+
+    @pytest.mark.parametrize("direction, ascending", _DIRECTIONS)
+    @pytest.mark.parametrize("field, column", _USER_CASES)
+    def test_rg_field_sorts_on_column(
+        self,
+        adapter: FairShareAdapter,
+        field: UserFairShareOrderField,
+        column: InstrumentedAttribute[Any],
+        direction: OrderDirection,
+        ascending: bool,
+    ) -> None:
+        order = adapter._convert_user_order_rg(UserFairShareOrder(field=field, direction=direction))
+        _assert_sorts_on(order, column, ascending)
+
+    def test_cases_cover_every_field(self) -> None:
+        assert {field for field, _ in _USER_CASES} == set(UserFairShareOrderField)
+
+
+class TestOrderListConversion:
+    """The list converters keep the caller's sort priority."""
+
+    def test_multiple_orders_keep_their_sequence(self, adapter: FairShareAdapter) -> None:
+        orders = adapter._convert_project_orders([
+            ProjectFairShareOrder(
+                field=ProjectFairShareOrderField.PROJECT_NAME,
+                direction=OrderDirection.ASC,
+            ),
+            ProjectFairShareOrder(
+                field=ProjectFairShareOrderField.CREATED_AT,
+                direction=OrderDirection.DESC,
+            ),
+        ])
+
+        assert len(orders) == 2
+        _assert_sorts_on(orders[0], ProjectRow.name, ascending=True)
+        _assert_sorts_on(orders[1], ProjectFairShareRow.created_at, ascending=False)
+
+    def test_empty_input_yields_no_orders(self, adapter: FairShareAdapter) -> None:
+        empty: Sequence[list[QueryOrder]] = [
+            adapter._convert_domain_orders([]),
+            adapter._convert_domain_orders_rg([]),
+            adapter._convert_project_orders([]),
+            adapter._convert_project_orders_rg([]),
+            adapter._convert_user_orders([]),
+            adapter._convert_user_orders_rg([]),
+        ]
+        assert all(orders == [] for orders in empty)


### PR DESCRIPTION
This is an auto-generated backport of #14076 to the 26.8 release.