### PR TITLE
fix(BA-7642): classify background task client errors by status in logging

### DIFF
--- a/changes/14189.fix.md
+++ b/changes/14189.fix.md
@@ -1,0 +1,1 @@
+Log a background task failing with a 4xx client error at warning without a traceback, instead of at error with one.

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -258,7 +258,10 @@ def _exception_to_task_result[**P](
             log.warning("Task cancelled")
             return TaskCancelledResult()
         except BackendAIError as e:
-            log.exception("BackendAIError in task: {}", e)
+            if e.status_code // 100 == 4:
+                log.warning("BackendAIError in task: {}", repr(e))
+            else:
+                log.exception("BackendAIError in task: {}", e)
             return TaskFailedResult(e)
         except Exception as e:
             log.exception("Unhandled error in task: {}", e)
@@ -403,7 +406,10 @@ class BackgroundTaskManager:
         except BackendAIError as e:
             status = BgtaskStatus.FAILED
             error_code = e.error_code()
-            log.exception("Task {} ({}): BackendAIError: {}", task_id, task_name, e)
+            if e.status_code // 100 == 4:
+                log.warning("Task {} ({}): BackendAIError: {}", task_id, task_name, repr(e))
+            else:
+                log.exception("Task {} ({}): BackendAIError: {}", task_id, task_name, e)
             msg = repr(e)
             return BgtaskFailedEvent(task_id=task_id, message=msg)
         except Exception as e:


### PR DESCRIPTION
## Summary

- A background task does not pass through an HTTP exception middleware, so the runner's own log line in `common/bgtask/bgtask.py` is the only record of a failure — it cannot be dropped, only classified.
- Log a 4xx `BackendAIError` at warning without a traceback and keep everything else at exception, in both places the runner catches one. This follows the branch already used in the REST and GraphQL exception middlewares; no shared helper is added, so the emitting file and line stay in the log record.
- The task result, status, error code and emitted event are unchanged for every case.

## Test plan

- [ ] a background task failing with a 4xx `BackendAIError` is logged at warning with no traceback
- [ ] a background task failing with a 5xx `BackendAIError` is logged at error with a traceback
- [ ] a background task failing with a non-`BackendAIError` exception is still logged at error with a traceback
- [ ] the task result recorded for each case is unchanged
- [ ] `pants test` passes for the affected packages

Resolves BA-7642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tiwzp4ZzyNGjPn7qUv6ohB