### PR TITLE
chore(BA-7646): remove per-request access logs from REST handlers

### DIFF
--- a/changes/14206.misc.md
+++ b/changes/14206.misc.md
@@ -1,0 +1,1 @@
+Remove redundant per-request access-log lines from manager REST v1 handlers.

--- a/src/ai/backend/manager/api/rest/acl/handler.py
+++ b/src/ai/backend/manager/api/rest/acl/handler.py
@@ -19,7 +19,6 @@ class AclHandler:
     """ACL API handler with constructor-injected dependencies."""
 
     async def get_permission(self, ctx: UserContext) -> APIResponse:
-        log.info("GET_PERMISSION (ak:{})", ctx.access_key)
         resp = GetPermissionsResponse(
             vfolder_host_permission_list=get_all_vfolder_host_permissions(),
         )

--- a/src/ai/backend/manager/api/rest/admin/handler.py
+++ b/src/ai/backend/manager/api/rest/admin/handler.py
@@ -54,20 +54,6 @@ class GQLMutationUnfrozenRequiredMiddleware:
         return next(root, info, **args)
 
 
-class GQLLoggingMiddleware:
-    def resolve(self, next: Any, root: Any, info: graphene.ResolveInfo, **args: Any) -> Any:
-        if info.path.prev is None:
-            graph_ctx = info.context
-            log.debug(
-                "ADMIN.GQL (ak:{}, {}:{}, op:{})",
-                graph_ctx.access_key,
-                info.operation.operation,
-                info.field_name,
-                info.operation.name,
-            )
-        return next(root, info, **args)
-
-
 class AdminHandler:
     """Admin API handler with constructor-injected dependencies."""
 
@@ -150,7 +136,6 @@ class AdminHandler:
                     GQLMutationUnfrozenRequiredMiddleware(manager_status),
                     GQLMetricMiddleware(),
                     GQLExceptionMiddleware(),
-                    GQLLoggingMiddleware(),
                 ],
             ),
         )

--- a/src/ai/backend/manager/api/rest/agent/handler.py
+++ b/src/ai/backend/manager/api/rest/agent/handler.py
@@ -33,7 +33,6 @@ class AgentHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search agents with filters, orders, and pagination."""
-        log.info("SEARCH_AGENTS (ak:{})", ctx.access_key)
 
         querier = self._adapter.build_querier(body.parsed)
 

--- a/src/ai/backend/manager/api/rest/auth/handler.py
+++ b/src/ai/backend/manager/api/rest/auth/handler.py
@@ -80,7 +80,6 @@ class AuthHandler:
     # ------------------------------------------------------------------
 
     async def test_get(self, ctx: UserContext) -> APIResponse:
-        log.info("AUTH.TEST(ak:{})", ctx.access_key)
         resp = VerifyAuthResponse(authorized="yes", echo="")
         return APIResponse.build(HTTPStatus.OK, resp)
 
@@ -89,7 +88,6 @@ class AuthHandler:
     # ------------------------------------------------------------------
 
     async def get_my_ip(self, request_ctx: RequestCtx) -> APIResponse:
-        log.info("AUTH.GET_MY_IP()")
         client_ip = extract_client_ip(request_ctx.request) or ""
         return APIResponse.build(HTTPStatus.OK, MyIpResponse(client_ip=client_ip))
 
@@ -98,7 +96,6 @@ class AuthHandler:
     # ------------------------------------------------------------------
 
     async def test_post(self, body: BodyParam[VerifyAuthRequest], ctx: UserContext) -> APIResponse:
-        log.info("AUTH.TEST(ak:{})", ctx.access_key)
         params = body.parsed
         resp = VerifyAuthResponse(authorized="yes", echo=params.echo)
         return APIResponse.build(HTTPStatus.OK, resp)
@@ -109,12 +106,6 @@ class AuthHandler:
 
     async def get_role(self, query: QueryParam[GetRoleRequest], ctx: UserContext) -> APIResponse:
         params = query.parsed
-        log.info(
-            "AUTH.ROLES(ak:{}, d:{}, g:{})",
-            ctx.access_key,
-            ctx.user_domain,
-            params.group,
-        )
         action = PublicGetRoleAction(
             user_id=ctx.user_uuid,
             group_id=params.group,
@@ -137,12 +128,6 @@ class AuthHandler:
         self, body: BodyParam[AuthorizeRequest], ctx: RequestCtx
     ) -> APIResponse | web.StreamResponse:
         params = body.parsed
-        log.info(
-            "AUTH.AUTHORIZE(d:{}, u:{}, passwd:****, type:{})",
-            params.domain,
-            params.username,
-            params.type,
-        )
         action = AuthorizeAction(
             request=ctx.request,
             type=AuthTokenType(params.type),
@@ -180,7 +165,6 @@ class AuthHandler:
 
     async def logout(self, body: BodyParam[LogoutRequest], ctx: UserContext) -> APIResponse:
         params = body.parsed
-        log.info("AUTH.LOGOUT(session_token:{}...)", params.session_token[:8])
         action = LogoutAction(
             user_id=UserID(ctx.user_uuid),
             session_token=params.session_token,
@@ -194,7 +178,6 @@ class AuthHandler:
 
     async def signup(self, body: BodyParam[SignupRequest], ctx: RequestCtx) -> APIResponse:
         params = body.parsed
-        log.info("AUTH.SIGNUP(d:{}, email:{}, passwd:****)", params.domain, params.email)
         action = SignupAction(
             request=ctx.request,
             domain_name=params.domain,
@@ -217,7 +200,6 @@ class AuthHandler:
 
     async def signout(self, body: BodyParam[SignoutRequest], ctx: UserContext) -> APIResponse:
         params = body.parsed
-        log.info("AUTH.SIGNOUT(d:{}, email:{})", ctx.user_domain, params.email)
         await self._auth.signout.run(
             SignoutAction(
                 user_id=UserID(ctx.user_uuid),
@@ -237,7 +219,6 @@ class AuthHandler:
         self, body: BodyParam[UpdateFullNameRequest], ctx: UserContext
     ) -> APIResponse:
         params = body.parsed
-        log.info("AUTH.UPDATE_FULL_NAME(d:{}, email:{})", ctx.user_domain, ctx.user_email)
         await self._auth.update_full_name.run(
             UpdateFullNameAction(
                 user_id=UserID(ctx.user_uuid),
@@ -259,7 +240,6 @@ class AuthHandler:
         req: RequestCtx,
     ) -> APIResponse:
         params = body.parsed
-        log.info("AUTH.UPDATE_PASSWORD(d:{}, email:{})", ctx.user_domain, ctx.user_email)
         action = UpdatePasswordAction(
             request=req.request,
             user_id=UserID(ctx.user_uuid),
@@ -283,11 +263,6 @@ class AuthHandler:
         self, body: BodyParam[UpdatePasswordNoAuthRequest], ctx: RequestCtx
     ) -> APIResponse:
         params = body.parsed
-        log.info(
-            "AUTH.UPDATE_PASSWORD_NO_AUTH(d:{}, u:{}, passwd:****)",
-            params.domain,
-            params.username,
-        )
         action = UpdatePasswordNoAuthAction(
             request=ctx.request,
             domain_name=params.domain,
@@ -306,7 +281,6 @@ class AuthHandler:
     # ------------------------------------------------------------------
 
     async def get_ssh_keypair(self, ctx: UserContext) -> APIResponse:
-        log.info("AUTH.GET_SSH_KEYPAIR(d:{}, ak:{})", ctx.user_domain, ctx.access_key)
         result = await self._auth.get_ssh_keypair.run(
             GetSSHKeypairAction(
                 user_id=UserID(ctx.user_uuid),
@@ -321,7 +295,6 @@ class AuthHandler:
     # ------------------------------------------------------------------
 
     async def generate_ssh_keypair(self, ctx: UserContext) -> APIResponse:
-        log.info("AUTH.REFRESH_SSH_KEYPAIR(d:{}, ak:{})", ctx.user_domain, ctx.access_key)
         result = await self._auth.generate_ssh_keypair.run(
             GenerateSSHKeypairAction(
                 user_id=UserID(ctx.user_uuid),
@@ -344,7 +317,6 @@ class AuthHandler:
         params = body.parsed
         pubkey = f"{params.pubkey.rstrip()}\n"
         privkey = f"{params.privkey.rstrip()}\n"
-        log.info("AUTH.SAVE_SSH_KEYPAIR(d:{}, ak:{})", ctx.user_domain, ctx.access_key)
         result = await self._auth.upload_ssh_keypair.run(
             UploadSSHKeypairAction(
                 user_id=UserID(ctx.user_uuid),

--- a/src/ai/backend/manager/api/rest/auto_scaling_rule/handler.py
+++ b/src/ai/backend/manager/api/rest/auto_scaling_rule/handler.py
@@ -79,7 +79,6 @@ class AutoScalingRuleHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Create a new auto-scaling rule."""
-        log.info("AUTO_SCALING_RULE.CREATE (ak:{})", ctx.access_key)
 
         creator = ModelDeploymentAutoScalingRuleCreator(
             model_deployment_id=body.parsed.model_deployment_id,
@@ -111,7 +110,6 @@ class AutoScalingRuleHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Get a specific auto-scaling rule."""
-        log.info("AUTO_SCALING_RULE.GET (ak:{})", ctx.access_key)
 
         action_result = await self._deployment.get_auto_scaling_rule.run(
             GetAutoScalingRuleAction(
@@ -131,7 +129,6 @@ class AutoScalingRuleHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search auto-scaling rules with filters, orders, and pagination."""
-        log.info("AUTO_SCALING_RULE.SEARCH (ak:{})", ctx.access_key)
 
         querier = self._adapter.build_querier(body.parsed)
 
@@ -156,7 +153,6 @@ class AutoScalingRuleHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Update an existing auto-scaling rule."""
-        log.info("AUTO_SCALING_RULE.UPDATE (ak:{})", ctx.access_key)
 
         rule_id = path.parsed.rule_id
         modifier = self._adapter.build_modifier(body.parsed)
@@ -180,7 +176,6 @@ class AutoScalingRuleHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Delete an auto-scaling rule."""
-        log.info("AUTO_SCALING_RULE.DELETE (ak:{})", ctx.access_key)
 
         action_result = await self._deployment.delete_auto_scaling_rule.run(
             DeleteAutoScalingRuleAction(

--- a/src/ai/backend/manager/api/rest/cluster_template/handler.py
+++ b/src/ai/backend/manager/api/rest/cluster_template/handler.py
@@ -98,11 +98,6 @@ class ClusterTemplateHandler:
         params = body.parsed
         domain = params.domain or ctx.user_domain
         owner_access_key = params.owner_access_key
-        log.info(
-            "CLUSTER_TEMPLATE.CREATE (ak:{0}/{1})",
-            ctx.access_key,
-            owner_access_key if owner_access_key and owner_access_key != ctx.access_key else "*",
-        )
 
         try:
             payload = load_json(params.payload)
@@ -137,8 +132,6 @@ class ClusterTemplateHandler:
     ) -> APIResponse:
         params = query.parsed
         user_role = req.request["user"]["role"]
-
-        log.info("CLUSTER_TEMPLATE.LIST (ak:{})", ctx.access_key)
 
         raw_group_id = params.group_id if hasattr(params, "group_id") else None
         group_id_filter = uuid.UUID(raw_group_id) if raw_group_id is not None else None
@@ -181,13 +174,6 @@ class ClusterTemplateHandler:
         params = query.parsed
         if params.format not in ("yaml", "json"):
             raise InvalidAPIParameters('format should be "yaml" or "json"')
-        log.info(
-            "CLUSTER_TEMPLATE.GET (ak:{0}/{1})",
-            ctx.access_key,
-            params.owner_access_key
-            if params.owner_access_key and params.owner_access_key != ctx.access_key
-            else "*",
-        )
 
         template_id = path.parsed.template_id
         action = GetClusterTemplateAction(template_id=SessionTemplateID(UUID(template_id)))
@@ -206,13 +192,6 @@ class ClusterTemplateHandler:
     ) -> APIResponse:
         template_id = path.parsed.template_id
         params = body.parsed
-        log.info(
-            "CLUSTER_TEMPLATE.PUT (ak:{0}/{1})",
-            ctx.access_key,
-            params.owner_access_key
-            if params.owner_access_key and params.owner_access_key != ctx.access_key
-            else "*",
-        )
 
         try:
             payload = load_json(params.payload)
@@ -240,14 +219,6 @@ class ClusterTemplateHandler:
         req: RequestCtx,
     ) -> APIResponse:
         template_id = path.parsed.template_id
-        params = query.parsed
-        log.info(
-            "CLUSTER_TEMPLATE.DELETE (ak:{0}/{1})",
-            ctx.access_key,
-            params.owner_access_key
-            if params.owner_access_key and params.owner_access_key != ctx.access_key
-            else "*",
-        )
 
         action = DeleteClusterTemplateAction(template_id=SessionTemplateID(UUID(template_id)))
         await self._template.delete_cluster.run(action)

--- a/src/ai/backend/manager/api/rest/compute_sessions/handler.py
+++ b/src/ai/backend/manager/api/rest/compute_sessions/handler.py
@@ -44,7 +44,6 @@ class ComputeSessionsHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search compute sessions with nested container data."""
-        log.info("SEARCH_SESSIONS (ak:{})", ctx.access_key)
 
         user = current_user()
         if user is None:

--- a/src/ai/backend/manager/api/rest/container_registry/handler.py
+++ b/src/ai/backend/manager/api/rest/container_registry/handler.py
@@ -93,7 +93,6 @@ class ContainerRegistryHandler:
         body: BodyParam[CreateContainerRegistryRequestModel],
     ) -> APIResponse:
         params = body.parsed
-        log.info("CREATE_CONTAINER_REGISTRY (registry_name:{})", params.registry_name)
 
         creator = ContainerRegistryCreator(
             url=params.url,
@@ -134,7 +133,6 @@ class ContainerRegistryHandler:
         path: PathParam[RegistryIdPath],
     ) -> APIResponse:
         registry_id = path.parsed.registry_id
-        log.info("DELETE_CONTAINER_REGISTRY (registry:{})", registry_id)
 
         await self._container_registry.delete_container_registry.run(
             DeleteContainerRegistryAction(
@@ -148,8 +146,6 @@ class ContainerRegistryHandler:
     # ------------------------------------------------------------------
 
     async def list_all(self) -> APIResponse:
-        log.info("LIST_ALL_CONTAINER_REGISTRIES")
-
         result = await self._container_registry.load_all_container_registries.run(
             LoadAllContainerRegistriesAction()
         )
@@ -182,11 +178,6 @@ class ContainerRegistryHandler:
         query: QueryParam[LoadContainerRegistriesQueryModel],
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "LOAD_CONTAINER_REGISTRIES (registry:{}, project:{})",
-            params.registry,
-            params.project,
-        )
 
         result = await self._container_registry.load_container_registries.run(
             LoadContainerRegistriesAction(registry=params.registry, project=params.project)
@@ -221,7 +212,6 @@ class ContainerRegistryHandler:
         path: PathParam[RegistryIdPath],
     ) -> APIResponse:
         registry_id = path.parsed.registry_id
-        log.info("PATCH_CONTAINER_REGISTRY (registry:{})", registry_id)
         params = body.parsed
 
         updater = ContainerRegistryUpdater(
@@ -290,7 +280,6 @@ class ContainerRegistryHandler:
         body: BodyParam[ImageOperationRequestModel],
     ) -> APIResponse:
         params = body.parsed
-        log.info("RESCAN_IMAGES (registry:{}, project:{})", params.registry, params.project)
 
         await self._container_registry.rescan_images.run(
             RescanImagesAction(
@@ -310,7 +299,6 @@ class ContainerRegistryHandler:
         body: BodyParam[ImageOperationRequestModel],
     ) -> APIResponse:
         params = body.parsed
-        log.info("CLEAR_IMAGES (registry:{}, project:{})", params.registry, params.project)
 
         await self._container_registry.clear_images.run(
             ClearImagesAction(registry=params.registry, project=params.project)
@@ -331,7 +319,6 @@ class ContainerRegistryHandler:
         event_type = params.type
         project = params.event_data.repository.namespace
         img_name = params.event_data.repository.name
-        log.info("HARBOR_WEBHOOK_HANDLER (event_type:{})", event_type)
 
         resources = [
             HarborWebhookResourceInput(

--- a/src/ai/backend/manager/api/rest/domain/handler.py
+++ b/src/ai/backend/manager/api/rest/domain/handler.py
@@ -73,7 +73,6 @@ class DomainHandler:
         body: BodyParam[CreateDomainRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("CREATE_DOMAIN (ak:{})", ctx.access_key)
         creator = DomainCreator(
             name=body.parsed.name,
             description=body.parsed.description,
@@ -110,7 +109,6 @@ class DomainHandler:
         path: PathParam[GetDomainPathParam],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("GET_DOMAIN (ak:{}, d:{})", ctx.access_key, path.parsed.domain_name)
         resolved = await self._domain.lookup.run(
             LookupDomainAction(name=DomainName(path.parsed.domain_name))
         )
@@ -128,7 +126,6 @@ class DomainHandler:
         body: BodyParam[SearchDomainsRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("SEARCH_DOMAINS (ak:{})", ctx.access_key)
         searcher = self._adapter.build_searcher(body.parsed)
 
         action_result = await self._domain.global_search.run(
@@ -156,7 +153,6 @@ class DomainHandler:
         ctx: UserContext,
     ) -> APIResponse:
         domain_name = path.parsed.domain_name
-        log.info("UPDATE_DOMAIN (ak:{}, d:{})", ctx.access_key, domain_name)
         target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
         updater = self._adapter.build_updater(body.parsed, target.entity_id())
 
@@ -174,7 +170,6 @@ class DomainHandler:
         body: BodyParam[DeleteDomainRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("DELETE_DOMAIN (ak:{}, d:{})", ctx.access_key, body.parsed.name)
         target = await self._domain.lookup.run(
             LookupDomainAction(name=DomainName(body.parsed.name))
         )
@@ -196,7 +191,6 @@ class DomainHandler:
         body: BodyParam[PurgeDomainRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("PURGE_DOMAIN (ak:{}, d:{})", ctx.access_key, body.parsed.name)
         target = await self._domain.lookup.run(
             LookupDomainAction(name=DomainName(body.parsed.name))
         )

--- a/src/ai/backend/manager/api/rest/domainconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/domainconfig/handler.py
@@ -57,7 +57,6 @@ class DomainConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("DOMAINCONFIG.CREATE(domain:{})", params.domain)
         target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(params.domain)))
         await self._domain.create_dotfile.run(
             CreateDomainDotfileAction(
@@ -74,7 +73,6 @@ class DomainConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info("DOMAINCONFIG.LIST_OR_GET(domain:{})", params.domain)
         resolved = await self._domain.lookup.run(LookupDomainAction(name=DomainName(params.domain)))
         target = await self._domain.get.run(GetDomainAction(domain_id=resolved.entity_id()))
         entries = DotfileEntries.unpack(target.data.dotfiles)
@@ -95,7 +93,6 @@ class DomainConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("DOMAINCONFIG.UPDATE(domain:{})", params.domain)
         target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(params.domain)))
         await self._domain.update_dotfile.run(
             UpdateDomainDotfileAction(
@@ -112,7 +109,6 @@ class DomainConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info("DOMAINCONFIG.DELETE(domain:{})", params.domain)
         target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(params.domain)))
         await self._domain.delete_dotfile.run(
             DeleteDomainDotfileAction(

--- a/src/ai/backend/manager/api/rest/error_log/handler.py
+++ b/src/ai/backend/manager/api/rest/error_log/handler.py
@@ -54,7 +54,6 @@ class ErrorLogHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("CREATE (ak:{})", ctx.access_key)
 
         severity = ErrorLogSeverity(params.severity.lower())
         creator = ErrorLogCreator(
@@ -78,7 +77,6 @@ class ErrorLogHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info("LIST (ak:{})", ctx.access_key)
 
         searcher = ErrorLogSearcher(
             pagination=OffsetPagination(
@@ -132,7 +130,6 @@ class ErrorLogHandler:
     ) -> APIResponse:
         path_params = path.parsed
         log_id = uuid.UUID(path_params.log_id)
-        log.info("CLEAR")
 
         action = DeleteErrorLogAction(log_id=ErrorLogID(log_id))
         await self._error_log.delete.run(action)

--- a/src/ai/backend/manager/api/rest/etcd/handler.py
+++ b/src/ai/backend/manager/api/rest/etcd/handler.py
@@ -62,7 +62,6 @@ class EtcdHandler:
     # ------------------------------------------------------------------
 
     async def get_resource_slots(self) -> APIResponse:
-        log.info("ETCD.GET_RESOURCE_SLOTS ()")
         action = GetResourceSlotsAction()
         result = await self._etcd_config.get_resource_slots.run(action)
         resp = ResourceSlotsResponse(root=result.slots)
@@ -77,7 +76,6 @@ class EtcdHandler:
         query: QueryParam[GetResourceMetadataQuery],
     ) -> APIResponse:
         params = query.parsed
-        log.info("ETCD.GET_RESOURCE_METADATA (sg:{})", params.sgroup)
         action = GetResourceMetadataAction(sgroup=params.sgroup)
         result = await self._etcd_config.get_resource_metadata.run(action)
         resp = ResourceMetadataResponse(root=result.metadata)
@@ -88,7 +86,6 @@ class EtcdHandler:
     # ------------------------------------------------------------------
 
     async def get_vfolder_types(self) -> APIResponse:
-        log.info("ETCD.GET_VFOLDER_TYPES ()")
         action = GetVfolderTypesAction()
         result = await self._etcd_config.get_vfolder_types.run(action)
         resp = VfolderTypesResponse(root=result.types)
@@ -99,7 +96,6 @@ class EtcdHandler:
     # ------------------------------------------------------------------
 
     async def get_docker_registries(self, ctx: UserContext) -> APIResponse:
-        log.info("ETCD.GET_DOCKER_REGISTRIES ()")
         log.warning(
             "ETCD.GET_DOCKER_REGISTRIES has been deprecated because it no longer uses etcd."
             " Use /resource/container-registries API instead."
@@ -126,12 +122,6 @@ class EtcdHandler:
            is used.  Prefer dedicated CRUD APIs when possible.
         """
         params = body.parsed
-        log.info(
-            "ETCD.GET_CONFIG (ak:{}, key:{}, prefix:{})",
-            ctx.access_key,
-            params.key,
-            params.prefix,
-        )
         action = GetConfigAction(key=params.key, prefix=params.prefix)
         result = await self._etcd_config.get_config.run(action)
         return APIResponse.build(HTTPStatus.OK, ConfigResultResponse(result=result.result))
@@ -147,12 +137,6 @@ class EtcdHandler:
     ) -> APIResponse:
         """Raw etcd key-value write."""
         params = body.parsed
-        log.info(
-            "ETCD.SET_CONFIG (ak:{}, key:{}, val:{})",
-            ctx.access_key,
-            params.key,
-            params.value,
-        )
         action = SetConfigAction(key=params.key, value=params.value)
         await self._etcd_config.set_config.run(action)
         return APIResponse.build(HTTPStatus.OK, OkResultResponse())
@@ -174,12 +158,6 @@ class EtcdHandler:
            is used.  This may delete sibling keys unexpectedly.
         """
         params = body.parsed
-        log.info(
-            "ETCD.DELETE_CONFIG (ak:{}, key:{}, prefix:{})",
-            ctx.access_key,
-            params.key,
-            params.prefix,
-        )
         action = DeleteConfigAction(key=params.key, prefix=params.prefix)
         await self._etcd_config.delete_config.run(action)
         return APIResponse.build(HTTPStatus.OK, OkResultResponse())

--- a/src/ai/backend/manager/api/rest/events/handler.py
+++ b/src/ai/backend/manager/api/rest/events/handler.py
@@ -86,7 +86,6 @@ class EventsHandler:
         request = ctx.request
         params = query.parsed
         session_name = params.session_name
-        session_id = params.session_id
         scope = params.scope
         user_role = request["user"]["role"]
         user_uuid = user_ctx.user_uuid
@@ -100,14 +99,6 @@ class EventsHandler:
         if scope == "*":
             scope = "session,kernel"
 
-        log.info(
-            "PUSH_SESSION_EVENTS (ak:{}, s:{} / s:{}, g:{}, scope:{})",
-            access_key,
-            session_name,
-            session_id,
-            group_name,
-            scope,
-        )
         priv_ctx = self._ctx
         current_task = asyncio.current_task()
         if current_task is None:
@@ -199,8 +190,6 @@ class EventsHandler:
         request = ctx.request
         priv_ctx = self._ctx
         task_id = query.parsed.task_id
-        access_key = user_ctx.access_key
-        log.info("PUSH_BACKGROUND_TASK_EVENTS (ak:{}, t:{})", access_key, task_id)
         current_task = asyncio.current_task()
         if current_task is None:
             raise NoCurrentTaskContext(

--- a/src/ai/backend/manager/api/rest/group/handler.py
+++ b/src/ai/backend/manager/api/rest/group/handler.py
@@ -57,7 +57,6 @@ class GroupHandler:
         body: BodyParam[RegistryQuotaModifyRequest],
     ) -> APIResponse:
         params = body.parsed
-        log.info("CREATE_REGISTRY_QUOTA (group:{})", params.group_id)
         scope_id = ProjectScope(project_id=uuid.UUID(params.group_id), domain_name=None)
         await self._container_registry.create_registry_quota.run(
             CreateRegistryQuotaAction(scope_id=scope_id, quota=params.quota)
@@ -73,7 +72,6 @@ class GroupHandler:
         query: QueryParam[RegistryQuotaRequest],
     ) -> APIResponse:
         params = query.parsed
-        log.info("READ_REGISTRY_QUOTA (group:{})", params.group_id)
         scope_id = ProjectScope(project_id=uuid.UUID(params.group_id), domain_name=None)
         result = await self._container_registry.read_registry_quota.run(
             ReadRegistryQuotaAction(scope_id=scope_id)
@@ -90,7 +88,6 @@ class GroupHandler:
         body: BodyParam[RegistryQuotaModifyRequest],
     ) -> APIResponse:
         params = body.parsed
-        log.info("UPDATE_REGISTRY_QUOTA (group:{})", params.group_id)
         scope_id = ProjectScope(project_id=uuid.UUID(params.group_id), domain_name=None)
         await self._container_registry.update_registry_quota.run(
             UpdateRegistryQuotaAction(scope_id=scope_id, quota=params.quota)
@@ -106,7 +103,6 @@ class GroupHandler:
         body: BodyParam[RegistryQuotaRequest],
     ) -> APIResponse:
         params = body.parsed
-        log.info("DELETE_REGISTRY_QUOTA (group:{})", params.group_id)
         scope_id = ProjectScope(project_id=uuid.UUID(params.group_id), domain_name=None)
         await self._container_registry.delete_registry_quota.run(
             DeleteRegistryQuotaAction(scope_id=scope_id)

--- a/src/ai/backend/manager/api/rest/groupconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/groupconfig/handler.py
@@ -74,7 +74,6 @@ class GroupConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("GROUPCONFIG.CREATE(group:{})", params.group)
         project_id = await self._resolve(params.group, params.domain, ctx)
         await self._project.create_dotfile.run(
             CreateProjectDotfileAction(
@@ -90,7 +89,6 @@ class GroupConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info("GROUPCONFIG.LIST_OR_GET(group:{})", params.group)
         project_id = await self._resolve(params.group, params.domain, ctx)
         project = await self._project.get_project.run(GetProjectAction(project_id=project_id))
         entries = DotfileEntries.unpack(project.data.dotfiles)
@@ -111,7 +109,6 @@ class GroupConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("GROUPCONFIG.UPDATE(group:{})", params.group)
         project_id = await self._resolve(params.group, params.domain, ctx)
         await self._project.update_dotfile.run(
             UpdateProjectDotfileAction(
@@ -127,7 +124,6 @@ class GroupConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info("GROUPCONFIG.DELETE(group:{})", params.group)
         project_id = await self._resolve(params.group, params.domain, ctx)
         await self._project.delete_dotfile.run(
             DeleteProjectDotfileAction(project_id=project_id, path=params.path)

--- a/src/ai/backend/manager/api/rest/image/handler.py
+++ b/src/ai/backend/manager/api/rest/image/handler.py
@@ -53,7 +53,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search images with filters, orders, and pagination."""
-        log.info("SEARCH (ak:{})", ctx.access_key)
         querier = self._adapter.build_querier(body.parsed)
         action_result = await self._image.search_images.run(SearchImagesAction(querier=querier))
         resp = SearchImagesResponse(
@@ -72,7 +71,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Get a single image by ID."""
-        log.info("GET (ak:{}, image_id:{})", ctx.access_key, path.parsed.image_id)
         action_result = await self._image.get_image_by_id.run(
             GetImageByIdAction(image_id=ImageID(path.parsed.image_id), image_status=None)
         )
@@ -89,7 +87,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Rescan an image from the registry."""
-        log.info("RESCAN (ak:{})", ctx.access_key)
         action_result = await self._image.scan_image.run(
             ScanImageAction(canonical=body.parsed.canonical, architecture=body.parsed.architecture)
         )
@@ -105,7 +102,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Create an image alias."""
-        log.info("ALIAS (ak:{})", ctx.access_key)
         action_result = await self._image.alias_image_by_id.run(
             AliasImageByIdAction(
                 image_id=ImageID(body.parsed.image_id),
@@ -125,7 +121,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Remove an image alias."""
-        log.info("DEALIAS (ak:{})", ctx.access_key)
         action_result = await self._image.dealias_image.run(
             DealiasImageAction(alias=body.parsed.alias)
         )
@@ -142,7 +137,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Forget (soft-delete) an image."""
-        log.info("FORGET (ak:{})", ctx.access_key)
         action_result = await self._image.forget_image_by_id.run(
             ForgetImageByIdAction(image_id=ImageID(body.parsed.image_id))
         )
@@ -157,7 +151,6 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Purge (hard-delete) an image."""
-        log.info("PURGE (ak:{})", ctx.access_key)
         action_result = await self._image.purge_image_by_id.run(
             PurgeImageByIdAction(image_id=ImageID(body.parsed.image_id))
         )

--- a/src/ai/backend/manager/api/rest/manager/handler.py
+++ b/src/ai/backend/manager/api/rest/manager/handler.py
@@ -169,7 +169,6 @@ class ManagerHandler:
     # ------------------------------------------------------------------
 
     async def fetch_manager_status(self, req: RequestCtx) -> APIResponse:
-        log.info("MANAGER.FETCH_MANAGER_STATUS ()")
         try:
             action = FetchManagerStatusAction()
             result = await self._manager_admin.fetch_status.run(action)
@@ -206,11 +205,6 @@ class ManagerHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info(
-            "MANAGER.UPDATE_MANAGER_STATUS (status:{}, force_kill:{})",
-            params.status,
-            params.force_kill,
-        )
         action = UpdateManagerStatusAction(
             status=params.status,
             force_kill=params.force_kill,

--- a/src/ai/backend/manager/api/rest/notification/handler.py
+++ b/src/ai/backend/manager/api/rest/notification/handler.py
@@ -91,7 +91,6 @@ class NotificationHandler:
         body: BodyParam[CreateNotificationChannelRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("CREATE_CHANNEL (ak:{})", ctx.access_key)
         validated_spec = body.parsed.spec
         creator = NotificationChannelCreator(
             name=body.parsed.name,
@@ -207,7 +206,6 @@ class NotificationHandler:
         body: BodyParam[CreateNotificationRuleRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("CREATE_RULE (ak:{})", ctx.access_key)
         creator = NotificationRuleCreator(
             name=body.parsed.name,
             description=body.parsed.description,

--- a/src/ai/backend/manager/api/rest/quota_scope/handler.py
+++ b/src/ai/backend/manager/api/rest/quota_scope/handler.py
@@ -46,7 +46,6 @@ class QuotaScopeHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Get a single quota scope by storage host and scope ID."""
-        log.info("GET (ak:{})", ctx.access_key)
         result = await self._vfs_storage.global_get_quota_scope.run(
             GetQuotaScopeAction(
                 storage_host_name=path.parsed.storage_host_name,
@@ -69,7 +68,6 @@ class QuotaScopeHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search all quota scopes across all volumes."""
-        log.info("SEARCH (ak:{})", ctx.access_key)
         result = await self._vfs_storage.global_search_quota_scopes.run(SearchQuotaScopesAction())
         quota_scopes = [
             QuotaScopeDTO(
@@ -101,7 +99,6 @@ class QuotaScopeHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Set quota limit for a scope."""
-        log.info("SET_QUOTA (ak:{})", ctx.access_key)
         result = await self._vfs_storage.global_set_quota_scope.run(
             SetQuotaScopeAction(
                 storage_host_name=body.parsed.storage_host_name,
@@ -125,7 +122,6 @@ class QuotaScopeHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Unset (remove) quota limit for a scope."""
-        log.info("UNSET_QUOTA (ak:{})", ctx.access_key)
         result = await self._vfs_storage.global_unset_quota_scope.run(
             UnsetQuotaScopeAction(
                 storage_host_name=body.parsed.storage_host_name,

--- a/src/ai/backend/manager/api/rest/resource/handler.py
+++ b/src/ai/backend/manager/api/rest/resource/handler.py
@@ -95,7 +95,6 @@ class ResourceHandler:
         query: QueryParam[ListPresetsQuery],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("LIST_PRESETS (ak:{})", ctx.access_key)
         params = query.parsed
         result = await self._resource_preset.list_presets.run(
             ListResourcePresetsAction(
@@ -117,12 +116,6 @@ class ResourceHandler:
     ) -> APIResponse:
         params = body.parsed
         resource_policy = req.request["keypair"]["resource_policy"]
-        log.info(
-            "CHECK_PRESETS (ak:{}, g:{}, sg:{})",
-            ctx.access_key,
-            params.group,
-            params.scaling_group,
-        )
         result = await self._resource_preset.check_presets.run(
             CheckResourcePresetsAction(
                 access_key=AccessKey(ctx.access_key),
@@ -159,7 +152,6 @@ class ResourceHandler:
     # ------------------------------------------------------------------
 
     async def recalculate_usage(self, ctx: UserContext) -> APIResponse:
-        log.info("RECALCULATE_USAGE ()")
         await self._agent.recalculate_usage.run(RecalculateUsageAction())
         return APIResponse.build(HTTPStatus.OK, EmptyResponse())
 
@@ -173,11 +165,6 @@ class ResourceHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "USAGE_PER_MONTH (g:[{}], month:{})",
-            ",".join(str(gid) for gid in params.group_ids) if params.group_ids else "",
-            params.month,
-        )
         result = await self._project.usage_per_month.run(
             UsagePerMonthAction(
                 group_ids=params.group_ids,
@@ -210,7 +197,6 @@ class ResourceHandler:
     # ------------------------------------------------------------------
 
     async def user_month_stats(self, ctx: UserContext) -> APIResponse:
-        log.info("USER_LAST_MONTH_STATS (ak:{}, u:{})", ctx.access_key, ctx.user_uuid)
         result = await self._user.user_month_stats.run(
             UserMonthStatsAction(user_id=UserID(ctx.user_uuid))
         )
@@ -221,7 +207,6 @@ class ResourceHandler:
     # ------------------------------------------------------------------
 
     async def admin_month_stats(self, ctx: UserContext) -> APIResponse:
-        log.info("ADMIN_LAST_MONTH_STATS ()")
         result = await self._user.admin_month_stats.run(AdminMonthStatsAction())
         return APIResponse.build(HTTPStatus.OK, RawListResponse(root=result.stats))
 
@@ -235,7 +220,6 @@ class ResourceHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info("GET_WATCHER_STATUS (ag:{})", params.agent_id)
         result = await self._agent.get_watcher_status.run(
             GetWatcherStatusAction(agent_id=AgentId(params.agent_id))
         )
@@ -251,7 +235,6 @@ class ResourceHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("WATCHER_AGENT_START (ag:{})", params.agent_id)
         result = await self._agent.watcher_agent_start.run(
             WatcherAgentStartAction(agent_id=AgentId(params.agent_id))
         )
@@ -267,7 +250,6 @@ class ResourceHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("WATCHER_AGENT_STOP (ag:{})", params.agent_id)
         result = await self._agent.watcher_agent_stop.run(
             WatcherAgentStopAction(agent_id=AgentId(params.agent_id))
         )
@@ -283,7 +265,6 @@ class ResourceHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info("WATCHER_AGENT_RESTART (ag:{})", params.agent_id)
         result = await self._agent.watcher_agent_restart.run(
             WatcherAgentRestartAction(agent_id=AgentId(params.agent_id))
         )

--- a/src/ai/backend/manager/api/rest/resource_group/handler.py
+++ b/src/ai/backend/manager/api/rest/resource_group/handler.py
@@ -77,12 +77,6 @@ class ResourceGroupHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "SGROUPS.LIST(ak:{}, g:{}, d:{})",
-            ctx.access_key,
-            params.group,
-            ctx.user_domain,
-        )
         domain_lookup = await self._domain.lookup.run(
             LookupDomainAction(name=DomainName(ctx.user_domain))
         )
@@ -121,12 +115,6 @@ class ResourceGroupHandler:
         query_params = query.parsed
         resource_group_name = path_params.scaling_group
         group_id_or_name = query_params.group
-        log.info(
-            "SGROUPS.LIST(ak:{}, g:{}, d:{})",
-            ctx.access_key,
-            group_id_or_name,
-            ctx.user_domain,
-        )
         action = GetWsproxyVersionAction(
             resource_group_name=resource_group_name,
             domain_name=ctx.user_domain,

--- a/src/ai/backend/manager/api/rest/resource_slot/handler.py
+++ b/src/ai/backend/manager/api/rest/resource_slot/handler.py
@@ -45,7 +45,6 @@ class ResourceSlotHandler:
         body: BodyParam[SearchResourceSlotTypesRequest],
     ) -> APIResponse:
         """Search resource slot types with filters, orders, and pagination."""
-        log.info("SEARCH_RESOURCE_SLOT_TYPES")
 
         searcher = self._adapter.build_searcher(body.parsed)
 
@@ -69,7 +68,6 @@ class ResourceSlotHandler:
     ) -> APIResponse:
         """Get a single resource slot type by slot_name."""
         slot_name = path.parsed.slot_name
-        log.info("GET_RESOURCE_SLOT_TYPE (slot_name:{})", slot_name)
 
         resolved = await self._resource_slot.public_lookup_resource_slot_type.run(
             LookupResourceSlotTypeAction(slot_name=slot_name)

--- a/src/ai/backend/manager/api/rest/scheduling_history/handler.py
+++ b/src/ai/backend/manager/api/rest/scheduling_history/handler.py
@@ -43,7 +43,6 @@ class SchedulingHistoryHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search session scheduling history."""
-        log.info("SEARCH_SESSION_HISTORY (ak:{})", ctx.access_key)
 
         querier = self._adapter.build_session_history_querier(body.parsed)
 
@@ -69,7 +68,6 @@ class SchedulingHistoryHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search deployment history."""
-        log.info("SEARCH_DEPLOYMENT_HISTORY (ak:{})", ctx.access_key)
 
         querier = self._adapter.build_deployment_history_querier(body.parsed)
 
@@ -95,7 +93,6 @@ class SchedulingHistoryHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Search route history."""
-        log.info("SEARCH_ROUTE_HISTORY (ak:{})", ctx.access_key)
 
         querier = self._adapter.build_route_history_querier(body.parsed)
 

--- a/src/ai/backend/manager/api/rest/service/handler.py
+++ b/src/ai/backend/manager/api/rest/service/handler.py
@@ -256,7 +256,6 @@ class ServiceHandler:
         self, query: QueryParam[ListServeRequestModel], ctx: UserContext
     ) -> APIResponse | web.StreamResponse:
         params = query.parsed
-        log.info("SERVE.LIST (email:{}, ak:{})", ctx.user_email, ctx.access_key)
 
         action = ListModelServiceAction(session_owener_id=ctx.user_uuid, name=params.name)
         result: ListModelServiceActionResult = await self._model_serving.list_model_service.run(
@@ -288,7 +287,6 @@ class ServiceHandler:
         self, body: BodyParam[SearchServicesRequestModel], ctx: UserContext
     ) -> APIResponse:
         params = body.parsed
-        log.info("SERVE.SEARCH (email:{}, ak:{})", ctx.user_email, ctx.access_key)
 
         adapter = ServiceSearchAdapter()
         conditions = adapter.convert_filter(params.filter) if params.filter else []
@@ -330,12 +328,6 @@ class ServiceHandler:
 
     async def get_info(self, path: PathParam[ServiceIdPathParam], ctx: UserContext) -> APIResponse:
         params = path.parsed
-        log.info(
-            "SERVE.GET_INFO (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            params.service_id,
-        )
 
         action = GetModelServiceInfoAction(deployment_id=DeploymentID(params.service_id))
         result: GetModelServiceInfoActionResult = (
@@ -432,12 +424,6 @@ class ServiceHandler:
 
     async def delete(self, path: PathParam[ServiceIdPathParam], ctx: UserContext) -> APIResponse:
         params = path.parsed
-        log.info(
-            "SERVE.DELETE (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            params.service_id,
-        )
 
         deployment_action = DestroyDeploymentAction(deployment_id=DeploymentID(params.service_id))
         deployment_result: DestroyDeploymentActionResult = (
@@ -452,12 +438,6 @@ class ServiceHandler:
 
     async def sync(self, path: PathParam[ServiceIdPathParam], ctx: UserContext) -> APIResponse:
         params = path.parsed
-        log.info(
-            "SERVE.SYNC (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            params.service_id,
-        )
 
         action = ForceSyncAction(deployment_id=DeploymentID(params.service_id))
         result = await self._model_serving.force_sync.run(action)
@@ -478,12 +458,6 @@ class ServiceHandler:
         path_params = path.parsed
         params = body.parsed
         request = req.request
-        log.info(
-            "SERVE.SCALE (email:{}, ak:{}, s:{})",
-            request["user"]["email"],
-            request["keypair"]["access_key"],
-            path_params.service_id,
-        )
 
         action = ScaleServiceReplicasAction(
             max_session_count_per_model_session=request["user"]["resource_policy"][
@@ -513,13 +487,6 @@ class ServiceHandler:
     ) -> APIResponse:
         path_params = path.parsed
         params = body.parsed
-        log.info(
-            "SERVE.UPDATE_ROUTE (email:{}, ak:{}, s:{}, r:{})",
-            ctx.user_email,
-            ctx.access_key,
-            path_params.service_id,
-            path_params.route_id,
-        )
 
         action = UpdateRouteAction(
             deployment_id=DeploymentID(path_params.service_id),
@@ -540,12 +507,6 @@ class ServiceHandler:
         self, path: PathParam[ServiceRouteIdPathParam], ctx: UserContext
     ) -> APIResponse:
         path_params = path.parsed
-        log.info(
-            "SERVE.DELETE_ROUTE (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            path_params.service_id,
-        )
 
         action = DeleteRouteAction(
             deployment_id=DeploymentID(path_params.service_id),
@@ -569,12 +530,6 @@ class ServiceHandler:
     ) -> APIResponse:
         path_params = path.parsed
         params = body.parsed
-        log.info(
-            "SERVE.GENERATE_TOKEN (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            path_params.service_id,
-        )
 
         action = GenerateTokenAction(
             deployment_id=DeploymentID(path_params.service_id),
@@ -596,12 +551,6 @@ class ServiceHandler:
         self, path: PathParam[ServiceIdPathParam], ctx: UserContext
     ) -> APIResponse:
         path_params = path.parsed
-        log.info(
-            "SERVE.LIST_ERRORS (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            path_params.service_id,
-        )
 
         action = ListErrorsAction(deployment_id=DeploymentID(path_params.service_id))
         result = await self._model_serving.list_errors.run(action)
@@ -623,12 +572,6 @@ class ServiceHandler:
         self, path: PathParam[ServiceIdPathParam], ctx: UserContext
     ) -> APIResponse:
         path_params = path.parsed
-        log.info(
-            "SERVE.CLEAR_ERROR (email:{}, ak:{}, s:{})",
-            ctx.user_email,
-            ctx.access_key,
-            path_params.service_id,
-        )
 
         action = ClearErrorAction(deployment_id=DeploymentID(path_params.service_id))
         await self._model_serving.clear_error.run(action)

--- a/src/ai/backend/manager/api/rest/session/handler.py
+++ b/src/ai/backend/manager/api/rest/session/handler.py
@@ -606,14 +606,6 @@ class SessionHandler:
         )
         requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
 
-        log.info(
-            "GET_OR_CREATE (ak:{0}/{1}, img:{2}, s:{3})",
-            requester_access_key,
-            owner_access_key if owner_access_key != requester_access_key else "*",
-            params.image,
-            params.session_name,
-        )
-
         domain_name = params.domain or request["user"]["domain_name"]
 
         # Use model_fields_set to detect which fields were explicitly provided
@@ -722,13 +714,6 @@ class SessionHandler:
             )
         )
         requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "GET_OR_CREATE (ak:{0}/{1}, img:{2}, s:{3})",
-            requester_access_key,
-            owner_access_key if owner_access_key != requester_access_key else "*",
-            params.image,
-            params.session_name,
-        )
         architecture = params.architecture or DEFAULT_IMAGE_ARCH
 
         result = await self._session.create_from_params.run(
@@ -794,12 +779,6 @@ class SessionHandler:
             )
         )
         requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "CREAT_CLUSTER (ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key if owner_access_key != requester_access_key else "*",
-            params.session_name,
-        )
 
         result = await self._session.create_cluster.run(
             CreateClusterAction(
@@ -842,16 +821,10 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         user = current_user()
         if user is None:
             raise UserNotFound("User not found in context")
-        log.info(
-            "MATCH_SESSIONS(ak:{0}/{1}, prefix:{2})",
-            requester_access_key,
-            owner_access_key,
-            params.id,
-        )
         result = await self._session.match_sessions.run(
             MatchSessionsAction(
                 id_or_name_prefix=params.id,
@@ -872,7 +845,7 @@ class SessionHandler:
     ) -> APIResponse:
         request = ctx.request
         params = body.parsed
-        scope = await self._auth.public_resolve_access_key_scope.run(
+        await self._auth.public_resolve_access_key_scope.run(
             PublicResolveAccessKeyScopeAction(
                 requester_access_key=request["keypair"]["access_key"],
                 requester_role=request["user"]["role"],
@@ -880,14 +853,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
         agent_id = AgentId(params.agent)
-        log.info(
-            "SYNC_AGENT_REGISTRY (ak:{}/{}, a:{})",
-            requester_access_key,
-            owner_access_key,
-            agent_id,
-        )
         await self._agent.sync_agent_registry.run(SyncAgentRegistryAction(agent_id=agent_id))
         return APIResponse.build(HTTPStatus.OK, CreateSessionResponse({}))
 
@@ -926,13 +892,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "GET_INFO (ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.get_session_info.run(
             GetSessionInfoAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -994,15 +954,6 @@ class SessionHandler:
         ):
             raise InsufficientPrivilege("You are not allowed to force-terminate others's sessions")
 
-        log.info(
-            "DESTROY (ak:{0}/{1}, s:{2}, forced:{3}, recursive: {4})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-            params.forced,
-            params.recursive,
-        )
-
         result = await self._session.destroy_session.run(
             DestroySessionAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1035,13 +986,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "EXECUTE(ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
 
         result = await self._session.execute_session.run(
             ExecuteSessionAction(
@@ -1074,13 +1019,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "INTERRUPT(ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         await self._session.interrupt.run(
             InterruptSessionAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1110,13 +1049,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "COMPLETE(ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
 
         action_result = await self._session.complete.run(
             CompleteAction(
@@ -1183,13 +1116,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "SHUTDOWN_SERVICE (ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         await self._session.shutdown_service.run(
             ShutdownServiceAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1216,13 +1143,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "UPLOAD_FILE (ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         await self._session.upload_files.run(
             UploadFilesAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1253,14 +1174,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "DOWNLOAD_FILE (ak:{0}/{1}, s:{2}, path:{3!r})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-            params.files[0],
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.download_files.run(
             DownloadFilesAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1292,14 +1206,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "DOWNLOAD_SINGLE (ak:{0}/{1}, s:{2}, path:{3!r})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-            params.file,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.download_file.run(
             DownloadFileAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1331,14 +1238,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "LIST_FILES (ak:{0}/{1}, s:{2}, path:{3})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-            params.path,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.list_files.run(
             ListFilesAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1371,14 +1271,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "RENAME_SESSION (ak:{0}/{1}, s:{2}, newname:{3})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-            new_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         await self._session.rename_session.run(
             RenameSessionAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1409,13 +1302,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "COMMIT_SESSION (ak:{}/{}, s:{})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         action_result = await self._session.commit_session.run(
             CommitSessionAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1449,13 +1336,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "CONVERT_SESSION_TO_IMAGE (ak:{}/{}, s:{})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.convert_session_to_image.run(
             ConvertSessionToImageAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1494,16 +1375,10 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         myself = asyncio.current_task()
         if myself is None:
             raise NoCurrentTaskContext("No current task context")
-        log.info(
-            "GET_COMMIT_STATUS (ak:{}/{}, s:{})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
         result = await self._session.get_commit_status.run(
             GetCommitStatusAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1535,13 +1410,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "GET_ABUSING_REPORT (ak:{}/{}, s:{})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.get_abusing_report.run(
             GetAbusingReportAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1576,13 +1445,7 @@ class SessionHandler:
                 owner_access_key=params.owner_access_key,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "GET_STATUS_HISTORY (ak:{}/{}, s:{})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.get_status_history.run(
             GetStatusHistoryAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1643,15 +1506,8 @@ class SessionHandler:
                 owner_access_key=params.owner_access_key,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         kernel_id = KernelId(params.kernel_id) if params.kernel_id is not None else None
-        log.info(
-            "GET_CONTAINER_LOG (ak:{}/{}, s:{}, k:{})",
-            requester_access_key,
-            owner_access_key,
-            session_name,
-            kernel_id,
-        )
         result = await self._session.get_container_logs.run(
             GetContainerLogsAction(
                 session_id=await self._resolve_session_id(owner_access_key, session_name),
@@ -1676,11 +1532,6 @@ class SessionHandler:
     ) -> web.StreamResponse:
         request = ctx.request
         params = query.parsed
-        log.info(
-            "GET_TASK_LOG (ak:{}, k:{})",
-            request["keypair"]["access_key"],
-            params.kernel_id,
-        )
         domain_name = request["user"]["domain_name"]
         user_role = request["user"]["role"]
         user_uuid = request["user"]["uuid"]
@@ -1712,13 +1563,7 @@ class SessionHandler:
                 owner_access_key=None,
             )
         )
-        requester_access_key, owner_access_key = scope.requester_access_key, scope.owner_access_key
-        log.info(
-            "GET_DEPENDENCY_GRAPH (ak:{0}/{1}, s:{2})",
-            requester_access_key,
-            owner_access_key,
-            root_session_name,
-        )
+        _, owner_access_key = scope.requester_access_key, scope.owner_access_key
         result = await self._session.get_dependency_graph.run(
             GetDependencyGraphAction(
                 session_id=await self._resolve_session_id(owner_access_key, root_session_name),

--- a/src/ai/backend/manager/api/rest/session_template/handler.py
+++ b/src/ai/backend/manager/api/rest/session_template/handler.py
@@ -99,11 +99,6 @@ class SessionTemplateHandler:
         params = body.parsed
         domain = params.domain or ctx.user_domain
         owner_access_key = params.owner_access_key
-        log.info(
-            "SESSION_TEMPLATE.CREATE (ak:{0}/{1})",
-            ctx.access_key,
-            owner_access_key if owner_access_key and owner_access_key != ctx.access_key else "*",
-        )
 
         try:
             payload = load_json(params.payload)
@@ -147,8 +142,6 @@ class SessionTemplateHandler:
         ctx: UserContext,
         req: RequestCtx,
     ) -> APIResponse:
-        log.info("SESSION_TEMPLATE.LIST (ak:{})", ctx.access_key)
-
         action = ListTaskTemplatesAction(user_uuid=UserID(ctx.user_uuid))
         result = await self._template.list_task.run(action)
 
@@ -183,13 +176,6 @@ class SessionTemplateHandler:
         params = query.parsed
         if params.format not in ("yaml", "json"):
             raise InvalidAPIParameters('format should be "yaml" or "json"')
-        log.info(
-            "SESSION_TEMPLATE.GET (ak:{0}/{1})",
-            ctx.access_key,
-            params.owner_access_key
-            if params.owner_access_key and params.owner_access_key != ctx.access_key
-            else "*",
-        )
 
         template_id = path.parsed.template_id
         action = GetTaskTemplateAction(template_id=SessionTemplateID(UUID(template_id)))
@@ -216,11 +202,6 @@ class SessionTemplateHandler:
         template_id = path.parsed.template_id
         domain = params.domain or ctx.user_domain
         owner_access_key = params.owner_access_key
-        log.info(
-            "SESSION_TEMPLATE.PUT (ak:{0}/{1})",
-            ctx.access_key,
-            owner_access_key if owner_access_key and owner_access_key != ctx.access_key else "*",
-        )
 
         try:
             payload = load_json(params.payload)
@@ -266,14 +247,6 @@ class SessionTemplateHandler:
         req: RequestCtx,
     ) -> APIResponse:
         template_id = path.parsed.template_id
-        params = query.parsed
-        log.info(
-            "SESSION_TEMPLATE.DELETE (ak:{0}/{1})",
-            ctx.access_key,
-            params.owner_access_key
-            if params.owner_access_key and params.owner_access_key != ctx.access_key
-            else "*",
-        )
 
         action = DeleteTaskTemplateAction(template_id=SessionTemplateID(UUID(template_id)))
         await self._template.delete_task.run(action)

--- a/src/ai/backend/manager/api/rest/stream/handler.py
+++ b/src/ai/backend/manager/api/rest/stream/handler.py
@@ -165,7 +165,6 @@ class StreamHandler:
         result = await self._stream.get_streaming_session.run(
             GetStreamingSessionAction(session_id=session_id),
         )
-        log.info("STREAM_PTY(s:{0})", session_name)
         stream_key = result.kernel_id
         kernel_host: str
         if result.kernel_host is None:
@@ -355,7 +354,6 @@ class StreamHandler:
         session_name_or_id = path.parsed.session_name
         session_name = await self._resolve_session_name(session_name_or_id)
         api_version = request["api_version"]
-        log.info("STREAM_EXECUTE(s:{0})", session_name)
         session_id = await self._resolve_session_id(session_name, user_id)
         session_result = await self._stream.get_streaming_session.run(
             GetStreamingSessionAction(session_id=session_id),
@@ -514,13 +512,6 @@ class StreamHandler:
         else:
             raise AppNotFound(f"{session_name}:{service}")
 
-        log.info(
-            "STREAM_WSPROXY (s:{}): tunneling {}:{} to {}",
-            session_name,
-            service,
-            sport["protocol"],
-            "{}:{}".format(*dest),
-        )
         if sport["protocol"] == "tcp":
             proxy_cls = TCPProxy
         elif sport["protocol"] == "pty":

--- a/src/ai/backend/manager/api/rest/user/handler.py
+++ b/src/ai/backend/manager/api/rest/user/handler.py
@@ -99,7 +99,6 @@ class UserHandler:
         body: BodyParam[CreateUserRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("CREATE_USER (ak:{})", ctx.access_key)
         password_info = PasswordInfo(
             password=body.parsed.password,
             algorithm=self._config_provider.config.auth.password_hash_algorithm,
@@ -152,7 +151,6 @@ class UserHandler:
         path: PathParam[GetUserPathParam],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("GET_USER (ak:{}, u:{})", ctx.access_key, path.parsed.user_id)
         action_result = await self._user.get_user.run(
             GetUserAction(user_id=UserID(path.parsed.user_id))
         )
@@ -169,7 +167,6 @@ class UserHandler:
         body: BodyParam[SearchUsersRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("SEARCH_USERS (ak:{})", ctx.access_key)
         searcher = self._adapter.build_searcher(body.parsed)
 
         action_result = await self._user.global_search.run(
@@ -196,8 +193,6 @@ class UserHandler:
         body: BodyParam[UpdateUserRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("UPDATE_USER (ak:{}, u:{})", ctx.access_key, path.parsed.user_id)
-
         # Build password info if password is being updated
         password_info: PasswordInfo | None = None
         if body.parsed.password is not None:
@@ -234,8 +229,6 @@ class UserHandler:
         body: BodyParam[DeleteUserRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("DELETE_USER (ak:{}, u:{})", ctx.access_key, body.parsed.user_id)
-
         await self._user.delete_user.run(DeleteUserAction(user_id=UserID(body.parsed.user_id)))
 
         resp = DeleteUserResponse(success=True)
@@ -250,8 +243,6 @@ class UserHandler:
         body: BodyParam[PurgeUserRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        log.info("PURGE_USER (ak:{}, u:{})", ctx.access_key, body.parsed.user_id)
-
         purge_shared = OptionalState[bool].nop()
         delegate_endpoint = OptionalState[bool].nop()
         if body.parsed.purge_shared_vfolders:

--- a/src/ai/backend/manager/api/rest/userconfig/handler.py
+++ b/src/ai/backend/manager/api/rest/userconfig/handler.py
@@ -100,7 +100,6 @@ class UserConfigHandler:
     ) -> APIResponse:
         params = body.parsed
         access_key = await self._owner_access_key(ctx, params.owner_access_key)
-        log.info("USERCONFIG.CREATE(ak:{})", access_key)
         await self._user.create_dotfile.run(
             CreateKeypairDotfileAction(
                 user_id=await self._owner(access_key),
@@ -117,7 +116,6 @@ class UserConfigHandler:
     ) -> APIResponse:
         params = query.parsed
         access_key = await self._owner_access_key(ctx, params.owner_access_key)
-        log.info("USERCONFIG.LIST_OR_GET(ak:{})", access_key)
         keypair = await self._user.get_keypair.run(
             GetKeypairAction(keypair_id=await self._keypair_id(access_key))
         )
@@ -140,7 +138,6 @@ class UserConfigHandler:
     ) -> APIResponse:
         params = body.parsed
         access_key = await self._owner_access_key(ctx, params.owner_access_key)
-        log.info("USERCONFIG.UPDATE(ak:{})", access_key)
         await self._user.update_dotfile.run(
             UpdateKeypairDotfileAction(
                 user_id=await self._owner(access_key),
@@ -157,7 +154,6 @@ class UserConfigHandler:
     ) -> APIResponse:
         params = query.parsed
         access_key = await self._owner_access_key(ctx, params.owner_access_key)
-        log.info("USERCONFIG.DELETE(ak:{})", access_key)
         await self._user.delete_dotfile.run(
             DeleteKeypairDotfileAction(
                 user_id=await self._owner(access_key),
@@ -173,7 +169,6 @@ class UserConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         access_key = AccessKey(ctx.access_key)
-        log.info("USERCONFIG.UPDATE_BOOTSTRAP_SCRIPT(ak:{})", access_key)
         await self._user.update_bootstrap_script.run(
             UpdateBootstrapScriptAction(
                 user_id=await self._owner(access_key),
@@ -188,7 +183,6 @@ class UserConfigHandler:
         ctx: UserContext,
     ) -> APIResponse:
         access_key = AccessKey(ctx.access_key)
-        log.info("USERCONFIG.GET_BOOTSTRAP_SCRIPT(ak:{})", access_key)
         result = await self._user.get_bootstrap_script.run(
             GetBootstrapScriptAction(user_id=await self._owner(access_key), access_key=access_key)
         )

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -235,16 +235,6 @@ class VFolderHandler:
         if params.group_id is not None:
             group_id_or_name = params.group_id
 
-        log.info(
-            "VFOLDER.CREATE (email:{}, ak:{}, vf:{}, vfh:{}, umod:{}, perm:{})",
-            ctx.user_email,
-            ctx.access_key,
-            params.name,
-            params.folder_host,
-            params.usage_mode.value,
-            params.permission.value,
-        )
-
         folder_host = params.folder_host
         unmanaged_path = params.unmanaged_path
 
@@ -318,11 +308,6 @@ class VFolderHandler:
         req: RequestCtx,
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "VFOLDER.LIST (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         user_scope = await self._auth.public_resolve_user_scope.run(
             PublicResolveUserScopeAction(
                 requester_uuid=ctx.user_uuid,
@@ -378,11 +363,6 @@ class VFolderHandler:
         req: RequestCtx,
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "VFOLDER.LIST_HOSTS (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         resource_policy = req.request["keypair"]["resource_policy"]
 
         result = await self._vfolder.list_hosts.run(
@@ -418,11 +398,6 @@ class VFolderHandler:
         self,
         ctx: UserContext,
     ) -> APIResponse:
-        log.info(
-            "VFOLDER.LIST_ALL_HOSTS (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         result = await self._vfolder.list_all_hosts.run(GlobalListAllHostsAction())
         resp = ListAllHostsResponse(
             default=result.default,
@@ -440,11 +415,6 @@ class VFolderHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "VFOLDER.VOLUME_PERF_METRIC (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         result = await self._vfolder.get_volume_perf_metric.run(
             GlobalGetVolumePerfMetricAction(folder_host=params.folder_host)
         )
@@ -459,11 +429,6 @@ class VFolderHandler:
         self,
         ctx: UserContext,
     ) -> APIResponse:
-        log.info(
-            "VFOLDER.LIST_ALLOWED_TYPES (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         result = await self._vfolder.list_allowed_types.run(GlobalListAllowedTypesAction())
         resp = ListAllowedTypesResponse(result.allowed_types)
         return APIResponse.build(HTTPStatus.OK, resp)
@@ -478,7 +443,7 @@ class VFolderHandler:
         req: RequestCtx,
     ) -> APIResponse:
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.GETINFO (email:{}, ak:{}, vf:{} (resolved-from:{!r}))",
             vfctx.user_email,
             vfctx.access_key,
@@ -539,11 +504,6 @@ class VFolderHandler:
             )
         )
         vfolder_row = resolved.row
-        log.info(
-            "VFOLDER.GET_QUOTA (email:{}, vf:{})",
-            ctx.user_email,
-            params.id,
-        )
 
         user_role = req.request["user"]["role"]
 
@@ -585,12 +545,6 @@ class VFolderHandler:
         )
         vfolder_row = resolved.row
         quota = int(params.input["size_bytes"])
-        log.info(
-            "VFOLDER.UPDATE_QUOTA (email:{}, quota:{}, vf:{})",
-            ctx.user_email,
-            quota,
-            params.id,
-        )
 
         user_role = req.request["user"]["role"]
         resource_policy = req.request["keypair"]["resource_policy"]
@@ -634,11 +588,6 @@ class VFolderHandler:
             )
         )
         vfolder_row = resolved.row
-        log.info(
-            "VFOLDER.GET_USAGE (email:{}, vf:{})",
-            ctx.user_email,
-            params.id,
-        )
         result = await self._vfolder.get_usage_legacy.run(
             GetVFolderUsageLegacyAction(
                 folder_host=params.folder_host,
@@ -673,7 +622,6 @@ class VFolderHandler:
             )
         )
         vfolder_row = resolved.row
-        log.info("VFOLDER.GET_USED_BYTES (vf:{})", params.id)
         result = await self._vfolder.get_used_bytes.run(
             GetVFolderUsedBytesAction(
                 folder_host=params.folder_host,
@@ -698,7 +646,7 @@ class VFolderHandler:
         params = body.parsed
         row = vfctx.vfolder_row
         new_name = params.new_name
-        log.info(
+        log.debug(
             "VFOLDER.RENAME (email:{}, ak:{}, vf:{} (resolved-from:{!r}), new-name:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -732,7 +680,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.UPDATE_OPTIONS (email:{}, ak:{}, vf:{} (resolved-from:{!r}))",
             vfctx.user_email,
             vfctx.access_key,
@@ -775,7 +723,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.MKDIR (email:{}, ak:{}, vf:{} (resolved-from:{!r}), paths:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -808,7 +756,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.CREATE_DOWNLOAD_SESSION(email:{}, ak:{}, vf:{} (resolved-from:{!r}), path:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -843,7 +791,7 @@ class VFolderHandler:
         row = vfctx.vfolder_row
         files = params.files
         filename = params.filename
-        log.info(
+        log.debug(
             "VFOLDER.CREATE_ARCHIVE_DOWNLOAD_SESSION"
             "(email:{}, ak:{}, vf:{} (resolved-from:{!r}), files:{})",
             vfctx.user_email,
@@ -875,7 +823,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.CREATE_UPLOAD_SESSION (email:{}, ak:{}, vf:{} (resolved-from:{!r}), path:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -907,7 +855,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.RENAME_FILE (email:{}, ak:{}, vf:{} (resolved-from:{!r}), "
             "target_path:{}, new_name:{})",
             vfctx.user_email,
@@ -940,14 +888,6 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
-            "VFOLDER.MOVE_FILE (email:{}, ak:{}, vf:{}, src:{}, dst:{})",
-            vfctx.user_email,
-            vfctx.access_key,
-            row["id"],
-            params.src,
-            params.dst,
-        )
         await self._vfolder_file.move_file.run(
             MoveFileAction(
                 user_uuid=vfctx.user_uuid,
@@ -971,7 +911,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.DELETE_FILES (email:{}, ak:{}, vf:{} (resolved-from:{!r}), "
             "path:{}, recursive:{})",
             vfctx.user_email,
@@ -1004,7 +944,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.DELETE_FILES_ASYNC (email:{}, ak:{}, vf:{} (resolved-from:{!r}), "
             "files:{}, recursive:{})",
             vfctx.user_email,
@@ -1039,7 +979,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = query.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.LIST_FILES (email:{}, ak:{}, vf:{} (resolved-from:{!r}), path:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -1067,11 +1007,6 @@ class VFolderHandler:
         self,
         ctx: UserContext,
     ) -> APIResponse:
-        log.info(
-            "VFOLDER.LIST_SENT_INVITATIONS (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         result = await self._vfolder_invite.list_sent_invitations.run(
             ListSentInvitationsAction(user_uuid=ctx.user_uuid)
         )
@@ -1105,12 +1040,6 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         inv_id = req.request.match_info["inv_id"]
-        log.info(
-            "VFOLDER.UPDATE_INVITATION (email:{}, ak:{}, inv:{})",
-            ctx.user_email,
-            ctx.access_key,
-            inv_id,
-        )
         await self._vfolder_invite.update_invitation.run(
             UpdateInvitationAction(
                 invitation_id=VFolderInvitationID(uuid.UUID(inv_id)),
@@ -1135,7 +1064,7 @@ class VFolderHandler:
         row = vfctx.vfolder_row
         perm = VFolderPermission(params.permission.value)
         invitee_emails = params.emails
-        log.info(
+        log.debug(
             "VFOLDER.INVITE (email:{}, ak:{}, vf:{} (resolved-from:{!r}), inv.users:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -1164,11 +1093,6 @@ class VFolderHandler:
         ctx: UserContext,
         req: RequestCtx,
     ) -> APIResponse:
-        log.info(
-            "VFOLDER.INVITATIONS (email:{}, ak:{})",
-            ctx.user_email,
-            ctx.access_key,
-        )
         result = await self._vfolder_invite.list_invitation.run(
             ListInvitationAction(user_uuid=ctx.user_uuid)
         )
@@ -1204,12 +1128,6 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         inv_id = params.inv_id
-        log.info(
-            "VFOLDER.ACCEPT_INVITATION (email:{}, ak:{}, inv:{})",
-            ctx.user_email,
-            ctx.access_key,
-            inv_id,
-        )
         await self._vfolder_invite.accept_invitation.run(
             AcceptInvitationAction(
                 invitation_id=VFolderInvitationID(uuid.UUID(inv_id)),
@@ -1230,12 +1148,6 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         inv_id = params.inv_id
-        log.info(
-            "VFOLDER.DELETE_INVITATION (email:{}, ak:{}, inv:{})",
-            ctx.user_email,
-            ctx.access_key,
-            inv_id,
-        )
         await self._vfolder_invite.reject_invitation.run(
             RejectInvitationAction(
                 invitation_id=VFolderInvitationID(uuid.UUID(inv_id)),
@@ -1257,7 +1169,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.SHARE (email:{}, ak:{}, vf:{} (resolved-from:{!r}), perm:{}, users:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -1290,7 +1202,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.UNSHARE (email:{}, ak:{}, vf:{} (resolved-from:{!r}), users:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -1323,12 +1235,6 @@ class VFolderHandler:
         resource_policy = req.request["keypair"]["resource_policy"]
         folder_id = params.vfolder_id
 
-        log.info(
-            "VFOLDER.DELETE_BY_ID (email:{}, ak:{}, vf:{})",
-            ctx.user_email,
-            ctx.access_key,
-            folder_id,
-        )
         try:
             await self._vfolder.move_to_trash_vfolder.run(
                 MoveToTrashVFolderAction(
@@ -1366,7 +1272,7 @@ class VFolderHandler:
             )
         )
         row = resolved.row
-        log.info(
+        log.debug(
             "VFOLDER.DELETE_BY_NAME (email:{}, ak:{}, vf:{} (resolved-from:{!r}))",
             ctx.user_email,
             ctx.access_key,
@@ -1409,7 +1315,7 @@ class VFolderHandler:
             )
         )
         row = resolved.row
-        log.info(
+        log.debug(
             "VFOLDER.GET_ID (email:{}, ak:{}, vf:{} (resolved-from:{!r}))",
             ctx.user_email,
             ctx.access_key,
@@ -1434,12 +1340,6 @@ class VFolderHandler:
         folder_id = params.vfolder_id
         user_uuid = ctx.user_uuid
 
-        log.info(
-            "VFOLDER.DELETE_FROM_TRASH_BIN (email:{}, ak:{}, vf:{})",
-            ctx.user_email,
-            ctx.access_key,
-            folder_id,
-        )
         try:
             await self._vfolder.delete_forever_vfolder.run(
                 DeleteForeverVFolderAction(
@@ -1489,12 +1389,6 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         folder_id = params.vfolder_id
-        log.info(
-            "VFOLDER.PURGE (email:{}, ak:{}, vf:{})",
-            ctx.user_email,
-            ctx.access_key,
-            folder_id,
-        )
         user_role = req.request["user"]["role"]
         if user_role not in (
             UserRole.ADMIN,
@@ -1523,12 +1417,6 @@ class VFolderHandler:
         params = body.parsed
         folder_id = params.vfolder_id
         user_uuid = ctx.user_uuid
-        log.info(
-            "VFOLDER.RESTORE (email:{}, ak:{}, vf:{})",
-            ctx.user_email,
-            ctx.access_key,
-            folder_id,
-        )
 
         await self._vfolder.restore_vfolder_from_trash.run(
             RestoreVFolderFromTrashAction(
@@ -1553,7 +1441,7 @@ class VFolderHandler:
         vfolder_id = row["id"]
         perm = row["permission"]
 
-        log.info(
+        log.debug(
             "VFOLDER.LEAVE(email:{}, ak:{}, vf:{} (resolved-from:{!r}), uid:{}, perm:{})",
             vfctx.user_email,
             vfctx.access_key,
@@ -1590,7 +1478,7 @@ class VFolderHandler:
     ) -> APIResponse:
         params = body.parsed
         row = vfctx.vfolder_row
-        log.info(
+        log.debug(
             "VFOLDER.CLONE (email:{}, ak:{}, vf:{} (resolved-from:{!r}), "
             "vft:{}, vfh:{}, umod:{}, perm:{})",
             vfctx.user_email,
@@ -1643,12 +1531,6 @@ class VFolderHandler:
     ) -> APIResponse:
         params = query.parsed
         target_vfid = params.vfolder_id
-        log.info(
-            "VFOLDER.LIST_SHARED_VFOLDERS (email:{}, ak:{}, vf:{})",
-            ctx.user_email,
-            ctx.access_key,
-            target_vfid,
-        )
         shared_rows = (
             (
                 await self._vfolder_sharing.public_list_shared.run(PublicListSharedVFoldersAction())
@@ -1693,14 +1575,6 @@ class VFolderHandler:
         vfolder_id = params.vfolder
         user_uuid = params.user
         perm = VFolderPermission(params.permission.value) if params.permission is not None else None
-        log.info(
-            "VFOLDER.UPDATE_SHARED_VFOLDER(email:{}, ak:{}, vf:{}, uid:{}, perm:{})",
-            ctx.user_email,
-            ctx.access_key,
-            vfolder_id,
-            user_uuid,
-            perm,
-        )
         if perm is not None:
             await self._vfolder_invite.update_invited_vfolder_mount_permission.run(
                 UpdateInvitedVFolderMountPermissionAction(
@@ -1730,13 +1604,6 @@ class VFolderHandler:
         params = body.parsed
         vfolder_id = params.vfolder_id
         user_perm_list = params.user_perm_list
-        log.info(
-            "VFOLDER.UPDATE_VFOLDER_SHARING_STATUS(email:{}, ak:{}, vf:{}, data:{})",
-            ctx.user_email,
-            ctx.access_key,
-            vfolder_id,
-            user_perm_list,
-        )
 
         to_delete: list[uuid.UUID] = []
         to_update: list[tuple[uuid.UUID, VFolderPermission]] = []
@@ -1765,12 +1632,6 @@ class VFolderHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = query.parsed
-        log.info(
-            "VFOLDER.GET_FSTAB_CONTENTS(email:{}, ak:{}, ag:{})",
-            ctx.user_email,
-            ctx.access_key,
-            params.agent_id,
-        )
         result = await self._vfolder.get_fstab_contents.run(
             GlobalGetFstabContentsAction(
                 agent_id=params.agent_id,
@@ -1792,10 +1653,6 @@ class VFolderHandler:
         self,
         ctx: UserContext,
     ) -> APIResponse:
-        log.info(
-            "VFOLDER.LIST_MOUNTS(ak:{})",
-            ctx.access_key,
-        )
         result = await self._vfolder.list_mounts.run(GlobalListMountsAction())
         resp = ListMountsResponse(
             manager=MountResultDTO(
@@ -1829,13 +1686,6 @@ class VFolderHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info(
-            "VFOLDER.MOUNT_HOST(ak:{}, name:{}, fs:{}, sg:{})",
-            ctx.access_key,
-            params.name,
-            params.fs_location,
-            params.scaling_group,
-        )
         result = await self._vfolder.mount_host.run(
             GlobalMountHostAction(
                 name=params.name,
@@ -1874,12 +1724,6 @@ class VFolderHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info(
-            "VFOLDER.UMOUNT_HOST(ak:{}, name:{}, sg:{})",
-            ctx.access_key,
-            params.name,
-            params.scaling_group,
-        )
         result = await self._vfolder.umount_host.run(
             GlobalUmountHostAction(
                 name=params.name,
@@ -1915,13 +1759,6 @@ class VFolderHandler:
         ctx: UserContext,
     ) -> APIResponse:
         params = body.parsed
-        log.info(
-            "VFOLDER.CHANGE_VFOLDER_OWNERSHIP(email:{}, ak:{}, vfid:{}, target:{})",
-            ctx.user_email,
-            ctx.access_key,
-            params.vfolder,
-            params.user_email,
-        )
         await self._vfolder.change_vfolder_ownership.run(
             ChangeVFolderOwnershipAction(
                 vfolder_uuid=VFolderUUID(params.vfolder),

--- a/src/ai/backend/manager/api/rest/vfs_storage/handler.py
+++ b/src/ai/backend/manager/api/rest/vfs_storage/handler.py
@@ -97,8 +97,6 @@ class VFSStorageHandler:
         filepath = req.filepath
         storage_name = path.parsed.storage_name
 
-        log.info("Download request for file: {} from storage: {}", filepath, storage_name)
-
         resolved = await self._vfs_storage.lookup.run(LookupVFSStorageAction(name=storage_name))
         action_result = await self._vfs_storage.get.run(
             GetVFSStorageAction(storage_id=resolved.entity_id())
@@ -134,8 +132,6 @@ class VFSStorageHandler:
         """Get VFS storage information by storage name."""
         storage_name = path.parsed.storage_name
 
-        log.info("Get storage request for storage: {}", storage_name)
-
         resolved = await self._vfs_storage.lookup.run(LookupVFSStorageAction(name=storage_name))
         action_result = await self._vfs_storage.get.run(
             GetVFSStorageAction(storage_id=resolved.entity_id())
@@ -156,7 +152,6 @@ class VFSStorageHandler:
         self,
     ) -> APIResponse:
         """List all VFS storages."""
-        log.info("List all VFS storages.")
 
         action_result = await self._vfs_storage.global_list_storages.run(
             ListVFSStorageAction(searcher=VFSStorageSearcher(pagination=NoPagination()))
@@ -183,10 +178,7 @@ class VFSStorageHandler:
     ) -> APIResponse:
         """List files recursively in a VFS storage directory via storage proxy."""
         req = body.parsed
-        directory = req.directory
         storage_name = path.parsed.storage_name
-
-        log.info("List files request for directory: {} from storage: {}", directory, storage_name)
 
         resolved = await self._vfs_storage.lookup.run(LookupVFSStorageAction(name=storage_name))
         action_result = await self._vfs_storage.get.run(

--- a/src/ai/backend/manager/plugin/totp/webapp.py
+++ b/src/ai/backend/manager/plugin/totp/webapp.py
@@ -32,7 +32,6 @@ async def initialize_otp_activation(request: web.Request) -> web.Response:
     db = root_app["_db"]
     ctx = cast(PrivateContext, request.app["context"])
     email = request["user"]["email"]
-    log.info("TOTP.INITIALIZE_OTP_ACTIVATION()")
     async with db.begin_readonly() as conn:
         query = (
             sa.select(users.c.totp_activated, users.c.totp_key)
@@ -76,7 +75,6 @@ async def finalize_otp_activation(request: web.Request, params: Any) -> web.Resp
     root_app = request.app["_root_app"]
     db = root_app["_db"]
     email = request["user"]["email"]
-    log.info("TOTP.FINALIZE_OTP_ACTIVATION(otp: {})", params["otp"])
 
     async with db.begin_readonly() as conn:
         query = (
@@ -117,7 +115,6 @@ async def deactivate_totp(request: web.Request) -> web.Response:
             raise GenericForbidden
         email = request.query["email"]
 
-    log.info("TOTP.DEACTIVATE_TOTP(email: {})", email)
     async with db.begin_readonly() as conn:
         query = (
             sa.select(users.c.totp_activated, users.c.totp_key)
@@ -154,7 +151,6 @@ async def initialize_anonymous_otp_activation(request: web.Request, params: Any)
     root_app = request.app["_root_app"]
     db = root_app["_db"]
     ctx = cast(PrivateContext, request.app["context"])
-    log.info("TOTP.INITIALIZE_OTP_ACTIVATION()")
     raw_token = params["registration_token"]
     try:
         token = ctx.token_parser.deserialize(raw_token)
@@ -194,7 +190,6 @@ async def finalize_anonymous_otp_activation(request: web.Request, params: Any) -
     root_app = request.app["_root_app"]
     db = root_app["_db"]
     ctx = cast(PrivateContext, request.app["context"])
-    log.info("TOTP.FINALIZE_OTP_ACTIVATION(otp: {})", params["otp"])
     raw_token = params["registration_token"]
     try:
         token = ctx.token_parser.deserialize(raw_token)


### PR DESCRIPTION
## Summary
- Delete 188 INFO-level per-request access-log lines across 30 manager REST v1 handlers and the TOTP webapp — the request itself is already logged (trace) by the middleware, who-did-what is in the audit log, and counts are in `backendai_api_request_count`.
- Lower the 18 vfolder `resolved-from` lines to debug: the audit row only holds the resolved id, so this is the only record of what the client-supplied name/id resolved to.
- Remove the now-no-op `GQLLoggingMiddleware` (the admin GraphQL access line, already lowered to debug in BA-7637) and its registration.

## Test plan
- [x] `pants fmt/fix/lint/check/test --changed-since=HEAD~1` all pass
- [x] Verified no format string is left with mismatched arguments (ruff F841/F401 clean)
- [x] Grepped the touched trees for remaining `log.info` access-log calls — none left

Resolves BA-7646