### PR TITLE
fix(BA-7637): log the admin GraphQL access line at debug (#14188)

### DIFF
--- a/changes/14188.fix.md
+++ b/changes/14188.fix.md
@@ -1,0 +1,1 @@
+Log the admin GraphQL per-operation access line at debug instead of info.

--- a/src/ai/backend/manager/api/rest/admin/handler.py
+++ b/src/ai/backend/manager/api/rest/admin/handler.py
@@ -58,7 +58,7 @@ class GQLLoggingMiddleware:
     def resolve(self, next: Any, root: Any, info: graphene.ResolveInfo, **args: Any) -> Any:
         if info.path.prev is None:
             graph_ctx = info.context
-            log.info(
+            log.debug(
                 "ADMIN.GQL (ak:{}, {}:{}, op:{})",
                 graph_ctx.access_key,
                 info.operation.operation,


### PR DESCRIPTION
This is an auto-generated backport of #14188 to the 26.4 release.