### PR TITLE
fix(BA-7638): count unmatched-route requests and log them at debug

### DIFF
--- a/changes/14187.fix.md
+++ b/changes/14187.fix.md
@@ -1,0 +1,1 @@
+Log a request to an unregistered path at debug instead of warning, and count it in the API request metric.

--- a/src/ai/backend/manager/api/rest/app.py
+++ b/src/ai/backend/manager/api/rest/app.py
@@ -185,8 +185,11 @@ def build_root_app(
             client_ip_middleware,
             # exception_middleware and auth_middleware are inserted later
             # in server_main() after dependencies are available.
-            api_middleware,
+            # The metric middleware wraps api_middleware so that requests to
+            # unregistered paths, which api_middleware rejects with 404 before
+            # reaching a handler, are still counted.
             build_api_metric_middleware(metrics.api),
+            api_middleware,
         ]
     )
     setup_reserved_response_headers(app)

--- a/src/ai/backend/manager/api/rest/middleware/exception.py
+++ b/src/ai/backend/manager/api/rest/middleware/exception.py
@@ -109,7 +109,10 @@ def build_exception_middleware(
             await stats_monitor.report_metric(
                 INCREMENT, f"ai.backend.manager.api.status.{ex.status_code}"
             )
-            if ex.status_code // 100 == 4:
+            if request.match_info.http_exception is not None and ex.status_code == 404:
+                # No route matched; the client probed a path this server does not serve.
+                log.debug("no route matched: ({} {}): {}", method, endpoint, ex)
+            elif ex.status_code // 100 == 4:
                 log.warning(
                     "client error raised inside handlers: ({} {}): {}", method, endpoint, ex
                 )

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -342,7 +342,7 @@ async def server_main(
         _error_monitor_ref = dep_resources.monitoring.error_monitor
 
         # Insert DI-based middlewares now that dependencies are available.
-        # Maintain order: request_id(0) → client_ip(1) → exception(2) → auth(3) → api → metric
+        # Maintain order: request_id(0) → client_ip(1) → exception(2) → auth(3) → metric → api
         root_app.middlewares.insert(
             2,
             build_exception_middleware(

--- a/tests/unit/manager/api/test_exception_middleware.py
+++ b/tests/unit/manager/api/test_exception_middleware.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from ai.backend.common.metrics.http import build_api_metric_middleware
+from ai.backend.manager.api.rest.app import api_middleware
+from ai.backend.manager.api.rest.middleware import build_exception_middleware
+from ai.backend.manager.errors.common import GenericForbidden, InternalServerError
+
+_EXCEPTION_MIDDLEWARE_LOGGER = "ai.backend.manager.api.rest.middleware.exception"
+
+
+class _RecordingMetric:
+    def __init__(self) -> None:
+        self.observations: list[dict[str, Any]] = []
+
+    def observe_request(self, **kwargs: Any) -> None:
+        self.observations.append(kwargs)
+
+
+def _build_app(metric: _RecordingMetric) -> web.Application:
+    config_provider = MagicMock()
+    config_provider.config.debug.enabled = False
+    app = web.Application(
+        middlewares=[
+            build_exception_middleware(
+                error_monitor=AsyncMock(),
+                stats_monitor=AsyncMock(),
+                config_provider=config_provider,
+            ),
+            build_api_metric_middleware(metric),
+            api_middleware,
+        ]
+    )
+
+    async def forbidden(request: web.Request) -> web.Response:
+        raise GenericForbidden
+
+    async def broken(request: web.Request) -> web.Response:
+        raise InternalServerError
+
+    app.router.add_route("GET", "/forbidden", forbidden)
+    app.router.add_route("GET", "/broken", broken)
+    return app
+
+
+async def test_unmatched_route_is_logged_at_debug_and_counted(
+    aiohttp_client: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    metric = _RecordingMetric()
+    client = await aiohttp_client(_build_app(metric))
+
+    with caplog.at_level(logging.DEBUG, logger=_EXCEPTION_MIDDLEWARE_LOGGER):
+        resp = await client.get("/license")
+
+    assert resp.status == 404
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG]
+    assert metric.observations == [
+        {
+            "method": "GET",
+            "endpoint": "/license",
+            "error_code": metric.observations[0]["error_code"],
+            "status_code": 404,
+            "duration": metric.observations[0]["duration"],
+        }
+    ]
+
+
+async def test_registered_handler_4xx_keeps_warning(
+    aiohttp_client: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    metric = _RecordingMetric()
+    client = await aiohttp_client(_build_app(metric))
+
+    with caplog.at_level(logging.DEBUG, logger=_EXCEPTION_MIDDLEWARE_LOGGER):
+        resp = await client.get("/forbidden")
+
+    assert resp.status == 403
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
+    assert metric.observations[0]["status_code"] == 403
+
+
+async def test_registered_handler_5xx_keeps_traceback(
+    aiohttp_client: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    metric = _RecordingMetric()
+    client = await aiohttp_client(_build_app(metric))
+
+    with caplog.at_level(logging.DEBUG, logger=_EXCEPTION_MIDDLEWARE_LOGGER):
+        resp = await client.get("/broken")
+
+    assert resp.status == 500
+    assert [r.levelno for r in caplog.records] == [logging.ERROR]
+    assert caplog.records[0].exc_info is not None
+    assert metric.observations[0]["status_code"] == 500


### PR DESCRIPTION
## Summary

- A request to a path with no registered route was logged at warning by the REST exception middleware. On staging that is 309 lines a day, 72% of all WARNING output, every one of them the Web UI probing `GET /license` to detect whether a feature is present. Such a request is now logged at debug.
- The demotion is safe to make only because the same request now appears in `backendai_api_request_count`. It did not before: `api_middleware` raises the routing 404 (`request.match_info.http_exception`) before delegating to a handler, and the metric middleware sat *inside* it, so unmatched-route requests ended before the metric was ever observed — the only 4xx series present was 405 on `/`. The metric middleware is therefore moved to wrap `api_middleware`; the order comment in `server.py` is updated to match. Without this, demoting the log would leave path scanning with no observable signal at all.
- The two cases are distinguished by routing, not by a path list: no route matched (`match_info.http_exception is not None` with status 404) goes to debug, while a 4xx returned by a matched handler keeps its warning level. Plugin-registered APIs become routes at startup, so their 4xx responses fall into the second case with no list to maintain.
- 405 (method not allowed) is left at warning — the path exists there.

Middleware order after this change: `request_id → client_ip → exception → auth → metric → api`.

## Test plan

- [ ] `tests/unit/manager/api/test_exception_middleware.py` — GET on an unregistered path emits a single DEBUG record and observes the metric with `status_code=404`
- [ ] same file — a 403 from a registered handler is still logged at warning
- [ ] same file — a 5xx from a registered handler is still logged with `exc_info`
- [ ] `pants fmt / fix / lint / check / test` pass for the affected packages

Backport: 26.8, 26.4

Resolves BA-7638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyE6mG8Pa2YgXjrnFG9efV
