### PR TITLE
fix(BA-7641): stop double-logging GraphQL client errors as ERROR in admin v2 handler (#14200)

### DIFF
--- a/changes/14200.fix.md
+++ b/changes/14200.fix.md
@@ -1,0 +1,1 @@
+Stop logging a GraphQL client error (e.g. a duplicate vfolder name) as ERROR twice in the admin v2 handler.

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -2,9 +2,11 @@ import re
 from typing import override
 
 import strawberry
+from graphql import GraphQLError
 from graphql.pyutils.undefined import Undefined as GraphQLUndefined
 from strawberry.federation import Schema
 from strawberry.schema.config import StrawberryConfig
+from strawberry.types import ExecutionContext
 
 from ai.backend.common.api_handlers import Sentinel as BackendSentinel
 from ai.backend.manager.api.gql.extensions import (
@@ -1022,6 +1024,16 @@ class Subscription:
 
 
 class CustomizedSchema(Schema):
+    @override
+    def process_errors(
+        self,
+        errors: list[GraphQLError],
+        execution_context: ExecutionContext | None = None,
+    ) -> None:
+        # Suppresses strawberry's default StrawberryLogger.error call; GQLExceptionHandlerExtension
+        # already logs every resolver error at the right level.
+        pass
+
     @override
     def as_str(self) -> str:
         # Strawberry picks up pydantic field defaults (including SENTINEL) as GraphQL

--- a/src/ai/backend/manager/api/rest/admin/handler.py
+++ b/src/ai/backend/manager/api/rest/admin/handler.py
@@ -220,10 +220,6 @@ class AdminHandler:
             operation_name=params.operation_name,
             context_value=gql_ctx,
         )
-        if result.errors:
-            for e in result.errors:
-                log.error("ADMIN.GQL.V2 Exception: {}", e.formatted)
-                log.debug("{}", repr(e))
         resp = GraphQLResponse(
             data=result.data,
             errors=[dict(e.formatted) for e in result.errors] if result.errors else None,


### PR DESCRIPTION
This is an auto-generated backport of #14200 to the 26.8 release.