### PR TITLE
feat(BA-7564): add the personal project type and its branches

### DIFF
--- a/changes/14104.feature.md
+++ b/changes/14104.feature.md
@@ -1,0 +1,1 @@
+Add a personal project type, which takes no members beyond its owner and is removed with that user.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -121,7 +121,7 @@ type Query {
     domain_name: String
     is_active: Boolean
 
-    """Added in 24.03.0. Available values: GENERAL, MODEL_STORE"""
+    """Added in 24.03.0. Available values: GENERAL, MODEL_STORE, PERSONAL"""
     type: [String] = ["GENERAL"]
   ): [Group]
   image(
@@ -941,7 +941,7 @@ type GroupNode implements Node @key(fields: "id") {
   integration_id: String
   resource_policy: String
 
-  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE']."""
+  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE', 'PERSONAL']."""
   type: String
 
   """Added in 24.03.7."""
@@ -2708,7 +2708,7 @@ type CreateGroup {
 }
 
 input GroupInput {
-  """Added in 24.03.0. Available values: GENERAL, MODEL_STORE"""
+  """Added in 24.03.0. Available values: GENERAL, MODEL_STORE, PERSONAL"""
   type: String = "GENERAL"
   description: String = ""
   is_active: Boolean = true

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -8472,7 +8472,7 @@ type GroupEdge
 input GroupInput
   @join__type(graph: GRAPHENE)
 {
-  """Added in 24.03.0. Available values: GENERAL, MODEL_STORE"""
+  """Added in 24.03.0. Available values: GENERAL, MODEL_STORE, PERSONAL"""
   type: String = "GENERAL"
   description: String = ""
   is_active: Boolean = true
@@ -8508,7 +8508,7 @@ type GroupNode implements Node
   integration_id: String @join__field(graph: GRAPHENE)
   resource_policy: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE']."""
+  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE', 'PERSONAL']."""
   type: String @join__field(graph: GRAPHENE)
 
   """Added in 24.03.7."""
@@ -15113,7 +15113,7 @@ input ProjectFairShareProjectNestedFilter
   """Filter by project active status."""
   isActive: Boolean = null
 
-  """Filter by project type (GENERAL, MODEL_STORE)."""
+  """Filter by project type (GENERAL, MODEL_STORE, PERSONAL)."""
   type: ProjectFairShareTypeEnumFilter = null
 }
 
@@ -15131,6 +15131,7 @@ enum ProjectFairShareTypeEnum
 {
   GENERAL @join__enumValue(graph: STRAWBERRY)
   MODEL_STORE @join__enumValue(graph: STRAWBERRY)
+  PERSONAL @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -15351,13 +15352,14 @@ type ProjectStorageInfo
 }
 
 """
-Added in 26.2.0. Project type determining its purpose and behavior. GENERAL: Standard project for general computation. MODEL_STORE: Project for model storage and management.
+Added in 26.2.0. Project type determining its purpose and behavior. GENERAL: Standard project for general computation. MODEL_STORE: Project for model storage and management. PERSONAL: Added in 26.9.0. Project holding one user's own resources, created and removed with that user.
 """
 enum ProjectTypeV2
   @join__type(graph: STRAWBERRY)
 {
   GENERAL @join__enumValue(graph: STRAWBERRY)
   MODEL_STORE @join__enumValue(graph: STRAWBERRY)
+  PERSONAL @join__enumValue(graph: STRAWBERRY)
 }
 
 """
@@ -16091,7 +16093,7 @@ type Query
     domain_name: String
     is_active: Boolean
 
-    """Added in 24.03.0. Available values: GENERAL, MODEL_STORE"""
+    """Added in 24.03.0. Available values: GENERAL, MODEL_STORE, PERSONAL"""
     type: [String] = ["GENERAL"]
   ): [Group] @join__field(graph: GRAPHENE)
   image(

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -10551,7 +10551,7 @@ input ProjectFairShareProjectNestedFilter {
   """Filter by project active status."""
   isActive: Boolean = null
 
-  """Filter by project type (GENERAL, MODEL_STORE)."""
+  """Filter by project type (GENERAL, MODEL_STORE, PERSONAL)."""
   type: ProjectFairShareTypeEnumFilter = null
 }
 
@@ -10565,6 +10565,7 @@ input ProjectFairShareScope {
 enum ProjectFairShareTypeEnum {
   GENERAL
   MODEL_STORE
+  PERSONAL
 }
 
 """
@@ -10732,11 +10733,12 @@ type ProjectStorageInfo {
 }
 
 """
-Added in 26.2.0. Project type determining its purpose and behavior. GENERAL: Standard project for general computation. MODEL_STORE: Project for model storage and management.
+Added in 26.2.0. Project type determining its purpose and behavior. GENERAL: Standard project for general computation. MODEL_STORE: Project for model storage and management. PERSONAL: Added in 26.9.0. Project holding one user's own resources, created and removed with that user.
 """
 enum ProjectTypeV2 {
   GENERAL
   MODEL_STORE
+  PERSONAL
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -15894,7 +15894,8 @@
         "description": "Project type determining its purpose and behavior.",
         "enum": [
           "general",
-          "model-store"
+          "model-store",
+          "personal"
         ],
         "title": "ProjectType",
         "type": "string"

--- a/src/ai/backend/common/dto/manager/v2/group/types.py
+++ b/src/ai/backend/common/dto/manager/v2/group/types.py
@@ -28,6 +28,7 @@ class ProjectType(StrEnum):
 
     GENERAL = "general"
     MODEL_STORE = "model-store"
+    PERSONAL = "personal"
 
 
 class ProjectOrderField(StrEnum):

--- a/src/ai/backend/manager/api/gql/fair_share/types/project.py
+++ b/src/ai/backend/manager/api/gql/fair_share/types/project.py
@@ -185,6 +185,7 @@ class ProjectFairShareTypeEnum(StrEnum):
 
     GENERAL = "general"
     MODEL_STORE = "model-store"
+    PERSONAL = "personal"
 
 
 @gql_pydantic_input(
@@ -229,7 +230,7 @@ class ProjectFairShareProjectNestedFilter(
     )
     is_active: bool | None = gql_field(description="Filter by project active status.", default=None)
     type: ProjectFairShareTypeEnumFilter | None = gql_field(
-        description="Filter by project type (GENERAL, MODEL_STORE).", default=None
+        description="Filter by project type (GENERAL, MODEL_STORE, PERSONAL).", default=None
     )
 
 

--- a/src/ai/backend/manager/api/gql/project_v2/types/enums.py
+++ b/src/ai/backend/manager/api/gql/project_v2/types/enums.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_enum
 
 
@@ -13,7 +14,9 @@ from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_enum
         description=(
             "Project type determining its purpose and behavior. "
             "GENERAL: Standard project for general computation. "
-            "MODEL_STORE: Project for model storage and management."
+            "MODEL_STORE: Project for model storage and management. "
+            f"PERSONAL: Added in {NEXT_RELEASE_VERSION}. "
+            "Project holding one user's own resources, created and removed with that user."
         ),
     ),
     name="ProjectTypeV2",
@@ -23,3 +26,4 @@ class ProjectTypeEnum(StrEnum):
 
     GENERAL = "general"
     MODEL_STORE = "model-store"
+    PERSONAL = "personal"

--- a/src/ai/backend/manager/data/project/types.py
+++ b/src/ai/backend/manager/data/project/types.py
@@ -39,6 +39,7 @@ class ProjectStatus(enum.StrEnum):
 class ProjectType(enum.StrEnum):
     GENERAL = "general"
     MODEL_STORE = "model-store"
+    PERSONAL = "personal"
 
     @classmethod
     @override
@@ -52,6 +53,8 @@ class ProjectType(enum.StrEnum):
                 return cls.GENERAL
             case "MODEL_STORE" | "MODEL-STORE":
                 return cls.MODEL_STORE
+            case "PERSONAL":
+                return cls.PERSONAL
             case _:
                 return None
 

--- a/src/ai/backend/manager/errors/resource.py
+++ b/src/ai/backend/manager/errors/resource.py
@@ -61,6 +61,37 @@ class ProjectPurgeInProgress(BackendAIError, web.HTTPConflict):
         )
 
 
+class PersonalProjectMemberAdditionError(BackendAIError, web.HTTPConflict):
+    """Raised when a write would add a member to a personal project."""
+
+    error_type = "https://api.backend.ai/probs/personal-project-member-addition"
+    error_title = "Personal project takes no members beyond its owner."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.GROUP,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class PersonalProjectDeletionError(BackendAIError, web.HTTPConflict):
+    """Raised when a personal project is deleted or purged on its own, apart from
+    the user it belongs to."""
+
+    error_type = "https://api.backend.ai/probs/personal-project-deletion"
+    error_title = "Personal project is removed with its user, not on its own."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.GROUP,
+            operation=ErrorOperation.HARD_DELETE,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
 class ProjectHasActiveKernelsError(BackendAIError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/project-has-active-kernels"
     error_title = "Project has active kernels."

--- a/src/ai/backend/manager/models/alembic/versions/a1f0c7b45de2_convert_groups_type_to_varchar.py
+++ b/src/ai/backend/manager/models/alembic/versions/a1f0c7b45de2_convert_groups_type_to_varchar.py
@@ -1,0 +1,46 @@
+"""convert groups.type from native ENUM to VARCHAR
+
+Revision ID: a1f0c7b45de2
+Revises: c8e4b1a09d37
+Create Date: 2026-09-01
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "a1f0c7b45de2"
+down_revision = "c8e4b1a09d37"
+branch_labels = None
+depends_on = None
+
+PROJECT_TYPES = ("general", "model-store", "personal")
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "groups",
+        "type",
+        type_=sa.VARCHAR(64),
+        existing_nullable=False,
+        postgresql_using="type::text",
+    )
+    op.execute(sa.text("DROP TYPE IF EXISTS projecttype"))
+
+
+def downgrade() -> None:
+    # 'personal' is included so rows written after the upgrade can be cast back.
+    op.execute(
+        sa.text(
+            f"CREATE TYPE projecttype AS ENUM ({', '.join(repr(value) for value in PROJECT_TYPES)})"
+        )
+    )
+    op.alter_column(
+        "groups",
+        "type",
+        type_=postgresql.ENUM(*PROJECT_TYPES, name="projecttype", create_type=False),
+        existing_nullable=False,
+        postgresql_using="type::projecttype",
+    )

--- a/src/ai/backend/manager/models/project/row.py
+++ b/src/ai/backend/manager/models/project/row.py
@@ -47,7 +47,6 @@ from ai.backend.manager.models.association_container_registries_groups import (
 from ai.backend.manager.models.base import (
     GUID,
     Base,
-    EnumValueType,
     ResourceSlotColumn,
     SlugType,
     StrEnumType,
@@ -198,7 +197,7 @@ class ProjectRow(LifecycleTimestampsMixin, Base):
     )
     type: Mapped[ProjectType] = mapped_column(
         "type",
-        EnumValueType(ProjectType),
+        StrEnumType(ProjectType),
         nullable=False,
         default=ProjectType.GENERAL,
     )

--- a/src/ai/backend/manager/models/project/updaters.py
+++ b/src/ai/backend/manager/models/project/updaters.py
@@ -11,8 +11,9 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.types import ResourceSlot
-from ai.backend.manager.data.project.types import ProjectData, ProjectStatus
+from ai.backend.manager.data.project.types import ProjectData, ProjectStatus, ProjectType
 from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.condition_utils import negate_conditions
 from ai.backend.manager.models.project.conditions import ProjectConditions
 from ai.backend.manager.models.project.row import ProjectRow
 from ai.backend.manager.models.specs.types import IntegrityErrorCheck
@@ -121,7 +122,8 @@ class ProjectDotfilesUpdater(DataUpdater[ProjectRow, ProjectData]):
 
 @dataclass
 class ProjectSoftDeleteUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
-    """Retires a project; refuses while a purge is working through it."""
+    """Retires a project; refuses while a purge is working through it, and refuses a
+    personal project, which goes with the user it belongs to."""
 
     project_id: ProjectID
 
@@ -140,7 +142,10 @@ class ProjectSoftDeleteUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
 
     @override
     def guard_conditions(self) -> list[QueryCondition]:
-        return [ProjectConditions.not_being_purged()]
+        return [
+            ProjectConditions.not_being_purged(),
+            negate_conditions([ProjectConditions.by_type_equals(ProjectType.PERSONAL)]),
+        ]
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/repositories/ops/user/write.py
+++ b/src/ai/backend/manager/repositories/ops/user/write.py
@@ -128,8 +128,8 @@ class UserWriteOps(RBACWriteOps):
         project_ids: Collection[ProjectID],
     ) -> None:
         """Enroll the user in each project's virtual scope — the domain's model-store
-        projects always included, and ``project_ids`` narrowed to projects that exist in
-        the domain."""
+        projects always included, ``project_ids`` narrowed to projects that exist in
+        the domain, and personal projects left out."""
         member = ScopeUserMember(user_id=user_id)
         for project_id in await self._domain_member_project_ids(domain_id, project_ids):
             project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)
@@ -144,12 +144,14 @@ class UserWriteOps(RBACWriteOps):
         project_ids: Collection[ProjectID],
     ) -> list[ProjectID]:
         """``project_ids`` narrowed to the domain's real projects, plus the domain's
-        model-store projects that every user joins."""
+        model-store projects that every user joins. A personal project is never among
+        them: it takes no member beyond the user it was created with."""
         stmt = (
             sa.select(ProjectRow.id)
             .join(DomainRow, DomainRow.name == ProjectRow.domain_name)
             .where(
                 DomainRow.id == domain_id,
+                ProjectRow.type != ProjectType.PERSONAL,
                 sa.or_(ProjectRow.id.in_(project_ids), ProjectRow.type == ProjectType.MODEL_STORE),
             )
         )

--- a/src/ai/backend/manager/repositories/project/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/project/db_source/db_source.py
@@ -29,11 +29,14 @@ from ai.backend.manager.clients.storage_proxy.session_manager import StorageSess
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.project.types import (
     ProjectData,
+    ProjectType,
     UnassignUserFailure,
     UnassignUsersResult,
 )
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.errors.resource import (
+    PersonalProjectDeletionError,
+    PersonalProjectMemberAdditionError,
     ProjectHasActiveEndpointsError,
     ProjectHasVFoldersMountedError,
     ProjectNotFound,
@@ -133,12 +136,27 @@ class ProjectDBSource:
             if existing_group is None:
                 raise ProjectNotFound(f"Group not found: {project_id}")
             if user_update_mode == "add":
+                await self._refuse_personal_project(w, project_id)
                 await self._add_users_to_project(w, project_id, user_ids)
             elif user_update_mode == "remove":
                 await w.remove_bulk_members(
                     ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
                     [EntityRef(entity_type=USER_ENTITY_TYPE, entity_id=uid) for uid in user_ids],
                 )
+
+    async def _refuse_personal_project(self, w: RBACWriteOps, project_id: ProjectID) -> None:
+        """Refuse the write when the project is a personal one, which keeps its owner
+        as its only member."""
+        result = await w.batch_query_in_global(
+            sa.select(ProjectRow.id).where(
+                ProjectRow.id == project_id, ProjectRow.type == ProjectType.PERSONAL
+            ),
+            BatchQuerier(pagination=NoPagination()),
+        )
+        if result.rows:
+            raise PersonalProjectMemberAdditionError(
+                f"Personal project takes no members: {project_id}"
+            )
 
     async def _users_addable_to_project(
         self,
@@ -395,6 +413,13 @@ class ProjectDBSource:
         """Completely remove a group and all its associated data."""
         project_id = ProjectID(group_id)
         async with self._db.begin_readonly_session_read_committed() as sess:
+            project_type = await sess.scalar(
+                sa.select(ProjectRow.type).where(ProjectRow.id == project_id)
+            )
+            if project_type is ProjectType.PERSONAL:
+                raise PersonalProjectDeletionError(
+                    f"Personal project is purged with its user: {project_id}"
+                )
             if await self._project_vfolders_mounted_to_active_kernels(sess, group_id):
                 raise ProjectHasVFoldersMountedError(
                     f"error on deleting project {group_id} with vfolders mounted to active kernels"
@@ -524,6 +549,7 @@ class ProjectDBSource:
             return []
 
         async with self._rbac_ops_provider.write_ops() as w:
+            await self._refuse_personal_project(w, project_id)
             # TODO: https://github.com/lablup/backend.ai/issues/10687
             role = await w.query(Querier(row_class=RoleRow, pk_value=role_id))
             if role is None:
@@ -612,6 +638,7 @@ class ProjectDBSource:
         Idempotent: adding an existing member is a no-op.
         """
         async with self._rbac_ops_provider.write_ops() as w:
+            await self._refuse_personal_project(w, project_id)
             await w.add_bulk_members(
                 EntityMembersAddition(
                     scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -107,6 +107,7 @@ from ai.backend.manager.models.vfolder import (
 )
 from ai.backend.manager.models.virtual_scope.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_scope.queries import user_scope_membership_query
+from ai.backend.manager.models.virtual_scope.virtual_scope import VirtualScopeRow
 from ai.backend.manager.repositories.base.querier import BatchQuerier, execute_batch_querier
 from ai.backend.manager.repositories.ops.rbac.provider import (
     EntityMembersAddition,
@@ -710,7 +711,8 @@ class UserDBSource:
     ) -> None:
         """Sync the user's project memberships to match ``group_ids`` (the domain's
         model-store projects always included) through the RBAC member ops, in its
-        own transaction.
+        own transaction. Personal projects stand outside the sync — none is joined
+        and the user's own is never left.
 
         Diff-based: only projects entering or leaving the target set are touched,
         preserving existing rows for unchanged memberships. Joining a project
@@ -724,6 +726,7 @@ class UserDBSource:
             target_result = await w.batch_query_in_global(
                 sa.select(ProjectRow.id).where(
                     ProjectRow.domain_name == domain_name,
+                    ProjectRow.type != ProjectType.PERSONAL,
                     sa.or_(
                         ProjectRow.id.in_([UUID(gid) for gid in group_ids]),
                         ProjectRow.type == ProjectType.MODEL_STORE,
@@ -735,7 +738,10 @@ class UserDBSource:
 
             current_result = await w.batch_query_in_global(
                 user_scope_membership_query(PROJECT_SCOPE_TYPE).where(
-                    EntityMembershipRow.entity_id == user_uuid
+                    EntityMembershipRow.entity_id == user_uuid,
+                    VirtualScopeRow.scope_id.not_in(
+                        sa.select(ProjectRow.id).where(ProjectRow.type == ProjectType.PERSONAL)
+                    ),
                 ),
                 BatchQuerier(pagination=NoPagination()),
             )

--- a/src/ai/backend/manager/services/project/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/project/KNOWLEDGE.md
@@ -1,7 +1,7 @@
 ---
 name: project-service-composition
 type: decision-table
-description: why a project's operations take the shapes they do, why dotfiles are a column of the project row, why membership takes a path of its own
+description: why a project's operations take the shapes they do, why dotfiles are a column of the project row, why membership takes a path of its own, what a personal project changes
 scope: src/ai/backend/manager/services/project
 keywords:
   - GroupProcessors
@@ -10,9 +10,12 @@ keywords:
   - GroupDotfilesUpdater
   - assign_users_to_project
   - RoleManagedEntityCreator
+  - ProjectType
+  - personal project
 sources:
   - src/ai/backend/manager/services/project/processors.py
   - src/ai/backend/manager/models/project
+  - src/ai/backend/manager/data/project/types.py
 generated:
   by: claude-code/opus-5
   at: 2026-08-22
@@ -28,3 +31,26 @@ scope, and an operation naming an existing project is single-entity.
 
 `backend.ai mgr ops list --concern organization --entity project` prints the wired
 list. Its output answers the entity type, shape, operation, gate and backing.
+
+## Personal projects
+
+`ProjectType.PERSONAL` changes behavior in two places; everything else behaves like a
+regular project.
+
+| Place | Behavior |
+|---|---|
+| Member addition | Refused on all four paths: the project member update (add), user assignment, user binding, and the project sync that a user create or update runs |
+| Deletion and purge | Refused on its own. A personal project goes with its user |
+
+The project sync on a user update leaves personal projects out of both sets. Keeping one
+out of the target set is not enough; it has to stay out of the current set too, or the
+sync detaches the user from their own personal project.
+
+Listing does not filter by type. The legacy group query already leaves them out through
+its `type=[GENERAL]` default, and v2 search judges by scope and permission alone. A domain
+search returns the projects that sit in the domain and the caller can reach, so a personal
+project is visible to its owner and to domain admins.
+
+Usage queries do not leave personal projects out. Their sessions consume real resources,
+so dropping them makes the installation-wide totals wrong, and both usage endpoints can
+name a project, which would then answer empty.

--- a/tests/unit/common/dto/manager/v2/group/test_types.py
+++ b/tests/unit/common/dto/manager/v2/group/test_types.py
@@ -18,8 +18,11 @@ class TestProjectType:
     def test_model_store_value(self) -> None:
         assert ProjectType.MODEL_STORE.value == "model-store"
 
+    def test_personal_value(self) -> None:
+        assert ProjectType.PERSONAL.value == "personal"
+
     def test_enum_members_count(self) -> None:
-        assert len(list(ProjectType)) == 2
+        assert len(list(ProjectType)) == 3
 
     def test_all_values_are_strings(self) -> None:
         for member in ProjectType:
@@ -30,6 +33,9 @@ class TestProjectType:
 
     def test_from_string_model_store(self) -> None:
         assert ProjectType("model-store") is ProjectType.MODEL_STORE
+
+    def test_from_string_personal(self) -> None:
+        assert ProjectType("personal") is ProjectType.PERSONAL
 
 
 class TestOrderDirection:

--- a/tests/unit/manager/api/gql/test_project_v2_types.py
+++ b/tests/unit/manager/api/gql/test_project_v2_types.py
@@ -98,6 +98,7 @@ class TestProjectV2GQL:
         for project_type, expected_enum in [
             (ProjectType.GENERAL, ProjectTypeEnum.GENERAL),
             (ProjectType.MODEL_STORE, ProjectTypeEnum.MODEL_STORE),
+            (ProjectType.PERSONAL, ProjectTypeEnum.PERSONAL),
         ]:
             dto = _make_project_node(project_type=project_type)
             project_gql = ProjectV2GQL.from_pydantic(dto)

--- a/tests/unit/manager/data/group/test_types.py
+++ b/tests/unit/manager/data/group/test_types.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
+
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.permission.types import OperationType
@@ -40,3 +42,16 @@ class TestGroupDataEntityOperations:
         # Sanity check: existing admin entries still receive full admin operations.
         assert set(operations[RBACElementType.VFOLDER]) == OperationType.admin_operations()
         assert set(operations[RBACElementType.USER]) == OperationType.admin_operations()
+
+
+class TestProjectType:
+    def test_personal_value(self) -> None:
+        assert ProjectType.PERSONAL.value == "personal"
+
+    def test_missing_accepts_upper_form(self) -> None:
+        assert ProjectType("PERSONAL") is ProjectType.PERSONAL
+        assert ProjectType("personal") is ProjectType.PERSONAL
+
+    def test_missing_returns_none_for_unknown(self) -> None:
+        with pytest.raises(ValueError):
+            ProjectType("no-such-type")

--- a/tests/unit/manager/repositories/group/test_assign_users_to_project.py
+++ b/tests/unit/manager/repositories/group/test_assign_users_to_project.py
@@ -15,6 +15,7 @@ from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.types import EntityType, ScopeType
 from ai.backend.manager.data.project.types import ProjectType
+from ai.backend.manager.errors.resource import PersonalProjectMemberAdditionError
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.domain import DomainRow
@@ -199,6 +200,46 @@ class TestAssignUsersToProject:
                     integration_id=None,
                     resource_policy=policy_name,
                     type=ProjectType.GENERAL,
+                )
+            )
+            session.add(
+                VirtualScopeRow(
+                    scope_type=ScopeType.PROJECT.value,
+                    scope_id=project_id,
+                )
+            )
+            await session.commit()
+        return project_id
+
+    @pytest.fixture
+    async def personal_project(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_domain: DomainFixtureData,
+    ) -> ProjectID:
+        project_id = ProjectID(uuid.uuid4())
+        policy_name = f"personal-policy-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as session:
+            session.add(
+                ProjectResourcePolicyRow(
+                    name=policy_name,
+                    max_vfolder_count=0,
+                    max_quota_scope_size=-1,
+                    max_network_count=3,
+                )
+            )
+            session.add(
+                ProjectRow(
+                    id=project_id,
+                    name=f"personal-project-{project_id.hex[:8]}",
+                    description="Personal project",
+                    is_active=True,
+                    domain_name=test_domain.domain_name,
+                    total_resource_slots=ResourceSlot(),
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                    integration_id=None,
+                    resource_policy=policy_name,
+                    type=ProjectType.PERSONAL,
                 )
             )
             session.add(
@@ -508,6 +549,39 @@ class TestAssignUsersToProject:
 
         assert list(bindings_into_user_scope) == []
         assert list(memberships_in_project_scope) == [same_domain_user_1]
+
+    async def test_assign_users_to_personal_project_refused(
+        self,
+        group_db_source: ProjectDBSource,
+        personal_project: ProjectID,
+        test_role: uuid.UUID,
+        same_domain_user_1: UserID,
+    ) -> None:
+        """A personal project keeps its owner as its only member."""
+        with pytest.raises(PersonalProjectMemberAdditionError):
+            await group_db_source.assign_users_to_project(
+                personal_project, [same_domain_user_1], test_role
+            )
+
+    async def test_bind_user_to_personal_project_refused(
+        self,
+        group_db_source: ProjectDBSource,
+        personal_project: ProjectID,
+        same_domain_user_1: UserID,
+    ) -> None:
+        """The membership-only write is refused for a personal project too."""
+        with pytest.raises(PersonalProjectMemberAdditionError):
+            await group_db_source.bind_user_to_project(same_domain_user_1, personal_project)
+
+    async def test_update_members_add_to_personal_project_refused(
+        self,
+        group_db_source: ProjectDBSource,
+        personal_project: ProjectID,
+        same_domain_user_1: UserID,
+    ) -> None:
+        """The legacy add path is refused for a personal project."""
+        with pytest.raises(PersonalProjectMemberAdditionError):
+            await group_db_source.update_members(personal_project, "add", [same_domain_user_1])
 
 
 class TestUnassignUsersFromProject:


### PR DESCRIPTION
## Summary
- Add `personal` to `ProjectType` across its four definitions (canonical, v2 DTO, `ProjectTypeV2`, fair-share) and regenerate the GraphQL schema dumps.
- Convert `groups.type` from the native `projecttype` enum to VARCHAR via `StrEnumType`, which `EnumValueType`'s deprecation notice already prescribes. Stored values are unchanged, so no data conversion; the column had no default and nothing else used the enum type.
- Branch on the type in the two places it changes behavior: a personal project refuses member additions on every path, and refuses being deleted or purged on its own. Listing and usage aggregation are deliberately untouched.

## Test plan
- [ ] `pants lint` / `check` / `test` pass (locally: 50 changed-dependent targets, 0 failures)
- [ ] `alembic upgrade head` converts `groups.type` to `varchar(64)` and drops the `projecttype` type
- [ ] `alembic downgrade` recreates the enum with all three values and casts back
- [ ] Adding a member to a personal project is refused on all four paths
- [ ] Deleting or purging a personal project on its own is refused
- [ ] Updating a user's projects neither joins a personal project nor detaches them from their own

Resolves BA-7564

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14104.org.readthedocs.build/en/14104/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14104.org.readthedocs.build/ko/14104/

<!-- readthedocs-preview sorna-ko end -->