### PR TITLE
feat(BA-7626): add UNDEFINED sentinel and drop it from update DTO dump and schema

### DIFF
--- a/changes/14216.feature.md
+++ b/changes/14216.feature.md
@@ -1,0 +1,1 @@
+Add the `UNDEFINED` sentinel for update DTOs: `BaseRequestModel` drops `UNDEFINED`-valued fields from `model_dump()` and from the OpenAPI schema, rejects wire values that would coerce into it, and `TriState.from_input()` / `OptionalState.from_input()` convert such fields into partial-update wrappers (BA-7626).

--- a/changes/14216.feature.md
+++ b/changes/14216.feature.md
@@ -1,1 +1,1 @@
-Add the `UNDEFINED` sentinel for update DTOs: `BaseRequestModel` drops `UNDEFINED`-valued fields from `model_dump()` and from the OpenAPI schema, rejects wire values that would coerce into it, and `TriState.from_input()` / `OptionalState.from_input()` convert such fields into partial-update wrappers (BA-7626).
+Add the `UNDEFINED` sentinel for update DTOs so that omitted fields are dropped from `model_dump()` and the OpenAPI schema instead of being sent as a value.

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -16,13 +16,22 @@ from typing import (
     cast,
     get_args,
     get_origin,
+    override,
 )
 
 from aiohttp import web
 from aiohttp.web_urldispatcher import UrlMappingMatchInfo
 from multidict import CIMultiDictProxy, MultiMapping
-from pydantic import AliasChoices, ConfigDict, RootModel
+from pydantic import (
+    AliasChoices,
+    ConfigDict,
+    RootModel,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+)
 from pydantic.fields import FieldInfo
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue
+from pydantic_core import CoreSchema
 from pydantic_core._pydantic_core import ValidationError
 
 from ai.backend.common.types import BackendAISchema, StreamReader
@@ -49,11 +58,113 @@ class Sentinel(enum.Enum):
 SENTINEL = Sentinel.TOKEN
 
 
+class Undefined(enum.Enum):
+    """Marks an update-request field that was not provided ("no change").
+
+    Update DTOs declare clearable fields as ``T | Undefined | None = Field(default=UNDEFINED)``:
+
+    | value       | meaning   |
+    | ----------- | --------- |
+    | ``UNDEFINED`` | no change |
+    | ``None``      | clear     |
+    | value         | update    |
+
+    ``BaseRequestModel`` drops ``UNDEFINED``-valued fields from ``model_dump()`` and from
+    ``model_json_schema()``, so the token never reaches the wire or the OpenAPI schema.
+    """
+
+    TOKEN = enum.auto()
+
+
+UNDEFINED = Undefined.TOKEN
+
+
+class _UndefinedFreeJsonSchema(GenerateJsonSchema):
+    """JSON schema generator that removes every trace of ``Undefined``.
+
+    pydantic renders ``T | Undefined | None`` as ``anyOf: [T, {$ref: Undefined}, null]`` with
+    ``default: <enum value>``. The ref is removed from ``anyOf``, the default is dropped only on
+    nodes where such a ref was removed, and the ``Undefined`` definition itself is deleted.
+    """
+
+    _UNDEFINED_REF_SUFFIX = f"/{Undefined.__name__}"
+
+    @override
+    def generate(self, schema: CoreSchema, mode: JsonSchemaMode = "validation") -> JsonSchemaValue:
+        json_schema = super().generate(schema, mode)
+        self._strip(json_schema)
+        defs = json_schema.get("$defs")
+        if isinstance(defs, dict):
+            defs.pop(Undefined.__name__, None)
+            if not defs:
+                del json_schema["$defs"]
+        return json_schema
+
+    @classmethod
+    def _is_undefined_ref(cls, node: Any) -> bool:
+        return isinstance(node, dict) and str(node.get("$ref", "")).endswith(
+            cls._UNDEFINED_REF_SUFFIX
+        )
+
+    @classmethod
+    def _strip(cls, node: Any) -> None:
+        if isinstance(node, dict):
+            variants = node.get("anyOf")
+            if isinstance(variants, list) and any(cls._is_undefined_ref(v) for v in variants):
+                remaining = [v for v in variants if not cls._is_undefined_ref(v)]
+                if node.get("default") == UNDEFINED.value:
+                    node.pop("default")
+                if len(remaining) == 1:
+                    node.pop("anyOf")
+                    node.update(remaining[0])
+                else:
+                    node["anyOf"] = remaining
+            for child in node.values():
+                cls._strip(child)
+        elif isinstance(node, list):
+            for child in node:
+                cls._strip(child)
+
+
 class BaseRequestModel(BackendAISchema):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         validate_by_name=True,
     )
+
+    @model_serializer(mode="wrap")
+    def _drop_undefined_fields(self, handler: SerializerFunctionWrapHandler) -> Any:
+        """Exclude ``UNDEFINED``-valued fields from every ``model_dump`` / ``model_dump_json``."""
+        data = handler(self)
+        if not isinstance(data, dict):
+            return data
+        skipped_keys: set[str] = set()
+        for name, field_info in type(self).model_fields.items():
+            if getattr(self, name, None) is UNDEFINED:
+                skipped_keys.add(name)
+                if field_info.alias:
+                    skipped_keys.add(field_info.alias)
+                if field_info.serialization_alias:
+                    skipped_keys.add(field_info.serialization_alias)
+        if not skipped_keys:
+            return data
+        return {k: v for k, v in data.items() if k not in skipped_keys}
+
+    @classmethod
+    @override
+    def model_json_schema(
+        cls,
+        by_alias: bool = True,
+        ref_template: str = "#/$defs/{model}",
+        schema_generator: type[GenerateJsonSchema] = _UndefinedFreeJsonSchema,
+        mode: JsonSchemaMode = "validation",
+    ) -> dict[str, Any]:
+        return super().model_json_schema(
+            by_alias=by_alias,
+            ref_template=ref_template,
+            schema_generator=schema_generator,
+            mode=mode,
+        )
 
 
 class BaseFieldModel(BackendAISchema):

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -24,14 +24,15 @@ from aiohttp.web_urldispatcher import UrlMappingMatchInfo
 from multidict import CIMultiDictProxy, MultiMapping
 from pydantic import (
     AliasChoices,
+    BaseModel,
     ConfigDict,
+    GetCoreSchemaHandler,
     RootModel,
     SerializerFunctionWrapHandler,
-    model_serializer,
 )
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue
-from pydantic_core import CoreSchema
+from pydantic_core import CoreSchema, core_schema
 from pydantic_core._pydantic_core import ValidationError
 
 from ai.backend.common.types import BackendAISchema, StreamReader
@@ -126,29 +127,43 @@ class _UndefinedFreeJsonSchema(GenerateJsonSchema):
                 cls._strip(child)
 
 
+def _drop_undefined_fields(model: BaseModel, handler: SerializerFunctionWrapHandler) -> Any:
+    """Exclude ``UNDEFINED``-valued fields from every ``model_dump`` / ``model_dump_json``."""
+    data = handler(model)
+    if not isinstance(data, dict):
+        return data
+    skipped_keys: set[str] = set()
+    for name, field_info in type(model).model_fields.items():
+        if getattr(model, name, None) is UNDEFINED:
+            skipped_keys.add(name)
+            if field_info.alias:
+                skipped_keys.add(field_info.alias)
+            if field_info.serialization_alias:
+                skipped_keys.add(field_info.serialization_alias)
+    if not skipped_keys:
+        return data
+    return {k: v for k, v in data.items() if k not in skipped_keys}
+
+
 class BaseRequestModel(BackendAISchema):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         validate_by_name=True,
     )
 
-    @model_serializer(mode="wrap")
-    def _drop_undefined_fields(self, handler: SerializerFunctionWrapHandler) -> Any:
-        """Exclude ``UNDEFINED``-valued fields from every ``model_dump`` / ``model_dump_json``."""
-        data = handler(self)
-        if not isinstance(data, dict):
-            return data
-        skipped_keys: set[str] = set()
-        for name, field_info in type(self).model_fields.items():
-            if getattr(self, name, None) is UNDEFINED:
-                skipped_keys.add(name)
-                if field_info.alias:
-                    skipped_keys.add(field_info.alias)
-                if field_info.serialization_alias:
-                    skipped_keys.add(field_info.serialization_alias)
-        if not skipped_keys:
-            return data
-        return {k: v for k, v in data.items() if k not in skipped_keys}
+    @classmethod
+    @override
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        schema = handler(source)
+        if schema["type"] == "model":
+            model_schema = cast(core_schema.ModelSchema, schema)
+            if "serialization" not in model_schema:
+                model_schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
+                    _drop_undefined_fields, info_arg=False
+                )
+        return schema
 
     @classmethod
     @override

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -173,8 +173,13 @@ class BaseRequestModel(BackendAISchema):
         cls, source: type[Any], handler: GetCoreSchemaHandler
     ) -> CoreSchema:
         schema = handler(source)
-        if schema["type"] == "model":
-            model_schema = cast(core_schema.ModelSchema, schema)
+        # Model validators (before/after/wrap) wrap the model node in function-* schemas;
+        # walk down to the model node itself.
+        node: Any = schema
+        while node["type"] != "model" and isinstance(node.get("schema"), dict):
+            node = node["schema"]
+        if node["type"] == "model":
+            model_schema = cast(core_schema.ModelSchema, node)
             if "serialization" not in model_schema:
                 model_schema["serialization"] = core_schema.wrap_serializer_function_ser_schema(
                     _drop_undefined_fields, info_arg=False

--- a/src/ai/backend/common/api_handlers.py
+++ b/src/ai/backend/common/api_handlers.py
@@ -27,6 +27,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
     RootModel,
     SerializerFunctionWrapHandler,
 )
@@ -72,47 +73,62 @@ class Undefined(enum.Enum):
 
     ``BaseRequestModel`` drops ``UNDEFINED``-valued fields from ``model_dump()`` and from
     ``model_json_schema()``, so the token never reaches the wire or the OpenAPI schema.
+    Only the ``Undefined.TOKEN`` object itself validates: wire values such as ``1`` or ``true``
+    are rejected instead of being coerced into "not provided".
     """
 
     TOKEN = enum.auto()
 
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: type[Any], handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.json_or_python_schema(
+            json_schema=core_schema.no_info_plain_validator_function(cls._reject_wire_value),
+            python_schema=core_schema.is_instance_schema(cls),
+        )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        return dict(_UNDEFINED_SCHEMA_MARKER)
+
+    @staticmethod
+    def _reject_wire_value(_value: Any) -> Any:
+        raise ValueError("Undefined cannot be provided on the wire")
+
 
 UNDEFINED = Undefined.TOKEN
+
+# Placeholder emitted for ``Undefined`` in JSON schemas; ``_UndefinedFreeJsonSchema`` removes it.
+_UNDEFINED_SCHEMA_MARKER: JsonSchemaValue = {"title": Undefined.__name__, "not": {}}
 
 
 class _UndefinedFreeJsonSchema(GenerateJsonSchema):
     """JSON schema generator that removes every trace of ``Undefined``.
 
-    pydantic renders ``T | Undefined | None`` as ``anyOf: [T, {$ref: Undefined}, null]`` with
-    ``default: <enum value>``. The ref is removed from ``anyOf``, the default is dropped only on
-    nodes where such a ref was removed, and the ``Undefined`` definition itself is deleted.
+    pydantic renders ``T | Undefined | None`` as ``anyOf: [T, <marker>, null]`` with
+    ``default: <enum value>``. The marker is removed from ``anyOf`` and the default is dropped
+    only on nodes where a marker was removed.
     """
-
-    _UNDEFINED_REF_SUFFIX = f"/{Undefined.__name__}"
 
     @override
     def generate(self, schema: CoreSchema, mode: JsonSchemaMode = "validation") -> JsonSchemaValue:
         json_schema = super().generate(schema, mode)
         self._strip(json_schema)
-        defs = json_schema.get("$defs")
-        if isinstance(defs, dict):
-            defs.pop(Undefined.__name__, None)
-            if not defs:
-                del json_schema["$defs"]
         return json_schema
 
-    @classmethod
-    def _is_undefined_ref(cls, node: Any) -> bool:
-        return isinstance(node, dict) and str(node.get("$ref", "")).endswith(
-            cls._UNDEFINED_REF_SUFFIX
-        )
+    @staticmethod
+    def _is_undefined_marker(node: Any) -> bool:
+        return isinstance(node, dict) and node == _UNDEFINED_SCHEMA_MARKER
 
     @classmethod
     def _strip(cls, node: Any) -> None:
         if isinstance(node, dict):
             variants = node.get("anyOf")
-            if isinstance(variants, list) and any(cls._is_undefined_ref(v) for v in variants):
-                remaining = [v for v in variants if not cls._is_undefined_ref(v)]
+            if isinstance(variants, list) and any(cls._is_undefined_marker(v) for v in variants):
+                remaining = [v for v in variants if not cls._is_undefined_marker(v)]
                 if node.get("default") == UNDEFINED.value:
                     node.pop("default")
                 if len(remaining) == 1:

--- a/src/ai/backend/manager/types.py
+++ b/src/ai/backend/manager/types.py
@@ -18,6 +18,7 @@ from graphql import UndefinedType
 from pydantic import AliasChoices, Field
 from strawberry.types.unset import UnsetType
 
+from ai.backend.common.api_handlers import Undefined
 from ai.backend.common.types import BackendAISchema, MountPermission, MountTypes
 
 if TYPE_CHECKING:
@@ -110,6 +111,15 @@ class TriState[TVal]:
         """
         self._state = state
         self._value = value
+
+    @classmethod
+    def from_input(cls, value: TVal | Undefined | None) -> TriState[TVal]:
+        """Convert a v2 update DTO field: ``UNDEFINED`` -> nop, ``None`` -> nullify, value -> update."""
+        if isinstance(value, Undefined):
+            return cls.nop()
+        if value is None:
+            return cls.nullify()
+        return cls.update(value)
 
     @classmethod
     def from_graphql(cls, value: TVal | None | UndefinedType) -> TriState[TVal]:
@@ -207,6 +217,18 @@ class OptionalState[TVal]:
             raise ValueError("OptionalState cannot be NULLIFY")
         self._state = state
         self._value = value
+
+    @classmethod
+    def from_input(cls, value: TVal | Undefined) -> OptionalState[TVal]:
+        """Convert a v2 update DTO field: ``UNDEFINED`` -> nop, value -> update.
+
+        ``None`` is rejected: a field that may be cleared must use ``TriState``.
+        """
+        if isinstance(value, Undefined):
+            return cls.nop()
+        if value is None:
+            raise ValueError("OptionalState cannot be NULLIFY")
+        return cls.update(value)
 
     @classmethod
     def from_graphql(cls, value: TVal | None | UndefinedType | UnsetType) -> OptionalState[TVal]:

--- a/tests/unit/common/test_undefined.py
+++ b/tests/unit/common/test_undefined.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import json
+from typing import cast
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+    model_validator,
+)
+from pydantic_core.core_schema import ValidatorFunctionWrapHandler
 
 from ai.backend.common.api_handlers import (
     UNDEFINED,
@@ -241,3 +250,56 @@ def test_int_field_with_undefined_still_accepts_one() -> None:
 
     assert IntUpdateInput.model_validate({"count": 1}).count == 1
     assert IntUpdateInput.model_validate({}).count is UNDEFINED
+
+
+class AfterValidatedInput(BaseRequestModel):
+    id: int
+    region: str | Undefined | None = Field(default=UNDEFINED)
+
+    @model_validator(mode="after")
+    def _check(self) -> AfterValidatedInput:
+        return self
+
+
+class WrapValidatedInput(BaseRequestModel):
+    id: int
+    region: str | Undefined | None = Field(default=UNDEFINED)
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _wrap(cls, data: object, handler: ValidatorFunctionWrapHandler) -> WrapValidatedInput:
+        return cast(WrapValidatedInput, handler(data))
+
+
+class BeforeValidatedInput(BaseRequestModel):
+    id: int
+    region: str | Undefined | None = Field(default=UNDEFINED)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _before(cls, data: object) -> object:
+        return data
+
+
+@pytest.mark.parametrize(
+    "model_cls", [AfterValidatedInput, WrapValidatedInput, BeforeValidatedInput]
+)
+def test_model_validator_does_not_disable_undefined_drop(model_cls: type[BaseRequestModel]) -> None:
+    """A before/after/wrap model validator wraps the core schema; UNDEFINED is still dropped."""
+    model = model_cls.model_validate({"id": 1})
+    assert model.model_dump() == {"id": 1}
+    assert json.loads(model.model_dump_json()) == {"id": 1}
+
+
+def test_subclass_model_serializer_takes_precedence() -> None:
+    """A subclass-level @model_serializer replaces the UNDEFINED-dropping serializer."""
+
+    class CustomSerializedInput(BaseRequestModel):
+        id: int
+        region: str | Undefined | None = Field(default=UNDEFINED)
+
+        @model_serializer(mode="wrap")
+        def _custom(self, handler: SerializerFunctionWrapHandler) -> dict[str, object]:
+            return {"custom": True}
+
+    assert CustomSerializedInput(id=1).model_dump() == {"custom": True}

--- a/tests/unit/common/test_undefined.py
+++ b/tests/unit/common/test_undefined.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from pydantic import BaseModel, ConfigDict, Field
 
 from ai.backend.common.api_handlers import (
@@ -9,6 +10,7 @@ from ai.backend.common.api_handlers import (
     BaseRequestModel,
     Undefined,
 )
+from ai.backend.common.exception import BackendAISchemaValidationFailed
 
 
 class UpdateSampleInput(BaseRequestModel):
@@ -215,3 +217,27 @@ def test_serialization_mode_schema_keeps_fields() -> None:
     schema = UpdateSampleInput.model_json_schema(mode="serialization")
     assert set(schema["properties"]) == {"id", "region", "nickName", "count"}
     assert "Undefined" not in json.dumps(schema)
+
+
+@pytest.mark.parametrize("wire_value", [1, True, 1.0])
+def test_wire_value_is_not_coerced_into_undefined_python_mode(wire_value: object) -> None:
+    """model_validate: the enum's raw value on the wire is rejected, not treated as omitted."""
+    with pytest.raises(BackendAISchemaValidationFailed):
+        UpdateSampleInput.model_validate({"id": 1, "region": wire_value})
+
+
+@pytest.mark.parametrize("wire_json", ['{"id": 1, "region": 1}', '{"id": 1, "region": true}'])
+def test_wire_value_is_not_coerced_into_undefined_json_mode(wire_json: str) -> None:
+    """model_validate_json: the enum's raw value on the wire is rejected."""
+    with pytest.raises(BackendAISchemaValidationFailed):
+        UpdateSampleInput.model_validate_json(wire_json)
+
+
+def test_int_field_with_undefined_still_accepts_one() -> None:
+    """An int | Undefined | None field still accepts the legitimate value 1."""
+
+    class IntUpdateInput(BaseRequestModel):
+        count: int | Undefined | None = Field(default=UNDEFINED)
+
+    assert IntUpdateInput.model_validate({"count": 1}).count == 1
+    assert IntUpdateInput.model_validate({}).count is UNDEFINED

--- a/tests/unit/common/test_undefined.py
+++ b/tests/unit/common/test_undefined.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ai.backend.common.api_handlers import (
+    UNDEFINED,
+    BaseRequestModel,
+    Undefined,
+)
+
+
+class UpdateSampleInput(BaseRequestModel):
+    id: int
+    region: str | Undefined | None = Field(default=UNDEFINED)
+    nickname: str | Undefined | None = Field(default=UNDEFINED, alias="nickName")
+    count: int | None = Field(default=1)
+
+
+class CreateSampleInput(BaseRequestModel):
+    name: str
+    description: str | None = None
+
+
+class OuterSampleInput(BaseRequestModel):
+    outer_id: int
+    inner: UpdateSampleInput
+
+
+class PlainEquivalentModel(BaseModel):
+    name: str
+    description: str | None = None
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_by_name=True,
+    )
+
+
+def test_omitted_field_mode_python_no_key() -> None:
+    """Omitted field: model_dump(mode='python') has no region key."""
+    model = UpdateSampleInput(id=1)
+    dumped = model.model_dump(mode="python")
+    assert "region" not in dumped
+    assert dumped["id"] == 1
+
+
+def test_omitted_field_mode_json_no_key() -> None:
+    """Omitted field: model_dump(mode='json') has no region key."""
+    model = UpdateSampleInput(id=1)
+    dumped = model.model_dump(mode="json")
+    assert "region" not in dumped
+    assert dumped["id"] == 1
+
+
+def test_omitted_field_with_none_includes_key() -> None:
+    """Omitted field: None value includes 'region': None."""
+    model = UpdateSampleInput(id=1, region=None)
+    dumped = model.model_dump(mode="python")
+    assert "region" in dumped
+    assert dumped["region"] is None
+
+
+def test_omitted_field_with_value_includes_value() -> None:
+    """Omitted field: a value includes the value."""
+    model = UpdateSampleInput(id=1, region="us-west")
+    dumped = model.model_dump(mode="python")
+    assert "region" in dumped
+    assert dumped["region"] == "us-west"
+
+
+def test_explicit_undefined_behaves_same_as_omitted() -> None:
+    """Explicit UNDEFINED: model_dump() has no region key (same as omitting)."""
+    model = UpdateSampleInput(id=1, region=UNDEFINED)
+    dumped = model.model_dump(mode="python")
+    assert "region" not in dumped
+
+
+def test_exclude_unset_true_drops_undefined_field() -> None:
+    """exclude_unset=True still drops UNDEFINED field."""
+    model = UpdateSampleInput(id=1)
+    dumped = model.model_dump(mode="python", exclude_unset=True)
+    assert "region" not in dumped
+
+
+def test_by_alias_true_drops_undefined_field_under_alias() -> None:
+    """by_alias=True: aliased UNDEFINED field dropped under both nickname and nickName."""
+    model = UpdateSampleInput(id=1)
+    dumped = model.model_dump(mode="python", by_alias=True)
+    assert "nickname" not in dumped
+    assert "nickName" not in dumped
+
+
+def test_by_alias_and_exclude_unset_drops_undefined() -> None:
+    """by_alias=True + exclude_unset=True: UNDEFINED field dropped."""
+    model = UpdateSampleInput(id=1)
+    dumped = model.model_dump(mode="python", by_alias=True, exclude_unset=True)
+    assert "nickname" not in dumped
+    assert "nickName" not in dumped
+
+
+def test_model_dump_json_no_region_key() -> None:
+    """model_dump_json(): output has no region key."""
+    model = UpdateSampleInput(id=1)
+    json_str = model.model_dump_json()
+    data = json.loads(json_str)
+    assert "region" not in data
+
+
+def test_model_dump_json_no_enum_leak() -> None:
+    """model_dump_json(): no enum value leak (1 would be the enum's internal value)."""
+    model = UpdateSampleInput(id=1)
+    json_str = model.model_dump_json()
+    # The entire JSON output should not contain the enum's numeric value
+    assert '"1"' not in json_str or '"id": 1' in json_str  # id is 1, but not as a string enum
+
+
+def test_model_validate_omitted_field_is_undefined() -> None:
+    """model_validate: omitted field gives UNDEFINED."""
+    model = UpdateSampleInput.model_validate({"id": 1})
+    assert model.region is UNDEFINED
+
+
+def test_model_validate_explicit_none_gives_none() -> None:
+    """model_validate: explicit None gives None."""
+    model = UpdateSampleInput.model_validate({"id": 1, "region": None})
+    assert model.region is None
+
+
+def test_model_json_schema_no_undefined_in_json() -> None:
+    """model_json_schema(): json.dumps(schema) contains no 'Undefined'."""
+    schema = UpdateSampleInput.model_json_schema()
+    schema_str = json.dumps(schema)
+    assert "Undefined" not in schema_str
+
+
+def test_model_json_schema_region_property_clean() -> None:
+    """model_json_schema(): properties.region has no Undefined ref and no default."""
+    schema = UpdateSampleInput.model_json_schema()
+    region_prop = schema["properties"]["region"]
+    # Should be simplified to {"anyOf": [{"type": "string"}, {"type": "null"}], ...}
+    # or just the innermost structure
+    schema_str = json.dumps(region_prop)
+    assert "Undefined" not in schema_str
+    assert "$ref" not in schema_str  # No Undefined ref
+
+
+def test_model_json_schema_no_default_on_undefined_field() -> None:
+    """model_json_schema(): region field has no default key."""
+    schema = UpdateSampleInput.model_json_schema()
+    region_prop = schema["properties"]["region"]
+    assert "default" not in region_prop
+
+
+def test_model_json_schema_count_preserves_legitimate_default() -> None:
+    """model_json_schema(): count field with default=1 still has 'default': 1."""
+    schema = UpdateSampleInput.model_json_schema()
+    count_prop = schema["properties"]["count"]
+    assert count_prop.get("default") == 1
+
+
+def test_model_json_schema_with_components_ref_template() -> None:
+    """model_json_schema(ref_template='#/components/schemas/{model}'): no Undefined."""
+    schema = UpdateSampleInput.model_json_schema(ref_template="#/components/schemas/{model}")
+    schema_str = json.dumps(schema)
+    assert "Undefined" not in schema_str
+
+
+def test_create_model_dump_equals_plain_basemodel() -> None:
+    """CreateSampleInput model_dump() equals identical plain BaseModel's."""
+    create_input = CreateSampleInput(name="test", description="desc")
+    plain_model = PlainEquivalentModel(name="test", description="desc")
+
+    create_dump = create_input.model_dump(mode="python")
+    plain_dump = plain_model.model_dump(mode="python")
+
+    assert create_dump == plain_dump
+
+
+def test_create_model_json_schema_equals_plain_basemodel() -> None:
+    """CreateSampleInput model_json_schema() equals identical plain BaseModel's (excluding title)."""
+    create_schema = CreateSampleInput.model_json_schema()
+    plain_schema = PlainEquivalentModel.model_json_schema()
+
+    # Remove titles and compare (they differ by class name but structure should be same)
+    create_schema_copy = dict(create_schema)
+    plain_schema_copy = dict(plain_schema)
+    create_schema_copy.pop("title", None)
+    plain_schema_copy.pop("title", None)
+    assert create_schema_copy == plain_schema_copy
+
+
+def test_nested_outer_dumps_without_inner_undefined() -> None:
+    """Nested case: outer model_dump() drops inner UNDEFINED fields."""
+    inner = UpdateSampleInput(id=1)  # region is UNDEFINED
+    outer = OuterSampleInput(outer_id=10, inner=inner)
+
+    dumped = outer.model_dump(mode="python")
+
+    # The outer should be present
+    assert dumped["outer_id"] == 10
+
+    # The inner dict should be present
+    assert "inner" in dumped
+    inner_dict = dumped["inner"]
+
+    # The inner's UNDEFINED field (region) should not be in the dumped dict
+    assert "region" not in inner_dict
+    assert inner_dict["id"] == 1
+
+
+def test_serialization_mode_schema_keeps_fields() -> None:
+    """model_json_schema(mode='serialization') keeps the model's properties (not {})."""
+    schema = UpdateSampleInput.model_json_schema(mode="serialization")
+    assert set(schema["properties"]) == {"id", "region", "nickName", "count"}
+    assert "Undefined" not in json.dumps(schema)

--- a/tests/unit/manager/test_types.py
+++ b/tests/unit/manager/test_types.py
@@ -1,0 +1,242 @@
+"""Tests for TriState and OptionalState partial-update wrappers."""
+
+from __future__ import annotations
+
+import pytest
+from graphql import Undefined as GraphQLUndefined
+from strawberry import UNSET
+
+from ai.backend.common.api_handlers import UNDEFINED
+from ai.backend.manager.types import OptionalState, TriState, _TriStateEnum
+
+# ============================================================================
+# TriState Tests
+# ============================================================================
+
+
+class TestTriStateFromInput:
+    """Test TriState.from_input() conversions."""
+
+    def test_from_input_undefined_is_nop(self) -> None:
+        """Scenario 1: from_input(UNDEFINED) → is_nop() True, optional_value() None."""
+        ts: TriState[str] = TriState.from_input(UNDEFINED)
+        assert ts.is_nop() is True
+        assert ts.optional_value() is None
+
+    def test_from_input_none_is_nullify(self) -> None:
+        """Scenario 2: from_input(None) → is_nullify() True."""
+        ts: TriState[str] = TriState.from_input(None)
+        assert ts.is_nullify() is True
+
+    def test_from_input_value_is_update(self) -> None:
+        """Scenario 3: from_input("x") → is_update() True, value() == "x"."""
+        ts: TriState[str] = TriState.from_input("x")
+        assert ts.is_update() is True
+        assert ts.value() == "x"
+
+    def test_from_input_falsy_values_are_update(self) -> None:
+        """Scenario 4: falsy-but-valid values (0, "", []) → update, not nop/nullify."""
+        # Zero
+        ts_int: TriState[int] = TriState.from_input(0)
+        assert ts_int.is_update() is True
+        assert ts_int.value() == 0
+
+        # Empty string
+        ts_str: TriState[str] = TriState.from_input("")
+        assert ts_str.is_update() is True
+        assert ts_str.value() == ""
+
+        # Empty list
+        ts_list: TriState[list[int]] = TriState.from_input([])
+        assert ts_list.is_update() is True
+        assert ts_list.value() == []
+
+
+class TestTriStateFromNullable:
+    """Test TriState.from_nullable() conversions."""
+
+    def test_from_nullable_none_is_nop(self) -> None:
+        """Scenario 5a: from_nullable(None) → nop (legacy unchanged behaviour)."""
+        ts: TriState[str] = TriState.from_nullable(None)
+        assert ts.is_nop() is True
+
+    def test_from_nullable_value_is_update(self) -> None:
+        """Scenario 5b: from_nullable(1) → update (legacy unchanged behaviour)."""
+        ts: TriState[int] = TriState.from_nullable(1)
+        assert ts.is_update() is True
+        assert ts.value() == 1
+
+
+class TestTriStateFromGraphQL:
+    """Test TriState.from_graphql() conversions."""
+
+    def test_from_graphql_none_is_nullify(self) -> None:
+        """Scenario 6a: from_graphql(None) → nullify."""
+        ts: TriState[str] = TriState.from_graphql(None)
+        assert ts.is_nullify() is True
+
+    def test_from_graphql_strawberry_unset_is_nop(self) -> None:
+        """Scenario 6b: from_graphql(strawberry.UNSET) → nop."""
+        ts: TriState[str] = TriState.from_graphql(UNSET)
+        assert ts.is_nop() is True
+
+    def test_from_graphql_graphql_undefined_is_nop(self) -> None:
+        """Scenario 6c: from_graphql(graphql.Undefined) → nop."""
+        ts: TriState[str] = TriState.from_graphql(GraphQLUndefined)
+        assert ts.is_nop() is True
+
+    def test_from_graphql_value_is_update(self) -> None:
+        """Scenario 6d: from_graphql(value) → update."""
+        ts: TriState[str] = TriState.from_graphql("value")
+        assert ts.is_update() is True
+        assert ts.value() == "value"
+
+
+class TestTriStateValue:
+    """Test TriState.value() access."""
+
+    def test_value_raises_when_nop(self) -> None:
+        """Scenario 7a: value() raises ValueError when state is nop."""
+        ts: TriState[str] = TriState.nop()
+        with pytest.raises(ValueError, match="Not allowed to get value when state is not UPDATE"):
+            ts.value()
+
+    def test_value_raises_when_nullify(self) -> None:
+        """Scenario 7b: value() raises ValueError when state is nullify."""
+        ts: TriState[str] = TriState.nullify()
+        with pytest.raises(ValueError, match="Not allowed to get value when state is not UPDATE"):
+            ts.value()
+
+
+class TestTriStateMap:
+    """Test TriState.map() preserves state."""
+
+    def test_map_update_applies_function(self) -> None:
+        """Scenario 8a: map() on update applies function to value."""
+        ts: TriState[int] = TriState.update(5)
+        mapped: TriState[int] = ts.map(lambda x: x * 2)
+        assert mapped.is_update() is True
+        assert mapped.value() == 10
+
+    def test_map_nullify_stays_nullify(self) -> None:
+        """Scenario 8b: map() on nullify stays nullify."""
+        ts: TriState[int] = TriState.nullify()
+        mapped: TriState[int] = ts.map(lambda x: x * 2)
+        assert mapped.is_nullify() is True
+
+    def test_map_nop_stays_nop(self) -> None:
+        """Scenario 8c: map() on nop stays nop."""
+        ts: TriState[int] = TriState.nop()
+        mapped: TriState[int] = ts.map(lambda x: x * 2)
+        assert mapped.is_nop() is True
+
+
+class TestTriStateUpdateDict:
+    """Test TriState.update_dict() state effects."""
+
+    def test_update_dict_update_sets_key(self) -> None:
+        """Scenario 9a: update_dict() on update sets key."""
+        ts: TriState[str] = TriState.update("value")
+        d: dict[str, object] = {}
+        ts.update_dict(d, "field")
+        assert d == {"field": "value"}
+
+    def test_update_dict_nullify_sets_key_to_none(self) -> None:
+        """Scenario 9b: update_dict() on nullify sets key to None."""
+        ts: TriState[str] = TriState.nullify()
+        d: dict[str, object] = {"field": "old"}
+        ts.update_dict(d, "field")
+        assert d == {"field": None}
+
+    def test_update_dict_nop_leaves_dict_untouched(self) -> None:
+        """Scenario 9c: update_dict() on nop leaves dict untouched."""
+        ts: TriState[str] = TriState.nop()
+        d: dict[str, object] = {"field": "old"}
+        ts.update_dict(d, "field")
+        assert d == {"field": "old"}
+
+
+# ============================================================================
+# OptionalState Tests
+# ============================================================================
+
+
+class TestOptionalStateFromInput:
+    """Test OptionalState.from_input() conversions."""
+
+    def test_from_input_undefined_is_nop(self) -> None:
+        """Scenario 10a: from_input(UNDEFINED) → nop."""
+        os: OptionalState[int] = OptionalState.from_input(UNDEFINED)
+        # nop state: optional_value() returns None
+        assert os.optional_value() is None
+
+    def test_from_input_value_is_update(self) -> None:
+        """Scenario 10b: from_input(5) → update with value() == 5."""
+        os: OptionalState[int] = OptionalState.from_input(5)
+        assert os.value() == 5
+        assert os.optional_value() == 5
+
+    def test_from_input_none_raises_error(self) -> None:
+        """Scenario 11: from_input(None) raises ValueError."""
+        with pytest.raises(ValueError, match="OptionalState cannot be NULLIFY"):
+            OptionalState.from_input(None)
+
+
+class TestOptionalStateConstructor:
+    """Test OptionalState constructor validation."""
+
+    def test_constructor_with_nullify_raises_error(self) -> None:
+        """Scenario 12: Constructing with NULLIFY state raises ValueError."""
+        with pytest.raises(ValueError, match="OptionalState cannot be NULLIFY"):
+            OptionalState(state=_TriStateEnum.NULLIFY, value=None)
+
+
+class TestOptionalStateFromGraphQL:
+    """Test OptionalState.from_graphql() conversions."""
+
+    def test_from_graphql_strawberry_unset_is_nop(self) -> None:
+        """Scenario 13a: from_graphql(strawberry.UNSET) → nop."""
+        os: OptionalState[int] = OptionalState.from_graphql(UNSET)
+        # nop state: optional_value() returns None
+        assert os.optional_value() is None
+
+    def test_from_graphql_none_raises_error(self) -> None:
+        """Scenario 13b: from_graphql(None) raises ValueError."""
+        with pytest.raises(ValueError, match="OptionalState cannot be NULLIFY"):
+            OptionalState.from_graphql(None)
+
+
+class TestOptionalStateMap:
+    """Test OptionalState.map() for update and nop."""
+
+    def test_map_update_applies_function(self) -> None:
+        """Scenario 14a: map() on update applies function to value."""
+        os: OptionalState[int] = OptionalState.update(3)
+        mapped: OptionalState[int] = os.map(lambda x: x + 10)
+        assert mapped.value() == 13
+        assert mapped.optional_value() == 13
+
+    def test_map_nop_stays_nop(self) -> None:
+        """Scenario 14b: map() on nop stays nop."""
+        os: OptionalState[int] = OptionalState.nop()
+        mapped: OptionalState[int] = os.map(lambda x: x + 10)
+        # nop state: optional_value() returns None
+        assert mapped.optional_value() is None
+
+
+class TestOptionalStateUpdateDict:
+    """Test OptionalState.update_dict() for update and nop."""
+
+    def test_update_dict_update_sets_key(self) -> None:
+        """OptionalState.update_dict() on update sets key."""
+        os: OptionalState[str] = OptionalState.update("data")
+        d: dict[str, object] = {}
+        os.update_dict(d, "field")
+        assert d == {"field": "data"}
+
+    def test_update_dict_nop_leaves_dict_untouched(self) -> None:
+        """OptionalState.update_dict() on nop leaves dict untouched."""
+        os: OptionalState[str] = OptionalState.nop()
+        d: dict[str, object] = {"field": "old"}
+        os.update_dict(d, "field")
+        assert d == {"field": "old"}


### PR DESCRIPTION
resolves #14167 (BA-7626)

## Summary
- Define `Undefined` / `UNDEFINED` in `common/api_handlers.py` as the "field not provided" marker for update DTOs (`UNDEFINED` = no change, `None` = clear, value = update).
- `BaseRequestModel` drops `UNDEFINED`-valued fields from `model_dump()` / `model_dump_json()` and removes every `Undefined` trace from `model_json_schema()`, so the token never reaches the wire or the OpenAPI spec. The behavior is attached at the core-schema level so the serialization-mode JSON schema keeps its fields and a before/after/wrap `@model_validator` on a DTO does not disable it.
- `Undefined` validates only as the enum instance itself; a wire `1` / `true` / `1.0` on a `T | Undefined | None` field is rejected instead of being coerced into "not provided".
- Add `TriState.from_input()` / `OptionalState.from_input()` for converting a v2 update DTO field into the partial-update wrappers.

Existing DTOs are unaffected: no DTO uses `Undefined` yet, and dump / validation-schema output of all `common/dto/manager/v2` request models was compared before and after with no difference.

## Test plan
- [x] `pants fmt/fix/lint/check` on changed files pass
- [x] `pants test tests/unit/common/test_undefined.py tests/unit/manager/test_types.py tests/unit/common/test_api_handlers.py tests/unit/common/dto/manager/v2::` pass (116 targets)
- [x] Local manager restarted; admin login, domain create → update → get → delete → purge verified with `./bai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQ8Hz7ixJ7AZNFkLUHqakB