### PR TITLE
fix(BA-7647): name the background task in the completion log line

### DIFF
--- a/changes/14205.fix.md
+++ b/changes/14205.fix.md
@@ -1,0 +1,1 @@
+Name the background task in its completion log line instead of leaving the name slot empty

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -445,7 +445,10 @@ class BackgroundTaskManager:
             cache_id = EventCacheDomain.BGTASK.cache_id(str(task_id))
             await self._event_producer.broadcast_event_with_cache(cache_id, bgtask_result_event)
             log.info(
-                "Task {} ({}): {}", task_id, task_name or "", bgtask_result_event.__class__.__name__
+                "Task {} ({}): {}",
+                task_id,
+                task_name or func.__name__,
+                bgtask_result_event.__class__.__name__,
             )
         finally:
             self._ongoing_tasks.pop(TaskID(task_id), None)


### PR DESCRIPTION
## Summary
- `_wrapper_task`'s completion log used its own unresolved `task_name`
  parameter with `task_name or ""`, so completed/failed background tasks
  logged `Task <uuid> (): <EventType>` with an empty name slot.
- `_observe_bgtask` already falls back to `func.__name__` when no name
  is given, but that resolution was local to that function and never
  reached the completion log in `_wrapper_task`.
- Apply the same `task_name or func.__name__` fallback at the
  completion log site so both success and failure lines name the task.

## Test plan
- [x] `pants fmt/fix/lint/check --changed-since=origin/main` pass
- [x] `pants test --changed-since=origin/main --changed-dependents=direct` passes (includes `tests/unit/common/bgtask/test_background_task.py`)

Resolves BA-7647

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMm1bGwLXLHbaDpvfWXCUQ