### PR TITLE
feat(BA-7515): support field-level patch on preset model_definition

### DIFF
--- a/changes/14148.feature.md
+++ b/changes/14148.feature.md
@@ -1,0 +1,1 @@
+Allow partial updates to a deployment revision preset's model_definition, preserving fields the request omits instead of resetting them

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -22497,9 +22497,6 @@ input UpdatePresetModelMetadataInput
   """Creation date of the model. Omit to keep the current value."""
   created: String
 
-  """Last modified date of the model. Omit to keep the current value."""
-  lastModified: String
-
   """Description of the model. Omit to keep the current value."""
   description: String
 

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -22014,8 +22014,10 @@ input UpdateDeploymentRevisionPresetInput
   """
   imageId: UUID
 
-  """Added in 26.9.0. Parsed model definition. Set to null to clear."""
-  modelDefinition: PresetModelDefinitionInput
+  """
+  Added in 26.9.0. Model definition patch. Set to null to clear the whole model definition.
+  """
+  modelDefinition: UpdatePresetModelDefinitionInput
 
   """Added in 26.4.4. Container startup command. Set to null to clear."""
   startupCommand: String
@@ -22404,6 +22406,162 @@ input UpdatePermissionInput
   scopeId: String = null
   entityType: RBACElementType = null
   operation: OperationType = null
+}
+
+"""
+Added in 26.9.0. Patch for a single preset model entry. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelConfigInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the model. Omit to keep the current value."""
+  name: String
+
+  """Path to the model file. Omit to keep the current value."""
+  modelPath: String
+
+  """Configuration for the model service. Omit to keep the current value."""
+  service: UpdatePresetModelServiceConfigInput
+
+  """Metadata about the model. Omit to keep the current value."""
+  metadata: UpdatePresetModelMetadataInput
+}
+
+"""
+Added in 26.9.0. Patch for a preset's model definition. Omit `models` to keep the current model entry.
+"""
+input UpdatePresetModelDefinitionInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Patch for the model definition's single model entry. Omit to keep the current model entry.
+  """
+  models: [UpdatePresetModelConfigInput!]
+}
+
+"""
+Added in 26.9.0. Patch for a preset model's health check. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelHealthCheckInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored. Omit to keep the current value.
+  """
+  enable: Boolean
+
+  """
+  Interval in seconds between health checks. Omit to keep the current value.
+  """
+  interval: Float
+
+  """Path to check for health status. Omit to keep the current value."""
+  path: String
+
+  """
+  Maximum number of retries for health check. Omit to keep the current value.
+  """
+  maxRetries: Int
+
+  """
+  Maximum time in seconds to wait for a health check response. Omit to keep the current value.
+  """
+  maxWaitTime: Float
+
+  """
+  Expected HTTP status code for a healthy response. Omit to keep the current value.
+  """
+  expectedStatusCode: Int
+
+  """
+  Initial delay in seconds before the first health check. Omit to keep the current value.
+  """
+  initialDelay: Float
+}
+
+"""
+Added in 26.9.0. Patch for a preset model's metadata. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelMetadataInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Author of the model. Omit to keep the current value."""
+  author: String
+
+  """Title of the model. Omit to keep the current value."""
+  title: String
+
+  """Version of the model. Omit to keep the current value."""
+  version: String
+
+  """Creation date of the model. Omit to keep the current value."""
+  created: String
+
+  """Last modified date of the model. Omit to keep the current value."""
+  lastModified: String
+
+  """Description of the model. Omit to keep the current value."""
+  description: String
+
+  """Task type of the model. Omit to keep the current value."""
+  task: String
+
+  """Category of the model. Omit to keep the current value."""
+  category: String
+
+  """Architecture of the model. Omit to keep the current value."""
+  architecture: String
+
+  """Frameworks used by the model. Omit to keep the current value."""
+  framework: [String!]
+
+  """Labels for the model. Omit to keep the current value."""
+  label: [String!]
+
+  """License of the model. Omit to keep the current value."""
+  license: String
+
+  """
+  Minimum resource requirements for the model. Omit to keep the current value.
+  """
+  minResource: JSON
+}
+
+"""
+Added in 26.9.0. Patch for a preset model's service config. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelServiceConfigInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Pre-start actions to execute before starting the model service. Omit to keep the current list; provide the full replacement list to change it.
+  """
+  preStartActions: [PreStartActionInput!]
+
+  """
+  Single-string command to start the model service. Omit to keep the current value.
+  """
+  command: String
+
+  """
+  Deprecated. Command to start the model service. Use `command` instead. Omit to keep the current value.
+  """
+  startCommand: [String!] @deprecated(reason: "Use `command` instead.")
+
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping. Omit to keep the current value.
+  """
+  shell: String
+
+  """
+  Port number for the model service. Must be greater than 1. Omit to keep the current value.
+  """
+  port: Int
+
+  """
+  Health check configuration for the model service. Omit to keep the current value.
+  """
+  healthCheck: UpdatePresetModelHealthCheckInput
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -15873,8 +15873,10 @@ input UpdateDeploymentRevisionPresetInput {
   """
   imageId: UUID
 
-  """Added in 26.9.0. Parsed model definition. Set to null to clear."""
-  modelDefinition: PresetModelDefinitionInput
+  """
+  Added in 26.9.0. Model definition patch. Set to null to clear the whole model definition.
+  """
+  modelDefinition: UpdatePresetModelDefinitionInput
 
   """Added in 26.4.4. Container startup command. Set to null to clear."""
   startupCommand: String
@@ -16213,6 +16215,152 @@ input UpdatePermissionInput {
   scopeId: String = null
   entityType: RBACElementType = null
   operation: OperationType = null
+}
+
+"""
+Added in 26.9.0. Patch for a single preset model entry. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelConfigInput {
+  """Name of the model. Omit to keep the current value."""
+  name: String
+
+  """Path to the model file. Omit to keep the current value."""
+  modelPath: String
+
+  """Configuration for the model service. Omit to keep the current value."""
+  service: UpdatePresetModelServiceConfigInput
+
+  """Metadata about the model. Omit to keep the current value."""
+  metadata: UpdatePresetModelMetadataInput
+}
+
+"""
+Added in 26.9.0. Patch for a preset's model definition. Omit `models` to keep the current model entry.
+"""
+input UpdatePresetModelDefinitionInput {
+  """
+  Patch for the model definition's single model entry. Omit to keep the current model entry.
+  """
+  models: [UpdatePresetModelConfigInput!]
+}
+
+"""
+Added in 26.9.0. Patch for a preset model's health check. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelHealthCheckInput {
+  """
+  Whether the route should be health-checked. When false the route activates immediately and the remaining fields are ignored. Omit to keep the current value.
+  """
+  enable: Boolean
+
+  """
+  Interval in seconds between health checks. Omit to keep the current value.
+  """
+  interval: Float
+
+  """Path to check for health status. Omit to keep the current value."""
+  path: String
+
+  """
+  Maximum number of retries for health check. Omit to keep the current value.
+  """
+  maxRetries: Int
+
+  """
+  Maximum time in seconds to wait for a health check response. Omit to keep the current value.
+  """
+  maxWaitTime: Float
+
+  """
+  Expected HTTP status code for a healthy response. Omit to keep the current value.
+  """
+  expectedStatusCode: Int
+
+  """
+  Initial delay in seconds before the first health check. Omit to keep the current value.
+  """
+  initialDelay: Float
+}
+
+"""
+Added in 26.9.0. Patch for a preset model's metadata. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelMetadataInput {
+  """Author of the model. Omit to keep the current value."""
+  author: String
+
+  """Title of the model. Omit to keep the current value."""
+  title: String
+
+  """Version of the model. Omit to keep the current value."""
+  version: String
+
+  """Creation date of the model. Omit to keep the current value."""
+  created: String
+
+  """Last modified date of the model. Omit to keep the current value."""
+  lastModified: String
+
+  """Description of the model. Omit to keep the current value."""
+  description: String
+
+  """Task type of the model. Omit to keep the current value."""
+  task: String
+
+  """Category of the model. Omit to keep the current value."""
+  category: String
+
+  """Architecture of the model. Omit to keep the current value."""
+  architecture: String
+
+  """Frameworks used by the model. Omit to keep the current value."""
+  framework: [String!]
+
+  """Labels for the model. Omit to keep the current value."""
+  label: [String!]
+
+  """License of the model. Omit to keep the current value."""
+  license: String
+
+  """
+  Minimum resource requirements for the model. Omit to keep the current value.
+  """
+  minResource: JSON
+}
+
+"""
+Added in 26.9.0. Patch for a preset model's service config. Omit a field to keep its current stored value.
+"""
+input UpdatePresetModelServiceConfigInput {
+  """
+  Pre-start actions to execute before starting the model service. Omit to keep the current list; provide the full replacement list to change it.
+  """
+  preStartActions: [PreStartActionInput!]
+
+  """
+  Single-string command to start the model service. Omit to keep the current value.
+  """
+  command: String
+
+  """
+  Deprecated. Command to start the model service. Use `command` instead. Omit to keep the current value.
+  """
+  startCommand: [String!] @deprecated(reason: "Use `command` instead.")
+
+  """
+  Shell used to run the command. If set, the kernel runs `[shell, '-c', command]`; null or empty disables shell wrapping. Omit to keep the current value.
+  """
+  shell: String
+
+  """
+  Port number for the model service. Must be greater than 1. Omit to keep the current value.
+  """
+  port: Int
+
+  """
+  Health check configuration for the model service. Omit to keep the current value.
+  """
+  healthCheck: UpdatePresetModelHealthCheckInput
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -16298,9 +16298,6 @@ input UpdatePresetModelMetadataInput {
   """Creation date of the model. Omit to keep the current value."""
   created: String
 
-  """Last modified date of the model. Omit to keep the current value."""
-  lastModified: String
-
   """Description of the model. Omit to keep the current value."""
   description: String
 

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -8389,6 +8389,432 @@
         "title": "CreateDeploymentRevisionPresetInput",
         "type": "object"
       },
+      "UpdatePresetModelConfigInput": {
+        "description": "Patch for a single preset model entry. Omit a field to keep its current stored value.",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Name"
+          },
+          "model_path": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Model Path"
+          },
+          "service": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UpdatePresetModelServiceConfigInput"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UpdatePresetModelMetadataInput"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "title": "UpdatePresetModelConfigInput",
+        "type": "object"
+      },
+      "UpdatePresetModelDefinitionInput": {
+        "description": "Patch for a preset's model definition. Omit `models` to keep the current model entry.",
+        "properties": {
+          "models": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UpdatePresetModelConfigInput"
+                },
+                "maxItems": 1,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Models"
+          }
+        },
+        "title": "UpdatePresetModelDefinitionInput",
+        "type": "object"
+      },
+      "UpdatePresetModelHealthCheckInput": {
+        "description": "Patch for a preset model's health check. Omit a field to keep its current stored value.",
+        "properties": {
+          "enable": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Enable"
+          },
+          "interval": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Interval"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Path"
+          },
+          "max_retries": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Max Retries"
+          },
+          "max_wait_time": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Max Wait Time"
+          },
+          "expected_status_code": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 100,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Expected Status Code"
+          },
+          "initial_delay": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Initial Delay"
+          }
+        },
+        "title": "UpdatePresetModelHealthCheckInput",
+        "type": "object"
+      },
+      "UpdatePresetModelMetadataInput": {
+        "description": "Patch for a preset model's metadata. Omit a field to keep its current stored value.",
+        "properties": {
+          "author": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Author"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Title"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Version"
+          },
+          "created": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Created"
+          },
+          "last_modified": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Last Modified"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Description"
+          },
+          "task": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Task"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Category"
+          },
+          "architecture": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Architecture"
+          },
+          "framework": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Framework"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Label"
+          },
+          "license": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "License"
+          },
+          "min_resource": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Min Resource"
+          }
+        },
+        "title": "UpdatePresetModelMetadataInput",
+        "type": "object"
+      },
+      "UpdatePresetModelServiceConfigInput": {
+        "description": "Patch for a preset model's service config. Omit a field to keep its current stored value.",
+        "properties": {
+          "pre_start_actions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/PreStartAction"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Pre Start Actions"
+          },
+          "command": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Command"
+          },
+          "start_command": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Start Command"
+          },
+          "shell": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Shell"
+          },
+          "port": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Port"
+          },
+          "health_check": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UpdatePresetModelHealthCheckInput"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "title": "UpdatePresetModelServiceConfigInput",
+        "type": "object"
+      },
       "UpdateDeploymentRevisionPresetInput": {
         "properties": {
           "id": {
@@ -8471,7 +8897,7 @@
           "model_definition": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/PresetModelDefinitionInput"
+                "$ref": "#/components/schemas/UpdatePresetModelDefinitionInput"
               },
               {
                 "$ref": "#/components/schemas/Sentinel"

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -8597,17 +8597,6 @@
             ],
             "title": "Created"
           },
-          "last_modified": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Modified"
-          },
           "description": {
             "anyOf": [
               {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -8402,7 +8402,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Name"
           },
           "model_path": {
@@ -8415,7 +8414,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Model Path"
           },
           "service": {
@@ -8427,7 +8425,7 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "title": "Service"
           },
           "metadata": {
             "anyOf": [
@@ -8438,7 +8436,7 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "title": "Metadata"
           }
         },
         "title": "UpdatePresetModelConfigInput",
@@ -8460,7 +8458,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Models"
           }
         },
@@ -8479,7 +8476,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Enable"
           },
           "interval": {
@@ -8491,7 +8487,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Interval"
           },
           "path": {
@@ -8503,7 +8498,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Path"
           },
           "max_retries": {
@@ -8515,7 +8509,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Max Retries"
           },
           "max_wait_time": {
@@ -8527,7 +8520,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Max Wait Time"
           },
           "expected_status_code": {
@@ -8540,7 +8532,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Expected Status Code"
           },
           "initial_delay": {
@@ -8553,7 +8544,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Initial Delay"
           }
         },
@@ -8572,7 +8562,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Author"
           },
           "title": {
@@ -8584,7 +8573,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Title"
           },
           "version": {
@@ -8596,7 +8584,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Version"
           },
           "created": {
@@ -8608,7 +8595,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Created"
           },
           "last_modified": {
@@ -8620,7 +8606,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Last Modified"
           },
           "description": {
@@ -8632,7 +8617,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Description"
           },
           "task": {
@@ -8644,7 +8628,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Task"
           },
           "category": {
@@ -8656,7 +8639,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Category"
           },
           "architecture": {
@@ -8668,7 +8650,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Architecture"
           },
           "framework": {
@@ -8683,7 +8664,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Framework"
           },
           "label": {
@@ -8698,7 +8678,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Label"
           },
           "license": {
@@ -8710,7 +8689,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "License"
           },
           "min_resource": {
@@ -8723,7 +8701,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Min Resource"
           }
         },
@@ -8745,7 +8722,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Pre Start Actions"
           },
           "command": {
@@ -8757,7 +8733,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Command"
           },
           "start_command": {
@@ -8772,7 +8747,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Start Command"
           },
           "shell": {
@@ -8784,7 +8758,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Shell"
           },
           "port": {
@@ -8797,7 +8770,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Port"
           },
           "health_check": {
@@ -8809,7 +8781,7 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "title": "Health Check"
           }
         },
         "title": "UpdatePresetModelServiceConfigInput",

--- a/src/ai/backend/common/config.py
+++ b/src/ai/backend/common/config.py
@@ -853,6 +853,137 @@ class PresetModelDefinition(BaseConfigModel):
         return ModelDefinitionDraft.model_validate(self.model_dump(exclude_unset=True))
 
 
+class PresetModelServiceConfigDraft(BaseConfigModel):
+    """Partial patch for a stored ``PresetModelServiceConfig``."""
+
+    pre_start_actions: list[PreStartAction] | None = None
+    start_command: str | None = None
+    shell: str | None = None
+    port: int | None = Field(default=None, gt=1)
+    health_check: ModelHealthCheckDraft | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_start_command(cls, data: Any) -> Any:
+        return resolve_model_service_start_command(data)
+
+    def to_resolved(self) -> PresetModelServiceConfig:
+        return PresetModelServiceConfig.model_validate(self.model_dump())
+
+
+class PresetModelConfigDraft(BaseConfigModel):
+    """Partial patch for a stored ``PresetModelConfig``."""
+
+    name: str | None = None
+    model_path: str | None = None
+    service: PresetModelServiceConfigDraft | None = None
+    metadata: ModelMetadata | None = None  # ModelMetadata is already all-Optional.
+
+    def to_resolved(self) -> PresetModelConfig:
+        service = self.service.to_resolved() if self.service is not None else None
+        payload = self.model_dump(exclude_none=True, exclude={"service"})
+        payload["service"] = service
+        return PresetModelConfig.model_validate(payload)
+
+
+def _merge_preset_service_config_draft(
+    base: PresetModelServiceConfigDraft,
+    override: PresetModelServiceConfigDraft,
+) -> PresetModelServiceConfigDraft:
+    s = override.model_fields_set
+    health_check: ModelHealthCheckDraft | None
+    if "health_check" in s and base.health_check is not None and override.health_check is not None:
+        health_check = _merge_health_check_draft(base.health_check, override.health_check)
+    else:
+        health_check = _pick_non_null_override(
+            base.health_check, override.health_check, "health_check" in s
+        )
+    return PresetModelServiceConfigDraft.model_construct(
+        _fields_set=base.model_fields_set | override.model_fields_set,
+        pre_start_actions=_pick_non_null_override(
+            base.pre_start_actions, override.pre_start_actions, "pre_start_actions" in s
+        ),
+        start_command=_pick_non_null_override(
+            base.start_command, override.start_command, "start_command" in s
+        ),
+        # shell requires explicit none to disable shell wrapping; otherwise the base is kept.
+        shell=_pick(base.shell, override.shell, "shell" in s),
+        port=_pick_non_null_override(base.port, override.port, "port" in s),
+        health_check=health_check,
+    )
+
+
+def _merge_preset_config_draft(
+    base: PresetModelConfigDraft,
+    override: PresetModelConfigDraft,
+) -> PresetModelConfigDraft:
+    s = override.model_fields_set
+    service: PresetModelServiceConfigDraft | None
+    if "service" in s and base.service is not None and override.service is not None:
+        service = _merge_preset_service_config_draft(base.service, override.service)
+    else:
+        service = _pick_non_null_override(base.service, override.service, "service" in s)
+    metadata: ModelMetadata | None
+    if "metadata" in s and base.metadata is not None and override.metadata is not None:
+        metadata = _merge_metadata(base.metadata, override.metadata)
+    else:
+        metadata = _pick_non_null_override(base.metadata, override.metadata, "metadata" in s)
+    return PresetModelConfigDraft.model_construct(
+        _fields_set=base.model_fields_set | override.model_fields_set,
+        name=_pick_non_null_override(base.name, override.name, "name" in s),
+        model_path=override.model_path if override.model_path is not None else base.model_path,
+        service=service,
+        metadata=metadata,
+    )
+
+
+class PresetModelDefinitionDraft(BaseConfigModel):
+    """Partial patch for a stored ``PresetModelDefinition``.
+
+    Used to merge a client-supplied partial update onto a preset's currently
+    stored ``model_definition`` so fields the client omits keep their
+    previous value instead of being reset or crashing on strict validation.
+    """
+
+    models: list[PresetModelConfigDraft] | None = None
+
+    @override
+    @classmethod
+    def build_validation_error(cls, info: SchemaValidationFailureInfo) -> BackendAIError:
+        return ModelDefinitionValidationError(
+            extra_msg=info.summary,
+            extra_data={"errors": info.errors},
+        )
+
+    def merge(self, override: PresetModelDefinitionDraft) -> PresetModelDefinitionDraft:
+        """Merge ``override`` over ``self`` and return a new draft.
+
+        ``models`` is merged element-wise by index. Within each element,
+        nested sub-models are merged recursively when both sides provide
+        them; otherwise the override's value (when explicitly set) wins.
+        """
+        if "models" not in override.model_fields_set or override.models is None:
+            return PresetModelDefinitionDraft.model_construct(models=self.models)
+        if self.models is None or not self.models:
+            return PresetModelDefinitionDraft.model_construct(models=override.models)
+        if not override.models:
+            return PresetModelDefinitionDraft.model_construct(models=self.models)
+        merged: list[PresetModelConfigDraft] = []
+        for i in range(max(len(self.models), len(override.models))):
+            if i >= len(self.models):
+                merged.append(override.models[i])
+            elif i >= len(override.models):
+                merged.append(self.models[i])
+            else:
+                merged.append(_merge_preset_config_draft(self.models[i], override.models[i]))
+        return PresetModelDefinitionDraft.model_construct(models=merged)
+
+    def to_resolved(self) -> PresetModelDefinition:
+        return PresetModelDefinition.model_validate({
+            "models": [m.to_resolved() for m in (self.models or [])],
+        })
+
+
 def find_config_file(daemon_name: str) -> Path:
     toml_path_from_env = os.environ.get("BACKEND_CONFIG_FILE", None)
     if not toml_path_from_env:

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -6,7 +6,12 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.config import DEFAULT_SHELL, PresetModelDefinition, PreStartAction
+from ai.backend.common.config import (
+    DEFAULT_SHELL,
+    PresetModelDefinition,
+    PresetModelDefinitionDraft,
+    PreStartAction,
+)
 from ai.backend.common.data.entity.image import ImageID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
@@ -173,6 +178,68 @@ class CreateDeploymentRevisionPresetInput(BaseRequestModel):
     )
 
 
+class UpdatePresetModelHealthCheckInput(BaseRequestModel):
+    """Patch for a preset model's health check. Omit a field to keep its current stored value."""
+
+    enable: bool | None = Field(default=None)
+    interval: float | None = Field(default=None)
+    path: str | None = Field(default=None)
+    max_retries: int | None = Field(default=None)
+    max_wait_time: float | None = Field(default=None)
+    expected_status_code: int | None = Field(default=None, gt=100)
+    initial_delay: float | None = Field(default=None, ge=0)
+
+
+class UpdatePresetModelMetadataInput(BaseRequestModel):
+    """Patch for a preset model's metadata. Omit a field to keep its current stored value."""
+
+    author: str | None = Field(default=None)
+    title: str | None = Field(default=None)
+    version: str | None = Field(default=None)
+    created: str | None = Field(default=None)
+    last_modified: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    task: str | None = Field(default=None)
+    category: str | None = Field(default=None)
+    architecture: str | None = Field(default=None)
+    framework: list[str] | None = Field(default=None)
+    label: list[str] | None = Field(default=None)
+    license: str | None = Field(default=None)
+    min_resource: dict[str, Any] | None = Field(default=None)
+
+
+class UpdatePresetModelServiceConfigInput(BaseRequestModel):
+    """Patch for a preset model's service config. Omit a field to keep its current stored value."""
+
+    pre_start_actions: list[PreStartAction] | None = Field(default=None)
+    command: str | None = Field(default=None)
+    start_command: list[str] | None = Field(default=None)
+    shell: str | None = Field(default=None)
+    port: int | None = Field(default=None, gt=1)
+    health_check: UpdatePresetModelHealthCheckInput | None = Field(default=None)
+
+
+class UpdatePresetModelConfigInput(BaseRequestModel):
+    """Patch for a single preset model entry. Omit a field to keep its current stored value."""
+
+    name: str | None = Field(default=None, min_length=1)
+    model_path: str | None = Field(default=None, min_length=1)
+    service: UpdatePresetModelServiceConfigInput | None = Field(default=None)
+    metadata: UpdatePresetModelMetadataInput | None = Field(default=None)
+
+
+class UpdatePresetModelDefinitionInput(BaseRequestModel):
+    """Patch for a preset's model definition. Omit `models` to keep the current model entry."""
+
+    models: list[UpdatePresetModelConfigInput] | None = Field(default=None, max_length=1)
+
+    def to_draft(self) -> PresetModelDefinitionDraft:
+        # exclude_unset keeps the resulting draft's model_fields_set aligned with what the
+        # caller actually provided, so merging onto the stored preset doesn't clobber fields
+        # the caller didn't touch.
+        return PresetModelDefinitionDraft.model_validate(self.model_dump(exclude_unset=True))
+
+
 class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
     id: UUID = Field(description="Preset ID.")
     runtime_variant_id: RuntimeVariantID | None = Field(default=None)
@@ -180,7 +247,7 @@ class UpdateDeploymentRevisionPresetInput(BaseRequestModel):
     description: str | Sentinel | None = Field(default=SENTINEL)
     rank: int | None = Field(default=None, ge=0)
     image_id: ImageID | Sentinel | None = Field(default=SENTINEL)
-    model_definition: PresetModelDefinitionInput | Sentinel | None = Field(default=SENTINEL)
+    model_definition: UpdatePresetModelDefinitionInput | Sentinel | None = Field(default=SENTINEL)
     resource_slots: list[ResourceSlotEntryInput] | None = Field(default=None)
     resource_opts: list[ResourceOptsEntryDTO] | None = Field(default=None)
     cluster_mode: str | None = Field(default=None, max_length=16)

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
 from pydantic import Field
@@ -28,6 +28,7 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.types import (
     DeploymentRevisionPresetOrderField,
 )
 from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsEntryDTO
+from ai.backend.common.tristate.unset import UNSET, Unset
 
 
 class PresetModelHealthCheckInput(BaseRequestModel):
@@ -181,57 +182,59 @@ class CreateDeploymentRevisionPresetInput(BaseRequestModel):
 class UpdatePresetModelHealthCheckInput(BaseRequestModel):
     """Patch for a preset model's health check. Omit a field to keep its current stored value."""
 
-    enable: bool | None = Field(default=None)
-    interval: float | None = Field(default=None)
-    path: str | None = Field(default=None)
-    max_retries: int | None = Field(default=None)
-    max_wait_time: float | None = Field(default=None)
-    expected_status_code: int | None = Field(default=None, gt=100)
-    initial_delay: float | None = Field(default=None, ge=0)
+    enable: bool | None | Unset = Field(default=UNSET)
+    interval: float | None | Unset = Field(default=UNSET)
+    path: str | None | Unset = Field(default=UNSET)
+    max_retries: int | None | Unset = Field(default=UNSET)
+    max_wait_time: float | None | Unset = Field(default=UNSET)
+    expected_status_code: Annotated[int, Field(gt=100)] | None | Unset = Field(default=UNSET)
+    initial_delay: Annotated[float, Field(ge=0)] | None | Unset = Field(default=UNSET)
 
 
 class UpdatePresetModelMetadataInput(BaseRequestModel):
     """Patch for a preset model's metadata. Omit a field to keep its current stored value."""
 
-    author: str | None = Field(default=None)
-    title: str | None = Field(default=None)
-    version: str | None = Field(default=None)
-    created: str | None = Field(default=None)
-    last_modified: str | None = Field(default=None)
-    description: str | None = Field(default=None)
-    task: str | None = Field(default=None)
-    category: str | None = Field(default=None)
-    architecture: str | None = Field(default=None)
-    framework: list[str] | None = Field(default=None)
-    label: list[str] | None = Field(default=None)
-    license: str | None = Field(default=None)
-    min_resource: dict[str, Any] | None = Field(default=None)
+    author: str | None | Unset = Field(default=UNSET)
+    title: str | None | Unset = Field(default=UNSET)
+    version: str | None | Unset = Field(default=UNSET)
+    created: str | None | Unset = Field(default=UNSET)
+    last_modified: str | None | Unset = Field(default=UNSET)
+    description: str | None | Unset = Field(default=UNSET)
+    task: str | None | Unset = Field(default=UNSET)
+    category: str | None | Unset = Field(default=UNSET)
+    architecture: str | None | Unset = Field(default=UNSET)
+    framework: list[str] | None | Unset = Field(default=UNSET)
+    label: list[str] | None | Unset = Field(default=UNSET)
+    license: str | None | Unset = Field(default=UNSET)
+    min_resource: dict[str, Any] | None | Unset = Field(default=UNSET)
 
 
 class UpdatePresetModelServiceConfigInput(BaseRequestModel):
     """Patch for a preset model's service config. Omit a field to keep its current stored value."""
 
-    pre_start_actions: list[PreStartAction] | None = Field(default=None)
-    command: str | None = Field(default=None)
-    start_command: list[str] | None = Field(default=None)
-    shell: str | None = Field(default=None)
-    port: int | None = Field(default=None, gt=1)
-    health_check: UpdatePresetModelHealthCheckInput | None = Field(default=None)
+    pre_start_actions: list[PreStartAction] | None | Unset = Field(default=UNSET)
+    command: str | None | Unset = Field(default=UNSET)
+    start_command: list[str] | None | Unset = Field(default=UNSET)
+    shell: str | None | Unset = Field(default=UNSET)
+    port: Annotated[int, Field(gt=1)] | None | Unset = Field(default=UNSET)
+    health_check: UpdatePresetModelHealthCheckInput | None | Unset = Field(default=UNSET)
 
 
 class UpdatePresetModelConfigInput(BaseRequestModel):
     """Patch for a single preset model entry. Omit a field to keep its current stored value."""
 
-    name: str | None = Field(default=None, min_length=1)
-    model_path: str | None = Field(default=None, min_length=1)
-    service: UpdatePresetModelServiceConfigInput | None = Field(default=None)
-    metadata: UpdatePresetModelMetadataInput | None = Field(default=None)
+    name: Annotated[str, Field(min_length=1)] | None | Unset = Field(default=UNSET)
+    model_path: Annotated[str, Field(min_length=1)] | None | Unset = Field(default=UNSET)
+    service: UpdatePresetModelServiceConfigInput | None | Unset = Field(default=UNSET)
+    metadata: UpdatePresetModelMetadataInput | None | Unset = Field(default=UNSET)
 
 
 class UpdatePresetModelDefinitionInput(BaseRequestModel):
     """Patch for a preset's model definition. Omit `models` to keep the current model entry."""
 
-    models: list[UpdatePresetModelConfigInput] | None = Field(default=None, max_length=1)
+    models: Annotated[list[UpdatePresetModelConfigInput], Field(max_length=1)] | None | Unset = (
+        Field(default=UNSET)
+    )
 
     def to_draft(self) -> PresetModelDefinitionDraft:
         # exclude_unset keeps the resulting draft's model_fields_set aligned with what the

--- a/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
+++ b/src/ai/backend/common/dto/manager/v2/deployment_revision_preset/request.py
@@ -198,7 +198,6 @@ class UpdatePresetModelMetadataInput(BaseRequestModel):
     title: str | None | Unset = Field(default=UNSET)
     version: str | None | Unset = Field(default=UNSET)
     created: str | None | Unset = Field(default=UNSET)
-    last_modified: str | None | Unset = Field(default=UNSET)
     description: str | None | Unset = Field(default=UNSET)
     task: str | None | Unset = Field(default=UNSET)
     category: str | None | Unset = Field(default=UNSET)

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -9,6 +9,7 @@ from ai.backend.common.config import (
     ModelMetadata,
     PresetModelConfig,
     PresetModelDefinition,
+    PresetModelDefinitionDraft,
     PresetModelServiceConfig,
     PreStartAction,
 )
@@ -24,9 +25,9 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
     CreateDeploymentRevisionPresetInput,
     DeploymentRevisionPresetFilter,
     DeploymentRevisionPresetOrder,
-    PresetModelDefinitionInput,
     SearchDeploymentRevisionPresetsInput,
     UpdateDeploymentRevisionPresetInput,
+    UpdatePresetModelDefinitionInput,
 )
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
     CreateDeploymentRevisionPresetPayload,
@@ -285,6 +286,12 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         self,
         input: UpdateDeploymentRevisionPresetInput,
     ) -> UpdateDeploymentRevisionPresetPayload:
+        # A model_definition patch merges onto the currently stored preset, so fetch it
+        # upfront when it's being patched (SENTINEL/None need no current value).
+        current: DeploymentRevisionPresetNode | None = None
+        if input.model_definition not in (SENTINEL, None):
+            current = await self.get(input.id)
+
         slot_creators: list[PresetResourceSlotCreator] | None = (
             [
                 PresetResourceSlotCreator(entry=entry)
@@ -304,7 +311,8 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             else OptionalState.nop()
         )
         model_def_state: TriState[PresetModelDefinition] = self._convert_model_definition_state(
-            input.model_definition
+            input.model_definition,
+            current.model_definition if current is not None else None,
         )
 
         updater = DeploymentPresetUpdater(
@@ -558,13 +566,18 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
 
     @staticmethod
     def _convert_model_definition_state(
-        value: PresetModelDefinitionInput | Sentinel | None,
+        value: UpdatePresetModelDefinitionInput | Sentinel | None,
+        current: PresetModelDefinitionInfoDTO | None,
     ) -> TriState[PresetModelDefinition]:
         if value is SENTINEL:
             return TriState.nop()
         if value is None:
             return TriState.nullify()
-        return TriState.update(value.to_model_definition())
+        base_draft = PresetModelDefinitionDraft()
+        if current is not None:
+            base_draft = PresetModelDefinitionDraft.model_validate(current.model_dump())
+        merged = base_draft.merge(value.to_draft())
+        return TriState.update(merged.to_resolved())
 
     @staticmethod
     def _convert_tri_state(value: Any) -> TriState[Any]:

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -48,6 +48,21 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
     UpdateDeploymentRevisionPresetInput as UpdateInputDTO,
 )
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    UpdatePresetModelConfigInput as UpdatePresetModelConfigInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    UpdatePresetModelDefinitionInput as UpdatePresetModelDefinitionInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    UpdatePresetModelHealthCheckInput as UpdatePresetModelHealthCheckInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    UpdatePresetModelMetadataInput as UpdatePresetModelMetadataInputDTO,
+)
+from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import (
+    UpdatePresetModelServiceConfigInput as UpdatePresetModelServiceConfigInputDTO,
+)
 from ai.backend.common.dto.manager.v2.deployment_revision_preset.response import (
     CreateDeploymentRevisionPresetPayload as CreatePayloadDTO,
 )
@@ -797,6 +812,189 @@ class CreateDeploymentRevisionPresetInputGQL(PydanticInputMixin[CreateInputDTO])
 
 @gql_pydantic_input(
     BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Patch for a preset model's health check. Omit a field to keep its "
+        "current stored value.",
+    ),
+    name="UpdatePresetModelHealthCheckInput",
+)
+class UpdatePresetModelHealthCheckInputGQL(
+    PydanticInputMixin[UpdatePresetModelHealthCheckInputDTO]
+):
+    enable: bool | None = gql_field(
+        default=UNSET,
+        description="Whether the route should be health-checked. When false the route "
+        "activates immediately and the remaining fields are ignored. Omit to keep the "
+        "current value.",
+    )
+    interval: float | None = gql_field(
+        default=UNSET,
+        description="Interval in seconds between health checks. Omit to keep the current value.",
+    )
+    path: str | None = gql_field(
+        default=UNSET,
+        description="Path to check for health status. Omit to keep the current value.",
+    )
+    max_retries: int | None = gql_field(
+        default=UNSET,
+        description="Maximum number of retries for health check. Omit to keep the current value.",
+    )
+    max_wait_time: float | None = gql_field(
+        default=UNSET,
+        description="Maximum time in seconds to wait for a health check response. Omit to "
+        "keep the current value.",
+    )
+    expected_status_code: int | None = gql_field(
+        default=UNSET,
+        description="Expected HTTP status code for a healthy response. Omit to keep the "
+        "current value.",
+    )
+    initial_delay: float | None = gql_field(
+        default=UNSET,
+        description="Initial delay in seconds before the first health check. Omit to keep "
+        "the current value.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Patch for a preset model's metadata. Omit a field to keep its current "
+        "stored value.",
+    ),
+    name="UpdatePresetModelMetadataInput",
+)
+class UpdatePresetModelMetadataInputGQL(PydanticInputMixin[UpdatePresetModelMetadataInputDTO]):
+    author: str | None = gql_field(
+        default=UNSET, description="Author of the model. Omit to keep the current value."
+    )
+    title: str | None = gql_field(
+        default=UNSET, description="Title of the model. Omit to keep the current value."
+    )
+    version: str | None = gql_field(
+        default=UNSET, description="Version of the model. Omit to keep the current value."
+    )
+    created: str | None = gql_field(
+        default=UNSET, description="Creation date of the model. Omit to keep the current value."
+    )
+    last_modified: str | None = gql_field(
+        default=UNSET,
+        description="Last modified date of the model. Omit to keep the current value.",
+    )
+    description: str | None = gql_field(
+        default=UNSET, description="Description of the model. Omit to keep the current value."
+    )
+    task: str | None = gql_field(
+        default=UNSET, description="Task type of the model. Omit to keep the current value."
+    )
+    category: str | None = gql_field(
+        default=UNSET, description="Category of the model. Omit to keep the current value."
+    )
+    architecture: str | None = gql_field(
+        default=UNSET, description="Architecture of the model. Omit to keep the current value."
+    )
+    framework: list[str] | None = gql_field(
+        default=UNSET, description="Frameworks used by the model. Omit to keep the current value."
+    )
+    label: list[str] | None = gql_field(
+        default=UNSET, description="Labels for the model. Omit to keep the current value."
+    )
+    license: str | None = gql_field(
+        default=UNSET, description="License of the model. Omit to keep the current value."
+    )
+    min_resource: JSON | None = gql_field(
+        default=UNSET,
+        description="Minimum resource requirements for the model. Omit to keep the current value.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Patch for a preset model's service config. Omit a field to keep its "
+        "current stored value.",
+    ),
+    name="UpdatePresetModelServiceConfigInput",
+)
+class UpdatePresetModelServiceConfigInputGQL(
+    PydanticInputMixin[UpdatePresetModelServiceConfigInputDTO]
+):
+    pre_start_actions: list[PreStartActionInputGQL] | None = gql_field(
+        default=UNSET,
+        description="Pre-start actions to execute before starting the model service. Omit "
+        "to keep the current list; provide the full replacement list to change it.",
+    )
+    command: str | None = gql_field(
+        default=UNSET,
+        description="Single-string command to start the model service. Omit to keep the "
+        "current value.",
+    )
+    start_command: list[str] | None = gql_field(
+        default=UNSET,
+        description="Deprecated. Command to start the model service. Use `command` instead. "
+        "Omit to keep the current value.",
+        deprecation_reason="Use `command` instead.",
+    )
+    shell: str | None = gql_field(
+        default=UNSET,
+        description="Shell used to run the command. If set, the kernel runs "
+        "`[shell, '-c', command]`; null or empty disables shell wrapping. Omit to keep the "
+        "current value.",
+    )
+    port: int | None = gql_field(
+        default=UNSET,
+        description="Port number for the model service. Must be greater than 1. Omit to "
+        "keep the current value.",
+    )
+    health_check: UpdatePresetModelHealthCheckInputGQL | None = gql_field(
+        default=UNSET,
+        description="Health check configuration for the model service. Omit to keep the "
+        "current value.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Patch for a single preset model entry. Omit a field to keep its current "
+        "stored value.",
+    ),
+    name="UpdatePresetModelConfigInput",
+)
+class UpdatePresetModelConfigInputGQL(PydanticInputMixin[UpdatePresetModelConfigInputDTO]):
+    name: str | None = gql_field(
+        default=UNSET, description="Name of the model. Omit to keep the current value."
+    )
+    model_path: str | None = gql_field(
+        default=UNSET, description="Path to the model file. Omit to keep the current value."
+    )
+    service: UpdatePresetModelServiceConfigInputGQL | None = gql_field(
+        default=UNSET,
+        description="Configuration for the model service. Omit to keep the current value.",
+    )
+    metadata: UpdatePresetModelMetadataInputGQL | None = gql_field(
+        default=UNSET, description="Metadata about the model. Omit to keep the current value."
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="Patch for a preset's model definition. Omit `models` to keep the "
+        "current model entry.",
+    ),
+    name="UpdatePresetModelDefinitionInput",
+)
+class UpdatePresetModelDefinitionInputGQL(PydanticInputMixin[UpdatePresetModelDefinitionInputDTO]):
+    models: list[UpdatePresetModelConfigInputGQL] | None = gql_field(
+        default=UNSET,
+        description="Patch for the model definition's single model entry. Omit to keep the "
+        "current model entry.",
+    )
+
+
+@gql_pydantic_input(
+    BackendAIGQLMeta(
         added_version="26.4.2",
         description="Update deployment revision preset input.",
     ),
@@ -841,10 +1039,10 @@ class UpdateDeploymentRevisionPresetInputGQL(PydanticInputMixin[UpdateInputDTO])
         ),
         default=UNSET,
     )
-    model_definition: PresetModelDefinitionInputGQL | None = gql_added_field(
+    model_definition: UpdatePresetModelDefinitionInputGQL | None = gql_added_field(
         BackendAIGQLMeta(
             added_version=NEXT_RELEASE_VERSION,
-            description="Parsed model definition. Set to null to clear.",
+            description="Model definition patch. Set to null to clear the whole model definition.",
         ),
         default=UNSET,
     )

--- a/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/revision_preset.py
@@ -877,10 +877,6 @@ class UpdatePresetModelMetadataInputGQL(PydanticInputMixin[UpdatePresetModelMeta
     created: str | None = gql_field(
         default=UNSET, description="Creation date of the model. Omit to keep the current value."
     )
-    last_modified: str | None = gql_field(
-        default=UNSET,
-        description="Last modified date of the model. Omit to keep the current value.",
-    )
     description: str | None = gql_field(
         default=UNSET, description="Description of the model. Omit to keep the current value."
     )

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -36,6 +36,9 @@ from ai.backend.common.dto.manager.v2.deployment_revision_preset.request import 
     PresetModelServiceConfigInput,
     SearchDeploymentRevisionPresetsInput,
     UpdateDeploymentRevisionPresetInput,
+    UpdatePresetModelConfigInput,
+    UpdatePresetModelDefinitionInput,
+    UpdatePresetModelServiceConfigInput,
 )
 from ai.backend.common.dto.manager.v2.resource_slot.types import ResourceOptsEntryDTO
 
@@ -260,6 +263,62 @@ class TestDeploymentRevisionPresetCRUD:
 
         get_result = await admin_v2_registry.deployment_revision_preset.get(preset_id)
         assert get_result.runtime_variant_id == other_runtime_variant_id
+
+    async def test_update_model_definition_partial_patch(
+        self,
+        admin_v2_registry: V2ClientRegistry,
+        runtime_variant_id: RuntimeVariantID,
+    ) -> None:
+        create_result = await admin_v2_registry.deployment_revision_preset.create(
+            CreateDeploymentRevisionPresetInput(
+                runtime_variant_id=runtime_variant_id,
+                name="patch-model-def-preset",
+                image_id=ImageID(uuid.uuid4()),
+                model_definition=PresetModelDefinitionInput(
+                    models=[
+                        PresetModelConfigInput(
+                            name="llama",
+                            model_path="/models/llama",
+                            service=PresetModelServiceConfigInput(
+                                command="python server.py",
+                                port=8080,
+                            ),
+                        ),
+                    ],
+                ),
+                resource_slots=[ResourceSlotEntryInput(resource_type="cpu", quantity="1")],
+                cluster_mode="single-node",
+                cluster_size=1,
+                replica_count=1,
+                deployment_strategy=DeploymentStrategyInput(type=DeploymentStrategy.ROLLING),
+            )
+        )
+        preset_id = create_result.preset.id
+
+        # Patch only service.port; name/model_path/command must survive from the stored preset.
+        update_result = await admin_v2_registry.deployment_revision_preset.update(
+            preset_id,
+            UpdateDeploymentRevisionPresetInput(
+                id=preset_id,
+                model_definition=UpdatePresetModelDefinitionInput(
+                    models=[
+                        UpdatePresetModelConfigInput(
+                            service=UpdatePresetModelServiceConfigInput(port=9090),
+                        ),
+                    ],
+                ),
+            ),
+        )
+        model_definition = update_result.preset.model_definition
+        assert model_definition is not None
+        model = model_definition.models[0]
+        assert model.name == "llama"
+        assert model.model_path == "/models/llama"
+        assert model.service is not None
+        assert model.service.command == "python server.py"
+        assert model.service.port == 9090
+
+        await admin_v2_registry.deployment_revision_preset.delete(preset_id)
 
     async def test_delete(
         self,


### PR DESCRIPTION
## Summary
- `UpdateDeploymentRevisionPresetInput.model_definition` now points at new `UpdatePresetModel{HealthCheck,Metadata,ServiceConfig,Config,Definition}Input` DTO/GQL types where every leaf field is independently omittable, instead of the Create-shaped type that required resending the whole block.
- Added `PresetModelServiceConfigDraft`/`PresetModelConfigDraft`/`PresetModelDefinitionDraft` (+ `merge()`) in `common/config.py`, mirroring the existing `ModelDefinitionDraft` pattern, so a patch merges onto the preset's currently-stored `model_definition` field-by-field instead of always replacing the whole block.
- `deployment_strategy` is unchanged (still full-replace via `PresetDeploymentStrategyInput`).

## Test plan
- [x] `pants fmt/lint/check/test` on changed files
- [x] Component test: patching only `service.port` on an existing preset's model_definition preserves `name`/`model_path`/`service.command`
- [x] GraphQL schema regenerated (`scripts/generate-graphql-schema.sh`) and diff reviewed — new types compose cleanly, `deploymentStrategy` field unaffected

Resolves BA-7515

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14148.org.readthedocs.build/en/14148/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14148.org.readthedocs.build/ko/14148/

<!-- readthedocs-preview sorna-ko end -->