### PR TITLE
chore: add a `--recreate` option to refresh GQL schemas when restarting dev setup

### DIFF
--- a/.claude/skills/halfstack/SKILL.md
+++ b/.claude/skills/halfstack/SKILL.md
@@ -211,9 +211,13 @@ The Hive Gateway serves the federated GraphQL schema. Regenerate when:
 cp docs/manager/graphql-reference/supergraph.graphql ./supergraph.graphql
 cp configs/graphql/gateway.config.ts ./gateway.config.ts
 
-# 3. Restart the gateway
-docker compose -f docker-compose.halfstack.current.yml restart backendai-half-apollo-router
+# 3. Recreate the gateway (docker configs are baked in at container creation,
+#    so `restart` would keep serving the old schema)
+docker compose -f docker-compose.halfstack.current.yml up -d --force-recreate --wait backendai-half-apollo-router
 ```
+
+Steps 1-3 in one command: `./scripts/refresh-graphql-gateway.sh --recreate`
+(without `--recreate` it only restarts the container, which keeps the old schema).
 
 If manager code is broken and `generate-graphql-schema.sh` fails,
 copy the last known-good supergraph from git:

--- a/.claude/skills/local-dev/SKILL.md
+++ b/.claude/skills/local-dev/SKILL.md
@@ -76,12 +76,12 @@ sleep 5
 ```
 
 If GQL schema changes affect the federated supergraph (new types, fields, modules),
-regenerate and restart the Hive Gateway — see `/halfstack` skill for details:
+regenerate and recreate the Hive Gateway — see `/halfstack` skill for details:
 
 ```bash
 ./scripts/generate-graphql-schema.sh
 cp docs/manager/graphql-reference/supergraph.graphql ./supergraph.graphql
-docker compose -f docker-compose.halfstack.current.yml restart backendai-half-apollo-router
+docker compose -f docker-compose.halfstack.current.yml up -d --force-recreate --wait backendai-half-apollo-router
 ```
 
 ## Related Skills

--- a/changes/14214.fix.md
+++ b/changes/14214.fix.md
@@ -1,0 +1,1 @@
+Add a `--recreate` option to `scripts/refresh-graphql-gateway.sh` so an updated GraphQL supergraph is actually applied to the Hive Gateway container.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,7 +28,7 @@ current, see `AGENTS.md` in this directory.
 |---|---|---|
 | `start-dev.sh` / `stop-dev.sh` | Start / stop every component server in tmux sessions | person |
 | `generate-graphql-schema.sh` | Dumps the GraphQL v1/v2 schemas and composes the supergraph | person; `install-dev.sh`, `release.sh`, `refresh-graphql-gateway.sh` |
-| `refresh-graphql-gateway.sh` | Regenerates the schema, copies it to the root, restarts the Apollo Router | person |
+| `refresh-graphql-gateway.sh` | Regenerates the schema, copies it to the root, restarts the Apollo Router (`--recreate` to recreate the container so config updates apply) | person |
 | `alembic-rebase.py` | Rebases a migration branch when alembic heads have diverged | person (`src/ai/backend/README.md`) |
 | `generate-rbac-fixture-permissions.py` | Re-emits the managed permission rows of `fixtures/manager/example-roles.json` | person |
 | `download-webui-release.sh` | Downloads and unpacks a WebUI bundle into `src/ai/backend/web` | person; `release.sh` |

--- a/scripts/refresh-graphql-gateway.sh
+++ b/scripts/refresh-graphql-gateway.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+RECREATE=0
+
+usage() {
+  cat <<'USAGE'
+Usage: refresh-graphql-gateway.sh [-r|--recreate]
+
+Regenerates the GraphQL schema, copies it to the project root and reloads the
+Apollo Router (Hive Gateway).
+
+  -r, --recreate  Recreate the gateway container instead of restarting it.
+                  Required when supergraph.graphql or gateway.config.ts changed:
+                  they are mounted as docker configs, which are materialized at
+                  container creation time, so a restart keeps the old content.
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r|--recreate)
+      RECREATE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -13,6 +47,12 @@ echo "==> 2. Copying schema and gateway config to project root..."
 cp docs/manager/graphql-reference/supergraph.graphql ./supergraph.graphql
 cp configs/graphql/gateway.config.ts ./gateway.config.ts
 
-echo "==> 3. Restarting Apollo Router..."
-docker compose -f docker-compose.halfstack.current.yml restart backendai-half-apollo-router
+if [ $RECREATE -eq 1 ]; then
+  echo "==> 3. Recreating Apollo Router..."
+  docker compose -f docker-compose.halfstack.current.yml up -d --force-recreate --wait backendai-half-apollo-router
+else
+  echo "==> 3. Restarting Apollo Router..."
+  docker compose -f docker-compose.halfstack.current.yml restart backendai-half-apollo-router
+  echo "    NOTE: the schema and gateway config are docker configs; pass --recreate to apply their updates."
+fi
 echo "==> Done!"


### PR DESCRIPTION
## Summary
- `supergraph.graphql` and `gateway.config.ts` are mounted as docker configs, which are materialized at container creation time — `docker compose restart` reuses the container, so a refreshed schema never reached the gateway.
- Add `-r, --recreate` to `scripts/refresh-graphql-gateway.sh`, which reloads via `up -d --force-recreate --wait`. The default stays `restart` and now prints a note pointing at the flag.
- `/halfstack` and `/local-dev` skill docs use the recreate form in their schema-refresh examples; `scripts/README.md` documents the flag.

## Test plan
- [x] `./scripts/refresh-graphql-gateway.sh --recreate` equivalent verified manually: after `up -d --force-recreate --wait backendai-half-apollo-router`, the in-container `/gateway/supergraph.graphql` checksum matches the regenerated root file (plain `restart` and `up -d` left the old content).
- [x] `bash -n scripts/refresh-graphql-gateway.sh`
- [ ] `./scripts/refresh-graphql-gateway.sh -h` prints usage

https://claude.ai/code/session_01GhRvnrrskHeM6ybsbHmFhF