### PR TITLE
fix(BA-7617): terminate a route whose bound session is terminal

### DIFF
--- a/changes/14145.fix.md
+++ b/changes/14145.fix.md
@@ -1,0 +1,1 @@
+Terminate a model service route as soon as its bound session ends, instead of waiting out the health check initial delay.

--- a/src/ai/backend/manager/sokovan/deployment/route/executor.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/executor.py
@@ -339,13 +339,13 @@ class RouteExecutor:
         )
 
     async def check_running_routes(self, routes: Sequence[RouteData]) -> RouteExecutionResult:
-        """Check health status of running routes.
+        """Check that each route's bound session is still alive.
 
         Args:
-            routes: Routes to check (should be HEALTHY or UNHEALTHY status)
+            routes: PROVISIONING or RUNNING routes to check
 
         Returns:
-            Result containing routes with updated health status
+            Result whose errors are the routes whose session is gone or terminal
         """
         # Phase 1: Load status
         with RouteRecorderContext.shared_phase("load_status"):
@@ -1182,12 +1182,18 @@ class RouteExecutor:
         route: RouteData,
         session_statuses: Mapping[ReplicaID, SessionStatus | None],
     ) -> None:
-        """Verify that route's session is in a valid state."""
+        """Verify that route's session is in a valid state.
+
+        A route with no bound session yet passes; the status map cannot tell that
+        case apart from a missing session row.
+        """
         pool = RouteRecorderContext.current_pool()
         recorder = pool.recorder(route.route_id)
 
         with recorder.phase("verify_session"):
             with recorder.step("check_session_exists"):
+                if route.session_id is None:
+                    return
                 session_status = session_statuses.get(route.route_id)
                 if session_status is None:
                     raise RouteSessionNotFound("No session associated with route")

--- a/src/ai/backend/manager/sokovan/deployment/route/handlers/running.py
+++ b/src/ai/backend/manager/sokovan/deployment/route/handlers/running.py
@@ -57,7 +57,7 @@ class RunningRouteHandler(RouteHandler):
     @override
     def target_statuses(cls) -> RouteTargetStatuses:
         return RouteTargetStatuses(
-            lifecycle=[RouteStatus.RUNNING],
+            lifecycle=[RouteStatus.PROVISIONING, RouteStatus.RUNNING],
         )
 
     @classmethod

--- a/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
+++ b/tests/unit/manager/sokovan/deployment/route/executor/test_route_executor.py
@@ -37,6 +37,7 @@ from ai.backend.common.types import SessionId
 from ai.backend.manager.data.deployment.types import (
     RouteHealthStatus,
     RouteStatus,
+    RouteSubStatus,
     RouteTrafficStatus,
 )
 from ai.backend.manager.data.model_serving.types import AppProxyRouteEntry
@@ -507,6 +508,75 @@ class TestCheckRunningRoutes:
         # Assert
         assert len(result.successes) == 1
         assert len(result.errors) == 1
+
+    @pytest.mark.parametrize(
+        "sub_status",
+        [RouteSubStatus.WARMING_UP, RouteSubStatus.STARTING],
+    )
+    async def test_provisioning_route_with_terminated_session_in_errors(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        running_route: RouteData,
+        session_status_terminated: MagicMock,
+        sub_status: RouteSubStatus,
+    ) -> None:
+        """RR-005: PROVISIONING route whose session died is in errors.
+
+        Given: PROVISIONING route with a session that is already terminal
+        When: Check running routes
+        Then: Route in errors list, without waiting for the initial delay
+        """
+        # Arrange
+        route = dataclasses.replace(
+            running_route,
+            status=RouteStatus.PROVISIONING,
+            sub_status=sub_status,
+            health_status=RouteHealthStatus.NOT_CHECKED,
+        )
+        mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {
+            route.route_id: session_status_terminated
+        }
+
+        entity_ids = [route.route_id]
+        with RouteRecorderContext.scope("test", entity_ids=entity_ids):
+            # Act
+            result = await route_executor.check_running_routes([route])
+
+        # Assert
+        assert len(result.successes) == 0
+        assert len(result.errors) == 1
+
+    async def test_route_without_session_in_successes(
+        self,
+        route_executor: RouteExecutor,
+        mock_deployment_repo: AsyncMock,
+        running_route: RouteData,
+    ) -> None:
+        """RR-006: PROVISIONING route not yet bound to a session passes.
+
+        Given: PROVISIONING+PENDING route with no session_id
+        When: Check running routes
+        Then: Route in successes list
+        """
+        # Arrange
+        route = dataclasses.replace(
+            running_route,
+            status=RouteStatus.PROVISIONING,
+            sub_status=RouteSubStatus.PENDING,
+            health_status=RouteHealthStatus.NOT_CHECKED,
+            session_id=None,
+        )
+        mock_deployment_repo.fetch_session_statuses_by_route_ids.return_value = {}
+
+        entity_ids = [route.route_id]
+        with RouteRecorderContext.scope("test", entity_ids=entity_ids):
+            # Act
+            result = await route_executor.check_running_routes([route])
+
+        # Assert
+        assert len(result.successes) == 1
+        assert len(result.errors) == 0
 
 
 # =============================================================================

--- a/tests/unit/manager/sokovan/deployment/route/handlers/test_running_handler.py
+++ b/tests/unit/manager/sokovan/deployment/route/handlers/test_running_handler.py
@@ -1,0 +1,37 @@
+"""Unit tests for RunningRouteHandler stage declaration.
+
+The session-liveness check itself lives in the executor tests; here we only
+pin down which routes the handler picks up and where a dead session sends them.
+"""
+
+from __future__ import annotations
+
+from ai.backend.manager.data.deployment.types import (
+    RouteHealthStatus,
+    RouteStatus,
+    RouteSubStatus,
+)
+from ai.backend.manager.sokovan.deployment.route.handlers.running import (
+    RunningRouteHandler,
+)
+
+
+class TestRunningHandler:
+    """Tests for RunningRouteHandler target statuses and transitions."""
+
+    def test_targets_provisioning_and_running_stages(self) -> None:
+        """RR-HANDLER-001: PROVISIONING routes are checked alongside RUNNING ones."""
+        target = RunningRouteHandler.target_statuses()
+        assert target.lifecycle == [RouteStatus.PROVISIONING, RouteStatus.RUNNING]
+        assert target.sub_status is None
+        assert target.health is None
+
+    def test_failure_transitions_to_terminating(self) -> None:
+        """RR-HANDLER-002: a dead session drains the route and resets its health."""
+        transitions = RunningRouteHandler.status_transitions()
+        assert transitions.failure is not None
+        assert transitions.failure.status == RouteStatus.TERMINATING
+        assert transitions.failure.sub_status == RouteSubStatus.DRAINING
+        assert transitions.failure.health_status == RouteHealthStatus.NOT_CHECKED
+        assert transitions.success is None
+        assert transitions.stale is None


### PR DESCRIPTION
## Summary

- A replica whose session died inside the health check `initial_delay` stayed in `PROVISIONING` + `WARMING_UP` until the warming-up timeout expired, because the session liveness check only ran on `RUNNING` routes.
- The running route handler now also picks up `PROVISIONING` routes, with no sub-status or health filter, so a terminal session sends the route straight to `TERMINATING` + `DRAINING`.
- A route with no `session_id` yet passes the check untouched. The status map cannot tell "not enqueued yet" apart from "session row gone", so the split is made on `RouteData.session_id`; without it every pre-enqueue `PENDING` route would be terminated.

## Test plan

- [x] A `PROVISIONING` + `WARMING_UP` route whose session is terminal is classified as a failure before the initial delay elapses.
- [x] The same holds for a `PROVISIONING` + `STARTING` route.
- [x] A `PROVISIONING` + `PENDING` route with `session_id` unset is not transitioned.
- [x] Existing `RUNNING` route behavior is unchanged.
- [x] The handler targets `[PROVISIONING, RUNNING]` and keeps the `TERMINATING` + `DRAINING` + `NOT_CHECKED` failure transition.

Resolves BA-7617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq47RTG5REBoXjgJG3cPRj