### PR TITLE
test(BA-7544): import GroupRow instead of the main-only ProjectRow

### DIFF
--- a/changes/14139.test.md
+++ b/changes/14139.test.md
@@ -1,0 +1,1 @@
+Fix the fair share adapter unit test importing `ai.backend.manager.models.project`, a module that only exists on the main branch, which broke test collection on the 26.8 branch.

--- a/tests/unit/manager/api/adapters/test_fair_share_adapter.py
+++ b/tests/unit/manager/api/adapters/test_fair_share_adapter.py
@@ -28,7 +28,7 @@ from ai.backend.manager.models.fair_share.row import (
     ProjectFairShareRow,
     UserFairShareRow,
 )
-from ai.backend.manager.models.project import ProjectRow
+from ai.backend.manager.models.group import GroupRow
 from ai.backend.manager.models.user import UserRow
 
 _DIRECTIONS = [(OrderDirection.ASC, True), (OrderDirection.DESC, False)]
@@ -49,8 +49,8 @@ _DOMAIN_RG_CASES: list[tuple[DomainFairShareOrderField, InstrumentedAttribute[An
 _PROJECT_CASES: list[tuple[ProjectFairShareOrderField, InstrumentedAttribute[Any]]] = [
     (ProjectFairShareOrderField.FAIR_SHARE_FACTOR, ProjectFairShareRow.fair_share_factor),
     (ProjectFairShareOrderField.CREATED_AT, ProjectFairShareRow.created_at),
-    (ProjectFairShareOrderField.PROJECT_NAME, ProjectRow.name),
-    (ProjectFairShareOrderField.PROJECT_IS_ACTIVE, ProjectRow.is_active),
+    (ProjectFairShareOrderField.PROJECT_NAME, GroupRow.name),
+    (ProjectFairShareOrderField.PROJECT_IS_ACTIVE, GroupRow.is_active),
 ]
 _USER_CASES: list[tuple[UserFairShareOrderField, InstrumentedAttribute[Any]]] = [
     (UserFairShareOrderField.FAIR_SHARE_FACTOR, UserFairShareRow.fair_share_factor),
@@ -196,7 +196,7 @@ class TestOrderListConversion:
         ])
 
         assert len(orders) == 2
-        _assert_sorts_on(orders[0], ProjectRow.name, ascending=True)
+        _assert_sorts_on(orders[0], GroupRow.name, ascending=True)
         _assert_sorts_on(orders[1], ProjectFairShareRow.created_at, ascending=False)
 
     def test_empty_input_yields_no_orders(self, adapter: FairShareAdapter) -> None:


### PR DESCRIPTION
## Summary

- `tests/unit/manager/api/adapters/test_fair_share_adapter.py` fails to collect on `26.8` with `ModuleNotFoundError: No module named 'ai.backend.manager.models.project'`.
- The BA-7544 backport (#14077) carried the test file over verbatim from `main`, where `models/group` was renamed to `models/project` and `GroupRow` to `ProjectRow`. That rename is not on `26.8`, which still has `models/group/row.py::GroupRow`.
- Import `GroupRow` from `ai.backend.manager.models.group` instead — the same name the production code under test uses (`models/fair_share/orders.py`) and the convention across the rest of `tests/unit/manager/`.

Test-only change; no production code is touched.

```
tests/unit/manager/api/adapters/test_fair_share_adapter.py:31: in <module>
    from ai.backend.manager.models.project import ProjectRow
E   ModuleNotFoundError: No module named 'ai.backend.manager.models.project'
```

## Test plan

- [x] `pants test tests/unit/manager/api/adapters/test_fair_share_adapter.py` — `✓ succeeded in 6.93s` (previously exit code 2, 0 items collected)
- [x] `pants fmt --changed-since=origin/26.8` — no changes
- [x] `pants fix --changed-since=origin/26.8` — no changes
- [x] `pants lint --changed-since=origin/26.8` — `✓ ruff check`, `✓ ruff format`, `✓ visibility`
- [x] `grep -rn "from ai.backend.manager.models.project" tests/ src/` — no other occurrence on this branch

Relates to BA-7544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wbFHT9DNDo9HhCXqztJkb
