### PR TITLE
fix(BA-7642): classify background task client errors by status in logging (#14189)

### DIFF
--- a/changes/14189.fix.md
+++ b/changes/14189.fix.md
@@ -1,0 +1,1 @@
+Log a background task failing with a 4xx client error at warning without a traceback, instead of at error with one.

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -258,7 +258,10 @@ def _exception_to_task_result[**P](
             log.warning("Task cancelled")
             return TaskCancelledResult()
         except BackendAIError as e:
-            log.exception("BackendAIError in task: {}", e)
+            if e.status_code // 100 == 4:
+                log.warning("BackendAIError in task: {}", repr(e))
+            else:
+                log.exception("BackendAIError in task: {}", e)
             return TaskFailedResult(e)
         except Exception as e:
             log.exception("Unhandled error in task: {}", e)
@@ -403,7 +406,10 @@ class BackgroundTaskManager:
         except BackendAIError as e:
             status = BgtaskStatus.FAILED
             error_code = e.error_code()
-            log.exception("Task {} ({}): BackendAIError: {}", task_id, task_name, e)
+            if e.status_code // 100 == 4:
+                log.warning("Task {} ({}): BackendAIError: {}", task_id, task_name, repr(e))
+            else:
+                log.exception("Task {} ({}): BackendAIError: {}", task_id, task_name, e)
             msg = repr(e)
             return BgtaskFailedEvent(task_id, msg)
         except Exception as e:


### PR DESCRIPTION
This is an auto-generated backport of #14189 to the 26.8 release.