### PR TITLE
fix(BA-7601): default resource preset update fields to UNSET, not None

### DIFF
--- a/changes/14143.fix.md
+++ b/changes/14143.fix.md
@@ -1,0 +1,1 @@
+Fix updateResourcePresetV2 clearing sharedMemory and resourceGroupName when omitted from the update input

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -22541,10 +22541,10 @@ input UpdateResourcePresetV2Input
   resourceSlots: [ResourceSlotEntryInput!] = null
 
   """Updated shared memory. Use null to clear."""
-  sharedMemory: BinarySizeInput = null
+  sharedMemory: BinarySizeInput
 
   """Updated resource group name. Use null to make global."""
-  resourceGroupName: String = null
+  resourceGroupName: String
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -16332,10 +16332,10 @@ input UpdateResourcePresetV2Input {
   resourceSlots: [ResourceSlotEntryInput!] = null
 
   """Updated shared memory. Use null to clear."""
-  sharedMemory: BinarySizeInput = null
+  sharedMemory: BinarySizeInput
 
   """Updated resource group name. Use null to make global."""
-  resourceGroupName: String = null
+  resourceGroupName: String
 }
 
 """

--- a/src/ai/backend/manager/api/gql/resource_preset/types.py
+++ b/src/ai/backend/manager/api/gql/resource_preset/types.py
@@ -207,11 +207,11 @@ class UpdateResourcePresetInputGQL(PydanticInputMixin[UpdateResourcePresetInputD
         default=None, description="Updated resource slot allocations."
     )
     shared_memory: BinarySizeInputGQL | None = gql_field(
-        default=None,
+        default=strawberry.UNSET,
         description="Updated shared memory. Use null to clear.",
     )
     resource_group_name: str | None = gql_field(
-        default=None,
+        default=strawberry.UNSET,
         description="Updated resource group name. Use null to make global.",
     )
 


### PR DESCRIPTION
Backport: None

## Summary
- `UpdateResourcePresetInputGQL.shared_memory` / `resource_group_name` defaulted to `None` instead of `strawberry.UNSET`, so omitting either field in `adminUpdateResourcePresetV2` was indistinguishable from explicitly setting it to `null`.
- Result: any partial update that omitted `sharedMemory` or `resourceGroupName` (e.g. renaming only) silently cleared both fields, since the adapter's `SENTINEL`-vs-`None` distinction never survived past the GQL layer.
- Fix: default both fields to `strawberry.UNSET` so the DTO's own `SENTINEL` default is preserved when the field is omitted.

## Test plan
- [x] Verified on local dev server: `adminUpdateResourcePresetV2` with only `{name}` preserves existing `shared_memory`/`resource_group_name`
- [x] Verified explicit `null` still clears `shared_memory`/`resource_group_name`
- [x] Verified a real value update still applies
- [x] Reproduced the bug on the pre-fix code (stash) to confirm the fix addresses it
- [x] `pants fmt/lint/check` pass (pre-commit + pre-push hooks)

Resolves BA-7601

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14143.org.readthedocs.build/en/14143/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14143.org.readthedocs.build/ko/14143/

<!-- readthedocs-preview sorna-ko end -->