### PR TITLE
fix(BA-7631): raise HTTP exceptions instead of returning them in web and appproxy

### DIFF
--- a/changes/14175.fix.md
+++ b/changes/14175.fix.md
@@ -1,0 +1,1 @@
+Raise HTTP exceptions instead of returning them from the webserver and appproxy handlers, keeping the appproxy redirects and the webserver's security response headers intact.

--- a/src/ai/backend/appproxy/coordinator/api/proxy.py
+++ b/src/ai/backend/appproxy/coordinator/api/proxy.py
@@ -221,7 +221,7 @@ async def proxy(
             ),
             headers={"Access-Control-Allow-Origin": "*", "Access-Control-Expose-Headers": "*"},
         )
-    return web.HTTPPermanentRedirect(app_url)
+    raise web.HTTPPermanentRedirect(app_url)
 
 
 async def init(_app: web.Application) -> None:

--- a/src/ai/backend/appproxy/coordinator/server.py
+++ b/src/ai/backend/appproxy/coordinator/server.py
@@ -242,7 +242,9 @@ async def exception_middleware(
             else:
                 log.warning("Client error: {0!r}", ex)
             raise
-        except web.HTTPException as ex:
+        except (web.HTTPSuccessful, web.HTTPRedirection):
+            raise
+        except web.HTTPError as ex:
             if ex.status_code == 404:
                 raise URLNotFound(extra_data=request.path) from ex
             if ex.status_code == 405:

--- a/src/ai/backend/appproxy/worker/api/setup.py
+++ b/src/ai/backend/appproxy/worker/api/setup.py
@@ -182,7 +182,7 @@ async def setup(
                 samesite="Lax",
                 max_age=604800,  # 7 days
             )
-            return response
+            raise response
         case ProxyProtocol.TCP:
             protocol = "tcp"
             queryparams = {

--- a/src/ai/backend/appproxy/worker/api/setup.py
+++ b/src/ai/backend/appproxy/worker/api/setup.py
@@ -192,7 +192,7 @@ async def setup(
                 "gateway": generate_proxy_url(port_config, protocol, circuit, redirect_path=None),
             }
             if jwt_body["redirect"]:
-                return web.HTTPFound(
+                raise web.HTTPFound(
                     f"http://localhost:45678/start?{urllib.parse.urlencode(queryparams)}",
                     headers=cors_headers,
                 )

--- a/src/ai/backend/appproxy/worker/server.py
+++ b/src/ai/backend/appproxy/worker/server.py
@@ -215,7 +215,9 @@ async def exception_middleware(
             ex.body_dict,
             status=ex.status_code,
         )
-    except web.HTTPException as ex:
+    except (web.HTTPSuccessful, web.HTTPRedirection):
+        raise
+    except web.HTTPError as ex:
         if ex.status_code == 404:
             raise URLNotFound(extra_data=request.path) from ex
         if ex.status_code == 405:

--- a/src/ai/backend/web/proxy.py
+++ b/src/ai/backend/web/proxy.py
@@ -306,15 +306,15 @@ async def _run_proxy_request(
             status=e.status,
             reason=e.reason,
         )
-    except BackendClientError:
+    except BackendClientError as e:
         log.exception("{}: BackendClientError", log_prefix)
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except ClientConnectionError:
         log.warning(
             "{}: ClientConnectionError - Client disconnected during proxying: method: {}, path: {}",
@@ -328,15 +328,15 @@ async def _run_proxy_request(
         # (e.g. ManagerConnectionUnavailable -> 503) must surface as their own
         # status code, not get rewritten to 500 by the generic catch below.
         raise
-    except Exception:
+    except Exception as e:
         log.exception("{}: unexpected error", log_prefix)
-        return web.HTTPInternalServerError(
+        raise web.HTTPInternalServerError(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/internal-server-error",
                 "title": "Something has gone wrong.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
 
 
 async def web_handler(
@@ -516,15 +516,15 @@ async def web_handler_with_jwt(
             status=e.status,
             reason=e.reason,
         )
-    except BackendClientError:
+    except BackendClientError as e:
         log.exception("web_handler_with_jwt: BackendClientError")
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except ClientConnectionError:
         log.warning(
             "web_handler_with_jwt: ClientConnectionError - Client disconnected during proxying: method: {}, path: {}",
@@ -537,15 +537,15 @@ async def web_handler_with_jwt(
         # (e.g. ManagerConnectionUnavailable -> 503) must surface as their own
         # status code, not get rewritten to 500 by the generic catch below.
         raise
-    except Exception:
+    except Exception as e:
         log.exception("web_handler_with_jwt: unexpected error")
-        return web.HTTPInternalServerError(
+        raise web.HTTPInternalServerError(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/internal-server-error",
                 "title": "Something has gone wrong.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
 
 
 async def apollo_router_handler(
@@ -661,26 +661,26 @@ async def web_plugin_handler(
             status=e.status,
             reason=e.reason,
         )
-    except BackendClientError:
+    except BackendClientError as e:
         log.exception("web_plugin_handler: BackendClientError")
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except web.HTTPException:
         raise
-    except Exception:
+    except Exception as e:
         log.exception("web_plugin_handler: unexpected error")
-        return web.HTTPInternalServerError(
+        raise web.HTTPInternalServerError(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/internal-server-error",
                 "title": "Something has gone wrong.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
 
 
 @asynccontextmanager
@@ -796,23 +796,23 @@ async def websocket_handler(
             status=e.status,
             reason=e.reason,
         )
-    except BackendClientError:
+    except BackendClientError as e:
         log.exception("websocket_handler: BackendClientError")
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except web.HTTPException:
         raise
-    except Exception:
+    except Exception as e:
         log.exception("websocket_handler: unexpected error")
-        return web.HTTPInternalServerError(
+        raise web.HTTPInternalServerError(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/internal-server-error",
                 "title": "Something has gone wrong.",
             }),
             content_type="application/problem+json",
-        )
+        ) from e

--- a/src/ai/backend/web/security.py
+++ b/src/ai/backend/web/security.py
@@ -46,6 +46,10 @@ async def security_policy_middleware(request: web.Request, handler: Handler) -> 
     try:
         security_policy.check_request_policies(request)
         response = await handler(request)
+    except web.HTTPException as e:
+        security_policy.apply_response_policies(e)
+        raise
+    else:
         return security_policy.apply_response_policies(response)
     finally:
         csp_nonce_var.reset(token)

--- a/src/ai/backend/web/server.py
+++ b/src/ai/backend/web/server.py
@@ -153,17 +153,17 @@ async def static_handler(request: web.Request) -> web.StreamResponse:
     file_path = (static_path / request_path).resolve()
     try:
         file_path.relative_to(static_path)
-    except (ValueError, FileNotFoundError):
-        return web.HTTPNotFound(
+    except (ValueError, FileNotFoundError) as e:
+        raise web.HTTPNotFound(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/generic-not-found",
                 "title": "Not Found",
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     if file_path.is_file():
         return apply_cache_headers(web.FileResponse(file_path), request_path)
-    return web.HTTPNotFound(
+    raise web.HTTPNotFound(
         text=json.dumps({
             "type": "https://api.backend.ai/probs/generic-not-found",
             "title": "Not Found",
@@ -248,20 +248,18 @@ async def update_password_no_auth(request: web.Request) -> web.Response:
         log.error("Login: JSON decoding error: {}", e)
         creds = {}
 
-    def _check_params(param_names: list[str]) -> web.Response | None:
+    def _check_params(param_names: list[str]) -> None:
         for param in param_names:
             if creds.get(param) is None:
-                return web.HTTPBadRequest(
+                raise web.HTTPBadRequest(
                     text=json.dumps({
                         "type": "https://api.backend.ai/probs/invalid-api-params",
                         "title": f"You must provide the {param} field.",
                     }),
                     content_type="application/problem+json",
                 )
-        return None
 
-    if (fail_resp := _check_params(["username", "current_password", "new_password"])) is not None:
-        return fail_resp
+    _check_params(["username", "current_password", "new_password"])
 
     result: dict[str, Any] = {
         "data": None,
@@ -293,14 +291,14 @@ async def update_password_no_auth(request: web.Request) -> web.Response:
         )
     except BackendClientError as e:
         # This is error, not failed login, so we should not update login history.
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
                 "details": str(e),
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except BackendAPIError as e:
         log.info(
             "LOGIN_HANDLER: Authorization failed (email:{}, ip:{}) - {}",
@@ -548,14 +546,14 @@ async def login_handler(request: web.Request) -> web.Response:
                 )
     except BackendClientError as e:
         # This is error, not failed login, so we should not update login history.
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
                 "details": str(e),
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except BackendAPIError as e:
         log.info(
             "LOGIN_HANDLER: Authorization failed (email:{}, ip:{}) - {}",
@@ -601,7 +599,7 @@ async def logout_handler(request: web.Request) -> web.Response:
                 "Failed to invalidate login session in Manager DB (token={})", session_token
             )
 
-    return web.HTTPOk()
+    raise web.HTTPOk()
 
 
 async def extend_login_session(request: web.Request) -> web.Response:
@@ -687,7 +685,7 @@ async def token_login_handler(request: web.Request) -> web.Response:
     # Check browser session exists.
     session = await get_session(request)
     if session.get("authenticated", False):
-        return web.HTTPBadRequest(
+        raise web.HTTPBadRequest(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/generic-bad-request",
                 "title": "You have already logged in.",
@@ -702,7 +700,7 @@ async def token_login_handler(request: web.Request) -> web.Response:
     if not auth_token:
         auth_token = request.cookies.get(auth_token_name)
     if not auth_token:
-        return web.HTTPBadRequest(
+        raise web.HTTPBadRequest(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/invalid-api-params",
                 "title": "You must provide cookie-based authentication token",
@@ -781,14 +779,14 @@ async def token_login_handler(request: web.Request) -> web.Response:
         result["authenticated"] = True
         result["data"] = public_return  # store public info from token
     except BackendClientError as e:
-        return web.HTTPBadGateway(
+        raise web.HTTPBadGateway(
             text=json.dumps({
                 "type": "https://api.backend.ai/probs/bad-gateway",
                 "title": "The proxy target server is inaccessible.",
                 "details": str(e),
             }),
             content_type="application/problem+json",
-        )
+        ) from e
     except BackendAPIError as e:
         log.info("Authorization failed for token {}: {}", auth_token, e)
         result["authenticated"] = False

--- a/tests/unit/webserver/test_security_policy.py
+++ b/tests/unit/webserver/test_security_policy.py
@@ -224,3 +224,19 @@ def test_csp_policy_without_nonce_keeps_directives_clean() -> None:
     policy = csp_policy_builder({"script-src": ["'self'"]})
     response = policy(web.Response())
     assert response.headers["Content-Security-Policy"] == "script-src 'self';"
+
+
+async def test_response_policies_apply_to_raised_exception() -> None:
+    test_app = web.Application()
+    test_app["security_policy"] = SecurityPolicy(
+        request_policies=[], response_policies=[set_content_type_nosniff_policy]
+    )
+    request = make_mocked_request("GET", "/", app=test_app)
+
+    async def handler(request: web.Request) -> web.Response:
+        raise web.HTTPFound("/elsewhere")
+
+    with pytest.raises(web.HTTPFound) as exc_info:
+        await security_policy_middleware(request, handler)
+
+    assert exc_info.value.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
Resolves #14173 (BA-7631)

## Summary
- Follow-up to #14166 for the remaining components. Returning an `HTTPException` object from a handler is deprecated since aiohttp 3.0 (`returning HTTPException object is deprecated (#2415)`) and fails on aiohttp 4 master with `AttributeError: ... object has no attribute 'prepare'` and a 500. Every site in `web/server.py` (10), `web/proxy.py` (8), `appproxy/coordinator/api/proxy.py` (1) and `appproxy/worker/api/setup.py` (2, one of them an `HTTPFound` built into a variable, given a cookie, and then returned) now raises. Sites inside `except` blocks chain the cause with `from e`.
- `web/server.py` `_check_params` returned the `HTTPBadRequest` for its caller to return; it now raises it and the caller no longer inspects a result.
- The appproxy coordinator and worker exception middlewares rewrote every non-`BackendAIError` HTTP exception other than 404/405 into `GenericBadRequest`, which would have turned the raised redirects into a 400. They now pass `HTTPSuccessful` and `HTTPRedirection` through untouched and apply the rewrite to `HTTPError` only, as the manager does since #14166.
- The webserver's `security_policy_middleware` applied its response policies (CSP, `X-Content-Type-Options`) only to the response the handler returned. It now applies them to a raised `HTTPException` as well before re-raising it, so the converted sites keep those headers.

## Behavior notes
- The webserver's `general_exception_middleware` re-raises every `HTTPException` untouched, but logs 4xx as a warning and 5xx with a traceback. The converted 4xx/5xx sites now produce those log lines; the returned responses did not.
- `logout_handler` raises `web.HTTPOk()`; the response is the same 200.

## Test plan
- [x] `tests/unit/webserver/test_security_policy.py`: a handler that raises `HTTPFound` gets the response policy headers on the exception. The file's 23 tests pass.
- [x] Live check on halfstack, webserver from `main` vs this branch, same requests: `/server/update-password-no-auth` and `/server/token-login` with missing fields (400), `/server/logout` (200), and with the manager stopped `/server/login`, `/server/token-login`, `/server/update-password-no-auth`, `/func/custom-auth/login` (502 / the pre-existing 500). Status, headers and bodies are identical. The webserver log now shows the `client error raised inside handlers` warning for the 4xx cases.
- [x] Same live check, `GET /..%2F..%2Fetc%2Fpasswd` (404 raised by `console_handler`): identical except the response now also carries `X-Content-Type-Options: nosniff`, which is the security policy middleware applying to raised exceptions.
- [x] Live check on halfstack, appproxy coordinator and worker from `main` vs this branch: with a running session, a token from `POST /v2/conf` and a circuit from `/v2/proxy/{token}/{session}/add`, `GET /v2/proxy/auth` (308 to the worker) and the worker's `GET /setup` (302 with the `appproxy_permit` cookie and CORS headers) are identical in status, headers and body.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdrsTvazb2QprMmS8DpEDM

