### PR TITLE
fix(BA-7639): stop logging a request failure twice

### DIFF
--- a/changes/14190.fix.md
+++ b/changes/14190.fix.md
@@ -1,0 +1,1 @@
+Stop recording a failed request twice in the manager logs; the request layer now decides the level once, so a 4xx from user input no longer appears as an error with a traceback.

--- a/src/ai/backend/manager/actions/processor/base.py
+++ b/src/ai/backend/manager/actions/processor/base.py
@@ -66,7 +66,6 @@ class ActionRunner[TAction: BaseAction, TActionResult: BaseActionResult]:
         try:
             result = await self._func(action)
         except BackendAIError as e:
-            log.exception("Action processing error: {}", e)
             status = OperationStatus.ERROR
             description = str(e)
             error_code = e.error_code()

--- a/src/ai/backend/manager/actions/run_status.py
+++ b/src/ai/backend/manager/actions/run_status.py
@@ -38,7 +38,6 @@ class ActionRunStatus:
         permission lookup timing out, say — is an ordinary ERROR.
         """
         if isinstance(exc, BackendAIError):
-            log.exception("Action processing error: {}", exc)
             error_code = exc.error_code()
             denied = during_validation and error_code.error_detail == ErrorDetail.FORBIDDEN
             return cls(

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -84,7 +84,7 @@ from ai.backend.common.dto.manager.session.types import (
     CreationConfigV6Template,
     CreationConfigV7,
 )
-from ai.backend.common.exception import BackendAIError, UnreachableError
+from ai.backend.common.exception import UnreachableError
 from ai.backend.common.types import (
     AccessKey,
     AgentId,
@@ -933,17 +933,13 @@ class SessionHandler:
             owner_access_key,
             session_name,
         )
-        try:
-            result = await self._session.get_session_info.run(
-                GetSessionInfoAction(
-                    session_id=await self._resolve_session_id(owner_access_key, session_name),
-                    session_name=session_name,
-                    owner_access_key=owner_access_key,
-                )
+        result = await self._session.get_session_info.run(
+            GetSessionInfoAction(
+                session_id=await self._resolve_session_id(owner_access_key, session_name),
+                session_name=session_name,
+                owner_access_key=owner_access_key,
             )
-        except BackendAIError:
-            log.exception("GET_INFO: exception")
-            raise
+        )
         resp = GetSessionInfoResponse(root=result.session_info.asdict())
         return APIResponse.build(
             HTTPStatus.OK,
@@ -1085,17 +1081,13 @@ class SessionHandler:
             owner_access_key,
             session_name,
         )
-        try:
-            await self._session.interrupt.run(
-                InterruptSessionAction(
-                    session_id=await self._resolve_session_id(owner_access_key, session_name),
-                    session_name=session_name,
-                    owner_access_key=owner_access_key,
-                )
+        await self._session.interrupt.run(
+            InterruptSessionAction(
+                session_id=await self._resolve_session_id(owner_access_key, session_name),
+                session_name=session_name,
+                owner_access_key=owner_access_key,
             )
-        except BackendAIError:
-            log.exception("INTERRUPT: exception")
-            raise
+        )
         return web.Response(status=HTTPStatus.NO_CONTENT)
 
     # ------------------------------------------------------------------
@@ -1198,18 +1190,14 @@ class SessionHandler:
             owner_access_key,
             session_name,
         )
-        try:
-            await self._session.shutdown_service.run(
-                ShutdownServiceAction(
-                    session_id=await self._resolve_session_id(owner_access_key, session_name),
-                    session_name=session_name,
-                    owner_access_key=owner_access_key,
-                    service_name=params.service_name,
-                )
+        await self._session.shutdown_service.run(
+            ShutdownServiceAction(
+                session_id=await self._resolve_session_id(owner_access_key, session_name),
+                session_name=session_name,
+                owner_access_key=owner_access_key,
+                service_name=params.service_name,
             )
-        except BackendAIError:
-            log.exception("SHUTDOWN_SERVICE: exception")
-            raise
+        )
         return web.Response(status=HTTPStatus.NO_CONTENT)
 
     # ------------------------------------------------------------------
@@ -1235,18 +1223,14 @@ class SessionHandler:
             owner_access_key,
             session_name,
         )
-        try:
-            await self._session.upload_files.run(
-                UploadFilesAction(
-                    session_id=await self._resolve_session_id(owner_access_key, session_name),
-                    session_name=session_name,
-                    owner_access_key=owner_access_key,
-                    reader=reader,
-                )
+        await self._session.upload_files.run(
+            UploadFilesAction(
+                session_id=await self._resolve_session_id(owner_access_key, session_name),
+                session_name=session_name,
+                owner_access_key=owner_access_key,
+                reader=reader,
             )
-        except BackendAIError:
-            log.exception("UPLOAD_FILES: exception")
-            raise
+        )
         return web.Response(status=HTTPStatus.NO_CONTENT)
 
     # ------------------------------------------------------------------
@@ -1668,24 +1652,14 @@ class SessionHandler:
             session_name,
             kernel_id,
         )
-        try:
-            result = await self._session.get_container_logs.run(
-                GetContainerLogsAction(
-                    session_id=await self._resolve_session_id(owner_access_key, session_name),
-                    session_name=session_name,
-                    owner_access_key=owner_access_key,
-                    kernel_id=kernel_id,
-                )
+        result = await self._session.get_container_logs.run(
+            GetContainerLogsAction(
+                session_id=await self._resolve_session_id(owner_access_key, session_name),
+                session_name=session_name,
+                owner_access_key=owner_access_key,
+                kernel_id=kernel_id,
             )
-        except BackendAIError:
-            log.exception(
-                "GET_CONTAINER_LOG(ak:{}/{}, kernel_id: {}, s:{}): unexpected error",
-                requester_access_key,
-                owner_access_key,
-                kernel_id,
-                session_name,
-            )
-            raise
+        )
         return APIResponse.build(
             HTTPStatus.OK,
             GetContainerLogsResponse(result.result),

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -430,7 +430,6 @@ class StreamHandler:
                     "msg": f"Invalid API parameters: {e!r}",
                 })
         except BackendAIError as e:
-            log.exception("STREAM_EXECUTE: exception")
             if not ws.closed:
                 await ws.send_json({
                     "status": "error",


### PR DESCRIPTION
## Summary

- Eight call sites logged a caught `BackendAIError` and re-raised it, while `rest/middleware/exception.py` catches the same exception and already records it at the level its status code calls for. Every request failure produced two records, and the inner one was always `error` with a traceback regardless of status — so a 4xx from user input read the same as a server fault and ERROR-based alerting was unusable.
- Removed the inner log at each site. The exception reaches the middleware unchanged: the handler wrapper in `api/rest/routing.py`, the auth middleware and the mounted sub-apps do not catch `BackendAIError`. Requests served over GraphQL are covered the same way by `api/gql/extensions/exception_handler.py`.
- In `api/rest/session/handler.py` the `try/except` held nothing but the log and the re-raise, so the block goes with it. Response status and body are unchanged.

## Test plan

- [ ] A request failing with a 409 produces exactly one log record, at `warning`, from the middleware
- [ ] A request failing with a 500 produces exactly one log record, at `error`, with a traceback
- [ ] HTTP response status and body are unchanged in both cases
- [ ] `pants test --changed-since=HEAD~1 --changed-dependents=direct` passes

Resolves BA-7639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWv6Qhs5DniUFwyhLqtDuU
