### PR TITLE
feat(BA-7558): enroll scope members without binding their virtual scope

### DIFF
--- a/changes/14103.feature.md
+++ b/changes/14103.feature.md
@@ -1,0 +1,1 @@
+Enroll scope members in the roster alone, never binding a user's virtual scope into a scope, and cap user-to-project enrollments to read.

--- a/src/ai/backend/manager/models/specs/KNOWLEDGE.md
+++ b/src/ai/backend/manager/models/specs/KNOWLEDGE.md
@@ -157,6 +157,9 @@ updater's fields rather than about a column name.
 
 - `member_of(row)` declares ontological belonging at creation time — a project joins
   its domain, a keypair joins its user.
+- A user member is enrolled in the roster alone: no row binds a user's virtual scope
+  into a scope, and a scope reaches what a user owns only through each entity's own
+  enrollment (BEP-1077).
 - It carries no permission caps — cap-bounded access is the object-sharing mechanism
   applied to existing entities and has its own audit trail.
 - Keeping the two separate keeps creation declarative and sharing revocable.

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -157,7 +157,8 @@ class ScopeCreationResult[TRow: Base]:
 
 class ScopeMember(ABC):
     """A member to attach to a scope; ``assign_role_on`` names the user to grant its
-    auto_assign roles, or ``None`` to skip."""
+    auto_assign roles, or ``None`` to skip, and ``permission_cap`` gives the cap every
+    row of this member kind carries in that scope kind."""
 
     @abstractmethod
     def entity_ref(self) -> EntityRef:
@@ -165,6 +166,10 @@ class ScopeMember(ABC):
 
     @abstractmethod
     def assign_role_on(self) -> UserID | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def permission_cap(self, scope: ScopeRef) -> Permission | None:
         raise NotImplementedError
 
 
@@ -183,6 +188,13 @@ class ScopeUserMember(ScopeMember):
     def assign_role_on(self) -> UserID:
         return self.user_id
 
+    @override
+    def permission_cap(self, scope: ScopeRef) -> Permission | None:
+        """A project roster caps its users to read; a domain roster carries no cap."""
+        if scope.scope_type == PROJECT_SCOPE_TYPE:
+            return Permission.READ
+        return None
+
 
 @dataclass
 class ScopeEntityMember(ScopeMember):
@@ -196,6 +208,10 @@ class ScopeEntityMember(ScopeMember):
 
     @override
     def assign_role_on(self) -> UserID | None:
+        return None
+
+    @override
+    def permission_cap(self, scope: ScopeRef) -> Permission | None:
         return None
 
 
@@ -954,11 +970,10 @@ class RBACWriteOps(WriteOps):
     async def add_bulk_members(
         self,
         addition: EntityMembersAddition,
-        permission_cap: Permission | None = None,
     ) -> None:
-        """Attach each member under the scope: membership in the scope's virtual scope
-        and the legacy scope association. The scope reaches the member entities
-        themselves, not the entities they own — use
+        """Attach each member under the scope: membership in the scope's virtual scope,
+        carrying the member kind's constant cap, and the legacy scope association. The
+        scope reaches the member entities themselves, not the entities they own — use
         :meth:`add_bulk_inheriting_members` when the member must inherit the scope's
         permissions over what it owns. Grants the scope's auto_assign roles to members
         whose ``assign_role_on`` returns a user id.
@@ -971,26 +986,26 @@ class RBACWriteOps(WriteOps):
             return
         scope = addition.scope
         virtual_scope_id = await self._resolve_virtual_scope_id(scope)
-        entity_refs = [member.entity_ref() for member in members]
-        await self._enroll_members_in_scope_vs(virtual_scope_id, entity_refs, permission_cap)
-        await self._associate_entities_with_scope(scope, entity_refs)
+        await self._enroll_members_in_scope_vs(virtual_scope_id, scope, members)
+        await self._associate_entities_with_scope(
+            scope, [member.entity_ref() for member in members]
+        )
         await self._grant_member_auto_assign_roles(scope, members)
 
     async def add_bulk_inheriting_members(
         self,
         addition: EntityMembersAddition,
-        permission_cap: Permission | None = None,
     ) -> None:
         """Attach each member so that it inherits the scope's permissions: everything
         :meth:`add_bulk_members` writes, plus the binding that carries those permissions
         onto every entity the member owns.
 
         Only for relations where that inheritance is intended — a domain over its
-        projects and users, a project over the container registries it contains. A
-        member that merely participates in the scope, such as a user in a project, is an
-        ordinary member: binding its virtual scope would expose everything it owns
-        elsewhere. Inheritance stays unidirectional; the reverse would widen every
-        member-scoped role at once.
+        projects, a project over the container registries it contains. Joining a scope's
+        roster is not such a relation: a user is an ordinary member of both its domain
+        and its projects, and no row ever binds a user's virtual scope into a scope.
+        Inheritance stays unidirectional; the reverse would widen every member-scoped
+        role at once.
 
         Raises :class:`VirtualScopeNotFound` for any missing virtual scope. Idempotent:
         existing rows keep their ``permission_cap``.
@@ -998,14 +1013,13 @@ class RBACWriteOps(WriteOps):
         members = list(addition.members)
         if not members:
             return
-        await self.add_bulk_members(addition, permission_cap)
+        await self.add_bulk_members(addition)
         member_scopes = [self._member_scope_ref(member.entity_ref()) for member in members]
-        await self._bind_scope_to_member_vs(addition.scope, member_scopes, permission_cap)
+        await self._bind_scope_to_member_vs(addition.scope, member_scopes)
 
     async def add_bulk_members_partial(
         self,
         addition: EntityMembersAddition,
-        permission_cap: Permission | None = None,
     ) -> EntityMembersResultWithFailures:
         """Add members as :meth:`add_bulk_members` does, isolating each member in its
         own savepoint: a failed member — including one without a virtual scope — lands
@@ -1023,9 +1037,8 @@ class RBACWriteOps(WriteOps):
             # The handler stays outside the savepoint — see bulk_create_scoped_partial.
             try:
                 async with self.savepoint():
-                    ref = member.entity_ref()
-                    await self._enroll_members_in_scope_vs(virtual_scope_id, [ref], permission_cap)
-                    await self._associate_entities_with_scope(scope, [ref])
+                    await self._enroll_members_in_scope_vs(virtual_scope_id, scope, [member])
+                    await self._associate_entities_with_scope(scope, [member.entity_ref()])
                 successes.append(member)
             except Exception as e:
                 errors.append(EntityMemberCreationError(member=member, exception=e, index=index))
@@ -1035,14 +1048,17 @@ class RBACWriteOps(WriteOps):
     async def _enroll_members_in_scope_vs(
         self,
         virtual_scope_id: VirtualScopeID,
-        refs: Sequence[EntityRef],
-        permission_cap: Permission | None,
+        scope: ScopeRef,
+        members: Sequence[ScopeMember],
     ) -> None:
-        """Enroll each entity in the scope's virtual scope."""
+        """Enroll each member in the scope's virtual scope with its kind's cap."""
         await self._bulk_create_dependent_ignore_conflicts(
             [
-                EntityMembershipCreatorSpec(entity_ref=ref, permission_cap=permission_cap)
-                for ref in refs
+                EntityMembershipCreatorSpec(
+                    entity_ref=member.entity_ref(),
+                    permission_cap=member.permission_cap(scope),
+                )
+                for member in members
             ],
             virtual_scope_id,
         )
@@ -1061,15 +1077,14 @@ class RBACWriteOps(WriteOps):
         self,
         scope: ScopeRef,
         member_scopes: Sequence[ScopeRef],
-        permission_cap: Permission | None,
     ) -> None:
-        """Bind the scope into each member's own virtual scope; raises
+        """Bind the scope into each member's own virtual scope, uncapped; raises
         :class:`VirtualScopeNotFound` for members without one."""
         member_virtual_scope_ids = await self._resolve_virtual_scope_ids(member_scopes)
         await self._bulk_create_dependent_ignore_conflicts(
             [
                 ScopeBindingCreatorSpec(
-                    anchor_scope=member_scope, bound_scope=scope, permission_cap=permission_cap
+                    anchor_scope=member_scope, bound_scope=scope, permission_cap=None
                 )
                 for member_scope in member_scopes
             ],

--- a/src/ai/backend/manager/repositories/ops/user/write.py
+++ b/src/ai/backend/manager/repositories/ops/user/write.py
@@ -113,11 +113,11 @@ class UserWriteOps(RBACWriteOps):
         )
 
     async def _enroll_in_domain(self, user_id: UserID, domain_id: DomainID) -> None:
-        """Enroll the user in its domain's virtual scope, inheriting the domain's
-        permissions over what the user owns."""
+        """Enroll the user in its domain's roster. The domain reaches what the user owns
+        through each entity's own enrollment, not through the user's virtual scope."""
         domain_scope = ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id)
         await self.ensure_scope(domain_scope)
-        await self.add_bulk_inheriting_members(
+        await self.add_bulk_members(
             EntityMembersAddition(scope=domain_scope, members=[ScopeUserMember(user_id=user_id)])
         )
 

--- a/src/ai/backend/manager/repositories/ops/v2/entity_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/entity_write.py
@@ -27,7 +27,7 @@ from ai.backend.common.data.entity.types import (
     EntityType,
     ScopeType,
 )
-from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import RBACTypeConversionError
 from ai.backend.logging import BraceStyleAdapter
@@ -239,6 +239,10 @@ class V2EntityWriteOps(V2WriteOpsBase):
         virtual scope — permission_cap NULL throughout, since capped sharing is the
         object-sharing mechanism, not creation.
 
+        A user member gets the membership alone: no row binds a user's virtual scope
+        into a scope, so a scope reaches what a user owns through each entity's own
+        enrollment.
+
         Pure graph edges — no role state is touched here; granting a joining
         user the parents' auto_assign roles is the explicit
         :meth:`_grant_auto_assign_roles` primitive, wired by the user domain. A
@@ -249,6 +253,8 @@ class V2EntityWriteOps(V2WriteOpsBase):
         await self._record_memberships([
             EntityMembershipEntry(member=member, parent=parent) for parent in parents
         ])
+        if member.entity_type() == USER_ENTITY_TYPE:
+            return
         member_virtual_scope_id = (await self._resolve_virtual_scope_ids([member]))[
             (member.entity_type(), member)
         ]

--- a/tests/unit/manager/repositories/ops/rbac/test_provider.py
+++ b/tests/unit/manager/repositories/ops/rbac/test_provider.py
@@ -96,6 +96,7 @@ from ai.backend.manager.repositories.ops.rbac.provider import (
     ScopeDeletion,
     ScopeEntityMember,
     ScopeMember,
+    ScopeUserMember,
 )
 from ai.backend.manager.repositories.permission_controller.role_manager import (
     ScopeSystemRoleData,
@@ -189,6 +190,7 @@ class StubMember(ScopeMember):
     member_id: UUID
     role_user: UserID | None = None
     entity_type: VirtualScopeEntityType = _TEST_MEMBER_ENTITY_TYPE
+    cap: Permission | None = None
 
     @override
     def entity_ref(self) -> EntityRef:
@@ -197,6 +199,10 @@ class StubMember(ScopeMember):
     @override
     def assign_role_on(self) -> UserID | None:
         return self.role_user
+
+    @override
+    def permission_cap(self, scope: ScopeRef) -> Permission | None:
+        return self.cap
 
 
 class RBACOpsTestRow(Base):
@@ -753,9 +759,8 @@ class TestAddBulkMembers:
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=scope,
-                    members=[StubMember(member_id=mid) for mid in member_ids],
+                    members=[StubMember(member_id=mid, cap=Permission.READ) for mid in member_ids],
                 ),
-                permission_cap=Permission.READ,
             )
 
         async with database_connection.begin_session_read_committed() as sess:
@@ -855,13 +860,21 @@ class TestAddBulkMembers:
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
         member_id = uuid.uuid4()
         member_scope = ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=member_id)
-        addition = EntityMembersAddition(scope=scope, members=[StubMember(member_id=member_id)])
-
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(member_scope)
-            await w.add_bulk_members(addition, permission_cap=Permission.READ)
-            await w.add_bulk_members(addition, permission_cap=Permission.full())
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=scope,
+                    members=[StubMember(member_id=member_id, cap=Permission.READ)],
+                )
+            )
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=scope,
+                    members=[StubMember(member_id=member_id, cap=Permission.full())],
+                )
+            )
 
         async with database_connection.begin_session_read_committed() as sess:
             scope_vs = (
@@ -916,6 +929,84 @@ class TestAddBulkMembers:
         assert binding_count == 1  # the self binding from ensure_scope
 
 
+class TestUserRosterEnrollment:
+    """A user joins a scope's roster only: the enrollment row carries the scope kind's
+    constant cap, and nothing is bound into the user's own VS."""
+
+    @pytest.fixture
+    async def roster_tables(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncGenerator[None, None]:
+        async with with_tables(
+            database_connection,
+            [
+                *_ENTITY_MEMBER_TABLES,
+                DomainRow,
+                UserResourcePolicyRow,
+                KeyPairResourcePolicyRow,
+                RoleRow,
+                UserRoleRow,
+                UserRow,
+                KeyPairRow,
+            ],
+        ):
+            yield
+
+    @pytest.mark.parametrize(
+        ("scope_type", "expected_cap"),
+        [
+            pytest.param(PROJECT_SCOPE_TYPE, Permission.READ, id="project-capped-to-read"),
+            pytest.param(DOMAIN_SCOPE_TYPE, None, id="domain-uncapped"),
+        ],
+    )
+    async def test_enrollment_carries_the_scope_kinds_cap(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+        provider: RBACOpsProvider,
+        roster_tables: None,
+        scope_type: ScopeType,
+        expected_cap: Permission | None,
+    ) -> None:
+        scope = ScopeRef(scope_type=scope_type, scope_id=uuid.uuid4())
+        user_id = UserID(uuid.uuid4())
+        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=user_id)
+
+        async with provider.write_ops() as w:
+            await w.ensure_scope(scope)
+            await w.ensure_scope(user_scope)
+            await w.add_bulk_members(
+                EntityMembersAddition(scope=scope, members=[ScopeUserMember(user_id=user_id)])
+            )
+
+        async with database_connection.begin_session_read_committed() as sess:
+            vs_by_scope = {
+                vs.scope_id: vs.id
+                for vs in (await sess.execute(sa.select(VirtualScopeRow))).scalars().all()
+            }
+            cap = await sess.scalar(
+                sa.select(EntityMembershipRow.permission_cap).where(
+                    EntityMembershipRow.virtual_scope_id == vs_by_scope[scope.scope_id],
+                    EntityMembershipRow.entity_id == user_id,
+                )
+            )
+            user_vs_bindings = {
+                (b.scope_type, b.scope_id)
+                for b in (
+                    await sess.execute(
+                        sa.select(ScopeBindingRow).where(
+                            ScopeBindingRow.virtual_scope_id == vs_by_scope[user_id]
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            }
+
+        assert cap == expected_cap
+        assert user_vs_bindings == {(USER_SCOPE_TYPE, user_id)}  # self binding only
+
+
 class TestAddBulkInheritingMembers:
     """add_bulk_inheriting_members writes everything add_bulk_members does and additionally binds
     the scope into the member's own VS — never the reverse binding."""
@@ -926,7 +1017,7 @@ class TestAddBulkInheritingMembers:
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """Each member gets membership, association, and the scope's binding (with cap)
+        """Each member gets membership, association, and the scope's uncapped binding
         in its own VS — and no reverse binding in the scope's VS."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
@@ -939,9 +1030,8 @@ class TestAddBulkInheritingMembers:
             await w.add_bulk_inheriting_members(
                 EntityMembersAddition(
                     scope=scope,
-                    members=[StubMember(member_id=mid) for mid in member_ids],
+                    members=[StubMember(member_id=mid, cap=Permission.READ) for mid in member_ids],
                 ),
-                permission_cap=Permission.READ,
             )
 
         async with database_connection.begin_session_read_committed() as sess:
@@ -980,7 +1070,7 @@ class TestAddBulkInheritingMembers:
             }
             assert member_bindings == {
                 (_TEST_MEMBER_SCOPE_TYPE, mid): None,  # self binding
-                (_TEST_SCOPE_TYPE, scope_id): Permission.READ,
+                (_TEST_SCOPE_TYPE, scope_id): None,
             }
         scope_vs_bindings = {
             (b.scope_type, b.scope_id)
@@ -989,14 +1079,14 @@ class TestAddBulkInheritingMembers:
         }
         assert scope_vs_bindings == {(_TEST_SCOPE_TYPE, scope_id)}  # self binding only
 
-    async def test_readd_is_idempotent_and_keeps_binding_cap(
+    async def test_readd_is_idempotent(
         self,
         database_connection: ExtendedAsyncSAEngine,
         provider: RBACOpsProvider,
         entity_member_tables: None,
     ) -> None:
-        """Re-adding the same member with a different cap is a no-op — no duplicate
-        membership or association, and the original binding cap is kept."""
+        """Re-adding the same member is a no-op — no duplicate membership, association,
+        or binding."""
         scope_id = uuid.uuid4()
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=scope_id)
         member_id = uuid.uuid4()
@@ -1006,8 +1096,8 @@ class TestAddBulkInheritingMembers:
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
             await w.ensure_scope(member_scope)
-            await w.add_bulk_inheriting_members(addition, permission_cap=Permission.READ)
-            await w.add_bulk_inheriting_members(addition, permission_cap=Permission.full())
+            await w.add_bulk_inheriting_members(addition)
+            await w.add_bulk_inheriting_members(addition)
 
         async with database_connection.begin_session_read_committed() as sess:
             scope_vs = (
@@ -1048,7 +1138,7 @@ class TestAddBulkInheritingMembers:
         caps_by_scope = {(b.scope_type, b.scope_id): b.permission_cap for b in binding_rows}
         assert caps_by_scope == {
             (_TEST_MEMBER_SCOPE_TYPE, member_id): None,  # self binding
-            (_TEST_SCOPE_TYPE, scope_id): Permission.READ,
+            (_TEST_SCOPE_TYPE, scope_id): None,
         }
 
     async def test_missing_member_vs_fails_the_whole_call(
@@ -1332,8 +1422,8 @@ class TestAddBulkMembersPartial:
         """Members are enrolled whether or not they have a VS of their own, and no
         binding is written into the one that does."""
         scope = ScopeRef(scope_type=_TEST_SCOPE_TYPE, scope_id=uuid.uuid4())
-        with_vs = StubMember(member_id=uuid.uuid4())
-        without_vs = StubMember(member_id=uuid.uuid4())
+        with_vs = StubMember(member_id=uuid.uuid4(), cap=Permission.READ)
+        without_vs = StubMember(member_id=uuid.uuid4(), cap=Permission.READ)
 
         async with provider.write_ops() as w:
             await w.ensure_scope(scope)
@@ -1341,8 +1431,7 @@ class TestAddBulkMembersPartial:
                 ScopeRef(scope_type=_TEST_MEMBER_SCOPE_TYPE, scope_id=with_vs.member_id)
             )
             result = await w.add_bulk_members_partial(
-                EntityMembersAddition(scope=scope, members=[with_vs, without_vs]),
-                permission_cap=Permission.READ,
+                EntityMembersAddition(scope=scope, members=[with_vs, without_vs])
             )
 
         assert result.successes == [with_vs, without_vs]

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_scope.py
@@ -17,6 +17,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
 from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE, RolePresetID
+from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
 from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
@@ -557,9 +558,11 @@ class TestCheckPermissionViaVirtualScope:
         assert row.entity_type == _UNMAPPED_ENTITY_TYPE
 
 
-class TestScopeMemberEnrollmentCascade:
-    """Enrolling a member under a scope only cascades the scope's permissions onto the
-    member's own entities when the member is attached as an inheriting member."""
+class TestUserRosterEnrollment:
+    """A user joining a project is enrolled in its roster only: the project's
+    permissions do not cascade onto what the user owns, they reach an owned entity
+    only through that entity's own enrollment, and they are clipped by the roster
+    cap on the member user itself."""
 
     @pytest.fixture
     async def db_with_rbac_tables(
@@ -604,13 +607,17 @@ class TestScopeMemberEnrollmentCascade:
     def ids(self) -> VSChainFixture:
         return VSChainFixture()
 
-    async def _grant_vfolder_read_on_project(
+    async def _grant_on_project(
         self,
         db: ExtendedAsyncSAEngine,
         ids: VSChainFixture,
         project_id: uuid.UUID,
+        entity_type: PermEntityType = PermEntityType.VFOLDER,
+        operation: OperationType = OperationType.READ,
+        permission: Permission = Permission.READ,
     ) -> None:
-        """Give the user a role holding vfolder READ on the project scope."""
+        """Give the user a role holding ``permission`` over ``entity_type`` on the
+        project scope."""
         async with db.begin_session() as db_sess:
             domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
             domain_id = DomainID(uuid.uuid4())
@@ -649,9 +656,9 @@ class TestScopeMemberEnrollmentCascade:
                     role_id=ids.role_id,
                     scope_type=PermScopeType.PROJECT,
                     scope_id=str(project_id),
-                    entity_type=PermEntityType.VFOLDER,
-                    operation=OperationType.READ,
-                    permission=Permission.READ,
+                    entity_type=entity_type,
+                    operation=operation,
+                    permission=permission,
                 )
             )
             await db_sess.flush()
@@ -680,27 +687,61 @@ class TestScopeMemberEnrollmentCascade:
             )
             await db_sess.flush()
 
-    async def test_project_member_keeps_own_entities_out_of_reach(
+    async def _enroll_session_in_project_vs(
+        self,
+        db: ExtendedAsyncSAEngine,
+        project_id: uuid.UUID,
+        session_id: uuid.UUID,
+    ) -> None:
+        """Enroll a session in the project's virtual scope, as session creation does for
+        the project the session runs in."""
+        async with db.begin_session() as db_sess:
+            project_vs_id = await db_sess.scalar(
+                sa.select(VirtualScopeRow.id).where(
+                    VirtualScopeRow.scope_type == PROJECT_SCOPE_TYPE,
+                    VirtualScopeRow.scope_id == project_id,
+                )
+            )
+            db_sess.add(
+                EntityMembershipRow(
+                    virtual_scope_id=project_vs_id,
+                    entity_type=SESSION_ENTITY_TYPE,
+                    entity_id=session_id,
+                    permission_cap=None,
+                )
+            )
+            await db_sess.flush()
+
+    async def _enroll_user_in_project(
+        self,
+        ops_provider: RBACOpsProvider,
+        project_scope: ScopeRef,
+        user_scope: ScopeRef,
+        user_id: UserID,
+    ) -> None:
+        async with ops_provider.write_ops() as w:
+            await w.ensure_scope(project_scope)
+            await w.ensure_scope(user_scope)
+            await w.add_bulk_members(
+                EntityMembersAddition(
+                    scope=project_scope, members=[ScopeUserMember(user_id=user_id)]
+                )
+            )
+
+    async def test_project_grant_does_not_reach_what_the_member_owns(
         self,
         db_with_rbac_tables: ExtendedAsyncSAEngine,
         db_source: PermissionDBSource,
         ops_provider: RBACOpsProvider,
         ids: VSChainFixture,
     ) -> None:
-        """A project-scope grant must not resolve onto a vfolder the member user owns:
-        joining a project makes the user an ordinary member, not an inheriting one."""
+        """A project-scope grant must not resolve onto a vfolder enrolled only in the
+        member user's own virtual scope: no row binds that scope into the project."""
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
         user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
-        await self._grant_vfolder_read_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
+        await self._grant_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
 
-        async with ops_provider.write_ops() as w:
-            await w.ensure_scope(project_scope)
-            await w.ensure_scope(user_scope)
-            await w.add_bulk_members(
-                EntityMembersAddition(
-                    scope=project_scope, members=[ScopeUserMember(user_id=ids.user_id)]
-                )
-            )
+        await self._enroll_user_in_project(ops_provider, project_scope, user_scope, ids.user_id)
         await self._own_vfolder_in_user_vs(db_with_rbac_tables, ids)
 
         key = EntityPermissionCheckKey(
@@ -712,34 +753,61 @@ class TestScopeMemberEnrollmentCascade:
         )
         assert result is False
 
-    async def test_inheriting_enrollment_does_cascade(
+    async def test_project_grant_reaches_an_entity_enrolled_in_the_project(
         self,
         db_with_rbac_tables: ExtendedAsyncSAEngine,
         db_source: PermissionDBSource,
         ops_provider: RBACOpsProvider,
         ids: VSChainFixture,
     ) -> None:
-        """The same topology attached as an inheriting member does reach the vfolder, so
-        the check above fails for the intended reason and not by accident."""
+        """The same grant does reach a session enrolled in the project's virtual scope,
+        so the check above fails for the intended reason and not by accident."""
         project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
         user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
-        await self._grant_vfolder_read_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
+        session_id = uuid.uuid4()
+        await self._grant_on_project(
+            db_with_rbac_tables,
+            ids,
+            ids.owner_scope_id,
+            entity_type=PermEntityType.SESSION,
+        )
 
-        async with ops_provider.write_ops() as w:
-            await w.ensure_scope(project_scope)
-            await w.ensure_scope(user_scope)
-            await w.add_bulk_inheriting_members(
-                EntityMembersAddition(
-                    scope=project_scope, members=[ScopeUserMember(user_id=ids.user_id)]
-                )
-            )
-        await self._own_vfolder_in_user_vs(db_with_rbac_tables, ids)
+        await self._enroll_user_in_project(ops_provider, project_scope, user_scope, ids.user_id)
+        await self._enroll_session_in_project_vs(
+            db_with_rbac_tables, ids.owner_scope_id, session_id
+        )
 
         key = EntityPermissionCheckKey(
             user_id=ids.user_id,
-            entity=VFolderUUID(ids.entity_id),
+            entity=SessionID(session_id),
         )
         result = await db_source.check_single_entity_permission_via_virtual_scope(
             key, Permission.READ
         )
         assert result is True
+
+    async def test_roster_cap_clips_the_grant_over_the_member_user(
+        self,
+        db_with_rbac_tables: ExtendedAsyncSAEngine,
+        db_source: PermissionDBSource,
+        ops_provider: RBACOpsProvider,
+        ids: VSChainFixture,
+    ) -> None:
+        """A project role holding user UPDATE resolves to READ over the member user:
+        the roster enrollment caps every project-to-user row to read."""
+        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
+        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        await self._grant_on_project(
+            db_with_rbac_tables,
+            ids,
+            ids.owner_scope_id,
+            entity_type=PermEntityType.USER,
+            operation=OperationType.UPDATE,
+            permission=Permission.READ | Permission.UPDATE,
+        )
+
+        await self._enroll_user_in_project(ops_provider, project_scope, user_scope, ids.user_id)
+
+        key = EntityPermissionCheckKey(user_id=ids.user_id, entity=UserID(ids.user_id))
+        resolved = await db_source.resolve_effective_permissions_via_virtual_scope([key])
+        assert resolved[key] == Permission.READ


### PR DESCRIPTION
## Summary
- Scope membership writes the roster only — no row binds a user's virtual scope into a scope, so a scope reaches what a user owns through each entity's own enrollment (BEP-1077 4.2).
- The roster row's cap is answered by the member kind, not the caller: user-to-project enrollments are capped to read, user-to-domain enrollments carry none. The `permission_cap` argument on the member-addition ops is gone, so the cap cannot vary per row.
- Creation-path bindings for non-user members are unchanged; the domain-to-project binding that carries a domain admin's reach already exists in both the backfill migration and the runtime create path.

Existing backfilled binding rows and roster caps are cleaned up by a separate migration (BA-7571); this change is code and tests only.

## Test plan
- [x] `pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=HEAD~1`
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=direct`
- [x] Roster enrollment writes the scope kind's cap and leaves the user's virtual scope with its self binding only
- [x] A project grant does not reach a vfolder enrolled only in the member user's virtual scope
- [x] The same grant does reach a session enrolled in the project's virtual scope
- [x] A project role holding user `READ|UPDATE` resolves to `READ` over the member user

Resolves BA-7558

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PtXUtJtPG4LLz4g6Q3wBS