### PR TITLE
refactor(BA-7428): read the vfolder host policy without the default keypair relationship

### DIFF
--- a/changes/14250.enhance.md
+++ b/changes/14250.enhance.md
@@ -1,0 +1,1 @@
+Resolve the vfolder host permissions of a user by joining the keypair resource policy directly, without loading the user and keypair rows through an ORM relationship.

--- a/src/ai/backend/manager/models/user/row.py
+++ b/src/ai/backend/manager/models/user/row.py
@@ -101,12 +101,6 @@ def _get_keypairs_join_condition() -> Any:
     return foreign(KeyPairRow.user) == UserRow.uuid
 
 
-def _get_default_keypair_join_condition() -> Any:
-    from ai.backend.manager.models.keypair import KeyPairRow
-
-    return (foreign(KeyPairRow.user) == UserRow.uuid) & KeyPairRow.is_default
-
-
 class UserRow(LifecycleTimestampsMixin, Base):
     __tablename__ = "users"
 
@@ -212,13 +206,6 @@ class UserRow(LifecycleTimestampsMixin, Base):
         foreign_keys="KeyPairRow.user",
     )
 
-    default_keypair: Mapped[KeyPairRow | None] = relationship(
-        "KeyPairRow",
-        primaryjoin=_get_default_keypair_join_condition,
-        foreign_keys="KeyPairRow.user",
-        viewonly=True,
-    )
-
     @classmethod
     def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
         return cls.uuid
@@ -232,14 +219,6 @@ class UserRow(LifecycleTimestampsMixin, Base):
         from ai.backend.manager.models.keypair import KeyPairRow
 
         return selectinload(UserRow.keypairs).options(joinedload(KeyPairRow.resource_policy_row))
-
-    @classmethod
-    def load_default_keypair(cls) -> _AbstractLoad:
-        from ai.backend.manager.models.keypair import KeyPairRow
-
-        return joinedload(UserRow.default_keypair).options(
-            joinedload(KeyPairRow.resource_policy_row)
-        )
 
     @classmethod
     def load_resource_policy(cls) -> _AbstractLoad:
@@ -302,7 +281,6 @@ class UserRow(LifecycleTimestampsMixin, Base):
             [by_user_uuid(user_uuid)],
             [
                 load_related_field(cls.load_keypairs()),
-                load_related_field(cls.load_default_keypair()),
                 load_related_field(cls.load_resource_policy()),
             ],
             db=db,

--- a/src/ai/backend/manager/repositories/ops/user/write.py
+++ b/src/ai/backend/manager/repositories/ops/user/write.py
@@ -78,12 +78,10 @@ class UserWriteOps(RBACWriteOps):
         await self._enroll_in_domain(user_id, full_creation.domain_id)
         await self._enroll_in_projects(user_id, full_creation.domain_id, full_creation.project_ids)
 
-        # The insert leaves the server-default columns unloaded, and default_keypair is the
-        # keypair created just above; reload both so callers can read the row without a
-        # sync-context lazy refresh.
+        # The insert leaves the server-default columns unloaded; reload them so callers
+        # can read the row without a sync-context lazy refresh.
         await self._sess.flush()
         await self._sess.refresh(user_row)
-        await self._sess.refresh(user_row, ["default_keypair"])
         return FullUserCreationResult(user_row=user_row, keypair=keypair)
 
     async def _create_user_scope(self, creation: ScopeCreation[UserRow]) -> UserRow:

--- a/src/ai/backend/manager/repositories/project/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/project/db_source/db_source.py
@@ -14,7 +14,6 @@ import msgpack
 import sqlalchemy as sa
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
-from sqlalchemy.orm import joinedload
 
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.entity.domain import DomainID
@@ -169,14 +168,10 @@ class ProjectDBSource:
         project_domain_subq = (
             sa.select(ProjectRow.domain_name).where(ProjectRow.id == project_id).scalar_subquery()
         )
-        query = (
-            sa.select(UserRow)
-            .where(
-                UserRow.uuid.in_(user_ids)
-                & (UserRow.domain_name == project_domain_subq)
-                & ~user_scope_membership_exists(PROJECT_SCOPE_TYPE, project_id, UserRow.uuid)
-            )
-            .options(joinedload(UserRow.default_keypair))
+        query = sa.select(UserRow).where(
+            UserRow.uuid.in_(user_ids)
+            & (UserRow.domain_name == project_domain_subq)
+            & ~user_scope_membership_exists(PROJECT_SCOPE_TYPE, project_id, UserRow.uuid)
         )
         result = await w.batch_query_in_global(query, BatchQuerier(pagination=NoPagination()))
         return [row.UserRow for row in result.rows]
@@ -592,15 +587,11 @@ class ProjectDBSource:
             existing_ids = {row.UserRow.uuid for row in existing_result.rows}
 
             # Fetch users that are actually members before removing
-            actual_assoc_query = (
-                sa.select(UserRow)
-                .where(
-                    UserRow.uuid.in_(unbinder.user_uuids)
-                    & user_scope_membership_exists(
-                        PROJECT_SCOPE_TYPE, ProjectID(unbinder.project_id), UserRow.uuid
-                    )
+            actual_assoc_query = sa.select(UserRow).where(
+                UserRow.uuid.in_(unbinder.user_uuids)
+                & user_scope_membership_exists(
+                    PROJECT_SCOPE_TYPE, ProjectID(unbinder.project_id), UserRow.uuid
                 )
-                .options(joinedload(UserRow.default_keypair))
             )
             assoc_result = await w.batch_query_in_global(
                 actual_assoc_query, BatchQuerier(pagination=NoPagination())

--- a/src/ai/backend/manager/repositories/session/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/session/db_source/db_source.py
@@ -141,7 +141,6 @@ class SessionDBSource:
                 sa.select(UserRow)
                 .join(SessionRow, SessionRow.user_uuid == UserRow.uuid)
                 .where(SessionRow.id == session_id)
-                .options(joinedload(UserRow.default_keypair))
             )
             user = await db_sess.scalar(query)
             if user is None:

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -12,7 +12,7 @@ from dateutil.tz import tzutc
 from sqlalchemy import Row
 from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
-from sqlalchemy.orm import joinedload, load_only, noload
+from sqlalchemy.orm import load_only, noload
 from sqlalchemy.sql.expression import bindparam
 
 from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
@@ -580,22 +580,14 @@ class UserDBSource:
 
     async def _get_user_by_email(self, session: SASession, email: str) -> UserRow:
         """Private method to get user by email."""
-        res = await session.scalar(
-            sa.select(UserRow)
-            .where(UserRow.email == email)
-            .options(joinedload(UserRow.default_keypair))
-        )
+        res = await session.scalar(sa.select(UserRow).where(UserRow.email == email))
         if res is None:
             raise UserNotFound(f"User with email {email} not found.")
         return res
 
     async def _get_user_by_uuid(self, session: SASession, user_uuid: UUID) -> UserRow:
         """Private method to get user by UUID."""
-        res = await session.scalar(
-            sa.select(UserRow)
-            .where(UserRow.uuid == user_uuid)
-            .options(joinedload(UserRow.default_keypair))
-        )
+        res = await session.scalar(sa.select(UserRow).where(UserRow.uuid == user_uuid))
         if res is None:
             raise UserNotFound(f"User with UUID {user_uuid} not found.")
         return res
@@ -923,7 +915,7 @@ class UserDBSource:
             UserSearchResult with matching users and pagination info.
         """
         async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(UserRow).options(joinedload(UserRow.default_keypair))
+            query = sa.select(UserRow)
             result = await execute_batch_querier(db_session, query, querier)
 
             items = [row.UserRow.to_data() for row in result.rows]
@@ -949,7 +941,7 @@ class UserDBSource:
             UserSearchResult with matching users and pagination info.
         """
         async with self._db.begin_readonly_session() as db_session:
-            query = sa.select(UserRow).options(joinedload(UserRow.default_keypair))
+            query = sa.select(UserRow)
             result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
 
             items = [row.UserRow.to_data() for row in result.rows]
@@ -978,9 +970,7 @@ class UserDBSource:
             UserSearchResult with matching users and pagination info.
         """
         async with self._db.begin_readonly_session() as db_session:
-            query = (
-                sa.select(UserRow).select_from(UserRow).options(joinedload(UserRow.default_keypair))
-            )
+            query = sa.select(UserRow).select_from(UserRow)
             result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
 
             items = [row.UserRow.to_data() for row in result.rows]
@@ -1008,7 +998,6 @@ class UserDBSource:
                     UserRoleRow,
                     UserRow.uuid == UserRoleRow.user_id,
                 )
-                .options(joinedload(UserRow.default_keypair))
             )
             result = await execute_batch_querier(db_session, query, querier, scopes=[scope])
 

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -301,23 +301,43 @@ class VfolderRepository:
 
                 return group_row.allowed_vfolder_hosts
 
-            user_row: UserRow | None = await db_session.scalar(
-                sa.select(UserRow)
-                .where(UserRow.uuid == user_uuid)
-                .options(
-                    selectinload(UserRow.default_keypair).selectinload(
-                        KeyPairRow.resource_policy_row
-                    )
-                )
-            )
-            if user_row is None:
-                raise UserNotFound(f"User with UUID {user_uuid} not found.")
-            if user_row.default_keypair is None:
+            allowed_hosts = await self._fetch_default_keypair_vfolder_hosts(db_session, user_uuid)
+            if allowed_hosts is None:
                 raise ObjectNotFound(object_name="User keypair")
-            if user_row.default_keypair.resource_policy_row is None:
-                raise ObjectNotFound(object_name="User keypair resource policy")
+            return allowed_hosts
 
-            return user_row.default_keypair.resource_policy_row.allowed_vfolder_hosts
+    async def _fetch_default_keypair_vfolder_hosts(
+        self, db_session: SASession, user_uuid: uuid.UUID
+    ) -> VFolderHostPermissionMap | None:
+        """
+        Read ``allowed_vfolder_hosts`` from the resource policy of the user's default
+        keypair. Returns ``None`` when the user has no default keypair.
+        """
+        stmt = (
+            sa.select(
+                KeyPairRow.access_key,
+                keypair_resource_policies.c.allowed_vfolder_hosts,
+            )
+            .select_from(UserRow)
+            .outerjoin(
+                KeyPairRow,
+                sa.and_(KeyPairRow.user == UserRow.uuid, KeyPairRow.is_default),
+            )
+            .outerjoin(
+                keypair_resource_policies,
+                keypair_resource_policies.c.name == KeyPairRow.resource_policy,
+            )
+            .where(UserRow.uuid == user_uuid)
+        )
+        row = (await db_session.execute(stmt)).first()
+        if row is None:
+            raise UserNotFound(f"User with UUID {user_uuid} not found.")
+        # The host-permission column reads a SQL NULL back as an empty map, so the
+        # keypair's own key is what tells an unmatched join apart from an empty policy.
+        if row.access_key is None:
+            return None
+        allowed_hosts: VFolderHostPermissionMap = row.allowed_vfolder_hosts
+        return allowed_hosts
 
     @vfolder_repository_resilience.apply()
     async def get_user_with_keypair_policy_vfolder_hosts(
@@ -2013,28 +2033,12 @@ class VfolderRepository:
         depend on volume availability must intersect with ``StorageSessionManager``.
         """
         async with self._db.begin_readonly_session_read_committed() as db_session:
-            user_row: UserRow | None = await db_session.scalar(
-                sa.select(UserRow)
-                .where(UserRow.uuid == user_uuid)
-                .options(
-                    selectinload(UserRow.default_keypair).selectinload(
-                        KeyPairRow.resource_policy_row
-                    )
-                )
-            )
-            if user_row is None:
-                raise UserNotFound(f"User with UUID {user_uuid} not found.")
-            if (
-                user_row.default_keypair is None
-                or user_row.default_keypair.resource_policy_row is None
-            ):
-                resource_policy: Mapping[str, Any] = {
-                    "allowed_vfolder_hosts": VFolderHostPermissionMap(),
-                }
-            else:
-                resource_policy = {
-                    "allowed_vfolder_hosts": user_row.default_keypair.resource_policy_row.allowed_vfolder_hosts,
-                }
+            allowed_hosts = await self._fetch_default_keypair_vfolder_hosts(db_session, user_uuid)
+            resource_policy: Mapping[str, Any] = {
+                "allowed_vfolder_hosts": allowed_hosts
+                if allowed_hosts is not None
+                else VFolderHostPermissionMap(),
+            }
             conn = await db_session.connection()
             return await get_allowed_vfolder_hosts_by_user(
                 conn=conn,

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -1455,7 +1455,7 @@ class TestDeploymentRevisionOperations:
                 RoleRow,
                 UserRoleRow,  # UserRow relationship dependency
                 UserRow,
-                KeyPairRow,  # UserRow.default_keypair relationship target
+                KeyPairRow,  # keypairs.user foreign key target
                 ProjectRow,
                 VFolderRow,
                 ContainerRegistryRow,

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -44,6 +44,7 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOwnershipType,
 )
 from ai.backend.manager.defs import DEFAULT_ROLE
+from ai.backend.manager.errors.common import ObjectNotFound
 from ai.backend.manager.errors.storage import (
     VFolderDeletionNotAllowed,
     VFolderFilterStatusFailed,
@@ -431,6 +432,8 @@ class TestVfolderRepositoryAllowedVfolderHosts:
                 UserRow,
                 KeyPairRow,
                 ProjectRow,
+                VirtualEntityRow,
+                EntityMembershipRow,
             ],
         ):
             yield database_connection
@@ -666,6 +669,153 @@ class TestVfolderRepositoryAllowedVfolderHosts:
         """Unknown user UUID raises UserNotFound."""
         with pytest.raises(UserNotFound):
             await vfolder_repository.get_user_with_keypair_policy_vfolder_hosts(uuid.uuid4())
+
+    # -- default keypair policy --
+
+    @pytest.fixture
+    async def user_with_default_keypair(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_user: uuid.UUID,
+        keypair_policy_with_hosts: str,
+    ) -> uuid.UUID:
+        """Bind a default keypair (pointing to keypair_policy_with_hosts) to ``test_user``."""
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                KeyPairRow(
+                    user=test_user,
+                    access_key=f"DK{test_user.hex[:14]}",
+                    secret_key=SecretValue("test-secret"),
+                    is_active=True,
+                    is_admin=False,
+                    is_default=True,
+                    resource_policy=keypair_policy_with_hosts,
+                    rate_limit=1000,
+                )
+            )
+            await db_sess.flush()
+        return test_user
+
+    async def test_get_allowed_vfolder_hosts_reads_the_default_keypair_policy(
+        self,
+        vfolder_repository: VfolderRepository,
+        user_with_default_keypair: uuid.UUID,
+    ) -> None:
+        """Without a group, the hosts come from the default keypair's resource policy."""
+        result = await vfolder_repository.get_allowed_vfolder_hosts(
+            user_uuid=user_with_default_keypair,
+            group_uuid=None,
+        )
+
+        assert result["local:volume1"] == {
+            VFolderHostPermission.CREATE,
+            VFolderHostPermission.MODIFY,
+        }
+
+    @pytest.fixture
+    async def user_with_default_keypair_on_empty_policy(
+        self,
+        db_with_cleanup: ExtendedAsyncSAEngine,
+        test_user: uuid.UUID,
+    ) -> uuid.UUID:
+        """Bind a default keypair whose resource policy allows no host at all."""
+        policy_name = f"test-kp-empty-policy-{uuid.uuid4().hex[:8]}"
+        async with db_with_cleanup.begin_session() as db_sess:
+            db_sess.add(
+                KeyPairResourcePolicyRow(
+                    name=policy_name,
+                    default_for_unspecified=DefaultForUnspecified.LIMITED,
+                    total_resource_slots=ResourceSlot(),
+                    max_session_lifetime=0,
+                    max_concurrent_sessions=10,
+                    max_concurrent_sftp_sessions=1,
+                    max_containers_per_session=1,
+                    idle_timeout=0,
+                    allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                )
+            )
+            await db_sess.flush()
+            db_sess.add(
+                KeyPairRow(
+                    user=test_user,
+                    access_key=f"EK{test_user.hex[:14]}",
+                    secret_key=SecretValue("test-secret"),
+                    is_active=True,
+                    is_admin=False,
+                    is_default=True,
+                    resource_policy=policy_name,
+                    rate_limit=1000,
+                )
+            )
+            await db_sess.flush()
+        return test_user
+
+    async def test_get_allowed_vfolder_hosts_accepts_a_policy_allowing_no_host(
+        self,
+        vfolder_repository: VfolderRepository,
+        user_with_default_keypair_on_empty_policy: uuid.UUID,
+    ) -> None:
+        """A default keypair whose policy allows no host returns an empty map, not an error."""
+        result = await vfolder_repository.get_allowed_vfolder_hosts(
+            user_uuid=user_with_default_keypair_on_empty_policy,
+            group_uuid=None,
+        )
+
+        assert result == VFolderHostPermissionMap()
+
+    async def test_get_allowed_vfolder_hosts_ignores_a_non_default_keypair(
+        self,
+        vfolder_repository: VfolderRepository,
+        user_with_active_keypair: uuid.UUID,
+    ) -> None:
+        """A keypair that is not the default one does not supply the policy."""
+        with pytest.raises(ObjectNotFound):
+            await vfolder_repository.get_allowed_vfolder_hosts(
+                user_uuid=user_with_active_keypair,
+                group_uuid=None,
+            )
+
+    async def test_get_allowed_vfolder_hosts_user_not_found(
+        self,
+        vfolder_repository: VfolderRepository,
+    ) -> None:
+        """Unknown user UUID raises UserNotFound rather than ObjectNotFound."""
+        with pytest.raises(UserNotFound):
+            await vfolder_repository.get_allowed_vfolder_hosts(
+                user_uuid=uuid.uuid4(),
+                group_uuid=None,
+            )
+
+    async def test_get_user_storage_host_permissions_unions_the_default_keypair_policy(
+        self,
+        vfolder_repository: VfolderRepository,
+        test_domain: DomainFixtureData,
+        user_with_default_keypair: uuid.UUID,
+    ) -> None:
+        """The default keypair's hosts join the domain and group hosts."""
+        result = await vfolder_repository.get_user_storage_host_permissions(
+            user_uuid=user_with_default_keypair,
+            domain_name=test_domain.domain_name,
+        )
+
+        assert result["local:volume1"] == {
+            VFolderHostPermission.CREATE,
+            VFolderHostPermission.MODIFY,
+        }
+
+    async def test_get_user_storage_host_permissions_without_a_default_keypair(
+        self,
+        vfolder_repository: VfolderRepository,
+        test_domain: DomainFixtureData,
+        test_user: uuid.UUID,
+    ) -> None:
+        """A user with no default keypair contributes no keypair hosts, and does not raise."""
+        result = await vfolder_repository.get_user_storage_host_permissions(
+            user_uuid=test_user,
+            domain_name=test_domain.domain_name,
+        )
+
+        assert result == VFolderHostPermissionMap()
 
 
 class TestVfolderRepositoryPurge:


### PR DESCRIPTION
## Summary

- The vfolder host lookup joins `keypairs` and `keypair_resource_policies` directly instead of walking `UserRow.default_keypair`, reading only the allowed host map rather than whole user and keypair rows (`secret_key` and `ssh_private_key` included).
- `UserRow.default_keypair` and `load_default_keypair()` are gone. The eager loads that remained in the user, project, and session db sources fed nothing once BA-7297 dropped `default_access_key` from `UserData`, so they go with the relationship.
- Behavior is unchanged: the same keypair resource policy column is read, a missing default keypair still raises `ObjectNotFound` for `get_allowed_vfolder_hosts` and still falls back to an empty map for `get_user_storage_host_permissions`. The unreachable "keypair without a resource policy" branch is dropped — that column is `NOT NULL` with a foreign key.

## Test plan

- [x] `pants test tests/unit/manager/repositories/vfolder/test_vfolder_repository.py` — five cases added: the default keypair's hosts, a policy allowing no host, a non-default keypair being ignored, an unknown user, and the empty-policy fallback in `get_user_storage_host_permissions`
- [x] `pants test --changed-since=origin/main --changed-dependents=direct`
- [x] `pants test tests/component/user/test_user_crud.py` — user creation no longer refreshes the relationship
- [x] `pants fmt/fix/lint/check --changed-since=origin/main`

Resolves BA-7428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp6F3zwRxWqoG9z3Dc8DGE