### PR TITLE
feat(BA-7659): create a personal project with every user

### DIFF
--- a/changes/14251.feature.md
+++ b/changes/14251.feature.md
@@ -1,0 +1,1 @@
+Create a personal project together with every user, holding the resources that user owns personally.

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -82,11 +82,13 @@ live in `models/specs/` — read `models/specs/AGENTS.md` before touching them.
 - To record which user a row came into being for, use **`creator_id`**. Do not coin
   another spelling; `vfolders.creator_id` already carries this meaning.
 - It is provenance, not ownership. Do NOT use it in an access decision.
-- Nullable by default. Where one row kind requires it, enforce it for that kind with a
-  `CHECK`.
-- The foreign key is `ON DELETE SET NULL`. Together with that `CHECK`, the database
-  refuses to delete a user while such a row is still there. `RESTRICT` is wrong here —
-  a row the user merely created would block their purge.
+- Always nullable, and the foreign key is `ON DELETE SET NULL`. When the user goes the
+  column empties and the row stays.
+- Do NOT add a `CHECK` requiring it, not even for one row kind. A row whose creator is
+  gone is a valid state, not a broken one — what the row holds outlives the account, and
+  a sweep collects it later. A `CHECK` turns that state into a refused user deletion.
+- `RESTRICT` is wrong for the same reason: a row the user merely created must not block
+  their purge.
 - Where a user may have at most one, lock it with a partial unique index.
   Precedent: `groups.creator_id`.
 

--- a/src/ai/backend/manager/models/AGENTS.md
+++ b/src/ai/backend/manager/models/AGENTS.md
@@ -74,6 +74,22 @@ live in `models/specs/` — read `models/specs/AGENTS.md` before touching them.
   declaration and a migration that disagree leave a freshly created database and a
   migrated one with different constraint names.
 
+## Creator columns
+
+- Ownership is answered by the `scope -> virtual_entity -> entity` path alone
+  (BEP-1077 §5.1). Do NOT put an `owner_*` column on a row — it leaves two answers to
+  the same question.
+- To record which user a row came into being for, use **`creator_id`**. Do not coin
+  another spelling; `vfolders.creator_id` already carries this meaning.
+- It is provenance, not ownership. Do NOT use it in an access decision.
+- Nullable by default. Where one row kind requires it, enforce it for that kind with a
+  `CHECK`.
+- The foreign key is `ON DELETE SET NULL`. Together with that `CHECK`, the database
+  refuses to delete a user while such a row is still there. `RESTRICT` is wrong here —
+  a row the user merely created would block their purge.
+- Where a user may have at most one, lock it with a partial unique index.
+  Precedent: `groups.creator_id`.
+
 ## Custom column types
 
 - Where possible, reuse the existing `TypeDecorator` wrappers in `models/base.py`.

--- a/src/ai/backend/manager/models/KNOWLEDGE.md
+++ b/src/ai/backend/manager/models/KNOWLEDGE.md
@@ -3,10 +3,11 @@ name: models-schema-declaration
 type: design-rationale
 description: models as the schema-declaration layer (per-domain row packages), why Rows carry no implementation, why models/specs specs are preferred over direct db-object manipulation (RBAC side effects), the rationale for avoiding direct session use and keeping implementation in repositories, why every id default is UUIDv7
 scope: src/ai/backend/manager/models
-keywords: [Row, ORM, specs, RBAC, session, repository, schema, alembic, uuid_generate_v7, server_default]
+keywords: [Row, ORM, specs, RBAC, session, repository, schema, alembic, uuid_generate_v7, server_default, creator_id, personal project, dangling]
 sources:
   - src/ai/backend/manager/models/specs
   - src/ai/backend/manager/models/uuid7.py
+  - src/ai/backend/manager/models/project/row.py
 generated:
   by: claude-code/opus-5
   at: 2026-09-05
@@ -66,3 +67,37 @@ no implementation".
   advanced. This matches PostgreSQL 18's built-in `uuidv7()`; once 18 is the minimum, the
   body becomes `RETURN uuidv7();`.
 - Because it mutates session state, it is not marked parallel safe.
+
+## Creator columns and the rows left behind
+
+Since BEP-1077, ownership is answered by the `scope -> virtual_entity -> entity` path
+alone. That is why no row carries an `owner_*` column — it would leave two answers to
+the same question, exactly the state the BEP set out to remove.
+
+`creator_id` answers a different question: **which user did this row come into being
+for**. Provenance, not ownership, so it takes no part in an access decision. The
+distinction is forced by personal projects. One is created together with its user, so
+something has to answer "which project is this user's", and reading that off the graph
+would answer an ownership question with view membership. The roster is also due to be
+rewritten as shares, so its shape moves; the column does not.
+
+### After the user is gone
+
+The foreign key is `ON DELETE SET NULL`. A user purge does not take the project.
+
+- What the project holds outlives the account. Destroying a personal folder in the same
+  transaction that removes the user row leaves no way to hand the data over.
+- Deleting a project means clearing out the resources in it, which is asynchronous work.
+  It does not belong in a synchronous purge transaction.
+- So a personal project holding a NULL creator is **dangling**, and the retention sweep
+  collects it. A delete request that wants the project gone too says so through an API
+  option; the deletion itself stays asynchronous.
+
+On a general project `creator_id` is plain audit information and an empty one means
+nothing. That is why the key is not `RESTRICT`: a team project someone created long ago
+must not block their purge.
+
+### How many
+
+A user has at most one personal project, held by a partial unique index. Dangling ones
+carry NULL, and NULLs do not collide in a unique index, so any number of them coexist.

--- a/src/ai/backend/manager/models/alembic/versions/c7a4f1e9b023_backfill_personal_projects.py
+++ b/src/ai/backend/manager/models/alembic/versions/c7a4f1e9b023_backfill_personal_projects.py
@@ -1,0 +1,158 @@
+"""record a project's creating user and backfill a personal project per user
+
+Adds ``groups.creator_id`` — provenance, not ownership, which stays the
+scope-virtual entity-entity path alone — and the partial unique index holding a user
+to at most one personal project. The column is nulled when its user goes, leaving the
+project dangling for the retention sweep.
+
+The backfill writes the project rows only. Their graph rows (virtual entity, the
+domain's own and govern edges, the roster) come with the one ownership-data migration,
+which provisions them for every entity at once.
+
+Revision ID: c7a4f1e9b023
+Revises: d5b3f8c26a41
+Create Date: 2026-09-05 15:10:00
+
+"""
+
+# Part of: NEXT_RELEASE_VERSION
+
+import re
+from typing import Final
+
+import sqlalchemy as sa
+from alembic import op
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "c7a4f1e9b023"
+down_revision = "d5b3f8c26a41"
+branch_labels = None
+depends_on = None
+
+# The project name column takes a slug: word characters, dots and hyphens, with no
+# run of separators and none at either edge. The tail is left free for the suffix a
+# name already taken in the domain needs.
+_NON_SLUG_CHARS: Final = re.compile(r"[^\w.-]")
+_SEPARATOR_RUN: Final = re.compile(r"[._-]{2,}")
+_EDGE_CHARS: Final = "._-"
+_NAME_BASE_LIMIT: Final = 60
+_NAME_SUFFIX_LIMIT: Final = 1000
+
+# An empty msgpack list, the dotfiles column's default.
+_EMPTY_DOTFILES: Final = b"\x90"
+
+_INDEX_NAME: Final = "uq_groups_personal_creator"
+
+_USERS_WITHOUT_A_PERSONAL_PROJECT: Final = sa.text("""
+    SELECT u.uuid AS user_uuid, u.username, u.domain_name
+    FROM users u
+    WHERE NOT EXISTS (
+        SELECT 1 FROM groups g
+        WHERE g.type = 'personal' AND g.creator_id = u.uuid
+    )
+    ORDER BY u.created_at, u.uuid
+""")
+
+_INSERT_PROJECT: Final = sa.text("""
+    INSERT INTO groups (
+        name, description, is_active, domain_name,
+        total_resource_slots, allowed_vfolder_hosts, dotfiles,
+        resource_policy, type, creator_id
+    )
+    VALUES (
+        :name, 'Personal Project', true, :domain_name,
+        '{}'::jsonb, '{}'::jsonb, :dotfiles,
+        :resource_policy, 'personal', :creator_id
+    )
+""")
+
+
+def _slugify(value: str) -> str:
+    """``value`` reduced to what the project name column accepts. Empty when nothing
+    survives."""
+    slug = _SEPARATOR_RUN.sub("-", _NON_SLUG_CHARS.sub("-", value))
+    slug = slug.strip(_EDGE_CHARS)[:_NAME_BASE_LIMIT]
+    return slug.rstrip(_EDGE_CHARS)
+
+
+def _free_name(taken: set[tuple[str, str]], domain_name: str, base: str) -> str:
+    """``base`` if the domain does not hold it, else the first free numeric suffix."""
+    if (domain_name, base) not in taken:
+        return base
+    for suffix in range(2, _NAME_SUFFIX_LIMIT):
+        candidate = f"{base}-{suffix}"
+        if (domain_name, candidate) not in taken:
+            return candidate
+    raise RuntimeError(f"No free personal project name for '{base}' in domain {domain_name}")
+
+
+def upgrade() -> None:
+    op.add_column("groups", sa.Column("creator_id", GUID(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk_groups_creator_id_users"),
+        "groups",
+        "users",
+        ["creator_id"],
+        ["uuid"],
+        ondelete="SET NULL",
+    )
+    backfill(op.get_bind())
+    # The index goes on after the backfill: it describes the state it produces.
+    op.create_index(
+        _INDEX_NAME,
+        "groups",
+        ["creator_id"],
+        unique=True,
+        postgresql_where=sa.text("type = 'personal'"),
+    )
+
+
+def backfill(conn: sa.Connection) -> None:
+    """Create the personal project every user is missing. Takes its connection so a
+    test can run it against a real database — static analysis does not reach SQL."""
+    resource_policy = conn.scalar(
+        sa.text("""
+            SELECT name FROM project_resource_policies
+            ORDER BY (name <> 'default'), name
+            LIMIT 1
+        """)
+    )
+    if resource_policy is None:
+        raise RuntimeError(
+            "No project resource policy exists; a personal project cannot be created without one."
+        )
+
+    users = conn.execute(_USERS_WITHOUT_A_PERSONAL_PROJECT).mappings().all()
+    if not users:
+        return
+    taken = {
+        (row.domain_name, row.name)
+        for row in conn.execute(sa.text("SELECT domain_name, name FROM groups"))
+    }
+
+    for user in users:
+        name = _free_name(
+            taken,
+            user["domain_name"],
+            _slugify(user["username"]) or str(user["user_uuid"]),
+        )
+        taken.add((user["domain_name"], name))
+        conn.execute(
+            _INSERT_PROJECT,
+            {
+                "name": name,
+                "domain_name": user["domain_name"],
+                "dotfiles": _EMPTY_DOTFILES,
+                "resource_policy": resource_policy,
+                "creator_id": user["user_uuid"],
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX_NAME, table_name="groups")
+    op.execute(sa.text("DELETE FROM groups WHERE type = 'personal'"))
+    op.drop_constraint(op.f("fk_groups_creator_id_users"), "groups", type_="foreignkey")
+    op.drop_column("groups", "creator_id")

--- a/src/ai/backend/manager/models/project/creators.py
+++ b/src/ai/backend/manager/models/project/creators.py
@@ -9,6 +9,7 @@ from typing import override
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
@@ -38,6 +39,7 @@ class ProjectCreator(RoleManagedEntityCreator[ProjectRow, ProjectData]):
     resource_policy: str | None = None
     container_registry: dict[str, str] | None = None
     dotfiles: bytes | None = None
+    creator_id: UserID | None = None
 
     @classmethod
     def model_store(cls, domain_id: DomainID, domain_name: str) -> ProjectCreator:
@@ -49,6 +51,22 @@ class ProjectCreator(RoleManagedEntityCreator[ProjectRow, ProjectData]):
             description="Model Store",
             resource_policy="default",
             type=ProjectType.MODEL_STORE,
+        )
+
+    @classmethod
+    def personal(
+        cls, name: str, domain_id: DomainID, domain_name: str, user_id: UserID
+    ) -> ProjectCreator:
+        """The personal project a user is registered with. Its resource limits are left
+        at the empty defaults; personal allowances are answered by the keypair policy."""
+        return cls(
+            name=name,
+            domain_id=domain_id,
+            domain_name=domain_name,
+            description="Personal Project",
+            resource_policy="default",
+            type=ProjectType.PERSONAL,
+            creator_id=user_id,
         )
 
     @override
@@ -103,6 +121,7 @@ class ProjectCreator(RoleManagedEntityCreator[ProjectRow, ProjectData]):
             resource_policy=self.resource_policy,
             dotfiles=self.dotfiles,
             container_registry=self.container_registry,
+            creator_id=self.creator_id,
         )
 
     @override

--- a/src/ai/backend/manager/models/project/row.py
+++ b/src/ai/backend/manager/models/project/row.py
@@ -148,6 +148,14 @@ class ProjectRow(LifecycleTimestampsMixin, Base):
     __tablename__ = "groups"
     __table_args__ = (
         sa.UniqueConstraint("name", "domain_name", name="uq_groups_name_domain_name"),
+        # A user has at most one personal project. A dangling one — its creator gone —
+        # holds NULL, and NULLs do not collide here.
+        sa.Index(
+            "uq_groups_personal_creator",
+            "creator_id",
+            unique=True,
+            postgresql_where=sa.text("type = 'personal'"),
+        ),
     )
 
     id: Mapped[ProjectID] = mapped_column(
@@ -200,6 +208,15 @@ class ProjectRow(LifecycleTimestampsMixin, Base):
         StrEnumType(ProjectType),
         nullable=False,
         default=ProjectType.GENERAL,
+    )
+    # Provenance, not ownership: ownership is the scope-virtual entity-entity path
+    # alone. Nulled when the user goes; a personal project left holding NULL is
+    # dangling and the retention sweep takes it.
+    creator_id: Mapped[UserID | None] = mapped_column(
+        "creator_id",
+        GUID(UserID),
+        sa.ForeignKey("users.uuid", ondelete="SET NULL"),
+        nullable=True,
     )
     container_registry: Mapped[dict[str, Any] | None] = mapped_column(
         "container_registry",

--- a/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/fair_share/db_source/db_source.py
@@ -50,7 +50,7 @@ from ai.backend.manager.models.fair_share.scopes import (
     ProjectFairShareOperationScope,
     UserFairShareOperationScope,
 )
-from ai.backend.manager.models.project import AssocGroupUserRow, ProjectRow
+from ai.backend.manager.models.project import AssocGroupUserRow, ProjectRow, ProjectType
 from ai.backend.manager.models.resource_group import ResourceGroupRow
 from ai.backend.manager.models.resource_slot import AgentResourceRow, ResourceSlotTypeRow
 from ai.backend.manager.models.resource_usage_history import (
@@ -451,7 +451,8 @@ class FairShareDBSource:
 
         This method returns all projects with complete fair share data
         (either from records or defaults). Projects do not need to be
-        registered in the resource group to appear in results.
+        registered in the resource group to appear in results. Personal
+        projects are left out.
 
         Args:
             scope: Required scope with resource_group.
@@ -477,6 +478,9 @@ class FairShareDBSource:
                         ProjectFairShareRow.resource_group_id == scope.resource_group_id,
                     ),
                 )
+                # A personal project holds one person's own work and is not a fair-share
+                # subject.
+                .where(ProjectRow.type != ProjectType.PERSONAL)
             )
 
             result = await execute_batch_querier(db_sess, query, querier, scopes=[scope])

--- a/src/ai/backend/manager/repositories/ops/base/provider.py
+++ b/src/ai/backend/manager/repositories/ops/base/provider.py
@@ -482,6 +482,17 @@ class WriteOps(ReadOps):
         """
         return await V2WriteOps(self._sess).create_entity(creator)
 
+    async def create_role_managed_entity[TRow: Base, TData](
+        self, creator: specs_creator.RoleManagedEntityCreator[TRow, TData]
+    ) -> TData:
+        """Insert a role-managed entity row, provision it in the RBAC graph and create
+        its preset roles, on this session.
+
+        For the transition: a caller whose transaction still runs legacy specs
+        beside this one reaches the v2 entity write here.
+        """
+        return await V2WriteOps(self._sess).create_role_managed_entity(creator)
+
     async def create_field[TOwnerID: EntityIdentifier, TRow: Base, TData: FieldData](
         self, owner_id: TOwnerID, creator: specs_creator.FieldCreator[TOwnerID, TRow, TData]
     ) -> TData:

--- a/src/ai/backend/manager/repositories/ops/user/write.py
+++ b/src/ai/backend/manager/repositories/ops/user/write.py
@@ -11,8 +11,11 @@ the removal of the legacy path in BA-7574.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Collection
 from dataclasses import dataclass
+from re import Pattern
+from typing import ClassVar
 
 import sqlalchemy as sa
 
@@ -22,9 +25,11 @@ from ai.backend.common.data.entity.types import ScopeRef
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.manager.data.keypair.types import KeyPairData, KeyPairSecrets
+from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.keypair.creators import DefaultKeypairCreator
 from ai.backend.manager.models.project import ProjectRow, ProjectType
+from ai.backend.manager.models.project.creators import ProjectCreator
 from ai.backend.manager.models.user import UserRow, UserStatus
 from ai.backend.manager.repositories.ops.rbac.provider import (
     EntityMembersAddition,
@@ -62,6 +67,14 @@ class FullUserCreationResult:
 class UserWriteOps(RBACWriteOps):
     """The RBAC write ops plus provisioning a user in full."""
 
+    # groups.name is a slug of at most 64 characters; the tail is reserved for the
+    # collision suffix a personal project's name may need.
+    _NON_SLUG_CHARS: ClassVar[Pattern[str]] = re.compile(r"[^\w.-]")
+    _SLUG_SEPARATOR_RUN: ClassVar[Pattern[str]] = re.compile(r"[._-]{2,}")
+    _SLUG_EDGE_CHARS: ClassVar[str] = "._-"
+    _PROJECT_NAME_BASE_LIMIT: ClassVar[int] = 60
+    _PROJECT_NAME_SUFFIX_LIMIT: ClassVar[int] = 1000
+
     async def create_full_user(
         self,
         full_creation: FullUserCreation,
@@ -69,13 +82,15 @@ class UserWriteOps(RBACWriteOps):
         """Provision a user end to end in one transaction.
 
         Creates the user scope (row, virtual entity, own-scope roles) and grants those
-        roles, writes the keypair the user authorizes with, then enrolls the user in
-        its domain's and projects' virtual entities.
+        roles, writes the keypair the user authorizes with, creates the personal project
+        the user alone belongs to, then enrolls the user in its domain's and projects'
+        virtual entities.
         """
         user_row = await self._create_user_scope(full_creation.creation)
         user_id = UserID(user_row.uuid)
         keypair = await self._create_default_keypair(user_id, user_row, full_creation)
         await self._enroll_in_domain(user_id, full_creation.domain_id)
+        await self._create_personal_project(user_id, user_row.username, full_creation.domain_id)
         await self._enroll_in_projects(user_id, full_creation.domain_id, full_creation.project_ids)
 
         # The insert leaves the server-default columns unloaded, and default_keypair is the
@@ -120,6 +135,74 @@ class UserWriteOps(RBACWriteOps):
         await self.add_bulk_members(
             EntityMembersAddition(scope=domain_scope, members=[ScopeUserMember(user_id=user_id)])
         )
+
+    async def _create_personal_project(
+        self, user_id: UserID, username: str, domain_id: DomainID
+    ) -> None:
+        """Create the user's personal project in its domain and put the user on the
+        roster as its only member. The project is created in the domain, so the domain's
+        roles reach it the way they reach every other project."""
+        domain_name = await self._domain_name(domain_id)
+        project = await self.create_role_managed_entity(
+            ProjectCreator.personal(
+                name=await self._personal_project_name(domain_name, username, user_id),
+                domain_id=domain_id,
+                domain_name=domain_name,
+                user_id=user_id,
+            )
+        )
+        await self.add_bulk_members(
+            EntityMembersAddition(
+                scope=ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(project.id)),
+                members=[ScopeUserMember(user_id=user_id)],
+            )
+        )
+
+    async def _domain_name(self, domain_id: DomainID) -> str:
+        """The name of the domain the user was created in. The user row's own
+        ``domain_name`` is filled by the database and is not loaded yet at this point."""
+        name = await self._sess.scalar(sa.select(DomainRow.name).where(DomainRow.id == domain_id))
+        if name is None:
+            raise DomainNotFound(f"Domain '{domain_id}' does not exist.")
+        return name
+
+    async def _personal_project_name(self, domain_name: str, username: str, user_id: UserID) -> str:
+        """The username as a slug, given a numeric suffix when the domain already holds
+        a project of that name. Falls back to the user id, which no name can collide
+        with, when the username slugifies to nothing or every suffix is taken."""
+        base = self._slugify(username) or str(user_id)
+        taken = set(
+            (
+                await self._sess.scalars(
+                    sa.select(ProjectRow.name).where(
+                        ProjectRow.domain_name == domain_name,
+                        sa.or_(
+                            ProjectRow.name == base,
+                            ProjectRow.name.like(f"{self._escape_like(base)}-%", escape="\\"),
+                        ),
+                    )
+                )
+            ).all()
+        )
+        if base not in taken:
+            return base
+        for suffix in range(2, self._PROJECT_NAME_SUFFIX_LIMIT):
+            candidate = f"{base}-{suffix}"
+            if candidate not in taken:
+                return candidate
+        return str(user_id)
+
+    def _slugify(self, value: str) -> str:
+        """``value`` reduced to what the project name column accepts: every other
+        character becomes a hyphen, runs of separators collapse, and the edges are
+        trimmed. Empty when nothing survives."""
+        slug = self._SLUG_SEPARATOR_RUN.sub("-", self._NON_SLUG_CHARS.sub("-", value))
+        slug = slug.strip(self._SLUG_EDGE_CHARS)[: self._PROJECT_NAME_BASE_LIMIT]
+        return slug.rstrip(self._SLUG_EDGE_CHARS)
+
+    def _escape_like(self, value: str) -> str:
+        """``value`` as a literal LIKE prefix; a slug may carry an underscore."""
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     async def _enroll_in_projects(
         self,

--- a/src/ai/backend/manager/repositories/user/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/user/db_source/db_source.py
@@ -396,7 +396,12 @@ class UserDBSource:
         raise UserPurgeInProgress(f"User is being purged: {user_uuid}")
 
     async def purge_user_by_uuid(self, user_uuid: UUID) -> None:
-        """Completely purge user and all associated data by UUID."""
+        """Completely purge user and all associated data by UUID.
+
+        The user's personal project is not among it. Its creator column is nulled by
+        the foreign key, leaving the project dangling for the retention sweep — the
+        resources it holds outlive the account rather than going with it.
+        """
         user_id = UserID(user_uuid)
         async with self._v2_ops.write_ops() as w:
             await w.batch_purge_field_entities(user_id, UserErrorLogPurger())

--- a/tests/component/auth/test_auth.py
+++ b/tests/component/auth/test_auth.py
@@ -49,7 +49,11 @@ from ai.backend.manager.data.user.types import UserStatus
 from ai.backend.manager.models.domain import DomainRow, domains
 from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import keypairs
-from ai.backend.manager.models.project import ProjectRow, association_groups_users
+from ai.backend.manager.models.project import (
+    ProjectRow,
+    ProjectType,
+    association_groups_users,
+)
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
@@ -1077,6 +1081,39 @@ class TestSignup:
                 )
             )
             await conn.execute(users.delete().where(users.c.email == email))
+
+    async def test_signup_creates_a_personal_project_for_the_new_user(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        domain_fixture: DomainFixtureData,
+        db_engine: SAEngine,
+        signup_default_project: _SignupDefaultProjectData,
+    ) -> None:
+        """Signing up creates the personal project too. Signup fills the username with
+        the e-mail address, so the project name is that address as a slug."""
+        unique = secrets.token_hex(4)
+        email = f"signup-personal-{unique}@test.local"
+        signup_default_project.cleanup_emails.append(email)
+
+        result = await admin_registry.auth.signup(
+            SignupRequest(
+                domain=domain_fixture.domain_name,
+                email=email,
+                password=f"SignupP@ss{unique}",
+            ),
+        )
+        assert isinstance(result, SignupResponse)
+
+        async with db_engine.begin() as conn:
+            user_uuid = await conn.scalar(sa.select(users.c.uuid).where(users.c.email == email))
+            creator_id = await conn.scalar(
+                sa.select(ProjectRow.creator_id).where(
+                    ProjectRow.domain_name == domain_fixture.domain_name,
+                    ProjectRow.type == ProjectType.PERSONAL,
+                    ProjectRow.name == email.replace("@", "-"),
+                )
+            )
+        assert creator_id == user_uuid
 
     async def test_signup_binds_user_to_default_project_via_ase(
         self,

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -121,7 +121,11 @@ from ai.backend.manager.models.image import ImageAliasRow, ImageRow
 from ai.backend.manager.models.kernel import kernels
 from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.keypair.ssh_key_validator import SSHKeyValidator
-from ai.backend.manager.models.project import ProjectRow, association_groups_users
+from ai.backend.manager.models.project import (
+    ProjectRow,
+    ProjectType,
+    association_groups_users,
+)
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
 )
@@ -644,6 +648,7 @@ async def resource_policy_fixture(
     by the user-creation flow:
     - "default" keypair resource policy: always assigned to new keypairs
     - "default" user resource policy: always assigned to new users (e.g. signup)
+    - "default" project resource policy: assigned to the personal project
     Teardown removes both the named policies and the "default" policies.
     The "default" policies are safe to delete here because user_factory
     (which depends on this fixture) runs its teardown first, purging all
@@ -711,8 +716,44 @@ async def resource_policy_fixture(
             )
             .on_conflict_do_nothing()
         )
+        # The personal project created with every user takes "default" too.
+        await conn.execute(
+            pg_insert(ProjectResourcePolicyRow.__table__)
+            .values(
+                name=default_policy_name,
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_network_count=3,
+            )
+            .on_conflict_do_nothing()
+        )
     yield policy_name
     async with db_engine.begin() as conn:
+        # A personal project outlives the user it was created for, so purging the
+        # users does not release the policy it holds. The fixture owning the policy
+        # clears them.
+        personal = (
+            await conn.scalars(
+                sa.select(ProjectRow.id).where(
+                    ProjectRow.type == ProjectType.PERSONAL,
+                    ProjectRow.resource_policy.in_([policy_name, default_policy_name]),
+                )
+            )
+        ).all()
+        if personal:
+            await conn.execute(
+                VirtualEntityRow.__table__.delete().where(
+                    VirtualEntityRow.__table__.c.entity_type == ScopeType.PROJECT,
+                    VirtualEntityRow.__table__.c.entity_id.in_(personal),
+                )
+            )
+            await conn.execute(
+                AssociationScopesEntitiesRow.__table__.delete().where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id.in_([str(pid) for pid in personal]),
+                )
+            )
+            await conn.execute(ProjectRow.__table__.delete().where(ProjectRow.id.in_(personal)))
         await conn.execute(
             keypair_resource_policies.delete().where(
                 keypair_resource_policies.c.name == default_policy_name
@@ -735,7 +776,7 @@ async def resource_policy_fixture(
         )
         await conn.execute(
             ProjectResourcePolicyRow.__table__.delete().where(
-                ProjectResourcePolicyRow.__table__.c.name == policy_name
+                ProjectResourcePolicyRow.__table__.c.name.in_([policy_name, default_policy_name])
             )
         )
 

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -18,6 +18,7 @@ from ai.backend.common.dto.manager.user import (
     DeleteUserRequest,
     DeleteUserResponse,
     GetUserResponse,
+    PurgeUserRequest,
     UserStatus,
 )
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -109,6 +110,81 @@ class TestUserCreateCrud:
             )
             assoc = row.fetchone()
         assert assoc is not None, "User should be associated with the given group"
+
+    async def test_s7_create_makes_a_personal_project_with_the_user_alone(
+        self,
+        user_factory: UserFactory,
+        domain_fixture: DomainFixtureData,
+        db_engine: SAEngine,
+    ) -> None:
+        """S-7: Creating a user through the REST path creates its personal project,
+        named after the username, with that user as its only member."""
+        result = await user_factory()
+
+        async with db_engine.begin() as conn:
+            project_id = await conn.scalar(
+                sa.select(ProjectRow.id).where(
+                    ProjectRow.domain_name == domain_fixture.domain_name,
+                    ProjectRow.type == ProjectType.PERSONAL,
+                    ProjectRow.name == result.user.username,
+                )
+            )
+            assert project_id is not None, "A personal project should be created"
+            member_ids = (
+                await conn.scalars(
+                    sa.select(AssociationScopesEntitiesRow.entity_id).where(
+                        AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                        AssociationScopesEntitiesRow.scope_id == str(project_id),
+                        AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    )
+                )
+            ).all()
+            creator_id = await conn.scalar(
+                sa.select(ProjectRow.creator_id).where(ProjectRow.id == project_id)
+            )
+        assert list(member_ids) == [str(result.user.id)]
+        assert creator_id == result.user.id
+
+    async def test_s8_purging_the_user_leaves_its_personal_project_dangling(
+        self,
+        admin_registry: BackendAIClientRegistry,
+        domain_fixture: DomainFixtureData,
+        resource_policy_fixture: str,
+        db_engine: SAEngine,
+    ) -> None:
+        """S-8: What the personal project holds outlives the account. The project stays
+        with no creator, which is what marks it for the retention sweep."""
+        unique = secrets.token_hex(4)
+        created = await admin_registry.user.create(
+            CreateUserRequest(
+                email=f"purge-personal-{unique}@test.local",
+                username=f"purge-personal-{unique}",
+                password="test-password-1234",
+                domain_name=domain_fixture.domain_name,
+                resource_policy=resource_policy_fixture,
+                status=UserStatus.ACTIVE,
+            )
+        )
+        async with db_engine.begin() as conn:
+            project_id = await conn.scalar(
+                sa.select(ProjectRow.id).where(
+                    ProjectRow.name == f"purge-personal-{unique}",
+                    ProjectRow.type == ProjectType.PERSONAL,
+                    ProjectRow.creator_id == str(created.user.id),
+                )
+            )
+        assert project_id is not None
+
+        await admin_registry.user.purge(PurgeUserRequest(user_id=created.user.id))
+
+        async with db_engine.begin() as conn:
+            row = (
+                await conn.execute(
+                    sa.select(ProjectRow.creator_id).where(ProjectRow.id == project_id)
+                )
+            ).first()
+        assert row is not None, "The personal project should outlive its user"
+        assert row.creator_id is None, "Its creator should be cleared"
 
     async def test_s4_create_with_status_inactive(
         self,

--- a/tests/unit/manager/models/alembic/BUILD
+++ b/tests/unit/manager/models/alembic/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/models/alembic/test_backfill_personal_projects.py
+++ b/tests/unit/manager/models/alembic/test_backfill_personal_projects.py
@@ -1,0 +1,271 @@
+"""Verifies the personal-project backfill migration against a real database.
+
+Static analysis does not reach the migration's SQL, so the data migration is exercised
+here: representative users go in, the backfill runs, and the rows it wrote are read
+back.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Table
+
+from ai.backend.common.data.entity.domain import DomainID, DomainName
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.models.alembic.versions.c7a4f1e9b023_backfill_personal_projects import (
+    backfill,
+)
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.entity_label.row import EntityLabelRow
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.project import ProjectRow, ProjectType
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_entity.entity_membership_cap import (
+    EntityMembershipCapRow,
+)
+from ai.backend.manager.models.virtual_entity.entity_membership_field import (
+    EntityMembershipFieldRow,
+)
+from ai.backend.manager.models.virtual_entity.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
+from ai.backend.testutils.db import HasTable, with_tables
+
+_TABLES: list[Table | type[HasTable]] = [
+    DomainRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    UserRow,
+    KeyPairRow,
+    ProjectRow,
+    AssociationScopesEntitiesRow,
+    VirtualEntityRow,
+    ScopeBindingRow,
+    EntityLabelRow,
+    EntityMembershipRow,
+    EntityMembershipCapRow,
+    EntityMembershipFieldRow,
+]
+
+
+@dataclass
+class DomainFixture:
+    """The domain the backfilled users belong to."""
+
+    name: DomainName
+    id: DomainID
+
+
+@pytest.fixture
+async def db(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    async with with_tables(database_connection, _TABLES):
+        yield database_connection
+
+
+@pytest.fixture
+async def domain(db: ExtendedAsyncSAEngine) -> DomainFixture:
+    domain_id = DomainID(uuid.uuid4())
+    domain_name = DomainName(f"test-domain-{uuid.uuid4().hex[:8]}")
+    async with db.begin_session() as session:
+        session.add(
+            DomainRow(
+                id=domain_id,
+                name=domain_name,
+                description="Test domain",
+                is_active=True,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                allowed_docker_registries=[],
+                dotfiles=b"",
+                integration_id=None,
+            )
+        )
+        session.add(
+            ProjectResourcePolicyRow(
+                name="default",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_network_count=3,
+            )
+        )
+        session.add(
+            UserResourcePolicyRow(
+                name="default",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=10,
+                max_customized_image_count=10,
+            )
+        )
+        session.add(
+            VirtualEntityRow(entity_type="domain", entity_id=domain_id),
+        )
+        await session.commit()
+    return DomainFixture(name=domain_name, id=domain_id)
+
+
+async def _add_user(db: ExtendedAsyncSAEngine, domain: DomainFixture, username: str) -> uuid.UUID:
+    """A user inserted directly, as one predating the personal-project path would be."""
+    user_uuid = uuid.uuid4()
+    async with db.begin_session() as session:
+        session.add(
+            UserRow(
+                uuid=user_uuid,
+                username=username,
+                email=f"{uuid.uuid4().hex[:8]}@test.local",
+                password=PasswordInfo(
+                    password="test-password",
+                    algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+                    rounds=1_000,
+                    salt_size=32,
+                ),
+                need_password_change=False,
+                domain_id=domain.id,
+                domain_name=domain.name,
+                role=UserRole.USER,
+                status=UserStatus.ACTIVE,
+                resource_policy="default",
+            )
+        )
+        session.add(VirtualEntityRow(entity_type="user", entity_id=user_uuid))
+        await session.commit()
+    return user_uuid
+
+
+async def _add_project(
+    db: ExtendedAsyncSAEngine,
+    domain: DomainFixture,
+    name: str,
+    project_type: ProjectType,
+    creator_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    project_id = uuid.uuid4()
+    async with db.begin_session() as session:
+        session.add(
+            ProjectRow(
+                id=project_id,
+                name=name,
+                domain_name=domain.name,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                resource_policy="default",
+                type=project_type,
+                creator_id=creator_id,
+            )
+        )
+        await session.commit()
+    return project_id
+
+
+async def _run_backfill(db: ExtendedAsyncSAEngine) -> None:
+    async with db.begin() as conn:
+        await conn.run_sync(backfill)
+
+
+async def _personal_projects(db: ExtendedAsyncSAEngine, domain: DomainFixture) -> list[ProjectRow]:
+    async with db.begin_readonly_session() as session:
+        return list(
+            (
+                await session.scalars(
+                    sa.select(ProjectRow).where(
+                        ProjectRow.domain_name == domain.name,
+                        ProjectRow.type == ProjectType.PERSONAL,
+                    )
+                )
+            ).all()
+        )
+
+
+class TestPersonalProjectBackfill:
+    async def test_creates_one_project_per_user_named_after_the_username(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_user(db, domain, "alice")
+        await _add_user(db, domain, "bob")
+
+        await _run_backfill(db)
+
+        projects = await _personal_projects(db, domain)
+        assert sorted(p.name for p in projects) == ["alice", "bob"]
+        assert all(p.resource_policy == "default" for p in projects)
+        assert all(p.total_resource_slots == ResourceSlot() for p in projects)
+
+    async def test_a_username_that_is_not_a_slug_is_slugified(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        """Signup fills the username with the e-mail address, which is not a slug."""
+        await _add_user(db, domain, "alice@test.local")
+
+        await _run_backfill(db)
+
+        assert [p.name for p in await _personal_projects(db, domain)] == ["alice-test.local"]
+
+    async def test_names_colliding_with_each_other_get_a_suffix(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_user(db, domain, "alice.test")
+        await _add_user(db, domain, "alice@test")
+        await _add_user(db, domain, "alice test")
+
+        await _run_backfill(db)
+
+        projects = await _personal_projects(db, domain)
+        assert sorted(p.name for p in projects) == ["alice-test", "alice-test-2", "alice.test"]
+
+    async def test_a_name_an_existing_project_holds_gets_a_suffix(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_project(db, domain, "alice", ProjectType.GENERAL)
+        await _add_user(db, domain, "alice")
+
+        await _run_backfill(db)
+
+        assert [p.name for p in await _personal_projects(db, domain)] == ["alice-2"]
+
+    async def test_running_it_again_creates_nothing(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_user(db, domain, "alice")
+
+        await _run_backfill(db)
+        await _run_backfill(db)
+
+        assert len(await _personal_projects(db, domain)) == 1
+
+    async def test_a_user_that_already_has_one_is_left_alone(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        user_uuid = await _add_user(db, domain, "alice")
+        await _add_project(db, domain, "alice-existing", ProjectType.PERSONAL, creator_id=user_uuid)
+
+        await _run_backfill(db)
+
+        assert [p.name for p in await _personal_projects(db, domain)] == ["alice-existing"]
+
+    async def test_the_project_records_the_user_it_was_created_for(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        user_uuid = await _add_user(db, domain, "alice")
+
+        await _run_backfill(db)
+
+        assert [p.creator_id for p in await _personal_projects(db, domain)] == [user_uuid]

--- a/tests/unit/manager/models/group/test_row.py
+++ b/tests/unit/manager/models/group/test_row.py
@@ -19,7 +19,11 @@ from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.project import ProjectRow
 from ai.backend.manager.models.project.row import resolve_group_name_or_id
 from ai.backend.manager.models.resource_group import ResourceGroupForDomainRow
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.testutils.db import with_tables
 from ai.backend.testutils.fixtures import DomainFixtureData
@@ -44,6 +48,8 @@ class TestResolveGroupNameOrId:
             [
                 DomainRow,
                 ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
             ],
         ):

--- a/tests/unit/manager/repositories/container_registry_quota/test_container_registry_quota_repository.py
+++ b/tests/unit/manager/repositories/container_registry_quota/test_container_registry_quota_repository.py
@@ -28,7 +28,11 @@ from ai.backend.manager.models.domain import DomainRow
 from ai.backend.manager.models.project import ProjectRow
 from ai.backend.manager.models.rbac import ProjectScope
 from ai.backend.manager.models.resource_group import ResourceGroupForDomainRow
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.container_registry_quota.repositories import (
     PerProjectRegistryQuotaRepositories,
@@ -97,6 +101,8 @@ class TestPerProjectRegistryQuotaRepository:
             [
                 DomainRow,
                 ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 ContainerRegistryRow,
             ],

--- a/tests/unit/manager/repositories/export/reports/test_project.py
+++ b/tests/unit/manager/repositories/export/reports/test_project.py
@@ -30,7 +30,11 @@ from ai.backend.manager.models.resource_group import (
     ResourceGroupOpts,
     ResourceGroupRow,
 )
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base.export import (
     ExportFieldDef,
@@ -752,6 +756,8 @@ class TestProjectExportExecuteStreamingDB:
             [
                 DomainRow,
                 ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 ResourceGroupRow,
                 ResourceGroupForProjectRow,
@@ -1024,6 +1030,8 @@ class TestGlobalContainerRegistryExport:
             [
                 DomainRow,
                 ProjectResourcePolicyRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 ResourceGroupRow,
                 ResourceGroupForProjectRow,

--- a/tests/unit/manager/repositories/ops/user/BUILD
+++ b/tests/unit/manager/repositories/ops/user/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/repositories/ops/user/test_create_full_user.py
+++ b/tests/unit/manager/repositories/ops/user/test_create_full_user.py
@@ -1,0 +1,353 @@
+"""Integration tests for the personal project ``create_full_user`` provisions."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Table
+
+from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID, DomainName
+from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
+from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
+from ai.backend.common.types import AccessKey, ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
+from ai.backend.manager.data.keypair.types import KeyPairSecrets
+from ai.backend.manager.data.permission.types import EntityType, ScopeType
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.entity_label.row import EntityLabelRow
+from ai.backend.manager.models.hasher.types import PasswordInfo
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.project import ProjectRow, ProjectType
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
+    RolePermissionPresetRow,
+)
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.models.rbac_models.user_role import UserRoleRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.user.creators import UserCreator
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_entity.entity_membership_cap import (
+    EntityMembershipCapRow,
+)
+from ai.backend.manager.models.virtual_entity.entity_membership_field import (
+    EntityMembershipFieldRow,
+)
+from ai.backend.manager.models.virtual_entity.scope_binding import ScopeBindingRow
+from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
+from ai.backend.manager.repositories.ops.user.provider import UserOpsProvider
+from ai.backend.manager.repositories.ops.user.write import FullUserCreation
+from ai.backend.manager.repositories.user.creators import UserScopeCreation
+from ai.backend.manager.secret.types import SecretValue
+from ai.backend.testutils.db import HasTable, with_tables
+from ai.backend.testutils.fixtures import DomainFixtureData
+
+_TABLES: list[Table | type[HasTable]] = [
+    DomainRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    RolePresetRow,
+    RolePermissionPresetRow,
+    RoleRow,
+    PermissionRow,
+    UserRoleRow,
+    UserRow,
+    KeyPairRow,
+    ProjectRow,
+    AssociationScopesEntitiesRow,
+    VirtualEntityRow,
+    ScopeBindingRow,
+    EntityLabelRow,
+    EntityMembershipRow,
+    EntityMembershipCapRow,
+    EntityMembershipFieldRow,
+]
+
+_KEYPAIR_POLICY_DEFAULTS = {
+    "total_resource_slots": ResourceSlot(),
+    "max_session_lifetime": 0,
+    "max_concurrent_sessions": 30,
+    "max_pending_session_count": None,
+    "max_pending_session_resource_slots": None,
+    "max_concurrent_sftp_sessions": 10,
+    "max_containers_per_session": 1,
+    "idle_timeout": 1800,
+    "allowed_vfolder_hosts": VFolderHostPermissionMap(),
+}
+
+
+@pytest.fixture
+async def db(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    async with with_tables(database_connection, _TABLES):
+        yield database_connection
+
+
+@pytest.fixture
+def provider(db: ExtendedAsyncSAEngine) -> UserOpsProvider:
+    return UserOpsProvider(db)
+
+
+@pytest.fixture
+async def domain(db: ExtendedAsyncSAEngine) -> DomainFixtureData:
+    """A domain, with the ``default`` policies every provisioned row falls back to."""
+    domain_id = DomainID(uuid.uuid4())
+    domain_name = DomainName(f"test-domain-{uuid.uuid4().hex[:8]}")
+    async with db.begin_session() as session:
+        session.add(
+            DomainRow(
+                id=domain_id,
+                name=domain_name,
+                description="Test domain",
+                is_active=True,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                allowed_docker_registries=[],
+                dotfiles=b"",
+                integration_id=None,
+            )
+        )
+        session.add(
+            UserResourcePolicyRow(
+                name="default",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_session_count_per_model_session=10,
+                max_customized_image_count=10,
+            )
+        )
+        session.add(
+            ProjectResourcePolicyRow(
+                name="default",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_network_count=3,
+            )
+        )
+        session.add(KeyPairResourcePolicyRow(name="default", **_KEYPAIR_POLICY_DEFAULTS))
+        await session.commit()
+    return DomainFixtureData(domain_name=domain_name, domain_id=domain_id)
+
+
+async def _create_user(
+    provider: UserOpsProvider,
+    domain_id: DomainID,
+    username: str,
+    project_ids: list[ProjectID] | None = None,
+) -> UserID:
+    unique = uuid.uuid4().hex[:8]
+    creator = UserCreator(
+        email=f"{unique}@test.local",
+        username=username,
+        password=PasswordInfo(
+            password="test-password",
+            algorithm=PasswordHashAlgorithm.PBKDF2_SHA256,
+            rounds=1_000,
+            salt_size=32,
+        ),
+        need_password_change=False,
+        domain_id=domain_id,
+    )
+    async with provider.write_ops() as w:
+        result = await w.create_full_user(
+            FullUserCreation(
+                creation=UserScopeCreation(spec=creator),
+                domain_id=domain_id,
+                project_ids=project_ids or [],
+                keypair_resource_policy="default",
+                keypair_secrets=KeyPairSecrets(
+                    access_key=AccessKey(f"AK{unique}"),
+                    secret_key=SecretValue(f"SK{unique}"),
+                    ssh_public_key="ssh-rsa test",
+                    ssh_private_key="test-private-key",
+                ),
+            )
+        )
+    return UserID(result.user_row.uuid)
+
+
+async def _personal_projects(
+    db: ExtendedAsyncSAEngine, domain_name: DomainName
+) -> list[ProjectRow]:
+    async with db.begin_readonly_session() as session:
+        return list(
+            (
+                await session.scalars(
+                    sa.select(ProjectRow).where(
+                        ProjectRow.domain_name == domain_name,
+                        ProjectRow.type == ProjectType.PERSONAL,
+                    )
+                )
+            ).all()
+        )
+
+
+def _node_of(entity_type: str, entity_id: uuid.UUID) -> sa.ScalarSelect[VirtualEntityID]:
+    return (
+        sa.select(VirtualEntityRow.id)
+        .where(
+            VirtualEntityRow.entity_type == entity_type,
+            VirtualEntityRow.entity_id == entity_id,
+        )
+        .scalar_subquery()
+    )
+
+
+async def _project_member_ids(db: ExtendedAsyncSAEngine, project_id: ProjectID) -> list[str]:
+    """The users enrolled in the project's virtual entity; the project's own
+    self-membership is not one of them."""
+    async with db.begin_readonly_session() as session:
+        return [
+            str(entity_id)
+            for entity_id in (
+                await session.scalars(
+                    sa.select(VirtualEntityRow.entity_id)
+                    .join(
+                        EntityMembershipRow,
+                        EntityMembershipRow.member_entity_id == VirtualEntityRow.id,
+                    )
+                    .where(
+                        EntityMembershipRow.virtual_entity_id
+                        == _node_of(PROJECT_ENTITY_TYPE, project_id),
+                        VirtualEntityRow.entity_type == USER_ENTITY_TYPE,
+                    )
+                )
+            ).all()
+        ]
+
+
+class TestPersonalProjectProvisioning:
+    """Creating a user creates the personal project it alone belongs to."""
+
+    async def test_creates_one_personal_project_with_the_user_as_only_member(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        user_id = await _create_user(provider, domain.domain_id, "alice")
+
+        projects = await _personal_projects(db, domain.domain_name)
+        assert len(projects) == 1
+        assert projects[0].name == "alice"
+        assert projects[0].resource_policy == "default"
+        assert projects[0].total_resource_slots == ResourceSlot()
+        assert await _project_member_ids(db, ProjectID(projects[0].id)) == [str(user_id)]
+
+    async def test_each_user_gets_its_own_personal_project(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        first = await _create_user(provider, domain.domain_id, "alice")
+        second = await _create_user(provider, domain.domain_id, "bob")
+
+        projects = {p.name: p for p in await _personal_projects(db, domain.domain_name)}
+        assert set(projects) == {"alice", "bob"}
+        assert await _project_member_ids(db, ProjectID(projects["alice"].id)) == [str(first)]
+        assert await _project_member_ids(db, ProjectID(projects["bob"].id)) == [str(second)]
+
+    async def test_username_is_slugified_into_the_project_name(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        """A username is not a slug — signup fills it with the e-mail address."""
+        await _create_user(provider, domain.domain_id, "alice@test.local")
+
+        assert [p.name for p in await _personal_projects(db, domain.domain_name)] == [
+            "alice-test.local"
+        ]
+
+    async def test_a_taken_name_gets_a_numeric_suffix(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        """Two usernames slugifying to the same base still both get a project."""
+        await _create_user(provider, domain.domain_id, "alice.test")
+        await _create_user(provider, domain.domain_id, "alice@test")
+        await _create_user(provider, domain.domain_id, "alice test")
+
+        projects = await _personal_projects(db, domain.domain_name)
+        assert sorted(p.name for p in projects) == ["alice-test", "alice-test-2", "alice.test"]
+
+    async def test_the_personal_project_is_created_in_the_domain(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        """``created_in`` puts the project on the domain's list, the way a project
+        created through the project path is."""
+        await _create_user(provider, domain.domain_id, "alice")
+        project_id = (await _personal_projects(db, domain.domain_name))[0].id
+
+        async with db.begin_readonly_session() as session:
+            owned = await session.scalar(
+                sa.select(sa.func.count())
+                .select_from(EntityMembershipRow)
+                .where(
+                    EntityMembershipRow.virtual_entity_id
+                    == _node_of(DOMAIN_ENTITY_TYPE, domain.domain_id),
+                    EntityMembershipRow.member_entity_id
+                    == _node_of(PROJECT_ENTITY_TYPE, project_id),
+                )
+            )
+        assert owned == 1
+
+    async def test_a_named_personal_project_enrolls_nobody(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        """``project_ids`` naming someone else's personal project adds no member."""
+        owner = await _create_user(provider, domain.domain_id, "alice")
+        owned_project = ProjectID((await _personal_projects(db, domain.domain_name))[0].id)
+
+        await _create_user(provider, domain.domain_id, "bob", project_ids=[owned_project])
+
+        assert await _project_member_ids(db, owned_project) == [str(owner)]
+
+    async def test_the_user_is_associated_with_the_project_scope(
+        self,
+        db: ExtendedAsyncSAEngine,
+        provider: UserOpsProvider,
+        domain: DomainFixtureData,
+    ) -> None:
+        """The roster write reaches the legacy scope association too."""
+        user_id = await _create_user(provider, domain.domain_id, "alice")
+        project_id = (await _personal_projects(db, domain.domain_name))[0].id
+
+        async with db.begin_readonly_session() as session:
+            associated = await session.scalar(
+                sa.select(sa.func.count())
+                .select_from(AssociationScopesEntitiesRow)
+                .where(
+                    AssociationScopesEntitiesRow.scope_type == ScopeType.PROJECT,
+                    AssociationScopesEntitiesRow.scope_id == str(project_id),
+                    AssociationScopesEntitiesRow.entity_type == EntityType.USER,
+                    AssociationScopesEntitiesRow.entity_id == str(user_id),
+                )
+            )
+        assert associated == 1

--- a/tests/unit/manager/repositories/resource_slot/test_db_source.py
+++ b/tests/unit/manager/repositories/resource_slot/test_db_source.py
@@ -22,7 +22,10 @@ from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.project import ProjectRow
 from ai.backend.manager.models.resource_group import ResourceGroupOpts, ResourceGroupRow
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
 from ai.backend.manager.models.resource_slot import (
     AgentResourceRow,
     ResourceAllocationRow,
@@ -30,6 +33,7 @@ from ai.backend.manager.models.resource_slot import (
 )
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.specs.pagination import OffsetPagination
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.resource_slot.db_source import ResourceSlotDBSource
@@ -171,6 +175,8 @@ class TestResourceAllocations:
                 DomainRow,
                 ProjectResourcePolicyRow,
                 ResourceGroupRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 AgentRow,
                 ContainerRegistryRow,
@@ -216,6 +222,8 @@ class TestAggregation:
                 DomainRow,
                 ProjectResourcePolicyRow,
                 ResourceGroupRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 AgentRow,
                 ContainerRegistryRow,
@@ -597,6 +605,8 @@ class TestComputeActualAgentResourceUsage:
                 DomainRow,
                 ProjectResourcePolicyRow,
                 ResourceGroupRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 AgentRow,
                 ContainerRegistryRow,

--- a/tests/unit/manager/test_reconcile_agent_resources.py
+++ b/tests/unit/manager/test_reconcile_agent_resources.py
@@ -29,13 +29,17 @@ from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.project import ProjectRow
 from ai.backend.manager.models.resource_group import ResourceGroupOpts, ResourceGroupRow
-from ai.backend.manager.models.resource_policy import ProjectResourcePolicyRow
+from ai.backend.manager.models.resource_policy import (
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
 from ai.backend.manager.models.resource_slot import (
     AgentResourceRow,
     ResourceAllocationRow,
     ResourceSlotTypeRow,
 )
 from ai.backend.manager.models.session import SessionRow
+from ai.backend.manager.models.user import UserRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.db.engine import create_async_engine
@@ -84,6 +88,8 @@ class TestReconcileAgentResources:
                 DomainRow,
                 ProjectResourcePolicyRow,
                 ResourceGroupRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 AgentRow,
                 ContainerRegistryRow,
@@ -476,6 +482,8 @@ class TestOrphanedAllocationCleanup:
                 DomainRow,
                 ProjectResourcePolicyRow,
                 ResourceGroupRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 AgentRow,
                 ContainerRegistryRow,
@@ -934,6 +942,8 @@ class TestTerminalSessionKernelReconciliation:
                 DomainRow,
                 ProjectResourcePolicyRow,
                 ResourceGroupRow,
+                UserResourcePolicyRow,
+                UserRow,
                 ProjectRow,
                 AgentRow,
                 ContainerRegistryRow,


### PR DESCRIPTION
## Summary

- Every user is now created with the personal project its personally owned resources will belong to (BEP-1077 Phase 1). All three entry points — REST/GraphQL, bulk and signup — reach the step through `create_full_user`, so it sits there once.
- `groups.creator_id` records the user a project was created for: provenance, not ownership, which stays the `scope -> virtual_entity -> entity` path alone. A partial unique index holds a user to at most one personal project, and the column is nulled when its user goes — the project is left dangling for the retention sweep rather than destroying what it holds.
- The migration backfills the project rows for existing users. Their graph rows come with the one ownership-data migration (BA-7571), which provisions them for every entity at once.

The project name is the username as a slug, given a numeric suffix where the domain already holds that name — a username is not a slug, and signup fills it with the e-mail address.

Personal projects are left out of the fair-share enumeration, the one place that enumerates every project.

## Test plan

- [x] `tests/unit/manager/repositories/ops/user/test_create_full_user.py` — the creation path against a real DB: one project per user, the user as its only member, slugification, suffix on collision, `created_in` toward the domain, and a named personal project enrolling nobody
- [x] `tests/unit/manager/models/alembic/test_backfill_personal_projects.py` — the data migration against a real DB: naming, collisions with existing projects, re-running it, and users that already have one
- [x] `tests/component/user` — the REST entry point, and that purging a user leaves the project with a null creator
- [x] `tests/component/auth` — the signup entry point
- [x] `tests/component/group`, `tests/component/project` — unchanged behavior
- [x] `pants fmt / fix / lint / check`

Resolves BA-7659
