### PR TITLE
fix(BA-7647): name the background task in the completion log line (#14205)

### DIFF
--- a/changes/14205.fix.md
+++ b/changes/14205.fix.md
@@ -1,0 +1,1 @@
+Name the background task in its completion log line instead of leaving the name slot empty

--- a/src/ai/backend/common/bgtask/bgtask.py
+++ b/src/ai/backend/common/bgtask/bgtask.py
@@ -445,7 +445,10 @@ class BackgroundTaskManager:
             cache_id = EventCacheDomain.BGTASK.cache_id(str(task_id))
             await self._event_producer.broadcast_event_with_cache(cache_id, bgtask_result_event)
             log.info(
-                "Task {} ({}): {}", task_id, task_name or "", bgtask_result_event.__class__.__name__
+                "Task {} ({}): {}",
+                task_id,
+                task_name or func.__name__,
+                bgtask_result_event.__class__.__name__,
             )
         finally:
             self._ongoing_tasks.pop(TaskID(task_id), None)


### PR DESCRIPTION
This is an auto-generated backport of #14205 to the 26.8 release.