### PR TITLE
fix(BA-7638): count unmatched-route requests and log them at debug (#14187)

### DIFF
--- a/changes/14187.fix.md
+++ b/changes/14187.fix.md
@@ -1,0 +1,1 @@
+Log a request to an unregistered path at debug instead of warning, and count it in the API request metric.

--- a/src/ai/backend/manager/api/rest/app.py
+++ b/src/ai/backend/manager/api/rest/app.py
@@ -183,8 +183,11 @@ def build_root_app(
             request_id_middleware,
             # exception_middleware and auth_middleware are inserted later
             # in server_main() after dependencies are available.
-            api_middleware,
+            # The metric middleware wraps api_middleware so that requests to
+            # unregistered paths, which api_middleware rejects with 404 before
+            # reaching a handler, are still counted.
             build_api_metric_middleware(metrics.api),
+            api_middleware,
         ]
     )
     if loop_error_handler is not None:

--- a/src/ai/backend/manager/api/rest/middleware/exception.py
+++ b/src/ai/backend/manager/api/rest/middleware/exception.py
@@ -109,7 +109,10 @@ def build_exception_middleware(
             await stats_monitor.report_metric(
                 INCREMENT, f"ai.backend.manager.api.status.{ex.status_code}"
             )
-            if ex.status_code // 100 == 4:
+            if request.match_info.http_exception is not None and ex.status_code == 404:
+                # No route matched; the client probed a path this server does not serve.
+                log.debug("no route matched: ({} {}): {}", method, endpoint, ex)
+            elif ex.status_code // 100 == 4:
                 log.warning(
                     "client error raised inside handlers: ({} {}): {}", method, endpoint, ex
                 )

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -340,7 +340,11 @@ async def server_main(
         _error_monitor_ref = dep_resources.monitoring.error_monitor
 
         # Insert DI-based middlewares now that dependencies are available.
+<<<<<<< HEAD
         # Maintain order: request_id(0) → exception(1) → auth(2) → api → metric
+=======
+        # Maintain order: request_id(0) → client_ip(1) → exception(2) → auth(3) → metric → api
+>>>>>>> 05ae645f (fix(BA-7638): count unmatched-route requests and log them at debug (#14187))
         root_app.middlewares.insert(
             1,
             build_exception_middleware(

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -340,11 +340,7 @@ async def server_main(
         _error_monitor_ref = dep_resources.monitoring.error_monitor
 
         # Insert DI-based middlewares now that dependencies are available.
-<<<<<<< HEAD
-        # Maintain order: request_id(0) → exception(1) → auth(2) → api → metric
-=======
-        # Maintain order: request_id(0) → client_ip(1) → exception(2) → auth(3) → metric → api
->>>>>>> 05ae645f (fix(BA-7638): count unmatched-route requests and log them at debug (#14187))
+        # Maintain order: request_id(0) → exception(1) → auth(2) → metric → api
         root_app.middlewares.insert(
             1,
             build_exception_middleware(

--- a/tests/unit/manager/api/test_exception_middleware.py
+++ b/tests/unit/manager/api/test_exception_middleware.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+
+from ai.backend.common.metrics.http import build_api_metric_middleware
+from ai.backend.manager.api.rest.app import api_middleware
+from ai.backend.manager.api.rest.middleware import build_exception_middleware
+from ai.backend.manager.errors.common import GenericForbidden, InternalServerError
+
+_EXCEPTION_MIDDLEWARE_LOGGER = "ai.backend.manager.api.rest.middleware.exception"
+
+
+class _RecordingMetric:
+    def __init__(self) -> None:
+        self.observations: list[dict[str, Any]] = []
+
+    def observe_request(self, **kwargs: Any) -> None:
+        self.observations.append(kwargs)
+
+
+def _build_app(metric: _RecordingMetric) -> web.Application:
+    config_provider = MagicMock()
+    config_provider.config.debug.enabled = False
+    app = web.Application(
+        middlewares=[
+            build_exception_middleware(
+                error_monitor=AsyncMock(),
+                stats_monitor=AsyncMock(),
+                config_provider=config_provider,
+            ),
+            build_api_metric_middleware(metric),
+            api_middleware,
+        ]
+    )
+
+    async def forbidden(request: web.Request) -> web.Response:
+        raise GenericForbidden
+
+    async def broken(request: web.Request) -> web.Response:
+        raise InternalServerError
+
+    app.router.add_route("GET", "/forbidden", forbidden)
+    app.router.add_route("GET", "/broken", broken)
+    return app
+
+
+async def test_unmatched_route_is_logged_at_debug_and_counted(
+    aiohttp_client: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    metric = _RecordingMetric()
+    client = await aiohttp_client(_build_app(metric))
+
+    with caplog.at_level(logging.DEBUG, logger=_EXCEPTION_MIDDLEWARE_LOGGER):
+        resp = await client.get("/license")
+
+    assert resp.status == 404
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG]
+    assert metric.observations == [
+        {
+            "method": "GET",
+            "endpoint": "/license",
+            "error_code": metric.observations[0]["error_code"],
+            "status_code": 404,
+            "duration": metric.observations[0]["duration"],
+        }
+    ]
+
+
+async def test_registered_handler_4xx_keeps_warning(
+    aiohttp_client: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    metric = _RecordingMetric()
+    client = await aiohttp_client(_build_app(metric))
+
+    with caplog.at_level(logging.DEBUG, logger=_EXCEPTION_MIDDLEWARE_LOGGER):
+        resp = await client.get("/forbidden")
+
+    assert resp.status == 403
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
+    assert metric.observations[0]["status_code"] == 403
+
+
+async def test_registered_handler_5xx_keeps_traceback(
+    aiohttp_client: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    metric = _RecordingMetric()
+    client = await aiohttp_client(_build_app(metric))
+
+    with caplog.at_level(logging.DEBUG, logger=_EXCEPTION_MIDDLEWARE_LOGGER):
+        resp = await client.get("/broken")
+
+    assert resp.status == 500
+    assert [r.levelno for r in caplog.records] == [logging.ERROR]
+    assert caplog.records[0].exc_info is not None
+    assert metric.observations[0]["status_code"] == 500


### PR DESCRIPTION
This is an auto-generated backport of #14187 to the 26.4 release.