### PR TITLE
feat(BA-7619): key permission rows by the permission bit

### DIFF
--- a/changes/14150.enhance.md
+++ b/changes/14150.enhance.md
@@ -1,0 +1,1 @@
+Key permission rows by the permission bit and drop the `operation` column; grant operations are no longer stored as permissions.

--- a/fixtures/manager/example-roles.json
+++ b/fixtures/manager/example-roles.json
@@ -265,7 +265,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -274,7 +273,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -283,7 +281,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -292,7 +289,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -301,7 +297,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -310,7 +305,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -319,7 +313,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -328,7 +321,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -337,7 +329,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -346,7 +337,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -355,7 +345,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -364,7 +353,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -373,7 +361,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -382,7 +369,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -391,7 +377,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -400,7 +385,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -409,7 +393,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -418,7 +401,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -427,7 +409,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -436,7 +417,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -445,7 +425,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -454,7 +433,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -463,7 +441,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -472,7 +449,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -481,7 +457,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -490,7 +465,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -499,7 +473,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -508,7 +481,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -517,7 +489,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -526,7 +497,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -535,7 +505,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -544,7 +513,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -553,7 +521,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -562,7 +529,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -571,7 +537,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -580,7 +545,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -589,7 +553,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -598,7 +561,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -607,7 +569,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -616,7 +577,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -625,7 +585,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -634,7 +593,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -643,7 +601,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -652,7 +609,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -661,7 +617,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -670,7 +625,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -679,7 +633,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -688,7 +641,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -697,7 +649,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -706,7 +657,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -715,7 +665,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -724,7 +673,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -733,7 +681,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -742,7 +689,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -751,7 +697,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -760,7 +705,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -769,7 +713,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -778,7 +721,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -787,7 +729,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -796,7 +737,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -805,7 +745,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -814,7 +753,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -823,7 +761,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -832,7 +769,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -841,7 +777,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -850,7 +785,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -859,7 +793,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -868,7 +801,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -877,7 +809,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -886,7 +817,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -895,7 +825,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -904,7 +833,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -913,7 +841,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -922,7 +849,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -931,7 +857,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -940,7 +865,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -949,7 +873,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -958,7 +881,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -967,7 +889,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -976,7 +897,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -985,7 +905,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -994,7 +913,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1003,7 +921,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1012,7 +929,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1021,7 +937,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1030,7 +945,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1039,7 +953,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1048,7 +961,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1057,7 +969,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1066,7 +977,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1075,7 +985,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1084,7 +993,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1093,7 +1001,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1102,7 +1009,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1111,7 +1017,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1120,7 +1025,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1129,7 +1033,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1138,7 +1041,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1147,7 +1049,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1156,7 +1057,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1165,7 +1065,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1174,7 +1073,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1183,7 +1081,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session:app_service",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1192,7 +1089,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session:app_service",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1201,7 +1097,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session:app_service",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1210,7 +1105,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session:app_service",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1219,7 +1113,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session:app_service",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1228,7 +1121,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1237,7 +1129,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1246,7 +1137,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1255,7 +1145,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "user",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1264,7 +1153,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1273,7 +1161,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1282,7 +1169,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1291,7 +1177,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1300,7 +1185,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1309,7 +1193,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder:data",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1318,7 +1201,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder:data",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1327,7 +1209,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder:data",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1336,7 +1217,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "vfolder:data",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1345,7 +1225,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session:app_service",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1354,7 +1233,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1363,7 +1241,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1372,7 +1249,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1381,7 +1257,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1390,7 +1265,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1399,7 +1273,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1408,7 +1281,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1417,7 +1289,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1426,7 +1297,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1435,7 +1305,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1444,7 +1313,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1453,7 +1321,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1462,7 +1329,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1471,7 +1337,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1480,7 +1345,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1489,7 +1353,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1498,7 +1361,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1507,7 +1369,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1516,7 +1377,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1525,7 +1385,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1534,7 +1393,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1543,7 +1401,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1552,7 +1409,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1561,7 +1417,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1570,7 +1425,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1579,7 +1433,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1588,7 +1441,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1597,7 +1449,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1606,7 +1457,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1615,7 +1465,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1624,7 +1473,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1633,7 +1481,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1642,7 +1489,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1651,7 +1497,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1660,7 +1505,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1669,7 +1513,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1678,7 +1521,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1687,7 +1529,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1696,7 +1537,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1705,7 +1545,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1714,7 +1553,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1723,7 +1561,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1732,7 +1569,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1741,7 +1577,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1750,7 +1585,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1759,7 +1593,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1768,7 +1601,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1777,7 +1609,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1786,7 +1617,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1795,7 +1625,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1804,7 +1633,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1813,7 +1641,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1822,7 +1649,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1831,7 +1657,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1840,7 +1665,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1849,7 +1673,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1858,7 +1681,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1867,7 +1689,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1876,7 +1697,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1885,7 +1705,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1894,7 +1713,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1903,7 +1721,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1912,7 +1729,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1921,7 +1737,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1930,7 +1745,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1939,7 +1753,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1948,7 +1761,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -1957,7 +1769,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -1966,7 +1777,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -1975,7 +1785,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -1984,7 +1793,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -1993,7 +1801,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2002,7 +1809,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2011,7 +1817,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2020,7 +1825,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2029,7 +1833,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2038,7 +1841,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2047,7 +1849,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2056,7 +1857,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2065,7 +1865,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2074,7 +1873,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2083,7 +1881,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2092,7 +1889,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2101,7 +1897,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2110,7 +1905,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2119,7 +1913,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2128,7 +1921,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2137,7 +1929,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2146,7 +1937,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2155,7 +1945,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2164,7 +1953,6 @@
             "scope_type": "user",
             "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2173,7 +1961,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2182,7 +1969,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2191,7 +1977,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2200,7 +1985,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2209,7 +1993,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2218,7 +2001,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2227,7 +2009,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2236,7 +2017,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2245,7 +2025,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2254,7 +2033,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2263,7 +2041,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2272,7 +2049,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2281,7 +2057,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2290,7 +2065,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2299,7 +2073,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2308,7 +2081,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2317,7 +2089,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2326,7 +2097,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2335,7 +2105,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2344,7 +2113,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2353,7 +2121,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2362,7 +2129,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2371,7 +2137,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2380,7 +2145,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2389,7 +2153,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2398,7 +2161,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2407,7 +2169,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2416,7 +2177,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2425,7 +2185,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2434,7 +2193,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2443,7 +2201,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2452,7 +2209,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2461,7 +2217,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2470,7 +2225,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2479,7 +2233,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2488,7 +2241,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2497,7 +2249,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2506,7 +2257,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2515,7 +2265,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2524,7 +2273,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2533,7 +2281,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2542,7 +2289,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2551,7 +2297,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2560,7 +2305,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2569,7 +2313,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2578,7 +2321,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2587,7 +2329,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2596,7 +2337,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2605,7 +2345,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2614,7 +2353,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2623,7 +2361,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2632,7 +2369,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2641,7 +2377,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2650,7 +2385,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2659,7 +2393,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2668,7 +2401,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2677,7 +2409,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2686,7 +2417,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2695,7 +2425,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2704,7 +2433,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2713,7 +2441,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2722,7 +2449,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2731,7 +2457,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2740,7 +2465,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2749,7 +2473,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2758,7 +2481,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2767,7 +2489,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2776,7 +2497,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2785,7 +2505,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2794,7 +2513,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2803,7 +2521,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2812,7 +2529,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2821,7 +2537,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2830,7 +2545,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2839,7 +2553,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2848,7 +2561,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2857,7 +2569,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2866,7 +2577,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2875,7 +2585,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2884,7 +2593,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2893,7 +2601,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2902,7 +2609,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2911,7 +2617,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2920,7 +2625,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2929,7 +2633,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2938,7 +2641,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2947,7 +2649,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -2956,7 +2657,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -2965,7 +2665,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -2974,7 +2673,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -2983,7 +2681,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -2992,7 +2689,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3001,7 +2697,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3010,7 +2705,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3019,7 +2713,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3028,7 +2721,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3037,7 +2729,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3046,7 +2737,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3055,7 +2745,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3064,7 +2753,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3073,7 +2761,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3082,7 +2769,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3091,7 +2777,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3100,7 +2785,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3109,7 +2793,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3118,7 +2801,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3127,7 +2809,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3136,7 +2817,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3145,7 +2825,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3154,7 +2833,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3163,7 +2841,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3172,7 +2849,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3181,7 +2857,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3190,7 +2865,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3199,7 +2873,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3208,7 +2881,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3217,7 +2889,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3226,7 +2897,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3235,7 +2905,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3244,7 +2913,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3253,7 +2921,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3262,7 +2929,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3271,7 +2937,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3280,7 +2945,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3289,7 +2953,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3298,7 +2961,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3307,7 +2969,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3316,7 +2977,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3325,7 +2985,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3334,7 +2993,6 @@
             "scope_type": "user",
             "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3343,7 +3001,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3352,7 +3009,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3361,7 +3017,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3370,7 +3025,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3379,7 +3033,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3388,7 +3041,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3397,7 +3049,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3406,7 +3057,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3415,7 +3065,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3424,7 +3073,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3433,7 +3081,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3442,7 +3089,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3451,7 +3097,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3460,7 +3105,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3469,7 +3113,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3478,7 +3121,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3487,7 +3129,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3496,7 +3137,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3505,7 +3145,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3514,7 +3153,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3523,7 +3161,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3532,7 +3169,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3541,7 +3177,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3550,7 +3185,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3559,7 +3193,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3568,7 +3201,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3577,7 +3209,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3586,7 +3217,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3595,7 +3225,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3604,7 +3233,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3613,7 +3241,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3622,7 +3249,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3631,7 +3257,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3640,7 +3265,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3649,7 +3273,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3658,7 +3281,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3667,7 +3289,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3676,7 +3297,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3685,7 +3305,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3694,7 +3313,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3703,7 +3321,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3712,7 +3329,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3721,7 +3337,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3730,7 +3345,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3739,7 +3353,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3748,7 +3361,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3757,7 +3369,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3766,7 +3377,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3775,7 +3385,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3784,7 +3393,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3793,7 +3401,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3802,7 +3409,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3811,7 +3417,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3820,7 +3425,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3829,7 +3433,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3838,7 +3441,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3847,7 +3449,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3856,7 +3457,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3865,7 +3465,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3874,7 +3473,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3883,7 +3481,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3892,7 +3489,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3901,7 +3497,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3910,7 +3505,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3919,7 +3513,6 @@
             "scope_type": "user",
             "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3928,7 +3521,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3937,7 +3529,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3946,7 +3537,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -3955,7 +3545,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -3964,7 +3553,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -3973,7 +3561,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -3982,7 +3569,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -3991,7 +3577,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4000,7 +3585,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4009,7 +3593,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4018,7 +3601,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4027,7 +3609,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4036,7 +3617,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4045,7 +3625,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4054,7 +3633,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4063,7 +3641,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4072,7 +3649,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4081,7 +3657,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4090,7 +3665,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4099,7 +3673,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4108,7 +3681,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4117,7 +3689,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4126,7 +3697,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4135,7 +3705,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4144,7 +3713,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4153,7 +3721,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4162,7 +3729,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4171,7 +3737,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4180,7 +3745,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4189,7 +3753,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4198,7 +3761,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4207,7 +3769,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4216,7 +3777,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4225,7 +3785,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4234,7 +3793,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4243,7 +3801,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4252,7 +3809,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4261,7 +3817,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4270,7 +3825,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4279,7 +3833,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4288,7 +3841,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4297,7 +3849,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4306,7 +3857,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4315,7 +3865,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4324,7 +3873,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4333,7 +3881,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4342,7 +3889,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4351,7 +3897,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4360,7 +3905,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4369,7 +3913,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4378,7 +3921,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4387,7 +3929,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4396,7 +3937,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4405,7 +3945,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4414,7 +3953,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4423,7 +3961,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4432,7 +3969,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4441,7 +3977,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4450,7 +3985,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4459,7 +3993,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4468,7 +4001,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4477,7 +4009,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4486,7 +4017,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4495,7 +4025,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4504,7 +4033,6 @@
             "scope_type": "domain",
             "scope_id": "b9e676dc-e23e-54c6-b350-e83fba4127e9",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4513,7 +4041,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4522,7 +4049,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4531,7 +4057,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4540,7 +4065,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4549,7 +4073,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4558,7 +4081,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4567,7 +4089,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4576,7 +4097,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4585,7 +4105,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4594,7 +4113,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4603,7 +4121,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4612,7 +4129,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4621,7 +4137,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4630,7 +4145,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4639,7 +4153,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4648,7 +4161,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4657,7 +4169,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4666,7 +4177,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4675,7 +4185,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4684,7 +4193,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4693,7 +4201,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4702,7 +4209,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4711,7 +4217,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4720,7 +4225,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4729,7 +4233,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4738,7 +4241,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4747,7 +4249,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4756,7 +4257,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4765,7 +4265,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4774,7 +4273,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4783,7 +4281,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4792,7 +4289,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4801,7 +4297,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4810,7 +4305,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4819,7 +4313,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4828,7 +4321,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4837,7 +4329,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4846,7 +4337,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4855,7 +4345,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4864,7 +4353,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4873,7 +4361,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4882,7 +4369,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4891,7 +4377,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4900,7 +4385,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4909,7 +4393,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4918,7 +4401,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4927,7 +4409,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4936,7 +4417,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4945,7 +4425,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4954,7 +4433,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -4963,7 +4441,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -4972,7 +4449,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -4981,7 +4457,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -4990,7 +4465,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -4999,7 +4473,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5008,7 +4481,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5017,7 +4489,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5026,7 +4497,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5035,7 +4505,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5044,7 +4513,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5053,7 +4521,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5062,7 +4529,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5071,7 +4537,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5080,7 +4545,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5089,7 +4553,6 @@
             "scope_type": "user",
             "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5098,7 +4561,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5107,7 +4569,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5116,7 +4577,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5125,7 +4585,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5134,7 +4593,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5143,7 +4601,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5152,7 +4609,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5161,7 +4617,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5170,7 +4625,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5179,7 +4633,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5188,7 +4641,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5197,7 +4649,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5206,7 +4657,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5215,7 +4665,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5224,7 +4673,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5233,7 +4681,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5242,7 +4689,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5251,7 +4697,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5260,7 +4705,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5269,7 +4713,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5278,7 +4721,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5287,7 +4729,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5296,7 +4737,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5305,7 +4745,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5314,7 +4753,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5323,7 +4761,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5332,7 +4769,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5341,7 +4777,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5350,7 +4785,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5359,7 +4793,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5368,7 +4801,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5377,7 +4809,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5386,7 +4817,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5395,7 +4825,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5404,7 +4833,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5413,7 +4841,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5422,7 +4849,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5431,7 +4857,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5440,7 +4865,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5449,7 +4873,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5458,7 +4881,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5467,7 +4889,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5476,7 +4897,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5485,7 +4905,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5494,7 +4913,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5503,7 +4921,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5512,7 +4929,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5521,7 +4937,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5530,7 +4945,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5539,7 +4953,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5548,7 +4961,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5557,7 +4969,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5566,7 +4977,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5575,7 +4985,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5584,7 +4993,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5593,7 +5001,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5602,7 +5009,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5611,7 +5017,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5620,7 +5025,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5629,7 +5033,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5638,7 +5041,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5647,7 +5049,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5656,7 +5057,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5665,7 +5065,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5674,7 +5073,6 @@
             "scope_type": "project",
             "scope_id": "8e32dd28-d319-4e3b-8851-ea37837699a5",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5683,7 +5081,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5692,7 +5089,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5701,7 +5097,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5710,7 +5105,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5719,7 +5113,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5728,7 +5121,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5737,7 +5129,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5746,7 +5137,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5755,7 +5145,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5764,7 +5153,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5773,7 +5161,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5782,7 +5169,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5791,7 +5177,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5800,7 +5185,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5809,7 +5193,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5818,7 +5201,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5827,7 +5209,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5836,7 +5217,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5845,7 +5225,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5854,7 +5233,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5863,7 +5241,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5872,7 +5249,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5881,7 +5257,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5890,7 +5265,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5899,7 +5273,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5908,7 +5281,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5917,7 +5289,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5926,7 +5297,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5935,7 +5305,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5944,7 +5313,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5953,7 +5321,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -5962,7 +5329,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -5971,7 +5337,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -5980,7 +5345,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -5989,7 +5353,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -5998,7 +5361,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6007,7 +5369,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6016,7 +5377,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6025,7 +5385,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6034,7 +5393,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6043,7 +5401,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6052,7 +5409,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6061,7 +5417,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6070,7 +5425,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6079,7 +5433,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6088,7 +5441,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6097,7 +5449,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6106,7 +5457,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6115,7 +5465,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6124,7 +5473,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6133,7 +5481,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6142,7 +5489,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6151,7 +5497,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6160,7 +5505,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6169,7 +5513,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6178,7 +5521,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6187,7 +5529,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6196,7 +5537,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6205,7 +5545,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6214,7 +5553,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6223,7 +5561,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6232,7 +5569,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6241,7 +5577,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6250,7 +5585,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6259,7 +5593,6 @@
             "scope_type": "project",
             "scope_id": "2de2b969-1d04-48a6-af16-0bc8adb3c831",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6268,7 +5601,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6277,7 +5609,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6286,7 +5617,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6295,7 +5625,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6304,7 +5633,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "session",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6313,7 +5641,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6322,7 +5649,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6331,7 +5657,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6340,7 +5665,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6349,7 +5673,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "agent",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6358,7 +5681,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6367,7 +5689,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6376,7 +5697,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6385,7 +5705,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6394,7 +5713,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "image",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6403,7 +5721,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6412,7 +5729,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6421,7 +5737,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6430,7 +5745,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6439,7 +5753,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "keypair",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6448,7 +5761,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6457,7 +5769,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6466,7 +5777,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6475,7 +5785,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6484,7 +5793,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "container_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6493,7 +5801,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6502,7 +5809,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6511,7 +5817,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6520,7 +5825,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6529,7 +5833,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "resource_group",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6538,7 +5841,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6547,7 +5849,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6556,7 +5857,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6565,7 +5865,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6574,7 +5873,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6583,7 +5881,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6592,7 +5889,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6601,7 +5897,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6610,7 +5905,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6619,7 +5913,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "artifact_registry",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6628,7 +5921,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config_fragment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6637,7 +5929,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config_fragment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6646,7 +5937,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config_fragment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6655,7 +5945,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config_fragment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6664,7 +5953,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "app_config_fragment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6673,7 +5961,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6682,7 +5969,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6691,7 +5977,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6700,7 +5985,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6709,7 +5993,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_channel",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6718,7 +6001,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6727,7 +6009,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6736,7 +6017,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6745,7 +6025,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6754,7 +6033,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "notification_rule",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6763,7 +6041,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6772,7 +6049,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6781,7 +6057,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6790,7 +6065,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6799,7 +6073,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_deployment",
-            "operation": "hard-delete",
             "permission": 16
         },
         {
@@ -6808,7 +6081,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "create",
             "permission": 4
         },
         {
@@ -6817,7 +6089,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "read",
             "permission": 1
         },
         {
@@ -6826,7 +6097,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "update",
             "permission": 2
         },
         {
@@ -6835,7 +6105,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "soft-delete",
             "permission": 8
         },
         {
@@ -6844,7 +6113,6 @@
             "scope_type": "user",
             "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
             "entity_type": "model_card",
-            "operation": "hard-delete",
             "permission": 16
         }
     ],

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -599,6 +599,23 @@ class Permission(enum.IntFlag):
         """
         return (required & ~self) == Permission.NONE
 
+    def to_operation(self) -> OperationType:
+        """The :class:`OperationType` of a single-bit mask — the inverse of
+        :meth:`from_operation` for the bits that have one."""
+        match self:
+            case Permission.READ:
+                return OperationType.READ
+            case Permission.UPDATE:
+                return OperationType.UPDATE
+            case Permission.CREATE:
+                return OperationType.CREATE
+            case Permission.SOFT_DELETE:
+                return OperationType.SOFT_DELETE
+            case Permission.HARD_DELETE:
+                return OperationType.HARD_DELETE
+            case _:
+                raise ValueError(f"{self!r} is not a single operation bit")
+
     @classmethod
     def from_operation(cls, operation: OperationType) -> Permission:
         """Map a single :class:`OperationType` to its corresponding bit.

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -1,7 +1,6 @@
 from typing import Any, override
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.bulk import BaseBulkAction
@@ -72,9 +71,7 @@ class BulkActionRBACValidator(BulkActionValidator):
         permission_map = await self._repository.check_bulk_permission_with_scope_chain(
             BulkPermissionCheckInput(
                 keys=keys,
-                permission=Permission.from_operation(
-                    action.operation_type().to_permission_operation()
-                ),
+                permission=action.operation_type().to_permission(),
             )
         )
 

--- a/src/ai/backend/manager/actions/validators/rbac/bulk.py
+++ b/src/ai/backend/manager/actions/validators/rbac/bulk.py
@@ -1,6 +1,7 @@
 from typing import Any, override
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.bulk import BaseBulkAction
@@ -71,7 +72,9 @@ class BulkActionRBACValidator(BulkActionValidator):
         permission_map = await self._repository.check_bulk_permission_with_scope_chain(
             BulkPermissionCheckInput(
                 keys=keys,
-                operation=action.operation_type().to_permission_operation(),
+                permission=Permission.from_operation(
+                    action.operation_type().to_permission_operation()
+                ),
             )
         )
 

--- a/src/ai/backend/manager/actions/validators/rbac/legacy.py
+++ b/src/ai/backend/manager/actions/validators/rbac/legacy.py
@@ -9,6 +9,7 @@ import logging
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.common.metrics.safe import SafeCounter
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -70,7 +71,7 @@ class LegacySingleEntityActionRBACValidator(SingleEntityActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=target.element_type,
                 ),
-                operation=operation,
+                permission=Permission.from_operation(operation),
             )
         )
         if not allowed:
@@ -115,7 +116,7 @@ class LegacyScopeActionRBACValidator(ScopeActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=entity_type.to_element(),
                 ),
-                operation=operation,
+                permission=Permission.from_operation(operation),
             )
         )
         if not allowed:

--- a/src/ai/backend/manager/actions/validators/rbac/legacy.py
+++ b/src/ai/backend/manager/actions/validators/rbac/legacy.py
@@ -9,7 +9,6 @@ import logging
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.common.metrics.safe import SafeCounter
 from ai.backend.logging.utils import BraceStyleAdapter
@@ -71,7 +70,7 @@ class LegacySingleEntityActionRBACValidator(SingleEntityActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=target.element_type,
                 ),
-                permission=Permission.from_operation(operation),
+                permission=action.operation_type().to_permission(),
             )
         )
         if not allowed:
@@ -116,7 +115,7 @@ class LegacyScopeActionRBACValidator(ScopeActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=entity_type.to_element(),
                 ),
-                permission=Permission.from_operation(operation),
+                permission=action.operation_type().to_permission(),
             )
         )
         if not allowed:

--- a/src/ai/backend/manager/actions/validators/rbac/scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/scope.py
@@ -1,7 +1,6 @@
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.scope import BaseScopeAction
@@ -46,9 +45,7 @@ class ScopeActionRBACValidator(ScopeActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=action.entity_type().to_element(),
                 ),
-                permission=Permission.from_operation(
-                    action.operation_type().to_permission_operation()
-                ),
+                permission=action.operation_type().to_permission(),
             )
         )
         if not allowed:

--- a/src/ai/backend/manager/actions/validators/rbac/scope.py
+++ b/src/ai/backend/manager/actions/validators/rbac/scope.py
@@ -1,6 +1,7 @@
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.scope import BaseScopeAction
@@ -45,7 +46,9 @@ class ScopeActionRBACValidator(ScopeActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=action.entity_type().to_element(),
                 ),
-                operation=action.operation_type().to_permission_operation(),
+                permission=Permission.from_operation(
+                    action.operation_type().to_permission_operation()
+                ),
             )
         )
         if not allowed:

--- a/src/ai/backend/manager/actions/validators/rbac/single_entity.py
+++ b/src/ai/backend/manager/actions/validators/rbac/single_entity.py
@@ -1,6 +1,7 @@
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
@@ -45,7 +46,9 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=target.element_type,
                 ),
-                operation=action.operation_type().to_permission_operation(),
+                permission=Permission.from_operation(
+                    action.operation_type().to_permission_operation()
+                ),
             )
         )
         if not allowed:

--- a/src/ai/backend/manager/actions/validators/rbac/single_entity.py
+++ b/src/ai/backend/manager/actions/validators/rbac/single_entity.py
@@ -1,7 +1,6 @@
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.action.single_entity import BaseSingleEntityAction
@@ -46,9 +45,7 @@ class SingleEntityActionRBACValidator(SingleEntityActionValidator):
                     entity_id=target.element_id,
                     subject_entity_type=target.element_type,
                 ),
-                permission=Permission.from_operation(
-                    action.operation_type().to_permission_operation()
-                ),
+                permission=action.operation_type().to_permission(),
             )
         )
         if not allowed:

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -14,7 +14,7 @@ from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.common.data.permission.types import OperationType as InternalOperationType
-from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.common.data.permission.types import Permission, RBACElementType
 from ai.backend.common.dto.manager.rbac import (
     OrderDirection,
     RoleDTO,
@@ -144,6 +144,7 @@ from ai.backend.manager.data.common.types import SearchResult
 from ai.backend.manager.data.permission.association_scopes_entities import (
     AssociationScopesEntitiesData,
 )
+from ai.backend.manager.data.permission.bit import single_bit
 from ai.backend.manager.data.permission.entity import EntityData
 from ai.backend.manager.data.permission.id import ObjectId
 from ai.backend.manager.data.permission.permission import PermissionData
@@ -878,7 +879,7 @@ class RBACAdapter(BaseAdapter):
                 scope_type=ScopeType(EntityType(scope_type)),
                 scope_id=input.scope_id,
                 entity_type=EntityType(RBACElementType(input.entity_type)),
-                operation=InternalOperationType(input.operation),
+                permission=self._permission_bit(input.operation),
             )
         )
         action_result = (
@@ -908,8 +909,8 @@ class RBACAdapter(BaseAdapter):
                 if input.entity_type is not None
                 else OptionalState.nop()
             ),
-            operation=(
-                OptionalState.update(InternalOperationType(input.operation))
+            permission=(
+                OptionalState.update(self._permission_bit(input.operation))
                 if input.operation is not None
                 else OptionalState.nop()
             ),
@@ -1009,7 +1010,7 @@ class RBACAdapter(BaseAdapter):
                     scope_type=f.scope_type,
                     scope_id=f.scope_id,
                     entity_type=f.entity_type,
-                    operation=f.operation.value,
+                    operation=f.permission.to_operation().value,
                     message=f.message,
                 )
                 for f in result.failures
@@ -1067,7 +1068,7 @@ class RBACAdapter(BaseAdapter):
                     scope_type=f.scope_type,
                     scope_id=f.scope_id,
                     entity_type=f.entity_type,
-                    operation=f.operation.value,
+                    operation=f.permission.to_operation().value,
                     message=f.message,
                 )
                 for f in result.failures
@@ -1082,7 +1083,7 @@ class RBACAdapter(BaseAdapter):
             scope_type=ScopeType(EntityType(scope_type)),
             scope_id=entry.scope_id,
             entity_type=EntityType(RBACElementType(entry.entity_type)),
-            operation=InternalOperationType(entry.operation),
+            permission=self._permission_bit(entry.operation),
         )
 
     async def bulk_revoke_role(self, input: BulkRevokeRoleInputDTO) -> BulkRevokeRoleResultPayload:
@@ -1187,6 +1188,32 @@ class RBACAdapter(BaseAdapter):
             conditions.append(in_factory([RBACElementType(v.value) for v in f.in_]))
         if f.not_in:
             conditions.append(not_in_factory([RBACElementType(v.value) for v in f.not_in]))
+        return conditions
+
+    def _permission_bit(self, operation: OperationTypeDTO | str) -> Permission:
+        """The permission bit an API operation names; grant operations name none."""
+        value = operation.value if isinstance(operation, OperationTypeDTO) else operation
+        return single_bit(Permission.from_operation(InternalOperationType(value)))
+
+    def _convert_operation_bit_filter(
+        self,
+        f: OperationTypeFilter,
+        *,
+        equals_factory: Callable[[Permission], QueryCondition],
+        not_equals_factory: Callable[[Permission], QueryCondition],
+        in_factory: Callable[[Collection[Permission]], QueryCondition],
+        not_in_factory: Callable[[Collection[Permission]], QueryCondition],
+    ) -> list[QueryCondition]:
+        """Translate an ``OperationTypeFilter`` into conditions on the permission bit."""
+        conditions: list[QueryCondition] = []
+        if f.equals is not None:
+            conditions.append(equals_factory(self._permission_bit(f.equals)))
+        if f.not_equals is not None:
+            conditions.append(not_equals_factory(self._permission_bit(f.not_equals)))
+        if f.in_:
+            conditions.append(in_factory([self._permission_bit(v) for v in f.in_]))
+        if f.not_in:
+            conditions.append(not_in_factory([self._permission_bit(v) for v in f.not_in]))
         return conditions
 
     @staticmethod
@@ -1564,12 +1591,12 @@ class RBACAdapter(BaseAdapter):
             )
         if f.operation is not None:
             raw_conditions.extend(
-                self._convert_operation_type_filter(
+                self._convert_operation_bit_filter(
                     f.operation,
-                    equals_factory=ScopedPermissionConditions.by_operation_equals,
-                    not_equals_factory=ScopedPermissionConditions.by_operation_not_equals,
-                    in_factory=ScopedPermissionConditions.by_operation_in,
-                    not_in_factory=ScopedPermissionConditions.by_operation_not_in,
+                    equals_factory=ScopedPermissionConditions.by_permission_equals,
+                    not_equals_factory=ScopedPermissionConditions.by_permission_not_equals,
+                    in_factory=ScopedPermissionConditions.by_permission_in,
+                    not_in_factory=ScopedPermissionConditions.by_permission_not_in,
                 )
             )
         conditions: list[QueryCondition] = []
@@ -1789,7 +1816,7 @@ class RBACAdapter(BaseAdapter):
             scope_type=RBACElementTypeDTO(data.scope_type),
             scope_id=data.scope_id,
             entity_type=RBACElementTypeDTO(data.entity_type),
-            operation=OperationTypeDTO(data.operation.value),
+            operation=OperationTypeDTO(data.permission.to_operation().value),
             created_at=data.created_at,
         )
 

--- a/src/ai/backend/manager/api/rest/rbac/permission_adapter.py
+++ b/src/ai/backend/manager/api/rest/rbac/permission_adapter.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 import uuid
 
 from ai.backend.common.data.entity.types import EntityType, ScopeType
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.dto.manager.rbac import (
     CreatePermissionRequest,
     PermissionDTO,
 )
+from ai.backend.manager.data.permission.bit import single_bit
 from ai.backend.manager.data.permission.permission import PermissionData
 from ai.backend.manager.repositories.base import Creator, Purger
 from ai.backend.manager.repositories.permission_controller.creators import (
@@ -35,7 +37,7 @@ class PermissionAdapter:
         return PermissionDTO(
             id=data.id,
             entity_type=data.entity_type,
-            operation=data.operation,
+            operation=data.permission.to_operation(),
         )
 
     @staticmethod
@@ -47,7 +49,7 @@ class PermissionAdapter:
                 scope_type=ScopeType(EntityType(request.scope_type)),
                 scope_id=request.scope_id,
                 entity_type=EntityType(request.entity_type),
-                operation=request.operation,
+                permission=single_bit(Permission.from_operation(request.operation)),
             )
         )
         return CreatePermissionAction(creator=creator)

--- a/src/ai/backend/manager/data/permission/bit.py
+++ b/src/ai/backend/manager/data/permission/bit.py
@@ -1,0 +1,19 @@
+"""The single-bit rule of ``permissions`` rows."""
+
+from __future__ import annotations
+
+from ai.backend.common.data.permission.types import Permission
+from ai.backend.manager.errors.permission import InvalidPermissionOperation
+
+
+def single_bit(permission: Permission) -> Permission:
+    """``permission`` if it is exactly one operation bit; a row holds one.
+
+    A grant operation has no bit, and a mask spans several rows, so neither
+    can be stored as a permission.
+    """
+    if permission == Permission.NONE or permission & (permission - 1):
+        raise InvalidPermissionOperation(
+            f"{permission!r} is not a single operation bit; a permission row holds one."
+        )
+    return permission

--- a/src/ai/backend/manager/data/permission/permission.py
+++ b/src/ai/backend/manager/data/permission/permission.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.manager.data.common.types import SearchResult
 
-from .types import OperationType, Permission
+from .types import Permission
 
 
 @dataclass
@@ -16,7 +16,6 @@ class PermissionCreator:
     scope_type: ScopeType
     scope_id: str
     entity_type: EntityType
-    operation: OperationType
     permission: Permission
 
 
@@ -27,7 +26,6 @@ class PermissionData:
     scope_type: EntityType
     scope_id: str
     entity_type: EntityType
-    operation: OperationType
     permission: Permission
     created_at: datetime
 
@@ -42,7 +40,7 @@ class ScopedPermissionCreateInput:
     scope_type: ScopeType
     scope_id: str
     entity_type: EntityType
-    operation: OperationType
+    permission: Permission
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -19,6 +19,7 @@ from .types import (
 )
 from .types import (
     OperationType,
+    Permission,
     RBACElementType,
     RoleSource,
 )
@@ -79,7 +80,7 @@ class ScopePermissionCheckInput:
     user_id: uuid.UUID
     target_entity_type: LegacyEntityType
     target_scope_id: ScopeId
-    operation: OperationType
+    permission: Permission
 
 
 @dataclass(frozen=True)
@@ -118,13 +119,13 @@ class PermissionResolutionKey:
 @dataclass(frozen=True)
 class ScopeChainPermissionCheckInput:
     key: PermissionResolutionKey
-    operation: OperationType
+    permission: Permission
 
 
 @dataclass(frozen=True)
 class BulkPermissionCheckInput:
     keys: list[PermissionResolutionKey]
-    operation: OperationType
+    permission: Permission
 
 
 @dataclass(frozen=True)
@@ -263,7 +264,7 @@ class BulkRolePermissionAddFailure:
     scope_type: ScopeType
     scope_id: str
     entity_type: EntityType
-    operation: OperationType
+    permission: Permission
     message: str
 
 

--- a/src/ai/backend/manager/errors/permission.py
+++ b/src/ai/backend/manager/errors/permission.py
@@ -13,6 +13,7 @@ from ai.backend.common.exception import (
 )
 
 __all__ = (
+    "InvalidPermissionOperation",
     "NotEnoughPermission",
     "ObjectPermissionNotFound",
     "PermissionNotFound",
@@ -81,6 +82,22 @@ class RoleNotAssigned(BackendAIError, web.HTTPBadRequest):
             domain=ErrorDomain.ROLE,
             operation=ErrorOperation.HARD_DELETE,
             error_detail=ErrorDetail.NOT_FOUND,
+        )
+
+
+class InvalidPermissionOperation(BackendAIError, web.HTTPBadRequest):
+    """An operation with no permission bit — a grant operation — cannot be stored
+    as a permission; sharing is judged from entity shares and scope CREATE."""
+
+    error_type = "https://api.backend.ai/probs/invalid-permission-operation"
+    error_title = "The operation cannot be stored as a permission."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.PERMISSION,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
 
 

--- a/src/ai/backend/manager/models/alembic/versions/5c1e7a2d9b40_key_permissions_by_permission_bit.py
+++ b/src/ai/backend/manager/models/alembic/versions/5c1e7a2d9b40_key_permissions_by_permission_bit.py
@@ -1,0 +1,57 @@
+"""key permissions by the permission bit and drop operation
+
+Revision ID: 5c1e7a2d9b40
+Revises: d4e6f8a0b2c3
+Create Date: 2026-09-03
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Part of: NEXT_RELEASE_VERSION
+
+# revision identifiers, used by Alembic.
+revision = "5c1e7a2d9b40"
+down_revision = "d4e6f8a0b2c3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # grant:* rows carry no bit; sharing is judged from entity shares and scope CREATE.
+    op.execute(sa.text("DELETE FROM permissions WHERE permission = 0"))
+    op.drop_constraint("uq_permissions_role_scope_entity_op", "permissions", type_="unique")
+    op.drop_column("permissions", "operation")
+    op.create_unique_constraint(
+        "uq_permissions_role_scope_entity_permission",
+        "permissions",
+        ["role_id", "scope_type", "scope_id", "entity_type", "permission"],
+    )
+    op.create_check_constraint(
+        op.f("ck_permissions_single_bit"),
+        "permissions",
+        "permission > 0 AND (permission & (permission - 1)) = 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(op.f("ck_permissions_single_bit"), "permissions", type_="check")
+    op.drop_constraint("uq_permissions_role_scope_entity_permission", "permissions", type_="unique")
+    op.add_column(
+        "permissions",
+        sa.Column("operation", sa.String(length=32), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE permissions SET operation = CASE permission"
+            " WHEN 1 THEN 'read' WHEN 2 THEN 'update' WHEN 4 THEN 'create'"
+            " WHEN 8 THEN 'soft-delete' WHEN 16 THEN 'hard-delete' END"
+        )
+    )
+    op.alter_column("permissions", "operation", nullable=False)
+    op.create_unique_constraint(
+        "uq_permissions_role_scope_entity_op",
+        "permissions",
+        ["role_id", "scope_type", "scope_id", "entity_type", "operation"],
+    )

--- a/src/ai/backend/manager/models/rbac_models/conditions.py
+++ b/src/ai/backend/manager/models/rbac_models/conditions.py
@@ -19,7 +19,7 @@ from ai.backend.manager.data.permission.id import ObjectId
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
-    OperationType,
+    Permission,
     RoleSource,
     ScopeType,
 )
@@ -271,9 +271,9 @@ class PermissionConditions:
         return inner
 
     @staticmethod
-    def by_operations(operations: list[OperationType]) -> QueryCondition:
+    def by_permissions(permissions: list[Permission]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return PermissionRow.operation.in_(operations)
+            return PermissionRow.permission.in_(permissions)
 
         return inner
 
@@ -1034,9 +1034,9 @@ class ScopedPermissionConditions:
         return inner
 
     @staticmethod
-    def by_operation(operation: str) -> QueryCondition:
+    def by_permission(permission: Permission) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return PermissionRow.operation == operation
+            return PermissionRow.permission == permission
 
         return inner
 
@@ -1272,30 +1272,30 @@ class ScopedPermissionConditions:
         return inner
 
     @staticmethod
-    def by_operation_equals(operation: OperationType) -> QueryCondition:
+    def by_permission_equals(permission: Permission) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return PermissionRow.operation == operation
+            return PermissionRow.permission == permission
 
         return inner
 
     @staticmethod
-    def by_operation_not_equals(operation: OperationType) -> QueryCondition:
+    def by_permission_not_equals(permission: Permission) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return PermissionRow.operation != operation
+            return PermissionRow.permission != permission
 
         return inner
 
     @staticmethod
-    def by_operation_in(operations: Collection[OperationType]) -> QueryCondition:
+    def by_permission_in(permissions: Collection[Permission]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return PermissionRow.operation.in_(list(operations))
+            return PermissionRow.permission.in_(list(permissions))
 
         return inner
 
     @staticmethod
-    def by_operation_not_in(operations: Collection[OperationType]) -> QueryCondition:
+    def by_permission_not_in(permissions: Collection[Permission]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return PermissionRow.operation.not_in(list(operations))
+            return PermissionRow.permission.not_in(list(permissions))
 
         return inner
 

--- a/src/ai/backend/manager/models/rbac_models/permission/permission.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/permission.py
@@ -8,16 +8,13 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.data.permission.bit import single_bit
 from ai.backend.manager.data.permission.permission import PermissionCreator, PermissionData
-from ai.backend.manager.data.permission.types import (
-    OperationType,
-    Permission,
-)
+from ai.backend.manager.data.permission.types import Permission
 from ai.backend.manager.models.base import (
     GUID,
     Base,
     IntFlagType,
-    StrEnumType,
 )
 from ai.backend.manager.models.mixins.timestamp import CreatedAtMixin
 
@@ -38,8 +35,12 @@ class PermissionRow(CreatedAtMixin, Base):
             "scope_type",
             "scope_id",
             "entity_type",
-            "operation",
-            name="uq_permissions_role_scope_entity_op",
+            "permission",
+            name="uq_permissions_role_scope_entity_permission",
+        ),
+        sa.CheckConstraint(
+            "permission > 0 AND (permission & (permission - 1)) = 0",
+            name="single_bit",
         ),
     )
 
@@ -59,9 +60,7 @@ class PermissionRow(CreatedAtMixin, Base):
     entity_type: Mapped[EntityType] = mapped_column(
         "entity_type", sa.String(length=32), nullable=False
     )
-    operation: Mapped[OperationType] = mapped_column(
-        "operation", StrEnumType(OperationType, length=32), nullable=False
-    )
+    # One row per operation bit; the bit is the row's identity.
     permission: Mapped[Permission] = mapped_column(
         "permission", IntFlagType(Permission), nullable=False
     )
@@ -73,8 +72,7 @@ class PermissionRow(CreatedAtMixin, Base):
             scope_type=input.scope_type,
             scope_id=input.scope_id,
             entity_type=input.entity_type,
-            operation=input.operation,
-            permission=input.permission,
+            permission=single_bit(input.permission),
         )
 
     def to_data(self) -> PermissionData:
@@ -84,7 +82,6 @@ class PermissionRow(CreatedAtMixin, Base):
             scope_type=self.scope_type,
             scope_id=self.scope_id,
             entity_type=self.entity_type,
-            operation=self.operation,
             permission=self.permission,
             created_at=self.created_at,
         )

--- a/src/ai/backend/manager/repositories/base/rbac/granter.py
+++ b/src/ai/backend/manager/repositories/base/rbac/granter.py
@@ -7,7 +7,6 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.data.permission.types import (
-    OperationType,
     Permission,
     RBACElementType,
     RelationType,
@@ -42,14 +41,14 @@ class RBACGranter:
         granted_entity_scope_type: The scope_type for entity-as-scope in permissions table.
         target_scope_id: The scope to associate the entity with (e.g., invitee's User scope).
         target_role_ids: The role ID(s) to grant permissions to.
-        operations: The operations to grant on the entity.
+        permission: The operation bits to grant on the entity.
     """
 
     granted_entity_id: ObjectId
     granted_entity_scope_type: RBACElementType
     target_scope_id: ScopeId
     target_role_ids: list[UUID]
-    operations: list[OperationType]
+    permission: Permission
 
 
 # =============================================================================
@@ -75,7 +74,7 @@ async def execute_rbac_granter(
     role_ids = granter.target_role_ids
     entity_id = granter.granted_entity_id
 
-    if not role_ids or not granter.operations:
+    if not role_ids or not granter.permission:
         return
 
     # 1. Insert ref edge in association_scopes_entities (visibility)
@@ -96,7 +95,7 @@ async def execute_rbac_granter(
 
     # 2. Insert entity-scope permissions (access control)
     #    Use ON CONFLICT DO NOTHING to safely handle repeated grants for the
-    #    same (role_id, scope_type, scope_id, entity_type, operation) tuple.
+    #    same (role_id, scope_type, scope_id, entity_type, permission) tuple.
     scope_type = granter.granted_entity_scope_type.to_scope_type()
     perm_values = [
         {
@@ -104,15 +103,15 @@ async def execute_rbac_granter(
             "scope_type": scope_type,
             "scope_id": entity_id.entity_id,
             "entity_type": entity_id.entity_type,
-            "operation": operation,
-            "permission": Permission.from_operation(operation),
+            "permission": bit,
         }
         for role_id in role_ids
-        for operation in granter.operations
+        for bit in Permission
+        if bit and granter.permission & bit
     ]
     perm_stmt = (
         pg_insert(PermissionRow)
         .values(perm_values)
-        .on_conflict_do_nothing(constraint="uq_permissions_role_scope_entity_op")
+        .on_conflict_do_nothing(constraint="uq_permissions_role_scope_entity_permission")
     )
     await db_sess.execute(perm_stmt)

--- a/src/ai/backend/manager/repositories/base/rbac/revoker.py
+++ b/src/ai/backend/manager/repositories/base/rbac/revoker.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-from ai.backend.common.data.permission.types import OperationType, RBACElementType
+from ai.backend.common.data.permission.types import Permission, RBACElementType
 from ai.backend.manager.data.permission.id import ObjectId
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
 
@@ -32,13 +32,13 @@ class RBACRevoker:
         entity_id: The entity to revoke access from.
         entity_scope_type: The scope type for entity-as-scope in permissions table.
         target_role_ids: The role ID(s) to revoke permissions from.
-        operations: Operations to revoke. If None, revokes all operations for the entity.
+        permission: Operation bits to revoke. If None, revokes every operation on the entity.
     """
 
     entity_id: ObjectId
     entity_scope_type: RBACElementType
     target_role_ids: list[UUID]
-    operations: list[OperationType] | None = None
+    permission: Permission | None = None
 
 
 # =============================================================================
@@ -51,7 +51,7 @@ async def _delete_permissions(
     role_ids: Collection[UUID],
     entity_id: ObjectId,
     scope_type: RBACElementType,
-    operations: list[OperationType] | None,
+    permission: Permission | None,
 ) -> int:
     """Delete permissions for the given entity-as-scope and roles."""
     if not role_ids:
@@ -64,8 +64,10 @@ async def _delete_permissions(
         PermissionRow.entity_type == entity_id.entity_type,
     ]
 
-    if operations is not None:
-        conditions.append(PermissionRow.operation.in_(operations))
+    if permission is not None:
+        conditions.append(
+            PermissionRow.permission.in_([bit for bit in Permission if bit and permission & bit])
+        )
 
     result = await db_sess.execute(sa.delete(PermissionRow).where(sa.and_(*conditions)))
     return cast(CursorResult[Any], result).rowcount or 0
@@ -100,7 +102,7 @@ async def execute_rbac_revoker(
         revoker.target_role_ids,
         revoker.entity_id,
         revoker.entity_scope_type,
-        revoker.operations,
+        revoker.permission,
     )
 
     await db_sess.flush()

--- a/src/ai/backend/manager/repositories/ops/rbac/provider.py
+++ b/src/ai/backend/manager/repositories/ops/rbac/provider.py
@@ -829,11 +829,12 @@ class RBACWriteOps(WriteOps):
                 scope_type=ScopeType(EntityType(self._scope_element_type(spec.scope))),
                 scope_id=str(spec.scope.scope_id),
                 entity_type=EntityType(entity_type),
-                operation=operation,
+                permission=Permission.from_operation(operation),
             )
             for spec, row in zip(specs, roles.rows, strict=True)
             for entity_type, operations in spec.entity_operations.items()
             for operation in operations
+            if Permission.from_operation(operation) != Permission.NONE
         ]
         if permissions:
             await self.bulk_create(BulkCreator(specs=permissions))

--- a/src/ai/backend/manager/repositories/ops/v2/entity_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/entity_write.py
@@ -349,12 +349,12 @@ class V2EntityWriteOps(V2WriteOpsBase):
                 ).to_scope_type(),
                 scope_id=str(spec.entity),
                 entity_type=entity_type.to_entity_type(),
-                operation=operation,
                 permission=Permission.from_operation(operation),
             )
             for spec, row in zip(specs, role_rows, strict=True)
             for entity_type, operations in spec.entity_operations.items()
             for operation in operations
+            if Permission.from_operation(operation) != Permission.NONE
         ]
         if permission_rows:
             self._sess.add_all(permission_rows)

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -11,6 +11,7 @@ from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import RBACElementType
+from ai.backend.manager.data.permission.bit import single_bit
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.status import PermissionStatus, RoleStatus
 from ai.backend.manager.data.permission.types import (
@@ -66,7 +67,7 @@ class PermissionCreatorSpec(CreatorSpec[PermissionRow]):
     scope_type: ScopeType
     scope_id: str
     entity_type: EntityType
-    operation: OperationType
+    permission: Permission
 
     @override
     def build_row(self) -> PermissionRow:
@@ -75,8 +76,7 @@ class PermissionCreatorSpec(CreatorSpec[PermissionRow]):
             scope_type=self.scope_type,
             scope_id=self.scope_id,
             entity_type=self.entity_type,
-            operation=self.operation,
-            permission=Permission.from_operation(self.operation),
+            permission=single_bit(self.permission),
         )
 
 

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -420,7 +420,7 @@ class PermissionDBSource:
                         scope_type=scoped_perm_input.scope_type,
                         scope_id=scoped_perm_input.scope_id,
                         entity_type=scoped_perm_input.entity_type,
-                        operation=scoped_perm_input.operation,
+                        permission=scoped_perm_input.permission,
                     )
                 )
                 await self._add_permission_to_group(db_session, perm_creator)
@@ -535,7 +535,7 @@ class PermissionDBSource:
         self,
         user_id: uuid.UUID,
         scope_id: ScopeId,
-        operation: OperationType,
+        permission: Permission,
     ) -> bool:
         inner_query = (
             sa.select(sa.literal(1))
@@ -552,7 +552,7 @@ class PermissionDBSource:
                         PermissionRow.scope_type == LegacyScopeType.GLOBAL,
                         PermissionRow.scope_id == scope_id.scope_id,
                     ),
-                    PermissionRow.operation == operation,
+                    PermissionRow.permission == permission,
                 )
             )
         )
@@ -590,11 +590,11 @@ class PermissionDBSource:
                     sa.or_(
                         sa.and_(
                             PermissionRow.scope_type == LegacyScopeType.GLOBAL,
-                            PermissionRow.operation == operation,
+                            PermissionRow.permission == Permission.from_operation(operation),
                         ),
                         sa.and_(
                             AssociationScopesEntitiesRow.entity_id.in_(object_id_for_cond),
-                            PermissionRow.operation == operation,
+                            PermissionRow.permission == Permission.from_operation(operation),
                         ),
                         sa.and_(
                             ObjectPermissionRow.entity_id.in_(object_id_for_cond),
@@ -972,9 +972,9 @@ class PermissionDBSource:
     ) -> bool:
         """Return whether the user holds *operation* on the target element."""
         granted = await self._resolve_permissions_via_direct_scope_walk(
-            [data.key], operation_filter=data.operation
+            [data.key], permission_filter=data.permission
         )
-        return data.operation in granted.get(data.key, frozenset())
+        return bool(granted.get(data.key, Permission.NONE) & data.permission)
 
     async def check_bulk_permission_with_scope_chain(
         self,
@@ -988,16 +988,16 @@ class PermissionDBSource:
         if not data.keys:
             return {}
         granted = await self._resolve_permissions_via_direct_scope_walk(
-            data.keys, operation_filter=data.operation
+            data.keys, permission_filter=data.permission
         )
-        return {key: data.operation in granted.get(key, frozenset()) for key in data.keys}
+        return {key: bool(granted.get(key, Permission.NONE) & data.permission) for key in data.keys}
 
     async def _resolve_permissions_via_direct_scope_walk(
         self,
         keys: Collection[PermissionResolutionKey],
         *,
-        operation_filter: OperationType | None = None,
-    ) -> Mapping[PermissionResolutionKey, frozenset[OperationType]]:
+        permission_filter: Permission | None = None,
+    ) -> Mapping[PermissionResolutionKey, Permission]:
         """Resolve granted operations for a collection of per-target keys.
 
         Groups input keys by ``(user_id, element_type, subject_entity_type)``
@@ -1005,10 +1005,10 @@ class PermissionDBSource:
         a scope-chain branch (walks parent AUTO scopes upward from each entity)
         and a self-scope branch (permission whose scope IS the entity itself).
         Returns a mapping keyed by the original ``PermissionResolutionKey``
-        objects. Keys that received no grant map to an empty frozenset.
+        objects. Keys that received no grant map to ``Permission.NONE``.
 
-        When ``operation_filter`` is set, only that operation is considered;
-        otherwise every granted operation is returned.
+        When ``permission_filter`` is set, only that bit is considered;
+        otherwise every granted bit is returned.
         """
         if not keys:
             return {}
@@ -1023,7 +1023,7 @@ class PermissionDBSource:
                 )
             ].append(key)
 
-        result: dict[PermissionResolutionKey, frozenset[OperationType]] = {}
+        result: dict[PermissionResolutionKey, Permission] = {}
         async with self._db.begin_readonly_session_read_committed() as db_session:
             for group_key, members in groups.items():
                 entity_ids = [k.entity_id for k in members]
@@ -1031,10 +1031,10 @@ class PermissionDBSource:
                     db_session=db_session,
                     group_key=group_key,
                     entity_ids=entity_ids,
-                    operation_filter=operation_filter,
+                    permission_filter=permission_filter,
                 )
                 for key in members:
-                    result[key] = frozenset(granted.get(key.entity_id, ()))
+                    result[key] = granted.get(key.entity_id, Permission.NONE)
         return result
 
     async def _resolve_permissions_for_group(
@@ -1043,13 +1043,13 @@ class PermissionDBSource:
         db_session: SASession,
         group_key: _PermissionGroupKey,
         entity_ids: Sequence[str],
-        operation_filter: OperationType | None,
-    ) -> Mapping[str, set[OperationType]]:
+        permission_filter: Permission | None,
+    ) -> Mapping[str, Permission]:
         """Run the scope-chain + self-scope query for a single
         ``(user_id, element_type, subject_entity_type)`` group with N entity_ids.
 
-        Returns a mapping from entity_id to the set of granted operations.
-        Entities that received no grant are absent from the returned mapping.
+        Returns a mapping from entity_id to the granted bits. Entities that
+        received no grant are absent from the returned mapping.
         """
         direct_scopes_cte = self._build_direct_scopes_cte(
             group_key.element_type.to_entity_type(), entity_ids
@@ -1057,15 +1057,15 @@ class PermissionDBSource:
         scope_walk_cte = self._build_scope_walk_cte(direct_scopes_cte)
 
         scope_chain_query = self._build_scope_chain_query(
-            direct_scopes_cte, scope_walk_cte, group_key, operation_filter
+            direct_scopes_cte, scope_walk_cte, group_key, permission_filter
         )
-        self_scope_query = self._build_self_scope_query(group_key, entity_ids, operation_filter)
+        self_scope_query = self._build_self_scope_query(group_key, entity_ids, permission_filter)
         combined_query = sa.union_all(scope_chain_query, self_scope_query)
 
-        granted: defaultdict[str, set[OperationType]] = defaultdict(set)
+        granted: defaultdict[str, Permission] = defaultdict(lambda: Permission.NONE)
         result = await db_session.execute(combined_query)
         for row in result:
-            granted[row.entity_id].add(row.operation)
+            granted[row.entity_id] |= Permission(row.permission)
         return granted
 
     def _build_scope_chain_query(
@@ -1073,7 +1073,7 @@ class PermissionDBSource:
         direct_scopes_cte: sa.CTE,
         scope_walk_cte: sa.CTE,
         group_key: _PermissionGroupKey,
-        operation_filter: OperationType | None,
+        permission_filter: Permission | None,
     ) -> sa.Select[Any]:
         """Build the scope-chain branch: walk parent AUTO scopes upward from
         each entity's direct scope and pick up permissions along the way.
@@ -1087,13 +1087,13 @@ class PermissionDBSource:
             roles.c.status == RoleStatus.ACTIVE,
             perm.c.entity_type == group_key.subject_entity_type.to_entity_type(),
         ]
-        if operation_filter is not None:
-            filters.append(perm.c.operation == operation_filter)
+        if permission_filter is not None:
+            filters.append(perm.c.permission == permission_filter)
 
         return (
             sa.select(
                 direct_scopes_cte.c.entity_id,
-                perm.c.operation,
+                perm.c.permission,
             )
             .select_from(
                 direct_scopes_cte.join(
@@ -1120,7 +1120,7 @@ class PermissionDBSource:
         self,
         group_key: _PermissionGroupKey,
         entity_ids: Sequence[str],
-        operation_filter: OperationType | None,
+        permission_filter: Permission | None,
     ) -> sa.Select[Any]:
         """Build the self-scope branch: pick up permissions whose scope IS
         the target entity itself.
@@ -1136,13 +1136,13 @@ class PermissionDBSource:
             perm.c.scope_id.in_(entity_ids),
             perm.c.entity_type == group_key.subject_entity_type.to_entity_type(),
         ]
-        if operation_filter is not None:
-            filters.append(perm.c.operation == operation_filter)
+        if permission_filter is not None:
+            filters.append(perm.c.permission == permission_filter)
 
         return (
             sa.select(
                 perm.c.scope_id.label("entity_id"),
-                perm.c.operation,
+                perm.c.permission,
             )
             .select_from(
                 perm.join(roles, roles.c.id == perm.c.role_id).join(
@@ -1155,17 +1155,17 @@ class PermissionDBSource:
     async def resolve_effective_permissions(
         self,
         keys: Collection[PermissionResolutionKey],
-    ) -> Mapping[PermissionResolutionKey, frozenset[OperationType]]:
+    ) -> Mapping[PermissionResolutionKey, Permission]:
         """Resolve the effective permissions for a collection of per-target keys.
 
         Each input key represents one ``(user_id, element_type, entity_id,
         subject_entity_type)`` combination. The result is a mapping keyed by
-        the same key object, with values being the set of operations the user
-        is authorized to perform on that entity.
+        the same key object, with values being the bits the user holds on that
+        entity.
 
         Keys sharing the same ``(user_id, element_type, subject_entity_type)``
         share one SQL round-trip; distinct groups dispatch separately. Keys
-        that received no grant map to an empty frozenset.
+        that received no grant map to ``Permission.NONE``.
         """
         return await self._resolve_permissions_via_direct_scope_walk(keys)
 

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -970,11 +970,11 @@ class PermissionDBSource:
         self,
         data: ScopeChainPermissionCheckInput,
     ) -> bool:
-        """Return whether the user holds *operation* on the target element."""
+        """Return whether the user holds every bit of ``permission`` on the target."""
         granted = await self._resolve_permissions_via_direct_scope_walk(
             [data.key], permission_filter=data.permission
         )
-        return bool(granted.get(data.key, Permission.NONE) & data.permission)
+        return granted.get(data.key, Permission.NONE).covers(data.permission)
 
     async def check_bulk_permission_with_scope_chain(
         self,
@@ -982,15 +982,15 @@ class PermissionDBSource:
     ) -> Mapping[PermissionResolutionKey, bool]:
         """Check whether the user holds *operation* on each target key in one go.
 
-        Returns a mapping from each input key to a boolean indicating whether
-        the operation is granted.
+        Returns a mapping from each input key to whether every bit of
+        ``permission`` is granted.
         """
         if not data.keys:
             return {}
         granted = await self._resolve_permissions_via_direct_scope_walk(
             data.keys, permission_filter=data.permission
         )
-        return {key: bool(granted.get(key, Permission.NONE) & data.permission) for key in data.keys}
+        return {key: granted.get(key, Permission.NONE).covers(data.permission) for key in data.keys}
 
     async def _resolve_permissions_via_direct_scope_walk(
         self,
@@ -1007,8 +1007,8 @@ class PermissionDBSource:
         Returns a mapping keyed by the original ``PermissionResolutionKey``
         objects. Keys that received no grant map to ``Permission.NONE``.
 
-        When ``permission_filter`` is set, only that bit is considered;
-        otherwise every granted bit is returned.
+        When ``permission_filter`` is set, only the bits of that mask are
+        considered; otherwise every granted bit is returned.
         """
         if not keys:
             return {}
@@ -1088,7 +1088,7 @@ class PermissionDBSource:
             perm.c.entity_type == group_key.subject_entity_type.to_entity_type(),
         ]
         if permission_filter is not None:
-            filters.append(perm.c.permission == permission_filter)
+            filters.append(perm.c.permission.op("&")(permission_filter) != 0)
 
         return (
             sa.select(
@@ -1137,7 +1137,7 @@ class PermissionDBSource:
             perm.c.entity_type == group_key.subject_entity_type.to_entity_type(),
         ]
         if permission_filter is not None:
-            filters.append(perm.c.permission == permission_filter)
+            filters.append(perm.c.permission.op("&")(permission_filter) != 0)
 
         return (
             sa.select(

--- a/src/ai/backend/manager/repositories/permission_controller/repository.py
+++ b/src/ai/backend/manager/repositories/permission_controller/repository.py
@@ -174,7 +174,7 @@ class PermissionControllerRepository:
                 scope_type=spec.scope_type,
                 scope_id=spec.scope_id,
                 entity_type=spec.entity_type,
-                operation=spec.operation,
+                permission=spec.permission,
                 message=str(error.exception),
             )
             for error in result.errors
@@ -215,7 +215,7 @@ class PermissionControllerRepository:
                 scope_type=spec.scope_type,
                 scope_id=spec.scope_id,
                 entity_type=spec.entity_type,
-                operation=spec.operation,
+                permission=spec.permission,
                 message=str(error.exception),
             )
             for error in result.errors
@@ -288,7 +288,7 @@ class PermissionControllerRepository:
     @permission_controller_repository_resilience.apply()
     async def check_permission_in_scope(self, data: ScopePermissionCheckInput) -> bool:
         return await self._db_source.check_scope_permission_exist(
-            data.user_id, data.target_scope_id, data.operation
+            data.user_id, data.target_scope_id, data.permission
         )
 
     @permission_controller_repository_resilience.apply()
@@ -485,4 +485,8 @@ class PermissionControllerRepository:
         chain (AUTO edges) and self-scope permissions to collect all operations
         the user can perform.
         """
-        return await self._db_source.resolve_effective_permissions(keys)
+        granted = await self._db_source.resolve_effective_permissions(keys)
+        return {
+            key: frozenset(bit.to_operation() for bit in Permission if bit and bits & bit)
+            for key, bits in granted.items()
+        }

--- a/src/ai/backend/manager/repositories/permission_controller/role_manager.py
+++ b/src/ai/backend/manager/repositories/permission_controller/role_manager.py
@@ -141,12 +141,13 @@ class RoleManager:
         permission_rows: list[PermissionRow] = []
         for element_type, operations in data.entity_operations().items():
             for operation in operations:
+                if Permission.from_operation(operation) == Permission.NONE:
+                    continue
                 creator = PermissionCreator(
                     role_id=role_id,
                     scope_type=ScopeType(EntityType(data.scope_id().scope_type)),
                     scope_id=data.scope_id().scope_id,
                     entity_type=EntityType(element_type),
-                    operation=operation,
                     permission=Permission.from_operation(operation),
                 )
                 permission_rows.append(PermissionRow.from_input(creator))
@@ -240,11 +241,11 @@ class RoleManager:
                     scope_type=ScopeType(EntityType(scope_id.scope_type)),
                     scope_id=scope_id.scope_id,
                     entity_type=EntityType(preset_permission.entity_type),
-                    operation=preset_permission.operation,
                     permission=Permission.from_operation(preset_permission.operation),
                 )
             )
             for preset_permission in permission_presets
+            if Permission.from_operation(preset_permission.operation) != Permission.NONE
         ]
         db_session.add_all(permission_rows)
         await db_session.flush()

--- a/src/ai/backend/manager/repositories/permission_controller/updaters.py
+++ b/src/ai/backend/manager/repositories/permission_controller/updaters.py
@@ -4,9 +4,10 @@ from dataclasses import dataclass, field
 from typing import Any, override
 
 from ai.backend.common.data.entity.types import EntityType, ScopeType
+from ai.backend.manager.data.permission.bit import single_bit
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
-    OperationType,
+    Permission,
     RoleSource,
 )
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -48,7 +49,7 @@ class PermissionUpdaterSpec(UpdaterSpec[PermissionRow]):
     scope_type: OptionalState[ScopeType] = field(default_factory=OptionalState.nop)
     scope_id: OptionalState[str] = field(default_factory=OptionalState.nop)
     entity_type: OptionalState[EntityType] = field(default_factory=OptionalState.nop)
-    operation: OptionalState[OperationType] = field(default_factory=OptionalState.nop)
+    permission: OptionalState[Permission] = field(default_factory=OptionalState.nop)
 
     @property
     @override
@@ -61,5 +62,6 @@ class PermissionUpdaterSpec(UpdaterSpec[PermissionRow]):
         self.scope_type.update_dict(to_update, "scope_type")
         self.scope_id.update_dict(to_update, "scope_id")
         self.entity_type.update_dict(to_update, "entity_type")
-        self.operation.update_dict(to_update, "operation")
+        if (permission := self.permission.optional_value()) is not None:
+            to_update["permission"] = single_bit(permission)
         return to_update

--- a/tests/component/idle_checker_assignment/conftest.py
+++ b/tests/component/idle_checker_assignment/conftest.py
@@ -325,7 +325,6 @@ async def project_read_permission(
                 scope_type=ScopeType.PROJECT,
                 scope_id=str(assignment_seed.project_id),
                 entity_type=EntityType.PROJECT,
-                operation=OperationType.READ,
                 permission=Permission.from_operation(OperationType.READ),
             )
         )
@@ -371,7 +370,6 @@ async def project_assignment_manage_permission(
                     scope_type=ScopeType.PROJECT,
                     scope_id=str(assignment_seed.project_id),
                     entity_type=EntityType.IDLE_CHECKER_ASSIGNMENT,
-                    operation=operation,
                     permission=Permission.from_operation(operation),
                 )
             )
@@ -415,7 +413,6 @@ async def user_self_scope_permission(
                     scope_type=ScopeType.USER,
                     scope_id=str(regular_user_fixture.user_uuid),
                     entity_type=EntityType.USER,
-                    operation=operation,
                     permission=Permission.from_operation(operation),
                 )
             )

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -20,7 +20,7 @@ from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
 from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
 from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
 from ai.backend.common.data.entity.vfolder import VFolderUUID
-from ai.backend.common.data.permission.types import EntityType, OperationType, Permission, ScopeType
+from ai.backend.common.data.permission.types import EntityType, Permission, ScopeType
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
@@ -431,7 +431,6 @@ async def _grant_model_card_read_permission(
                 scope_type=ScopeType.PROJECT,
                 scope_id=str(model_store_project_fixture),
                 entity_type=EntityType.MODEL_CARD,
-                operation=OperationType.READ,
                 permission=Permission.READ,
             )
         )

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -53,7 +53,6 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
-    OperationType,
     Permission,
     ScopeType,
 )
@@ -285,7 +284,6 @@ async def rbac_permission_fixture(
                 scope_type=ScopeType.PROJECT,
                 scope_id=str(group_fixture),
                 entity_type=EntityType.PROJECT,
-                operation=OperationType.UPDATE,
                 permission=Permission.UPDATE,
             )
         )
@@ -339,7 +337,6 @@ async def admin_target_project_permission(
                 scope_type=ScopeType.PROJECT,
                 scope_id=str(target_project_fixture),
                 entity_type=EntityType.PROJECT,
-                operation=OperationType.UPDATE,
                 permission=Permission.UPDATE,
             )
         )
@@ -503,7 +500,6 @@ async def member_role_fixture(
                 scope_type=ScopeType.PROJECT,
                 scope_id=str(target_project_fixture),
                 entity_type=EntityType.USER,
-                operation=OperationType.READ,
                 permission=Permission.READ,
             )
         )

--- a/tests/component/project/test_project_purge.py
+++ b/tests/component/project/test_project_purge.py
@@ -19,7 +19,6 @@ from ai.backend.common.dto.manager.v2.group.request import PurgeProjectInput
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
-    OperationType,
     Permission,
     ScopeType,
 )
@@ -133,7 +132,6 @@ async def project_with_rbac_rows(
                     "scope_type": ScopeType.PROJECT,
                     "scope_id": scope_id,
                     "entity_type": EntityType.PROJECT,
-                    "operation": OperationType.UPDATE,
                     "permission": Permission.UPDATE,
                 },
                 {
@@ -141,7 +139,6 @@ async def project_with_rbac_rows(
                     "scope_type": ScopeType.PROJECT,
                     "scope_id": scope_id,
                     "entity_type": EntityType.PROJECT,
-                    "operation": OperationType.READ,
                     "permission": Permission.READ,
                 },
             ])

--- a/tests/component/rbac/test_rbac_permission.py
+++ b/tests/component/rbac/test_rbac_permission.py
@@ -8,6 +8,7 @@ import pytest
 from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.permission.types import (
     OperationType,
+    Permission,
     RBACElementType,
 )
 from ai.backend.common.data.permission.types import (
@@ -73,7 +74,7 @@ class TestPermissionCreate:
                 scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                 scope_id=domain_fixture.domain_name,
                 entity_type=EntityType(RBACElementType.SESSION),
-                operation=OperationType.READ,
+                permission=Permission.READ,
             )
         )
         result = await permission_controller_processors.create_permission.wait_for_complete(
@@ -84,7 +85,7 @@ class TestPermissionCreate:
         assert result.data.role_id == target_role.role.id
         assert result.data.scope_type == LegacyScopeType.DOMAIN.value
         assert result.data.entity_type == LegacyEntityType.SESSION.value
-        assert result.data.operation == OperationType.READ
+        assert result.data.permission == Permission.READ
 
         # Cleanup
         await permission_controller_processors.delete_permission.wait_for_complete(
@@ -131,13 +132,13 @@ class TestPermissionCreate:
                             scope_type=ScopeType(EntityType(scope_type)),
                             scope_id=scope_id,
                             entity_type=EntityType(entity_type),
-                            operation=operation,
+                            permission=Permission.from_operation(operation),
                         )
                     )
                 )
             )
             assert result.data.entity_type == entity_type.value
-            assert result.data.operation == operation
+            assert result.data.permission == Permission.from_operation(operation)
             assert result.data.role_id == target_role.role.id
             created_ids.append(result.data.id)
 
@@ -161,7 +162,7 @@ class TestPermissionCreate:
             scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
             scope_id=domain_fixture.domain_name,
             entity_type=EntityType(RBACElementType.VFOLDER),
-            operation=OperationType.READ,
+            permission=Permission.READ,
         )
 
         result = await permission_controller_processors.create_permission.wait_for_complete(
@@ -200,7 +201,7 @@ class TestPermissionDelete:
                         scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                         scope_id=domain_fixture.domain_name,
                         entity_type=EntityType(RBACElementType.SESSION),
-                        operation=OperationType.HARD_DELETE,
+                        permission=Permission.HARD_DELETE,
                     )
                 )
             )
@@ -229,7 +230,7 @@ class TestPermissionDelete:
                         scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                         scope_id=domain_fixture.domain_name,
                         entity_type=EntityType(RBACElementType.IMAGE),
-                        operation=OperationType.SOFT_DELETE,
+                        permission=Permission.SOFT_DELETE,
                     )
                 )
             )
@@ -305,7 +306,7 @@ class TestCheckPermissionInScope:
                         scope_type=ScopeType(EntityType(RBACElementType.DOMAIN)),
                         scope_id=domain_fixture.domain_name,
                         entity_type=EntityType(RBACElementType.SESSION),
-                        operation=OperationType.READ,
+                        permission=Permission.READ,
                     )
                 )
             )
@@ -323,7 +324,7 @@ class TestCheckPermissionInScope:
                     target_scope_id=ScopeId(
                         scope_type=LegacyScopeType.DOMAIN, scope_id=domain_fixture.domain_name
                     ),
-                    operation=OperationType.READ,
+                    permission=Permission.READ,
                 )
             )
             assert has_perm is True
@@ -350,7 +351,7 @@ class TestCheckPermissionInScope:
                 target_scope_id=ScopeId(
                     scope_type=LegacyScopeType.DOMAIN, scope_id=domain_fixture.domain_name
                 ),
-                operation=OperationType.READ,
+                permission=Permission.READ,
             )
         )
         assert has_perm is False

--- a/tests/component/user/test_user.py
+++ b/tests/component/user/test_user.py
@@ -42,7 +42,6 @@ from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
-    OperationType,
     Permission,
     ScopeType,
 )
@@ -450,7 +449,6 @@ async def user_with_rbac_rows(
                 scope_type=ScopeType.USER,
                 scope_id=scope_id,
                 entity_type=EntityType.USER,
-                operation=OperationType.READ,
                 permission=Permission.READ,
             )
         )

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -40,7 +40,6 @@ from ai.backend.manager.api.rest.v2.vfolder.registry import register_v2_vfolder_
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
     EntityType,
-    OperationType,
     Permission,
     ScopeType,
 )
@@ -235,7 +234,6 @@ async def regular_user_vfolder_create_permission(
                 scope_type=ScopeType.PROJECT,
                 scope_id=str(group_fixture),
                 entity_type=EntityType.VFOLDER,
-                operation=OperationType.CREATE,
                 permission=Permission.CREATE,
             )
         )

--- a/tests/unit/manager/actions/validators/test_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_rbac_validators.py
@@ -266,7 +266,6 @@ async def _grant_permission(
                 scope_type=scope_type,
                 scope_id=scope_id,
                 entity_type=entity_type,
-                operation=operation,
                 permission=Permission.from_operation(operation),
             )
         )

--- a/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
@@ -297,6 +297,28 @@ async def _seed_user_with_role(
         await db_sess.flush()
 
 
+def _single_bit_rows(
+    *,
+    role_id: uuid.UUID,
+    scope_type: object,
+    scope_id: str,
+    entity_type: object,
+    permission: Permission,
+) -> list[PermissionRow]:
+    """One permissions row per bit of ``permission`` — the row is keyed by its bit."""
+    return [
+        PermissionRow(
+            role_id=role_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            entity_type=entity_type,
+            permission=bit,
+        )
+        for bit in Permission
+        if bit and permission & bit
+    ]
+
+
 async def _grant_permission(
     db: ExtendedAsyncSAEngine,
     *,
@@ -317,13 +339,12 @@ async def _grant_permission(
         domain_name = f"test-domain-{uuid.uuid4().hex[:8]}"
         domain_id = DomainID(uuid.uuid4())
         db_sess.add(DomainRow(id=domain_id, name=domain_name, total_resource_slots=ResourceSlot()))
-        db_sess.add(
-            PermissionRow(
+        db_sess.add_all(
+            _single_bit_rows(
                 role_id=role_id,
                 scope_type=scope_type,
                 scope_id=str(scope_id),
                 entity_type=entity_type,
-                operation=operation,
                 permission=permission
                 if permission is not None
                 else Permission.from_operation(operation),

--- a/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
+++ b/tests/unit/manager/repositories/base/rbac/test_entity_purger.py
@@ -379,7 +379,6 @@ class TestRBACEntityPurgerWithPermissions:
                     scope_type=ScopeType.VFOLDER,
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
-                    operation=op,
                     permission=Permission.from_operation(op),
                 )
                 db_sess.add(perm)
@@ -437,7 +436,6 @@ class TestRBACEntityPurgerWithPermissions:
                     scope_type=ScopeType.VFOLDER,
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
                 db_sess.add(perm)
@@ -771,7 +769,6 @@ class TestRBACEntityBatchPurger:
                     scope_type=ScopeType.VFOLDER,
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
                 db_sess.add(perm)
@@ -1081,7 +1078,6 @@ class TestRBACEntityPurgerTransactionRollback:
                     scope_type=ScopeType.VFOLDER,
                     scope_id=str(entity_uuid),
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
             )

--- a/tests/unit/manager/repositories/base/rbac/test_granter.py
+++ b/tests/unit/manager/repositories/base/rbac/test_granter.py
@@ -11,7 +11,12 @@ from uuid import UUID
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.data.permission.types import OperationType, RBACElementType, RelationType
+from ai.backend.common.data.permission.types import (
+    OperationType,
+    Permission,
+    RBACElementType,
+    RelationType,
+)
 from ai.backend.manager.data.permission.id import ObjectId, ScopeId
 from ai.backend.manager.data.permission.types import (
     EntityType,
@@ -36,6 +41,14 @@ if TYPE_CHECKING:
 # =============================================================================
 # Tables List
 # =============================================================================
+
+
+def _mask(operations: list[OperationType]) -> Permission:
+    mask = Permission.NONE
+    for operation in operations:
+        mask |= Permission.from_operation(operation)
+    return mask
+
 
 GRANTER_TABLES = [
     RoleRow,
@@ -152,7 +165,7 @@ class TestGranterBasic:
                 granted_entity_scope_type=ctx.entity_scope_type,
                 target_scope_id=ctx.target_scope_id,
                 target_role_ids=[ctx.role_id],
-                operations=[OperationType.READ, OperationType.UPDATE],
+                permission=Permission.READ | Permission.UPDATE,
             )
             await execute_rbac_granter(db_sess, granter)
 
@@ -170,7 +183,7 @@ class TestGranterBasic:
 
             # Verify permission details
             perms = (await db_sess.scalars(sa.select(PermissionRow))).all()
-            operations = {perm.operation for perm in perms}
+            operations = {perm.permission.to_operation() for perm in perms}
             assert operations == {OperationType.READ, OperationType.UPDATE}
             for perm in perms:
                 assert perm.role_id == ctx.role_id
@@ -192,7 +205,7 @@ class TestGranterBasic:
                 granted_entity_scope_type=ctx.entity_scope_type,
                 target_scope_id=ctx.target_scope_id,
                 target_role_ids=[],
-                operations=[OperationType.READ],
+                permission=Permission.READ,
             )
             await execute_rbac_granter(db_sess, granter)
 
@@ -252,7 +265,7 @@ class TestGranterMultipleRoles:
                 granted_entity_scope_type=ctx.entity_scope_type,
                 target_scope_id=ctx.target_scope_id,
                 target_role_ids=ctx.role_ids,
-                operations=[OperationType.READ],
+                permission=Permission.READ,
             )
             await execute_rbac_granter(db_sess, granter)
 
@@ -322,14 +335,14 @@ class TestGranterMultipleOperations:
                 granted_entity_scope_type=ctx.entity_scope_type,
                 target_scope_id=ctx.target_scope_id,
                 target_role_ids=[ctx.role_id],
-                operations=all_operations,
+                permission=_mask(all_operations),
             )
             await execute_rbac_granter(db_sess, granter)
 
             # Verify all operations were granted
             perms = (await db_sess.scalars(sa.select(PermissionRow))).all()
             assert len(perms) == len(all_operations)
-            granted_ops = {perm.operation for perm in perms}
+            granted_ops = {perm.permission.to_operation() for perm in perms}
             assert granted_ops == set(all_operations)
 
     async def test_granter_with_empty_operations(
@@ -346,7 +359,7 @@ class TestGranterMultipleOperations:
                 granted_entity_scope_type=ctx.entity_scope_type,
                 target_scope_id=ctx.target_scope_id,
                 target_role_ids=[ctx.role_id],
-                operations=[],
+                permission=Permission.NONE,
             )
             await execute_rbac_granter(db_sess, granter)
 
@@ -412,7 +425,7 @@ class TestGranterIdempotency:
                 granted_entity_scope_type=ctx.entity_scope_type,
                 target_scope_id=ctx.target_scope_id,
                 target_role_ids=[ctx.role_id],
-                operations=[OperationType.READ, OperationType.UPDATE],
+                permission=Permission.READ | Permission.UPDATE,
             )
 
         async with database_connection.begin_session_read_committed() as db_sess:
@@ -447,7 +460,7 @@ class TestGranterIdempotency:
                     granted_entity_scope_type=ctx.entity_scope_type,
                     target_scope_id=ctx.target_scope_id,
                     target_role_ids=[ctx.role_id],
-                    operations=[OperationType.READ],
+                    permission=Permission.READ,
                 ),
             )
 
@@ -459,14 +472,14 @@ class TestGranterIdempotency:
                     granted_entity_scope_type=ctx.entity_scope_type,
                     target_scope_id=ctx.target_scope_id,
                     target_role_ids=[ctx.role_id],
-                    operations=[OperationType.READ, OperationType.UPDATE],
+                    permission=Permission.READ | Permission.UPDATE,
                 ),
             )
 
         async with database_connection.begin_session_read_committed() as db_sess:
             perms = (await db_sess.scalars(sa.select(PermissionRow))).all()
             assert len(perms) == 2
-            assert {perm.operation for perm in perms} == {
+            assert {perm.permission.to_operation() for perm in perms} == {
                 OperationType.READ,
                 OperationType.UPDATE,
             }

--- a/tests/unit/manager/repositories/base/rbac/test_revoker.py
+++ b/tests/unit/manager/repositories/base/rbac/test_revoker.py
@@ -116,7 +116,6 @@ class TestRevokerBasic:
                     scope_type=entity_scope_type.to_scope_type(),
                     scope_id=entity_id.entity_id,
                     entity_type=entity_id.entity_type,
-                    operation=op,
                     permission=Permission.from_operation(op),
                 )
                 db_sess.add(perm)
@@ -148,7 +147,7 @@ class TestRevokerBasic:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[ctx.role_id],
-                operations=None,  # Revoke all operations
+                permission=None,  # Revoke all operations
             )
             await execute_rbac_revoker(db_sess, revoker)
 
@@ -172,7 +171,7 @@ class TestRevokerBasic:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[],
-                operations=None,
+                permission=None,
             )
             await execute_rbac_revoker(db_sess, revoker)
 
@@ -194,14 +193,14 @@ class TestRevokerBasic:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[ctx.role_id],
-                operations=[OperationType.READ],
+                permission=Permission.READ,
             )
             await execute_rbac_revoker(db_sess, revoker)
 
             # Verify UPDATE still exists
             remaining_perms = (await db_sess.scalars(sa.select(PermissionRow))).all()
             assert len(remaining_perms) == 1
-            assert remaining_perms[0].operation == OperationType.UPDATE
+            assert remaining_perms[0].permission == Permission.UPDATE
 
     async def test_revoker_with_none_operations_removes_all(
         self,
@@ -217,7 +216,7 @@ class TestRevokerBasic:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[ctx.role_id],
-                operations=None,
+                permission=None,
             )
             await execute_rbac_revoker(db_sess, revoker)
 
@@ -265,7 +264,6 @@ class TestRevokerMultipleRoles:
                     scope_type=entity_scope_type.to_scope_type(),
                     scope_id=entity_id.entity_id,
                     entity_type=entity_id.entity_type,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
                 db_sess.add(perm)
@@ -295,7 +293,7 @@ class TestRevokerMultipleRoles:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[ctx.role_id1, ctx.role_id2],
-                operations=None,
+                permission=None,
             )
             await execute_rbac_revoker(db_sess, revoker)
 
@@ -317,7 +315,7 @@ class TestRevokerMultipleRoles:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[ctx.role_id1],
-                operations=None,
+                permission=None,
             )
             await execute_rbac_revoker(db_sess, revoker)
 
@@ -356,7 +354,6 @@ class TestRevokerIdempotent:
                 scope_type=entity_scope_type.to_scope_type(),
                 scope_id=entity_id.entity_id,
                 entity_type=entity_id.entity_type,
-                operation=OperationType.READ,
                 permission=Permission.READ,
             )
             db_sess.add(perm)
@@ -383,7 +380,7 @@ class TestRevokerIdempotent:
                 entity_id=ctx.entity_id,
                 entity_scope_type=ctx.entity_scope_type,
                 target_role_ids=[ctx.role_id],
-                operations=None,
+                permission=None,
             )
 
             # First revoke

--- a/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
+++ b/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
@@ -487,9 +487,9 @@ async def _scope_roles(database: ExtendedAsyncSAEngine, scope_id: UUID) -> dict[
 async def _role_permissions(database: ExtendedAsyncSAEngine, role_id: UUID) -> set[OperationType]:
     async with database.begin_readonly_session() as sess:
         rows = await sess.scalars(
-            sa.select(PermissionRow.operation).where(PermissionRow.role_id == role_id)
+            sa.select(PermissionRow.permission).where(PermissionRow.role_id == role_id)
         )
-        return set(rows.all())
+        return {permission.to_operation() for permission in rows.all()}
 
 
 async def _row_count(database: ExtendedAsyncSAEngine) -> int:

--- a/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_bulk_permission_with_scope_chain.py
@@ -427,7 +427,6 @@ class TestCheckBulkPermissionWithScopeChain:
                         scope_type=scope_type,
                         scope_id=scope_id,
                         entity_type=entry.entity_type,
-                        operation=entry.operation,
                         permission=Permission.from_operation(entry.operation),
                     )
                 )
@@ -475,7 +474,6 @@ class TestCheckBulkPermissionWithScopeChain:
                     scope_type=ScopeType.PROJECT,
                     scope_id=fixture_ids.project_id,
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
             )
@@ -497,7 +495,7 @@ class TestCheckBulkPermissionWithScopeChain:
             )
             for vfolder_id in fixture.vfolder_ids
         ]
-        return BulkPermissionCheckInput(keys=keys, operation=operation)
+        return BulkPermissionCheckInput(keys=keys, permission=Permission.from_operation(operation))
 
     @staticmethod
     def _bool_by_entity_id(
@@ -513,7 +511,7 @@ class TestCheckBulkPermissionWithScopeChain:
     ) -> None:
         """Empty key sequence returns empty mapping."""
         result = await db_source.check_bulk_permission_with_scope_chain(
-            BulkPermissionCheckInput(keys=[], operation=OperationType.READ)
+            BulkPermissionCheckInput(keys=[], permission=Permission.READ)
         )
         assert result == {}
 

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_entity.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_via_virtual_entity.py
@@ -111,6 +111,28 @@ class VSChainSpec:
     role_status: RoleStatus = RoleStatus.ACTIVE
 
 
+def _single_bit_rows(
+    *,
+    role_id: uuid.UUID,
+    scope_type: object,
+    scope_id: str,
+    entity_type: object,
+    permission: Permission,
+) -> list[PermissionRow]:
+    """One permissions row per bit of ``permission`` — the row is keyed by its bit."""
+    return [
+        PermissionRow(
+            role_id=role_id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+            entity_type=entity_type,
+            permission=bit,
+        )
+        for bit in Permission
+        if bit and permission & bit
+    ]
+
+
 class TestCheckPermissionViaVirtualEntity:
     @pytest.fixture
     async def db_with_rbac_tables(
@@ -250,13 +272,12 @@ class TestCheckPermissionViaVirtualEntity:
                         permission_cap=spec.entity_cap,
                     )
                 )
-            db_sess.add(
-                PermissionRow(
+            db_sess.add_all(
+                _single_bit_rows(
                     role_id=ids.role_id,
                     scope_type=PermScopeType.PROJECT,
                     scope_id=str(ids.bound_scope_id),
                     entity_type=PermEntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=spec.granted,
                 )
             )
@@ -524,7 +545,6 @@ class TestCheckPermissionViaVirtualEntity:
                     scope_type=ScopeType(EntityType("project")),
                     scope_id=str(ids.bound_scope_id),
                     entity_type=_UNMAPPED_ENTITY_TYPE,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
             )
@@ -559,16 +579,15 @@ class TestCheckPermissionViaVirtualEntity:
             await db_sess.execute(
                 sa.text(
                     "INSERT INTO permissions"
-                    " (role_id, scope_type, scope_id, entity_type, operation, permission)"
+                    " (role_id, scope_type, scope_id, entity_type, permission)"
                     " VALUES"
-                    " (:role_id, :scope_type, :scope_id, :entity_type, :operation, :permission)"
+                    " (:role_id, :scope_type, :scope_id, :entity_type, :permission)"
                 ),
                 {
                     "role_id": fixture_ids.role_id,
                     "scope_type": str(ScopeType(EntityType("project"))),
                     "scope_id": str(fixture_ids.bound_scope_id),
                     "entity_type": str(_UNMAPPED_ENTITY_TYPE),
-                    "operation": OperationType.READ.value,
                     "permission": int(Permission.READ),
                 },
             )
@@ -671,13 +690,12 @@ class TestUserRosterEnrollment:
             db_sess.add(RoleRow(id=ids.role_id, name="project-role", status=RoleStatus.ACTIVE))
             await db_sess.flush()
             db_sess.add(UserRoleRow(user_id=ids.user_id, role_id=ids.role_id))
-            db_sess.add(
-                PermissionRow(
+            db_sess.add_all(
+                _single_bit_rows(
                     role_id=ids.role_id,
                     scope_type=PermScopeType.PROJECT,
                     scope_id=str(project_id),
                     entity_type=entity_type,
-                    operation=operation,
                     permission=permission,
                 )
             )

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
@@ -272,7 +272,6 @@ class TestCheckPermissionWithScopeChain:
                     scope_type=scope_type,
                     scope_id=scope_id,
                     entity_type=entry.entity_type,
-                    operation=entry.operation,
                     permission=Permission.from_operation(entry.operation),
                 )
                 db_sess.add(perm)
@@ -293,7 +292,7 @@ class TestCheckPermissionWithScopeChain:
                 entity_id=fixture.vfolder_id,
                 subject_entity_type=subject_entity_type,
             ),
-            operation=operation,
+            permission=Permission.from_operation(operation),
         )
 
     @pytest.mark.parametrize(
@@ -712,7 +711,6 @@ class TestCheckPermissionWithScopeChain:
                 scope_type=ScopeType.PROJECT,
                 scope_id=fixture_ids.project_id,
                 entity_type=EntityType.VFOLDER,
-                operation=OperationType.READ,
                 permission=Permission.READ,
             )
             db_sess.add(perm)
@@ -828,7 +826,6 @@ class TestCheckPermissionWithScopeChain:
                     scope_type=scope_type,
                     scope_id=scope_id,
                     entity_type=EntityType.VFOLDER,
-                    operation=operation,
                     permission=Permission.from_operation(operation),
                 )
                 db_sess.add(perm)
@@ -1098,7 +1095,6 @@ class TestCheckPermissionWithScopeChain:
                 scope_type=ScopeType.PROJECT,
                 scope_id=fixture_ids.project_id,
                 entity_type=EntityType.VFOLDER,
-                operation=OperationType.READ,
                 permission=Permission.READ,
             )
             db_sess.add(perm)

--- a/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
+++ b/tests/unit/manager/repositories/permission_controller/test_check_permission_with_scope_chain.py
@@ -325,6 +325,48 @@ class TestCheckPermissionWithScopeChain:
         assert result is expected
 
     @pytest.mark.parametrize(
+        ("permission_setup", "expected"),
+        [
+            pytest.param(
+                [PermissionEntry("project", OperationType.CREATE)],
+                False,
+                id="create-only-does-not-cover-upsert",
+            ),
+            pytest.param(
+                [
+                    PermissionEntry("project", OperationType.CREATE),
+                    PermissionEntry("project", OperationType.UPDATE),
+                ],
+                True,
+                id="create-and-update-cover-upsert",
+            ),
+        ],
+        indirect=["permission_setup"],
+    )
+    async def test_mask_requires_every_bit(
+        self,
+        db_source: PermissionDBSource,
+        user_with_active_role: ScopeChainFixture,
+        vfolder_in_project_auto: None,
+        permission_setup: None,
+        expected: bool,
+    ) -> None:
+        """A multi-bit requirement (UPSERT = CREATE|UPDATE) holds only with every bit."""
+        fixture = user_with_active_role
+        result = await db_source.check_permission_with_scope_chain(
+            ScopeChainPermissionCheckInput(
+                key=PermissionResolutionKey(
+                    user_id=fixture.user_id,
+                    element_type=RBACElementType.VFOLDER,
+                    entity_id=fixture.vfolder_id,
+                    subject_entity_type=RBACElementType.VFOLDER,
+                ),
+                permission=Permission.CREATE | Permission.UPDATE,
+            )
+        )
+        assert result is expected
+
+    @pytest.mark.parametrize(
         ("permission_setup", "check_op", "expected"),
         [
             pytest.param(

--- a/tests/unit/manager/repositories/permission_controller/test_create_preset_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_create_preset_roles.py
@@ -205,7 +205,9 @@ class TestCreatePresetRoles:
             for row in permission_rows:
                 assert row.scope_type == ScopeType.DOMAIN.value
                 assert row.scope_id == domain_id
-            assert {(row.entity_type, row.operation) for row in permission_rows} == {
+            assert {
+                (row.entity_type, row.permission.to_operation()) for row in permission_rows
+            } == {
                 (entity_type.value, operation)
                 for entity_type, operation in domain_preset.permissions
             }

--- a/tests/unit/manager/repositories/permission_controller/test_permission_conditions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_permission_conditions.py
@@ -5,7 +5,11 @@ Tests verify that condition factories produce correct SQLAlchemy expressions.
 
 from __future__ import annotations
 
-from ai.backend.manager.data.permission.types import EntityType, OperationType, ScopeType
+from ai.backend.manager.data.permission.types import (
+    EntityType,
+    Permission,
+    ScopeType,
+)
 from ai.backend.manager.models.rbac_models.conditions import (
     AssignedUserConditions,
     PermissionConditions,
@@ -43,15 +47,15 @@ class TestPermissionConditions:
         assert "permissions.entity_type IN" in compiled
         assert "session" in compiled.lower()
 
-    def test_by_operations_produces_in_clause(self) -> None:
-        """by_operations should generate operation IN (...) clause."""
-        condition = PermissionConditions.by_operations([OperationType.READ, OperationType.CREATE])
+    def test_by_permissions_produces_in_clause(self) -> None:
+        """by_permissions should generate permission IN (...) clause."""
+        condition = PermissionConditions.by_permissions([Permission.READ, Permission.CREATE])
         clause = condition()
 
         compiled = str(clause.compile(compile_kwargs={"literal_binds": True}))
-        assert "permissions.operation IN" in compiled
-        assert "read" in compiled.lower()
-        assert "create" in compiled.lower()
+        assert "permissions.permission IN" in compiled
+        assert str(int(Permission.READ)) in compiled
+        assert str(int(Permission.CREATE)) in compiled
 
 
 class TestExistsPermissionCombined:
@@ -87,7 +91,7 @@ class TestExistsPermissionCombined:
         """exists_permission_combined should combine multiple operation filters."""
         permission_conditions = [
             PermissionConditions.by_scope_types([ScopeType.DOMAIN, ScopeType.PROJECT]),
-            PermissionConditions.by_operations([OperationType.READ, OperationType.UPDATE]),
+            PermissionConditions.by_permissions([Permission.READ, Permission.UPDATE]),
         ]
 
         condition = AssignedUserConditions.exists_permission_combined(permission_conditions)
@@ -97,11 +101,11 @@ class TestExistsPermissionCombined:
 
         # Verify both scope_types and operations are in the WHERE clause
         assert "permissions.scope_type IN" in compiled
-        assert "permissions.operation IN" in compiled
+        assert "permissions.permission IN" in compiled
         assert "domain" in compiled.lower()
         assert "project" in compiled.lower()
-        assert "read" in compiled.lower()
-        assert "update" in compiled.lower()
+        assert str(int(Permission.READ)) in compiled
+        assert str(int(Permission.UPDATE)) in compiled
 
     def test_exists_permission_combined_empty_conditions(self) -> None:
         """exists_permission_combined with empty list should produce basic EXISTS with join only."""

--- a/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_resolve_effective_permissions.py
@@ -479,7 +479,6 @@ class TestResolveEffectivePermissions:
                         scope_type=scope_type,
                         scope_id=scope_id,
                         entity_type=entry.entity_type,
-                        operation=entry.operation,
                         permission=Permission.from_operation(entry.operation),
                     )
                 )
@@ -504,9 +503,12 @@ class TestResolveEffectivePermissions:
 
     @staticmethod
     def _ops_by_entity_id(
-        result: Mapping[PermissionResolutionKey, frozenset[OperationType]],
+        result: Mapping[PermissionResolutionKey, Permission],
     ) -> dict[str, frozenset[OperationType]]:
-        return {key.entity_id: ops for key, ops in result.items()}
+        return {
+            key.entity_id: frozenset(bit.to_operation() for bit in Permission if bit and bits & bit)
+            for key, bits in result.items()
+        }
 
     # ── Tests: empty / no permission ──
 
@@ -831,7 +833,6 @@ class TestResolveEffectivePermissions:
                     scope_type=ScopeType.PROJECT,
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
             )
@@ -867,7 +868,6 @@ class TestResolveEffectivePermissions:
                     scope_type=ScopeType.PROJECT,
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.READ,
                     permission=Permission.READ,
                 )
             )
@@ -878,7 +878,6 @@ class TestResolveEffectivePermissions:
                     scope_type=ScopeType.PROJECT,
                     scope_id=fixture.project_id,
                     entity_type=EntityType.VFOLDER,
-                    operation=OperationType.UPDATE,
                     permission=Permission.UPDATE,
                 )
             )

--- a/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permissions_bulk.py
@@ -79,7 +79,7 @@ def _spec(
         scope_type=ScopeType(EntityType(scope_type)),
         scope_id=scope_id,
         entity_type=EntityType(entity_type),
-        operation=operation,
+        permission=Permission.from_operation(operation),
     )
 
 
@@ -119,8 +119,7 @@ class TestBulkRolePermissions:
                         scope_type=seed_permission.scope_type,
                         scope_id=seed_permission.scope_id,
                         entity_type=seed_permission.entity_type,
-                        operation=seed_permission.operation,
-                        permission=Permission.from_operation(seed_permission.operation),
+                        permission=seed_permission.permission,
                     )
                 )
             await session.commit()
@@ -140,8 +139,7 @@ class TestBulkRolePermissions:
                     scope_type=spec.scope_type,
                     scope_id=spec.scope_id,
                     entity_type=spec.entity_type,
-                    operation=spec.operation,
-                    permission=Permission.from_operation(spec.operation),
+                    permission=spec.permission,
                 )
             )
             await session.commit()
@@ -169,13 +167,13 @@ class TestBulkRolePermissions:
         role_id: uuid.UUID,
         entity_type: EntityType,
     ) -> set[OperationType]:
-        stmt = sa.select(PermissionRow.operation).where(
+        stmt = sa.select(PermissionRow.permission).where(
             PermissionRow.role_id == role_id,
             PermissionRow.entity_type == entity_type,
         )
         async with db.begin_readonly_session() as session:
             rows = (await session.execute(stmt)).scalars().all()
-        return set(rows)
+        return {permission.to_operation() for permission in rows}
 
     # ---------- bulk_add_role_permissions ----------
 

--- a/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
@@ -124,7 +124,6 @@ class TestSearchPermissions:
                     scope_type=ScopeType.DOMAIN,
                     scope_id="test-domain",
                     entity_type=entity_type,
-                    operation=operation,
                     permission=Permission.from_operation(operation),
                 )
                 db_sess.add(perm)

--- a/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
+++ b/tests/unit/manager/services/permission_controller/test_permission_controller_service.py
@@ -692,7 +692,6 @@ class TestCreatePermission:
             scope_type=ScopeType(EntityType(LegacyScopeType.DOMAIN)),
             scope_id="test-domain",
             entity_type=EntityType(LegacyEntityType.USER),
-            operation=OperationType.READ,
             permission=Permission.READ,
             created_at=datetime.now(UTC),
         )
@@ -716,7 +715,6 @@ class TestCreatePermission:
             scope_type=ScopeType(EntityType(LegacyScopeType.GLOBAL)),
             scope_id="global",
             entity_type=EntityType(LegacyEntityType.USER),
-            operation=OperationType.CREATE,
             permission=Permission.CREATE,
             created_at=datetime.now(UTC),
         )
@@ -756,7 +754,6 @@ class TestDeletePermission:
             scope_type=ScopeType(EntityType(LegacyScopeType.DOMAIN)),
             scope_id="test-domain",
             entity_type=EntityType(LegacyEntityType.USER),
-            operation=OperationType.READ,
             permission=Permission.READ,
             created_at=datetime.now(UTC),
         )
@@ -798,7 +795,6 @@ class TestSearchPermissions:
             scope_type=ScopeType(EntityType(LegacyScopeType.DOMAIN)),
             scope_id="test-domain",
             entity_type=EntityType(LegacyEntityType.USER),
-            operation=OperationType.READ,
             permission=Permission.READ,
             created_at=datetime.now(UTC),
         )


### PR DESCRIPTION
## Summary
- Drop the deprecated `permissions.operation` column: each row is one operation bit, unique on the key plus `permission`, checked to be a single bit. `grant:*` rows carry no bit and are removed by the migration; sharing is judged from entity shares and scope CREATE, so a grant operation is rejected as a permission.
- Internal surfaces speak `Permission` bits: `PermissionCreator`, `PermissionData`, the check inputs, the creator/updater specs, the permission conditions, the granter/revoker and the scope-walk resolver. `OperationType` survives only at the REST/GraphQL boundary, converted in the adapters; preset instantiation skips operations without a bit.
- `fixtures/manager/example-roles.json` drops the `operation` column; tests seed one row per bit.

## Test plan
- [ ] `pants test --changed-since=origin/main --changed-dependents=direct` (permission_controller, base/rbac, ops, actions/validators, component rbac/project/user/vfolder)
- [ ] `alembic upgrade head` on a DB holding `grant:*` rows removes them and rebuilds the unique constraint

Resolves BA-7619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQ66JjXhyNj2NtB3aGGpPa