### PR TITLE
feat(BA-7409): default session, kernel and deployment ids to UUIDv7

### DIFF
--- a/changes/14159.enhance.md
+++ b/changes/14159.enhance.md
@@ -1,0 +1,1 @@
+New session, kernel and deployment rows now get a UUIDv7 id, so inserts land at the end of the primary key index instead of scattering across it.

--- a/src/ai/backend/manager/cli/dbschema.py
+++ b/src/ai/backend/manager/cli/dbschema.py
@@ -11,6 +11,7 @@ import click
 
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.errors.resource import ConfigurationLoadFailed
+from ai.backend.manager.models.uuid7 import UUID_GENERATE_V7_DDL
 
 if TYPE_CHECKING:
     from .context import CLIContext
@@ -249,6 +250,7 @@ def oneshot(_cli_ctx: CLIContext, alembic_config: str) -> None:
         engine = create_async_engine(sa_url)
         async with engine.begin() as connection:
             await connection.exec_driver_sql('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";')
+            await connection.exec_driver_sql(UUID_GENERATE_V7_DDL)
             current_rev = await connection.run_sync(_get_current_rev_sync)
         if current_rev is None:
             # For a fresh clean database, create all from scratch.

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -41,6 +41,26 @@ live in `models/specs/` — read `models/specs/AGENTS.md` before touching them.
   by the spec's type (rationale: `KNOWLEDGE.md`).
 - Do NOT open a db session to manipulate Rows directly — the implementation belongs in a repository.
 
+## Id column defaults
+
+- Give every id column a `server_default`. Do not mint the value in Python.
+- The default generator is `uuid_generate_v7()`. Use it for a new table and whenever
+  you revisit an existing table's default.
+- Use `uuid_generate_v4()` in the cases below. When you cannot tell which applies, use v4.
+
+| Use v4 when | Examples |
+|---|---|
+| The id reaches an untrusted holder | `endpoint_tokens`, `login_sessions`, `entity_invitations`, `vfolder_invitations` |
+| Knowing the id is itself what grants access | an unsigned share link |
+
+- Never read an id as a time. Ordering and creation time belong to the `created_at` columns.
+- Changing a default changes two places: the Row declaration and an
+  `ALTER COLUMN ... SET DEFAULT` in the migration. Editing only the Python declaration
+  leaves a freshly created database and a migrated one with different schemas.
+- A foreign key column naming an owner or a parent gets no default. An INSERT that omits
+  the value must be rejected.
+- The function DDL lives in `models/uuid7.py`. Execute that string rather than copying it.
+
 ## Custom column types
 
 - Where possible, reuse the existing `TypeDecorator` wrappers in `models/base.py`.

--- a/src/ai/backend/manager/models/KNOWLEDGE.md
+++ b/src/ai/backend/manager/models/KNOWLEDGE.md
@@ -1,14 +1,15 @@
 ---
 name: models-schema-declaration
 type: design-rationale
-description: models as the schema-declaration layer (per-domain row packages), why Rows carry no implementation, why models/specs specs are preferred over direct db-object manipulation (RBAC side effects), the rationale for avoiding direct session use and keeping implementation in repositories
+description: models as the schema-declaration layer (per-domain row packages), why Rows carry no implementation, why models/specs specs are preferred over direct db-object manipulation (RBAC side effects), the rationale for avoiding direct session use and keeping implementation in repositories, why id defaults split between UUIDv7 and UUIDv4
 scope: src/ai/backend/manager/models
-keywords: [Row, ORM, specs, RBAC, session, repository, schema, alembic]
+keywords: [Row, ORM, specs, RBAC, session, repository, schema, alembic, uuid_generate_v7, server_default]
 sources:
   - src/ai/backend/manager/models/specs
+  - src/ai/backend/manager/models/uuid7.py
 generated:
-  by: claude-code/fable-5
-  at: 2026-08-10
+  by: claude-code/opus-5
+  at: 2026-09-03
 status: stable
 ---
 
@@ -39,3 +40,19 @@ no implementation".
 - Avoid code that opens a db session and manipulates Rows directly — implementation belongs in the repository.
 - Reason one: transaction boundaries are the repository's responsibility, so scattered direct sessions break atomicity guarantees.
 - Reason two: direct sessions become the channel through which Rows leak into layers above the repository — a bypass of the layering rule that Rows do not rise above `repositories/`.
+
+## Why id defaults split between v7 and v4
+
+- The leading 60 bits of a UUIDv7 are the generation time, so a new row's id lands at the
+  right edge of the primary key index instead of scattering across it the way v4 does.
+  The busier the table is written, the more this is worth.
+- The price is that the id reveals when it was made. That is harmless for an internal
+  identifier, but an id handed to an untrusted holder leaks its issue time on its own.
+  Tokens and invitations therefore stay on v4.
+- v4 and v7 are both the `uuid` type, so a column may hold a mix. Existing rows never need
+  to be rewritten.
+- The function is strictly increasing within a session: it remembers the last value it
+  handed out in a session setting and steps up by the smallest unit when the clock has not
+  advanced. This matches PostgreSQL 18's built-in `uuidv7()`; once 18 is the minimum, the
+  body becomes `RETURN uuidv7();`.
+- Because it mutates session state, it is not marked parallel safe.

--- a/src/ai/backend/manager/models/alembic/versions/8f3b1c7ad204_add_uuid_generate_v7.py
+++ b/src/ai/backend/manager/models/alembic/versions/8f3b1c7ad204_add_uuid_generate_v7.py
@@ -1,0 +1,42 @@
+"""add uuid_generate_v7 and use it for session, kernel and deployment ids
+
+Revision ID: 8f3b1c7ad204
+Revises: 5c1e7a2d9b40
+Create Date: 2026-09-03
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.uuid7 import DROP_UUID_GENERATE_V7_DDL, UUID_GENERATE_V7_DDL
+
+# Part of: NEXT_RELEASE_VERSION
+
+# revision identifiers, used by Alembic.
+revision = "8f3b1c7ad204"
+down_revision = "5c1e7a2d9b40"
+branch_labels = None
+depends_on = None
+
+# Existing rows keep their v4 ids; the two versions share the uuid type.
+_TARGET_TABLES = (
+    "sessions",
+    "kernels",
+    "endpoints",
+    "deployment_revisions",
+    "routings",
+    "replica_groups",
+)
+
+
+def upgrade() -> None:
+    op.execute(sa.text(UUID_GENERATE_V7_DDL))
+    for table in _TARGET_TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} ALTER COLUMN id SET DEFAULT uuid_generate_v7()"))
+
+
+def downgrade() -> None:
+    for table in _TARGET_TABLES:
+        op.execute(sa.text(f"ALTER TABLE {table} ALTER COLUMN id SET DEFAULT uuid_generate_v4()"))
+    op.execute(sa.text(DROP_UUID_GENERATE_V7_DDL))

--- a/src/ai/backend/manager/models/deployment_revision/row.py
+++ b/src/ai/backend/manager/models/deployment_revision/row.py
@@ -89,7 +89,7 @@ class DeploymentRevisionRow(CreatedAtMixin, Base):
         "id",
         GUID(DeploymentRevisionID),
         primary_key=True,
-        server_default=sa.text("uuid_generate_v4()"),
+        server_default=sa.text("uuid_generate_v7()"),
     )
     endpoint: Mapped[DeploymentID] = mapped_column("endpoint", GUID(DeploymentID), nullable=False)
     revision_number: Mapped[int] = mapped_column("revision_number", sa.Integer, nullable=False)

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -169,7 +169,7 @@ class EndpointRow(Base):
     )
 
     id: Mapped[DeploymentID] = mapped_column(
-        "id", GUID(DeploymentID), primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id", GUID(DeploymentID), primary_key=True, server_default=sa.text("uuid_generate_v7()")
     )
     name: Mapped[str] = mapped_column("name", sa.String(length=512), nullable=False)
     created_user: Mapped[UUID] = mapped_column("created_user", GUID, nullable=False)

--- a/src/ai/backend/manager/models/kernel/row.py
+++ b/src/ai/backend/manager/models/kernel/row.py
@@ -144,7 +144,7 @@ class KernelRow(CreatedAtMixin, Base):
     # The Backend.AI-side UUID for each kernel
     # (mapped to a container in the docker backend and a pod in the k8s backend)
     id: Mapped[KernelId] = mapped_column(
-        "id", KernelIDColumnType, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id", KernelIDColumnType, primary_key=True, server_default=sa.text("uuid_generate_v7()")
     )
     # session_id == id when the kernel is the main container in a multi-container session or a
     # single-container session.

--- a/src/ai/backend/manager/models/replica_group/row.py
+++ b/src/ai/backend/manager/models/replica_group/row.py
@@ -45,7 +45,7 @@ class ReplicaGroupRow(LifecycleTimestampsMixin, Base):
         "id",
         GUID(ReplicaGroupID),
         primary_key=True,
-        server_default=sa.text("uuid_generate_v4()"),
+        server_default=sa.text("uuid_generate_v7()"),
     )
     deployment_id: Mapped[DeploymentID] = mapped_column(
         "deployment_id",

--- a/src/ai/backend/manager/models/routing/row.py
+++ b/src/ai/backend/manager/models/routing/row.py
@@ -55,7 +55,7 @@ class RoutingRow(Base):
     )
 
     id: Mapped[ReplicaID] = mapped_column(
-        "id", GUID(ReplicaID), primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id", GUID(ReplicaID), primary_key=True, server_default=sa.text("uuid_generate_v7()")
     )
     endpoint: Mapped[DeploymentID] = mapped_column(
         "endpoint",

--- a/src/ai/backend/manager/models/session/row.py
+++ b/src/ai/backend/manager/models/session/row.py
@@ -361,7 +361,7 @@ def _get_user_row_join_condition() -> sa.sql.elements.ColumnElement[Any]:
 class SessionRow(CreatedAtMixin, Base):
     __tablename__ = "sessions"
     id: Mapped[SessionId] = mapped_column(
-        "id", SessionIDColumnType, primary_key=True, server_default=sa.text("uuid_generate_v4()")
+        "id", SessionIDColumnType, primary_key=True, server_default=sa.text("uuid_generate_v7()")
     )
     creation_id: Mapped[str | None] = mapped_column(
         "creation_id", sa.String(length=32), unique=False, index=False

--- a/src/ai/backend/manager/models/uuid7.py
+++ b/src/ai/backend/manager/models/uuid7.py
@@ -1,0 +1,31 @@
+"""
+UUIDv7 generation on the database side.
+
+The function is strictly increasing within a session, matching PostgreSQL 18's
+built-in ``uuidv7()``. Once PG 18 is the minimum, the body becomes
+``RETURN uuidv7();``.
+"""
+
+UUID_GENERATE_V7_DDL = """
+CREATE OR REPLACE FUNCTION uuid_generate_v7() RETURNS uuid
+LANGUAGE plpgsql VOLATILE PARALLEL UNSAFE AS $$
+DECLARE
+  ticks bigint;
+  last  bigint;
+BEGIN
+  ticks := floor(extract(epoch FROM clock_timestamp()) * 1000 * 4096)::bigint;
+  last := NULLIF(current_setting('backendai.uuid7_last', true), '')::bigint;
+  IF last IS NOT NULL AND ticks <= last THEN
+    ticks := last + 1;
+  END IF;
+  PERFORM set_config('backendai.uuid7_last', ticks::text, false);
+  RETURN encode(
+    overlay(
+      overlay(uuid_send(gen_random_uuid())
+        placing substring(int8send(ticks >> 12) from 3) from 1 for 6)
+      placing int2send((x'7000'::int | (ticks & 4095)::int)::int2) from 7 for 2
+    ), 'hex')::uuid;
+END $$;
+"""
+
+DROP_UUID_GENERATE_V7_DDL = "DROP FUNCTION IF EXISTS uuid_generate_v7()"

--- a/src/ai/backend/testutils/db.py
+++ b/src/ai/backend/testutils/db.py
@@ -9,6 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.sql.ddl import SchemaGenerator
 from sqlalchemy.sql.schema import ForeignKeyConstraint
 
+from ai.backend.manager.models.uuid7 import UUID_GENERATE_V7_DDL
+
 
 class HasTable(Protocol):
     """Protocol for SQLAlchemy ORM model classes with __table__ attribute."""
@@ -112,6 +114,7 @@ async def with_tables(
     async with engine.begin() as conn:
         # Create uuid-ossp extension for uuid_generate_v4()
         await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'))
+        await conn.execute(text(UUID_GENERATE_V7_DDL))
         await conn.run_sync(_create_tables_sync, tables)
 
     try:

--- a/tests/unit/manager/models/test_uuid7.py
+++ b/tests/unit/manager/models/test_uuid7.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+import sqlalchemy as sa
+
+from ai.backend.manager.models.base import GUID
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.testutils.db import with_tables
+
+_metadata = sa.MetaData()
+uuid7_probes = sa.Table(
+    "uuid7_probes",
+    _metadata,
+    sa.Column("id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v7()")),
+)
+
+
+class TestUUIDGenerateV7:
+    @pytest.fixture
+    async def db(
+        self,
+        database_connection: ExtendedAsyncSAEngine,
+    ) -> AsyncIterator[ExtendedAsyncSAEngine]:
+        async with with_tables(database_connection, [uuid7_probes]):
+            yield database_connection
+
+    async def _generate(self, db: ExtendedAsyncSAEngine, count: int) -> list[uuid.UUID]:
+        async with db.begin_readonly_session() as sess:
+            rows = await sess.execute(
+                sa.select(sa.func.uuid_generate_v7(type_=sa.Uuid())).select_from(
+                    sa.func.generate_series(1, count)
+                )
+            )
+            return [r[0] for r in rows]
+
+    async def test_version_and_variant_bits(self, db: ExtendedAsyncSAEngine) -> None:
+        (value,) = await self._generate(db, 1)
+        assert value.version == 7
+        assert (value.bytes[8] & 0b1100_0000) == 0b1000_0000
+
+    async def test_timestamp_prefix_is_the_generation_time(self, db: ExtendedAsyncSAEngine) -> None:
+        before = datetime.now(UTC).timestamp() * 1000
+        (value,) = await self._generate(db, 1)
+        after = datetime.now(UTC).timestamp() * 1000
+
+        embedded_ms = int.from_bytes(value.bytes[:6], "big")
+        assert before - 1000 <= embedded_ms <= after + 1000
+
+    async def test_values_strictly_increase_within_a_session(
+        self, db: ExtendedAsyncSAEngine
+    ) -> None:
+        values = await self._generate(db, 1000)
+        assert len(set(values)) == len(values)
+        assert values == sorted(values)
+
+    async def test_server_default_fills_the_id_column(self, db: ExtendedAsyncSAEngine) -> None:
+        async with db.begin_session() as sess:
+            for _ in range(3):
+                await sess.execute(sa.insert(uuid7_probes))
+
+        async with db.begin_readonly_session() as sess:
+            ids = list((await sess.execute(sa.select(uuid7_probes.c.id))).scalars())
+
+        assert len(ids) == 3
+        assert all(value.version == 7 for value in ids)


### PR DESCRIPTION
## Summary
- Add `uuid_generate_v7()` to the database — a UUIDv7 generator that is strictly increasing within a session, matching PostgreSQL 18's `uuidv7()`. The body becomes `RETURN uuidv7();` once PG 18 is the minimum.
- Default the ids of `sessions`, `kernels`, `endpoints`, `deployment_revisions`, `routings` and `replica_groups` to it, so new rows insert in index order.
- Keep `uuid_generate_v4()` wherever the id reaches an untrusted holder (endpoint tokens, login sessions, invitations).

## Test plan
- [x] `uuid_generate_v7()` returns version nibble 7 and variant bits `10`
- [x] The leading 48 bits equal the generation time in milliseconds
- [x] 1000 values generated in one session are unique and strictly increasing
- [x] A column defaulting to it fills in on INSERT under `with_tables`
- [ ] CI: migration upgrade and downgrade against a live database

Resolves BA-7409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GajRnXWUtkhTpoxzYsYjUr