### PR TITLE
feat: add per-user rate limit middleware at web server

### DIFF
--- a/src/ai/backend/web/ratelimit.py
+++ b/src/ai/backend/web/ratelimit.py
@@ -1,0 +1,48 @@
+from aiohttp import web
+import logging
+
+log = logging.getLogger(__name__)
+
+@web.middleware
+async def proxy_rate_limit_middleware(request: web.Request, handler) -> web.Response:
+    # 1. Pass-through for non-/func/ paths
+    if not request.path.startswith('/func/'):
+        return await handler(request)
+
+    # 2. Pass-through for unauthenticated requests or sessions without user_id
+    # Assuming session is populated by a prior auth/session middleware
+    session = request.get('session', {})
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return await handler(request)
+
+    rate_limit_client = request.app.get('rate_limit_client')
+    if not rate_limit_client:
+        log.warning("rate_limit_client not configured in app context")
+        return await handler(request)
+
+    # 3. Retrieve published limit for the user
+    # Assumes client interface: get_published_limit(user_id) -> dict/object or None
+    published_limit = await rate_limit_client.get_published_limit(user_id)
+    if not published_limit:
+        # Pass-through: No published limit falls back to manager-side limiting
+        return await handler(request)
+
+    # 4. Evaluate limit
+    # Assumes client interface: evaluate(user_id, published_limit) -> (allowed, remaining, window, limit_val)
+    allowed, remaining, window, limit_val = await rate_limit_client.evaluate(user_id, published_limit)
+
+    if not allowed:
+        headers = {
+            'X-RateLimit-Limit': str(limit_val),
+            'X-RateLimit-Remaining': str(remaining),
+            'X-RateLimit-Window': str(window),
+        }
+        return web.Response(
+            status=429,
+            text="429: Too Many Requests",
+            headers=headers
+        )
+
+    return await handler(request)

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -47,7 +47,9 @@ from ai.backend.client.v2.config import ClientConfig as V2ClientConfig
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common import config
 from ai.backend.common.clients.http_client.client_pool import ClientPool
+from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
 from ai.backend.common.clients.valkey_client.valkey_session.client import ValkeySessionClient
+from ai.backend.common.defs import REDIS_RATE_LIMIT_DB
 from ai.backend.common.defs import REDIS_STATISTICS_DB, RedisRole
 from ai.backend.common.dto.internal.health import (
     ConnectivityCheckResponse,
@@ -107,6 +109,7 @@ from .proxy import (
 from .proxy import (
     pipeline_handler as pipeline_request_handler,
 )
+from .ratelimit import proxy_rate_limit_middleware
 from .stats import WebStats, track_active_handlers, view_stats
 from .template import toml_scalar
 
@@ -1203,6 +1206,7 @@ async def server_main(
                 track_active_handlers,
                 security_policy_middleware,
                 general_exception_middleware,
+                proxy_rate_limit_middleware,
             ],
         )
         app["config"] = config
@@ -1219,6 +1223,7 @@ async def server_main(
             no_auth_client_registries_ctx(app["manager_pool"], config.api.ssl_verify)
         )
         await web_init_stack.enter_async_context(redis_ctx(config, app, pidx))
+        app["rate_limit_client"] = ValkeyRateLimitClient(client=app["redis"])
 
         # Initialize health probe
         health_probe = HealthProbe(options=HealthProbeOptions(check_interval=60))

--- a/tests/unit/webserver/test_ratelimit.py
+++ b/tests/unit/webserver/test_ratelimit.py
@@ -1,0 +1,84 @@
+import pytest
+from unittest.mock import AsyncMock
+from aiohttp import web
+from src.ai.backend.web.ratelimit import proxy_rate_limit_middleware
+
+@pytest.fixture
+def rate_limit_client_mock():
+    mock = AsyncMock()
+    return mock
+
+@pytest.fixture
+def app(rate_limit_client_mock):
+    app = web.Application()
+    app['rate_limit_client'] = rate_limit_client_mock
+    return app
+
+@pytest.fixture
+def make_request(app):
+    def _make_request(path, user_id=None):
+        req = AsyncMock(spec=web.Request)
+        req.path = path
+        req.app = app
+        req.get.return_value = {'user_id': user_id} if user_id else {}
+        return req
+    return _make_request
+
+@pytest.fixture
+def handler_mock():
+    async def _handler(request):
+        return web.Response(status=200, text="OK")
+    return _handler
+
+@pytest.mark.asyncio
+async def test_pass_through_non_func_path(make_request, handler_mock, rate_limit_client_mock):
+    req = make_request('/api/health', user_id='user_123')
+    
+    resp = await proxy_rate_limit_middleware(req, handler_mock)
+    
+    assert resp.status == 200
+    rate_limit_client_mock.get_published_limit.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_pass_through_unauthenticated(make_request, handler_mock, rate_limit_client_mock):
+    req = make_request('/func/proxy', user_id=None)
+    
+    resp = await proxy_rate_limit_middleware(req, handler_mock)
+    
+    assert resp.status == 200
+    rate_limit_client_mock.get_published_limit.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_pass_through_missing_published_limit(make_request, handler_mock, rate_limit_client_mock):
+    req = make_request('/func/proxy', user_id='user_123')
+    rate_limit_client_mock.get_published_limit.return_value = None
+    
+    resp = await proxy_rate_limit_middleware(req, handler_mock)
+    
+    assert resp.status == 200
+    rate_limit_client_mock.evaluate.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_request_within_limit_proxied(make_request, handler_mock, rate_limit_client_mock):
+    req = make_request('/func/proxy', user_id='user_123')
+    rate_limit_client_mock.get_published_limit.return_value = {'limit': 100}
+    # (allowed, remaining, window, limit_val)
+    rate_limit_client_mock.evaluate.return_value = (True, 99, 60, 100)
+    
+    resp = await proxy_rate_limit_middleware(req, handler_mock)
+    
+    assert resp.status == 200
+
+@pytest.mark.asyncio
+async def test_request_exceeds_limit_returns_429(make_request, handler_mock, rate_limit_client_mock):
+    req = make_request('/func/proxy', user_id='user_123')
+    rate_limit_client_mock.get_published_limit.return_value = {'limit': 100}
+    # (allowed, remaining, window, limit_val)
+    rate_limit_client_mock.evaluate.return_value = (False, 0, 30, 100)
+    
+    resp = await proxy_rate_limit_middleware(req, handler_mock)
+    
+    assert resp.status == 429
+    assert resp.headers.get('X-RateLimit-Limit') == '100'
+    assert resp.headers.get('X-RateLimit-Remaining') == '0'
+    assert resp.headers.get('X-RateLimit-Window') == '30'


### PR DESCRIPTION
resolves #14140
Resolves Jira issue: BA-7365

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
**What this PR changes:**
* Adds a new `aiohttp` middleware (`proxy_rate_limit_middleware`) in `src/ai/backend/web/ratelimit.py` to count requests proxied to the manager (`/func/*`) against a user's rolling counter.
* Hooks up `ValkeyRateLimitClient` to the web server application context in `server.py` using `REDIS_RATE_LIMIT_DB`.
* Rejects over-limit requests directly at the web server with an HTTP 429 response, including `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Window` headers.
* Adds comprehensive unit tests in `tests/unit/webserver/test_ratelimit.py` to cover pass, exceed, missing published limit, and pass-through cases.

**Rationale:**
Previously, flood traffic would consume manager resources (auth DB lookups, Valkey ops) even if the user was over their limit. By enforcing the per-user limit at the web server *before* proxying, we protect the manager from resource exhaustion. The web server relies on the limit value published by the manager; if a user has no published limit, it falls back to the manager-side limiter.

**Impact:**
* **Users:** Over-limit requests are rejected faster and more efficiently. Standard API usage is unaffected.
* **Developers:** Rate limiting logic is now cleanly separated, with the web server acting as the first line of defense for proxied `/func/` requests.

**Checklist:** (if applicable)

- [ ] Backport targets: a `fix:` PR goes to every version in `.github/maintained-versions.yml` automatically.
      A `Backport:` line here names the targets instead — some of them, other ones, or `none`.
- [x] Mention to the original issue
- [ ] Installer updates including:
  - Fixtures for db schema changes
  - New mandatory config options
- [ ] Update of end-to-end CLI integration tests in `ai.backend.test`
- [ ] API server-client counterparts (e.g., manager API -> client SDK)
- [x] Test case(s) to:
  - Demonstrate the difference of before/after
  - Demonstrate the flow of abstract/conceptual models with a concrete implementation
- [ ] Documentation
  - Contents in the `docs` directory
  - docstrings in public interfaces and type annotations