### PR TITLE
refactor(BA-7563): split full user creation into dedicated user ops

### DIFF
--- a/changes/14100.enhance.md
+++ b/changes/14100.enhance.md
@@ -1,0 +1,1 @@
+Move full user creation onto dedicated user DB ops so the shared RBAC ops no longer carry it.

--- a/src/ai/backend/manager/repositories/AGENTS.md
+++ b/src/ai/backend/manager/repositories/AGENTS.md
@@ -53,7 +53,7 @@
 - A primitive only one domain uses does NOT go on the general ops. Write ops extending
   `V2WriteOps` and a provider extending `V2DBOpsProvider` that overrides `write_ops()`,
   and inject that provider only into the repositories needing the primitive
-  (`ops/v2/reconciler/`, `ops/v2/container_registry/`, `ops/rbac/`).
+  (`ops/v2/reconciler/`, `ops/v2/container_registry/`, `ops/rbac/`, `ops/user/`).
 - Separating into a repository is the default; internal operations may use db directly.
 - ops methods take only spec types (Querier/Creator/Updater/Upserter/Purger, `DependentCreatorSpec`).
   A single spec owns only a single table.

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -62,7 +62,8 @@ from ai.backend.manager.models.user import (
 from ai.backend.manager.models.user.creators import UserCreator
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_scope.queries import user_scope_membership_exists
-from ai.backend.manager.repositories.ops.rbac.provider import FullUserCreation, RBACOpsProvider
+from ai.backend.manager.repositories.ops.user.provider import UserOpsProvider
+from ai.backend.manager.repositories.ops.user.write import FullUserCreation
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.user.creators import UserScopeCreation
 from ai.backend.manager.secret.pool import KeyProviderPool
@@ -106,7 +107,7 @@ class AuthDBSource:
     """
 
     _db: ExtendedAsyncSAEngine
-    _rbac_ops_provider: RBACOpsProvider
+    _user_ops_provider: UserOpsProvider
     _v2_ops: V2DBOpsProvider
     _key_provider_pool: KeyProviderPool
 
@@ -117,7 +118,7 @@ class AuthDBSource:
         key_provider_pool: KeyProviderPool,
     ) -> None:
         self._db = db
-        self._rbac_ops_provider = RBACOpsProvider(db)
+        self._user_ops_provider = UserOpsProvider(db)
         self._v2_ops = v2_ops_provider
         self._key_provider_pool = key_provider_pool
 
@@ -164,7 +165,7 @@ class AuthDBSource:
     ) -> UserCreationData:
         """Provision a signup user in one transaction: the row, its default keypair,
         and its domain/project (model-store included) scope enrollments."""
-        async with self._rbac_ops_provider.write_ops() as w:
+        async with self._user_ops_provider.write_ops() as w:
             result = await w.create_full_user(
                 FullUserCreation(
                     creation=UserScopeCreation(spec=user_spec),

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -21,8 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_SCOPE_TYPE
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
+from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
 from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE
 from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import EntityRef, EntityType, ScopeID, ScopeRef, ScopeType
@@ -32,10 +32,8 @@ from ai.backend.common.data.permission.types import (
     Permission,
     RBACElementType,
 )
-from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.exception import RBACTypeConversionError, UnreachableError
 from ai.backend.logging import BraceStyleAdapter
-from ai.backend.manager.data.keypair.types import KeyPairData, KeyPairSecrets
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -56,8 +54,7 @@ from ai.backend.manager.errors.role_preset import InvalidRoleNameTemplate
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
-from ai.backend.manager.models.keypair.creators import DefaultKeypairCreator
-from ai.backend.manager.models.project import ProjectRow, ProjectType
+from ai.backend.manager.models.project import ProjectRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
@@ -68,7 +65,7 @@ from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
 from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
 from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
 from ai.backend.manager.models.resource_group.row import ResourceGroupRow
-from ai.backend.manager.models.user import UserRow, UserStatus
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.scope_binding import ScopeBindingRow
 from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
@@ -156,31 +153,6 @@ class ScopeCreationResult[TRow: Base]:
 
     row: TRow
     auto_grant_role_ids: list[UUID]
-
-
-@dataclass
-class FullUserCreation:
-    """Everything needed to provision a user in full: the user-scope creation, the
-    scopes to enroll in, the default keypair's policy, and that keypair's key material.
-
-    The caller generates ``keypair_secrets`` because the secret key is encrypted through
-    the key provider pool before it is bound.
-    """
-
-    creation: ScopeCreation[UserRow]
-    domain_id: DomainID
-    project_ids: Collection[ProjectID]
-    keypair_resource_policy: str
-    keypair_secrets: KeyPairSecrets
-    keypair_rate_limit: int | None = None
-
-
-@dataclass
-class FullUserCreationResult:
-    """A fully provisioned user: the row and the keypair the user authorizes with."""
-
-    user_row: UserRow
-    keypair: KeyPairData
 
 
 class ScopeMember(ABC):
@@ -978,74 +950,6 @@ class RBACWriteOps(WriteOps):
         ]
         if specs:
             await self.bulk_create(BulkCreator(specs=specs))
-
-    async def create_full_user(
-        self,
-        full_creation: FullUserCreation,
-    ) -> FullUserCreationResult:
-        """Provision a user end to end in one transaction.
-
-        Creates the user scope (row, virtual scope, own-scope roles) and grants those
-        roles, writes the keypair the user authorizes with, then enrolls the user in
-        its domain's and projects' virtual scopes — the domain's model-store projects
-        always included, and ``project_ids`` narrowed to projects that exist in the
-        domain.
-        """
-        creation_result = await self.create_scope(full_creation.creation)
-        user_row = creation_result.row
-        user_id = UserID(user_row.uuid)
-        await self.assign_roles_to_user(user_id, creation_result.auto_grant_role_ids)
-
-        keypair = await self.create_field(
-            user_id,
-            DefaultKeypairCreator(
-                secrets=full_creation.keypair_secrets,
-                is_active=user_row.status == UserStatus.ACTIVE,
-                is_admin=user_row.role in (UserRole.SUPERADMIN, UserRole.ADMIN),
-                resource_policy=full_creation.keypair_resource_policy,
-                rate_limit=full_creation.keypair_rate_limit,
-            ),
-        )
-
-        member = ScopeUserMember(user_id=user_id)
-        domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=full_creation.domain_id)
-        await self.ensure_scope(domain_scope)
-        await self.add_bulk_inheriting_members(
-            EntityMembersAddition(scope=domain_scope, members=[member])
-        )
-        for project_id in await self._domain_member_project_ids(
-            full_creation.domain_id, full_creation.project_ids
-        ):
-            project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
-            await self.ensure_scope(project_scope)
-            await self.add_bulk_members(
-                EntityMembersAddition(scope=project_scope, members=[member])
-            )
-
-        # The insert leaves the server-default columns unloaded, and default_keypair is the
-        # keypair created just above; reload both so callers can read the row without a
-        # sync-context lazy refresh.
-        await self._sess.flush()
-        await self._sess.refresh(user_row)
-        await self._sess.refresh(user_row, ["default_keypair"])
-        return FullUserCreationResult(user_row=user_row, keypair=keypair)
-
-    async def _domain_member_project_ids(
-        self,
-        domain_id: DomainID,
-        project_ids: Collection[ProjectID],
-    ) -> list[ProjectID]:
-        """``project_ids`` narrowed to the domain's real projects, plus the domain's
-        model-store projects that every user joins."""
-        stmt = (
-            sa.select(ProjectRow.id)
-            .join(DomainRow, DomainRow.name == ProjectRow.domain_name)
-            .where(
-                DomainRow.id == domain_id,
-                sa.or_(ProjectRow.id.in_(project_ids), ProjectRow.type == ProjectType.MODEL_STORE),
-            )
-        )
-        return [ProjectID(row) for row in (await self._sess.scalars(stmt)).all()]
 
     async def add_bulk_members(
         self,

--- a/src/ai/backend/manager/repositories/ops/user/provider.py
+++ b/src/ai/backend/manager/repositories/ops/user/provider.py
@@ -1,0 +1,25 @@
+"""User provisioning DB ops provider.
+
+Hands out the user provisioning ops where :class:`RBACOpsProvider` hands out the RBAC
+ones, so full user creation reaches a repository by injection rather than by every
+repository inheriting it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import override
+
+from ai.backend.manager.repositories.ops.rbac.provider import RBACOpsProvider
+from ai.backend.manager.repositories.ops.user.write import UserWriteOps
+
+
+class UserOpsProvider(RBACOpsProvider):
+    """Hands out :class:`UserWriteOps` for the read-write surface."""
+
+    @asynccontextmanager
+    @override
+    async def write_ops(self) -> AsyncIterator[UserWriteOps]:
+        async with self._db.begin_session_read_committed() as sess:
+            yield UserWriteOps(sess)

--- a/src/ai/backend/manager/repositories/ops/user/write.py
+++ b/src/ai/backend/manager/repositories/ops/user/write.py
@@ -1,0 +1,156 @@
+"""User provisioning writes: creating a user in full within one transaction.
+
+Only the user domain provisions a user, so the primitive sits here:
+:class:`UserWriteOps` extends the RBAC write ops with it, and a repository handed the
+RBAC ones never sees it.
+
+Extending the legacy RBAC lineage is temporary: the primitives user creation stands on
+live only on the legacy RBAC ops. The move to the v2 lineage (``ops/v2/user/``) follows
+the removal of the legacy path in BA-7574.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.user.types import UserRole
+from ai.backend.manager.data.keypair.types import KeyPairData, KeyPairSecrets
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.keypair.creators import DefaultKeypairCreator
+from ai.backend.manager.models.project import ProjectRow, ProjectType
+from ai.backend.manager.models.user import UserRow, UserStatus
+from ai.backend.manager.repositories.ops.rbac.provider import (
+    EntityMembersAddition,
+    RBACWriteOps,
+    ScopeCreation,
+    ScopeUserMember,
+)
+
+
+@dataclass
+class FullUserCreation:
+    """Everything needed to provision a user in full: the user-scope creation, the
+    scopes to enroll in, the default keypair's policy, and that keypair's key material.
+
+    The caller generates ``keypair_secrets`` because the secret key is encrypted through
+    the key provider pool before it is bound.
+    """
+
+    creation: ScopeCreation[UserRow]
+    domain_id: DomainID
+    project_ids: Collection[ProjectID]
+    keypair_resource_policy: str
+    keypair_secrets: KeyPairSecrets
+    keypair_rate_limit: int | None = None
+
+
+@dataclass
+class FullUserCreationResult:
+    """A fully provisioned user: the row and the keypair the user authorizes with."""
+
+    user_row: UserRow
+    keypair: KeyPairData
+
+
+class UserWriteOps(RBACWriteOps):
+    """The RBAC write ops plus provisioning a user in full."""
+
+    async def create_full_user(
+        self,
+        full_creation: FullUserCreation,
+    ) -> FullUserCreationResult:
+        """Provision a user end to end in one transaction.
+
+        Creates the user scope (row, virtual scope, own-scope roles) and grants those
+        roles, writes the keypair the user authorizes with, then enrolls the user in
+        its domain's and projects' virtual scopes.
+        """
+        user_row = await self._create_user_scope(full_creation.creation)
+        user_id = UserID(user_row.uuid)
+        keypair = await self._create_default_keypair(user_id, user_row, full_creation)
+        await self._enroll_in_domain(user_id, full_creation.domain_id)
+        await self._enroll_in_projects(user_id, full_creation.domain_id, full_creation.project_ids)
+
+        # The insert leaves the server-default columns unloaded, and default_keypair is the
+        # keypair created just above; reload both so callers can read the row without a
+        # sync-context lazy refresh.
+        await self._sess.flush()
+        await self._sess.refresh(user_row)
+        await self._sess.refresh(user_row, ["default_keypair"])
+        return FullUserCreationResult(user_row=user_row, keypair=keypair)
+
+    async def _create_user_scope(self, creation: ScopeCreation[UserRow]) -> UserRow:
+        """Write the user row with its virtual scope and own-scope roles, and grant
+        those roles to the user."""
+        creation_result = await self.create_scope(creation)
+        user_row = creation_result.row
+        await self.assign_roles_to_user(UserID(user_row.uuid), creation_result.auto_grant_role_ids)
+        return user_row
+
+    async def _create_default_keypair(
+        self,
+        user_id: UserID,
+        user_row: UserRow,
+        full_creation: FullUserCreation,
+    ) -> KeyPairData:
+        """Write the keypair the user authorizes with."""
+        return await self.create_field(
+            user_id,
+            DefaultKeypairCreator(
+                secrets=full_creation.keypair_secrets,
+                is_active=user_row.status == UserStatus.ACTIVE,
+                is_admin=user_row.role in (UserRole.SUPERADMIN, UserRole.ADMIN),
+                resource_policy=full_creation.keypair_resource_policy,
+                rate_limit=full_creation.keypair_rate_limit,
+            ),
+        )
+
+    async def _enroll_in_domain(self, user_id: UserID, domain_id: DomainID) -> None:
+        """Enroll the user in its domain's virtual scope, inheriting the domain's
+        permissions over what the user owns."""
+        domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id)
+        await self.ensure_scope(domain_scope)
+        await self.add_bulk_inheriting_members(
+            EntityMembersAddition(scope=domain_scope, members=[ScopeUserMember(user_id=user_id)])
+        )
+
+    async def _enroll_in_projects(
+        self,
+        user_id: UserID,
+        domain_id: DomainID,
+        project_ids: Collection[ProjectID],
+    ) -> None:
+        """Enroll the user in each project's virtual scope — the domain's model-store
+        projects always included, and ``project_ids`` narrowed to projects that exist in
+        the domain."""
+        member = ScopeUserMember(user_id=user_id)
+        for project_id in await self._domain_member_project_ids(domain_id, project_ids):
+            project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
+            await self.ensure_scope(project_scope)
+            await self.add_bulk_members(
+                EntityMembersAddition(scope=project_scope, members=[member])
+            )
+
+    async def _domain_member_project_ids(
+        self,
+        domain_id: DomainID,
+        project_ids: Collection[ProjectID],
+    ) -> list[ProjectID]:
+        """``project_ids`` narrowed to the domain's real projects, plus the domain's
+        model-store projects that every user joins."""
+        stmt = (
+            sa.select(ProjectRow.id)
+            .join(DomainRow, DomainRow.name == ProjectRow.domain_name)
+            .where(
+                DomainRow.id == domain_id,
+                sa.or_(ProjectRow.id.in_(project_ids), ProjectRow.type == ProjectType.MODEL_STORE),
+            )
+        )
+        return [ProjectID(row) for row in (await self._sess.scalars(stmt)).all()]

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -110,11 +110,10 @@ from ai.backend.manager.models.virtual_scope.queries import user_scope_membershi
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.ops.rbac.provider import (
     EntityMembersAddition,
-    FullUserCreation,
-    RBACOpsProvider,
-    RBACWriteOps,
     ScopeUserMember,
 )
+from ai.backend.manager.repositories.ops.user.provider import UserOpsProvider
+from ai.backend.manager.repositories.ops.user.write import FullUserCreation, UserWriteOps
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.user.creators import (
     UserCreateSpec,
@@ -131,7 +130,7 @@ class UserDBSource:
 
     _db: ExtendedAsyncSAEngine
     _v2_ops: V2DBOpsProvider
-    _rbac_ops_provider: RBACOpsProvider
+    _user_ops_provider: UserOpsProvider
     _key_provider_pool: KeyProviderPool
 
     def __init__(
@@ -142,7 +141,7 @@ class UserDBSource:
     ) -> None:
         self._db = db
         self._v2_ops = v2_ops_provider
-        self._rbac_ops_provider = RBACOpsProvider(db)
+        self._user_ops_provider = UserOpsProvider(db)
         self._key_provider_pool = key_provider_pool
 
     async def get_user_by_uuid(self, user_uuid: UUID) -> UserData:
@@ -183,12 +182,12 @@ class UserDBSource:
         """
         async with self._db.begin_readonly_session_read_committed() as session:
             policy = await self._default_keypair_resource_policy(session)
-        async with self._rbac_ops_provider.write_ops() as w:
+        async with self._user_ops_provider.write_ops() as w:
             return await self._create_user_with_keypair_and_groups(w, creator, group_ids, policy)
 
     async def _create_user_with_keypair_and_groups(
         self,
-        w: RBACWriteOps,
+        w: UserWriteOps,
         creator: UserCreator,
         group_ids: list[str] | None,
         keypair_resource_policy: str,
@@ -239,7 +238,7 @@ class UserDBSource:
 
         async with self._db.begin_readonly_session_read_committed() as session:
             policy = await self._default_keypair_resource_policy(session)
-        async with self._rbac_ops_provider.write_ops() as w:
+        async with self._user_ops_provider.write_ops() as w:
             for idx, item in enumerate(items):
                 try:
                     async with w.savepoint():
@@ -721,7 +720,7 @@ class UserDBSource:
         """
         member_ref = EntityRef(entity_type=USER_ENTITY_TYPE, entity_id=UserID(user_uuid))
         left_project_ids: list[ProjectID] = []
-        async with self._rbac_ops_provider.write_ops() as w:
+        async with self._user_ops_provider.write_ops() as w:
             target_result = await w.batch_query_in_global(
                 sa.select(ProjectRow.id).where(
                     ProjectRow.domain_name == domain_name,


### PR DESCRIPTION
## Summary
- Move `FullUserCreation` / `FullUserCreationResult` and `create_full_user` off the shared RBAC write ops into `repositories/ops/user/` as `UserWriteOps` / `UserOpsProvider`, so only the repositories that provision users carry the primitive.
- Break `create_full_user` into the steps it already ran: user scope, default keypair, domain enrollment, project enrollment.
- Inject the new provider into the auth and user db sources; the four user-creation entry points keep the same single funnel and the same behavior.

## Test plan
- [ ] `pants lint check --changed-since=origin/main`
- [ ] `pants test --changed-since=origin/main --changed-dependents=direct`
- [ ] Sign up a user through the REST signup endpoint and confirm the keypair, domain enrollment and project enrollment rows

Resolves BA-7563