### PR TITLE
chore(BA-7556): run the relation RBAC validator

### DIFF
--- a/changes/14097.misc.md
+++ b/changes/14097.misc.md
@@ -1,0 +1,1 @@
+Wire the RBAC validator into relation actions so linking and unlinking two entities is permission-checked.

--- a/src/ai/backend/manager/actions/validators/rbac/__init__.py
+++ b/src/ai/backend/manager/actions/validators/rbac/__init__.py
@@ -4,12 +4,16 @@ from ai.backend.manager.actions.v2.bulk.validator.rbac import (
     VirtualScopeAtomicBulkActionRBACValidator,
     VirtualScopePartialBulkActionRBACValidator,
 )
+from ai.backend.manager.actions.v2.relation.validator.rbac import (
+    VirtualScopeRelationActionRBACValidator,
+)
 from ai.backend.manager.actions.v2.scope.validator.rbac import (
     VirtualScopeScopeActionRBACValidator,
 )
 from ai.backend.manager.actions.v2.single_entity.validator.rbac import (
     VirtualScopeSingleEntityActionRBACValidator,
 )
+from ai.backend.manager.actions.v2.validators import ActionValidators as V2ActionValidators
 from ai.backend.manager.actions.validators.rbac.bulk import BulkActionRBACValidator
 from ai.backend.manager.actions.validators.rbac.legacy import (
     LegacyScopeActionRBACValidator,
@@ -36,9 +40,23 @@ class LegacyRBACValidators:
 
 @dataclass
 class VirtualScopeRBACValidators:
-    """RBAC validators for the v2 action bases (actions/v2/{single_entity,bulk,scope})."""
+    """RBAC validators for the v2 action bases (actions/v2/{single_entity,bulk,scope,relation})."""
 
     scope: VirtualScopeScopeActionRBACValidator
     single_entity: VirtualScopeSingleEntityActionRBACValidator
     partial_bulk: VirtualScopePartialBulkActionRBACValidator
     atomic_bulk: VirtualScopeAtomicBulkActionRBACValidator
+    relation: VirtualScopeRelationActionRBACValidator
+
+    def to_action_validators(self) -> V2ActionValidators:
+        """Place every validator in this bundle into its shape's slot.
+
+        The processors read the slots, so a validator missing from here never runs.
+        """
+        return V2ActionValidators(
+            single_entity=[self.single_entity],
+            partial_bulk=[self.partial_bulk],
+            atomic_bulk=[self.atomic_bulk],
+            scope=[self.scope],
+            relation=[self.relation],
+        )

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -31,7 +31,6 @@ from ai.backend.manager.actions.monitors.audit_log import AuditLogMonitor
 from ai.backend.manager.actions.monitors.prometheus import PrometheusMonitor
 from ai.backend.manager.actions.monitors.reporter import ReporterMonitor
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
-from ai.backend.manager.actions.v2 import validators as v2_validators
 from ai.backend.manager.actions.v2.bulk.monitor.audit_log import BulkActionAuditLogMonitor
 from ai.backend.manager.actions.v2.bulk.monitor.prometheus import BulkActionPrometheusMonitor
 from ai.backend.manager.actions.v2.bulk.monitor.reporter import BulkActionReporterMonitor
@@ -54,6 +53,9 @@ from ai.backend.manager.actions.v2.lookup.bulk_monitor.audit_log import (
 from ai.backend.manager.actions.v2.lookup.monitor.audit_log import LookupActionAuditLogMonitor
 from ai.backend.manager.actions.v2.lookup.monitor.prometheus import (
     LookupActionPrometheusMonitor,
+)
+from ai.backend.manager.actions.v2.relation.validator.rbac import (
+    VirtualScopeRelationActionRBACValidator,
 )
 from ai.backend.manager.actions.v2.scope.monitor.audit_log import ScopeActionAuditLogMonitor
 from ai.backend.manager.actions.v2.scope.monitor.prometheus import ScopeActionPrometheusMonitor
@@ -401,6 +403,9 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             atomic_bulk=VirtualScopeAtomicBulkActionRBACValidator(
                 permission_controller_repository, config_provider
             ),
+            relation=VirtualScopeRelationActionRBACValidator(
+                permission_controller_repository, config_provider
+            ),
         )
 
         processor_bundle = await stack.enter_dependency(
@@ -415,12 +420,7 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                     legacy_rbac=legacy_rbac_validators,
                     virtual_scope_rbac=virtual_scope_rbac_validators,
                 ),
-                v2_validators=v2_validators.ActionValidators(
-                    single_entity=[virtual_scope_rbac_validators.single_entity],
-                    partial_bulk=[virtual_scope_rbac_validators.partial_bulk],
-                    atomic_bulk=[virtual_scope_rbac_validators.atomic_bulk],
-                    scope=[virtual_scope_rbac_validators.scope],
-                ),
+                v2_validators=virtual_scope_rbac_validators.to_action_validators(),
             ),
         )
         processors = processor_bundle.processors

--- a/src/ai/backend/testutils/action_validators.py
+++ b/src/ai/backend/testutils/action_validators.py
@@ -6,6 +6,9 @@ from ai.backend.manager.actions.v2.bulk.validator.rbac import (
     VirtualScopeAtomicBulkActionRBACValidator,
     VirtualScopePartialBulkActionRBACValidator,
 )
+from ai.backend.manager.actions.v2.relation.validator.rbac import (
+    VirtualScopeRelationActionRBACValidator,
+)
 from ai.backend.manager.actions.v2.scope.validator.rbac import (
     VirtualScopeScopeActionRBACValidator,
 )
@@ -26,4 +29,5 @@ def mock_virtual_scope_rbac_validators() -> VirtualScopeRBACValidators:
         single_entity=MagicMock(spec=VirtualScopeSingleEntityActionRBACValidator),
         partial_bulk=MagicMock(spec=VirtualScopePartialBulkActionRBACValidator),
         atomic_bulk=MagicMock(spec=VirtualScopeAtomicBulkActionRBACValidator),
+        relation=MagicMock(spec=VirtualScopeRelationActionRBACValidator),
     )

--- a/tests/unit/manager/actions/validators/test_validator_wiring.py
+++ b/tests/unit/manager/actions/validators/test_validator_wiring.py
@@ -1,0 +1,36 @@
+"""The v2 RBAC bundle has to reach every slot the processors read."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from ai.backend.manager.actions.v2.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import VirtualScopeRBACValidators
+from ai.backend.testutils.action_validators import mock_virtual_scope_rbac_validators
+
+
+class TestVirtualScopeRBACValidatorWiring:
+    def test_every_bundled_validator_reaches_a_slot(self) -> None:
+        bundle = mock_virtual_scope_rbac_validators()
+        slots = bundle.to_action_validators()
+        wired = [
+            validator
+            for slot in dataclasses.fields(ActionValidators)
+            for validator in getattr(slots, slot.name)
+        ]
+
+        for bundled_field in dataclasses.fields(VirtualScopeRBACValidators):
+            validator = getattr(bundle, bundled_field.name)
+            assert any(validator is entry for entry in wired), (
+                f"{bundled_field.name} validator is not wired into any slot"
+            )
+
+    def test_slots_hold_their_own_shape(self) -> None:
+        bundle = mock_virtual_scope_rbac_validators()
+        validators = bundle.to_action_validators()
+
+        assert validators.single_entity == [bundle.single_entity]
+        assert validators.partial_bulk == [bundle.partial_bulk]
+        assert validators.atomic_bulk == [bundle.atomic_bulk]
+        assert validators.scope == [bundle.scope]
+        assert validators.relation == [bundle.relation]


### PR DESCRIPTION
## Summary
- The relation RBAC validator existed but the composer never placed it in the `relation` slot the processors read, so link and unlink actions ran without a permission check.
- Slot assignment moves onto `VirtualScopeRBACValidators.to_action_validators()`, so the bundle and the slots can only diverge in one place.
- A test asserts every validator in the bundle reaches a slot.
- The relation shape (BA-7517) exists only on `main`, so no released version is affected.

## Test plan
- [x] `pants fmt/fix/lint/check`
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=direct`
- [ ] Relation action denied for a user lacking permission on either named scope

Resolves BA-7556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UHunnb7nv25o1yKLePFEX
