### PR TITLE
chore: keep the container registry group foreign key names under 63 characters

### DIFF
--- a/changes/14240.misc.md
+++ b/changes/14240.misc.md
@@ -1,0 +1,1 @@
+Keep the container registry group foreign key names within PostgreSQL's 63-character identifier limit, so the migration adding them applies.

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -62,6 +62,18 @@ live in `models/specs/` — read `models/specs/AGENTS.md` before touching them.
 - `IDColumn()`, `SessionIDColumn()` and `KernelIDColumn()` in `models/base.py` stay on v4:
   old migrations reproduce past schemas through them. Do not use them for a new table.
 
+## Constraint names
+
+- Leave a constraint unnamed and let the naming convention in `models/base.py` name it.
+- Past 63 characters — PostgreSQL's identifier limit — SQLAlchemy truncates the generated
+  name with a 4-character md5 suffix, leaving an unreadable one
+  (`fk_..._registry_id__4a21`). A foreign key joining two long table names lands there.
+  Name those explicitly with `sa.ForeignKey(..., name=...)`, within 63 characters.
+  Precedent: `association_container_registries_groups`.
+- A constraint named explicitly carries that same string into the migration. A Row
+  declaration and a migration that disagree leave a freshly created database and a
+  migrated one with different constraint names.
+
 ## Custom column types
 
 - Where possible, reuse the existing `TypeDecorator` wrappers in `models/base.py`.

--- a/src/ai/backend/manager/models/alembic/AGENTS.md
+++ b/src/ai/backend/manager/models/alembic/AGENTS.md
@@ -11,6 +11,11 @@
   revision identifier. Do NOT hardcode a version; the `NEXT_RELEASE_VERSION` placeholder is frozen to the actual version. For backports the placeholder freezes per branch, so both `d` and `d'` keep the same placeholder.
 - **Do NOT edit the revision of a released migration** — do not modify the `revision`/`down_revision` of an
   already-released migration. Editing `down_revision` is allowed only when inserting a backport into the main chain before merge.
+- **Wrap a convention-generated constraint name in `op.f()`** — `op.create_foreign_key(op.f("fk_..."), ...)`.
+  A bare string has the convention applied to it again and is exempt from truncation, so it
+  either disagrees with the name `mgr schema oneshot` produces or trips the 63-character limit
+  with `IdentifierError`. Autogenerate already renders these wrapped. A constraint the Row
+  declaration names explicitly is not wrapped (rule: `models/AGENTS.md`).
 
 ## Diverged heads
 

--- a/src/ai/backend/manager/models/alembic/versions/c1d7a3e9f5b2_add_fks_to_container_registry_project_relation.py
+++ b/src/ai/backend/manager/models/alembic/versions/c1d7a3e9f5b2_add_fks_to_container_registry_project_relation.py
@@ -15,8 +15,11 @@ branch_labels = None
 depends_on = None
 
 TABLE = "association_container_registries_groups"
-FK_REGISTRY = f"fk_{TABLE}_registry_id_container_registries"
-FK_PROJECT = f"fk_{TABLE}_group_id_groups"
+# Shortened from the metadata naming convention, which would generate a 75-character
+# name for the registry key — over PostgreSQL's 63-character limit. The Row declaration
+# names both keys the same way.
+FK_REGISTRY = f"fk_{TABLE}_registry_id"
+FK_PROJECT = f"fk_{TABLE}_group_id"
 
 
 def upgrade() -> None:

--- a/src/ai/backend/manager/models/association_container_registries_groups/row.py
+++ b/src/ai/backend/manager/models/association_container_registries_groups/row.py
@@ -30,12 +30,22 @@ class AssociationContainerRegistriesGroupsRow(Base):
     registry_id: Mapped[ContainerRegistryID] = mapped_column(
         "registry_id",
         GUID(ContainerRegistryID),
-        sa.ForeignKey("container_registries.id", ondelete="CASCADE"),
+        # Named explicitly: the naming convention would generate a 75-character name,
+        # over PostgreSQL's 63-character limit.
+        sa.ForeignKey(
+            "container_registries.id",
+            ondelete="CASCADE",
+            name="fk_association_container_registries_groups_registry_id",
+        ),
         nullable=False,
     )
     group_id: Mapped[ProjectID] = mapped_column(
         "group_id",
         GUID(ProjectID),
-        sa.ForeignKey("groups.id", ondelete="CASCADE"),
+        sa.ForeignKey(
+            "groups.id",
+            ondelete="CASCADE",
+            name="fk_association_container_registries_groups_group_id",
+        ),
         nullable=False,
     )


### PR DESCRIPTION
## Summary

- The metadata naming convention generates `fk_association_container_registries_groups_registry_id_container_registries` — 75 characters, over PostgreSQL's 63-character identifier limit. Migration `c1d7a3e9f5b2` passed that name to `op.create_foreign_key` as a bare string, which is exempt from SQLAlchemy's truncation, so `alembic upgrade` raised `IdentifierError`.
- Name both foreign keys explicitly, in the Row declaration and the migration alike, so a database created by `mgr schema oneshot` and a migrated one carry the same constraint names. (Left to the convention, the two disagree: `create_all` truncates to `fk_..._registry_id__4a21`, the migration does not truncate at all.)
- Record the rule in `models/AGENTS.md` (name explicitly past 63 characters) and `models/alembic/AGENTS.md` (wrap a convention-generated name in `op.f()`).

`c1d7a3e9f5b2` is not on any maintained release branch, so this is a same-release fix — `chore`/`misc`, no backport.

## Test plan

- [x] `pants fmt ::`, `pants fix ::`, `pants lint --changed-since=origin/main`
- [x] Compiled `CreateTable` for `association_container_registries_groups` against the PostgreSQL dialect; both emitted names now match the migration exactly
- [ ] `alembic upgrade head` against a local DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ae1qiWAYvAcwuj47toTKiY