### PR TITLE
fix(BA-7641): stop double-logging GraphQL client errors as ERROR in admin v2 handler

### DIFF
--- a/changes/14200.fix.md
+++ b/changes/14200.fix.md
@@ -1,0 +1,1 @@
+Stop logging a GraphQL client error (e.g. a duplicate vfolder name) as ERROR twice in the admin v2 handler.

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -2,9 +2,11 @@ import re
 from typing import override
 
 import strawberry
+from graphql import GraphQLError
 from graphql.pyutils.undefined import Undefined as GraphQLUndefined
 from strawberry.federation import Schema
 from strawberry.schema.config import StrawberryConfig
+from strawberry.types import ExecutionContext
 
 from ai.backend.common.api_handlers import Sentinel as BackendSentinel
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
@@ -1070,6 +1072,16 @@ class Subscription:
 
 
 class CustomizedSchema(Schema):
+    @override
+    def process_errors(
+        self,
+        errors: list[GraphQLError],
+        execution_context: ExecutionContext | None = None,
+    ) -> None:
+        # Suppresses strawberry's default StrawberryLogger.error call; GQLExceptionHandlerExtension
+        # already logs every resolver error at the right level.
+        pass
+
     @override
     def as_str(self) -> str:
         # Strawberry picks up pydantic field defaults (including SENTINEL) as GraphQL

--- a/src/ai/backend/manager/api/rest/admin/handler.py
+++ b/src/ai/backend/manager/api/rest/admin/handler.py
@@ -222,10 +222,6 @@ class AdminHandler:
             operation_name=params.operation_name,
             context_value=gql_ctx,
         )
-        if result.errors:
-            for e in result.errors:
-                log.error("ADMIN.GQL.V2 Exception: {}", e.formatted)
-                log.debug("{}", repr(e))
         resp = GraphQLResponse(
             data=result.data,
             errors=[dict(e.formatted) for e in result.errors] if result.errors else None,


### PR DESCRIPTION
## Summary
- `GQLExceptionHandlerExtension` already logs every GraphQL resolver error at the correct level (debug for client errors, error+traceback for server errors), so the admin handler's own `log.error` call in `_execute_strawberry` and strawberry's default `process_errors` logging (via `strawberry.execution`) were pure duplicates.
- Removed the admin handler's explicit error logging and overrode `CustomizedSchema.process_errors` to suppress strawberry's default per-error logging, instead of silencing the `strawberry.execution` logger globally.
- A duplicate-vfolder-name request (a client error) no longer produces extra ERROR log lines beyond the one already correctly classified by `GQLExceptionHandlerExtension`.

## Test plan
- [x] `pants fmt`, `pants fix`, `pants lint` pass
- [x] `pants check --changed-since=HEAD~1` passes (mypy)
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=direct` passes
- [x] Verified `strawberry.schema.base.BaseSchema.process_errors` default behavior directly against the installed strawberry source to confirm it is library-default logging, not app code

Resolves BA-7641

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018byQHP1PpDuDF6waxA5uwG