### PR TITLE
fix(BA-7692): make local-registry images usable for sessions

### DIFF
--- a/changes/14265.fix.md
+++ b/changes/14265.fix.md
@@ -1,0 +1,1 @@
+Fix local container registry image scanning and session startup broken by Docker Engine 29 and the missing local-image guards.

--- a/src/ai/backend/agent/agent.py
+++ b/src/ai/backend/agent/agent.py
@@ -2149,7 +2149,7 @@ class AbstractAgent[
                     log.debug("Image {} is already being pulled, skipping", img_canonical)
                     return
 
-                need_to_pull = await self.check_image(
+                need_to_pull = (not img_ref.is_local) and await self.check_image(
                     img_ref, img_conf["digest"], AutoPullBehavior(img_conf["auto_pull"])
                 )
 

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -1841,8 +1841,9 @@ class DockerAgent(AbstractAgent[DockerKernel, DockerKernelCreationContext]):
             if cached_distro:
                 return cached_distro
 
+            image_ref = ImageRef.from_image_config(image)
             container_config: dict[str, Any] = {
-                "Image": image["canonical"],
+                "Image": image_ref.short if image_ref.is_local else image_ref.canonical,
                 "Tty": True,
                 "Privileged": False,
                 "AttachStdin": False,

--- a/src/ai/backend/manager/container_registry/local.py
+++ b/src/ai/backend/manager/container_registry/local.py
@@ -76,7 +76,7 @@ class LocalRegistry(BaseContainerRegistry):
             summary = {
                 "Id": data["Id"],
                 "RepoDigests": data.get("RepoDigests", []),
-                "Config.Image": data["Config"]["Image"],
+                "Config.Image": data["Config"].get("Image"),
                 "ContainerConfig.Image": data.get("ContainerConfig", {}).get("Image", None),
                 "Architecture": architecture,
             }

--- a/tests/unit/agent/docker/test_resolve_image_distro.py
+++ b/tests/unit/agent/docker/test_resolve_image_distro.py
@@ -1,0 +1,113 @@
+"""The distro probe container must address local images by the name Docker knows them by."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from ai.backend.agent.docker.agent import DockerAgent
+from ai.backend.common.types import AutoPullBehavior, ImageConfig
+
+LDD_OUTPUT = ["ldd (Ubuntu GLIBC 2.35-0ubuntu3.4) 2.35\n"]
+
+
+def _image_config(canonical: str, registry_name: str, *, is_local: bool) -> ImageConfig:
+    return ImageConfig(
+        architecture="x86_64",
+        project="",
+        canonical=canonical,
+        is_local=is_local,
+        digest="sha256:2140e699b3beaf7f96a0081fd9c9406bc3832b435cdb60dfa2d261f7d2f34a1c",
+        labels={},
+        repo_digest=None,
+        registry={
+            "name": registry_name,
+            "url": "http://127.0.0.1",
+            "username": None,
+            "password": None,
+        },
+        auto_pull=AutoPullBehavior.DIGEST,
+    )
+
+
+@pytest.fixture
+def created_configs(mocker: MockerFixture) -> list[dict[str, Any]]:
+    """Capture the container config the distro probe sends to Docker."""
+    captured: list[dict[str, Any]] = []
+
+    container = MagicMock()
+    container.start = AsyncMock()
+    container.wait = AsyncMock()
+    container.log = AsyncMock(return_value=LDD_OUTPUT)
+    container.stop = AsyncMock()
+    container.delete = AsyncMock()
+
+    async def _create(config: dict[str, Any]) -> MagicMock:
+        captured.append(config)
+        return container
+
+    docker = MagicMock()
+    docker.containers.create = _create
+
+    @asynccontextmanager
+    async def _docker() -> AsyncIterator[MagicMock]:
+        yield docker
+
+    mocker.patch("ai.backend.agent.docker.agent.Docker", _docker)
+    return captured
+
+
+@pytest.fixture
+def agent() -> DockerAgent:
+    """A bare agent carrying only the attributes ``resolve_image_distro()`` touches."""
+    instance = object.__new__(DockerAgent)
+    instance.valkey_stat_client = MagicMock()
+    instance.valkey_stat_client.get_image_distro = AsyncMock(return_value=None)
+    instance.valkey_stat_client.set_image_distro = AsyncMock()
+    return instance
+
+
+class TestResolveImageDistro:
+    async def test_local_image_probed_by_its_docker_name(
+        self,
+        agent: DockerAgent,
+        created_configs: list[dict[str, Any]],
+    ) -> None:
+        """`local/` is a Backend.AI registry prefix, not part of the Docker image name."""
+        image = _image_config("local/ngc-pytorch:26.07-py3", "local", is_local=True)
+
+        distro = await agent.resolve_image_distro(image)
+
+        assert distro == "ubuntu22.04"
+        assert created_configs[0]["Image"] == "ngc-pytorch:26.07-py3"
+
+    async def test_remote_image_probed_by_its_canonical_name(
+        self,
+        agent: DockerAgent,
+        created_configs: list[dict[str, Any]],
+    ) -> None:
+        """Registry-backed images keep the registry prefix, which Docker needs to resolve them."""
+        image = _image_config(
+            "cr.backend.ai/stable/python:3.9-ubuntu20.04", "cr.backend.ai", is_local=False
+        )
+
+        await agent.resolve_image_distro(image)
+
+        assert created_configs[0]["Image"] == "cr.backend.ai/stable/python:3.9-ubuntu20.04"
+
+    async def test_labelled_image_skips_the_probe(
+        self,
+        agent: DockerAgent,
+        created_configs: list[dict[str, Any]],
+    ) -> None:
+        """An image declaring its base distro needs no probe container at all."""
+        image = _image_config("local/ngc-pytorch:26.07-py3", "local", is_local=True)
+        image["labels"] = {"ai.backend.base-distro": "ubuntu20.04"}
+
+        assert await agent.resolve_image_distro(image) == "ubuntu20.04"
+        assert created_configs == []

--- a/tests/unit/agent/test_local_image_handling.py
+++ b/tests/unit/agent/test_local_image_handling.py
@@ -1,0 +1,98 @@
+"""Local (``type=local`` registry) images must never be pulled from a registry."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ai.backend.agent.dummy.agent import DummyAgent
+from ai.backend.common.types import AgentId, AutoPullBehavior, ImageConfig
+
+
+def _image_config(canonical: str, registry_name: str, *, is_local: bool) -> ImageConfig:
+    return ImageConfig(
+        architecture="x86_64",
+        project="",
+        canonical=canonical,
+        is_local=is_local,
+        digest="sha256:2140e699b3beaf7f96a0081fd9c9406bc3832b435cdb60dfa2d261f7d2f34a1c",
+        labels={},
+        repo_digest=None,
+        registry={
+            "name": registry_name,
+            "url": "http://127.0.0.1",
+            "username": None,
+            "password": None,
+        },
+        auto_pull=AutoPullBehavior.DIGEST,
+    )
+
+
+LOCAL_IMAGE = _image_config("local/ngc-pytorch:26.07-py3", "local", is_local=True)
+REMOTE_IMAGE = _image_config(
+    "cr.backend.ai/stable/python:3.9-ubuntu20.04", "cr.backend.ai", is_local=False
+)
+
+
+class _ImmediateBackgroundTaskManager:
+    """Runs the task inline so the test observes its effects without a real event loop task."""
+
+    async def start(self, func: Any, **kwargs: Any) -> uuid.UUID:
+        await func(AsyncMock(), **kwargs)
+        return uuid.uuid4()
+
+
+@dataclass
+class AgentUnderTest:
+    """A bare agent carrying only what ``check_and_pull()`` touches, plus its stubs."""
+
+    agent: DummyAgent
+    check_image: AsyncMock
+    pull_image: AsyncMock
+    anycast_event: AsyncMock
+
+
+@pytest.fixture
+def agent() -> AgentUnderTest:
+    instance = object.__new__(DummyAgent)
+    check_image = AsyncMock(return_value=True)
+    pull_image = AsyncMock()
+    anycast_event = AsyncMock()
+    setattr(instance, "id", AgentId("i-test"))
+    setattr(instance, "_active_pulls", {})
+    setattr(instance, "background_task_manager", _ImmediateBackgroundTaskManager())
+    setattr(instance, "local_config", SimpleNamespace(api=SimpleNamespace(pull_timeout=10.0)))
+    setattr(instance, "check_image", check_image)
+    setattr(instance, "pull_image", pull_image)
+    setattr(instance, "anycast_event", anycast_event)
+    return AgentUnderTest(instance, check_image, pull_image, anycast_event)
+
+
+class TestCheckAndPull:
+    async def test_local_image_is_never_pulled(self, agent: AgentUnderTest) -> None:
+        """A local image lives in the Docker daemon already; pulling it is a hard error."""
+        await agent.agent.check_and_pull({"local/ngc-pytorch:26.07-py3": LOCAL_IMAGE})
+
+        agent.check_image.assert_not_awaited()
+        agent.pull_image.assert_not_awaited()
+
+    async def test_local_image_still_reports_pull_finished(self, agent: AgentUnderTest) -> None:
+        """The scheduler waits for this event, so skipping the pull must not skip the event."""
+        await agent.agent.check_and_pull({"local/ngc-pytorch:26.07-py3": LOCAL_IMAGE})
+
+        (call,) = agent.anycast_event.await_args_list
+        assert type(call.args[0]).__name__ == "ImagePullFinishedEvent"
+
+    async def test_remote_image_is_pulled_when_missing(self, agent: AgentUnderTest) -> None:
+        """The local-image guard must not disable pulling for ordinary registry images."""
+        await agent.agent.check_and_pull({
+            "cr.backend.ai/stable/python:3.9-ubuntu20.04": REMOTE_IMAGE
+        })
+
+        agent.check_image.assert_awaited_once()
+        agent.pull_image.assert_awaited_once()

--- a/tests/unit/manager/container_registry/BUILD
+++ b/tests/unit/manager/container_registry/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/container_registry/test_local.py
+++ b/tests/unit/manager/container_registry/test_local.py
@@ -57,6 +57,8 @@ def scan_context() -> Iterator[None]:
     finally:
         all_updates.reset(tokens[0])
         rescan_counts.reset(tokens[1])
+        concurrency_sema.reset(tokens[2])
+        progress_reporter.reset(tokens[3])
 
 
 @pytest.fixture

--- a/tests/unit/manager/container_registry/test_local.py
+++ b/tests/unit/manager/container_registry/test_local.py
@@ -1,0 +1,154 @@
+"""Tests for scanning images from the local Docker daemon (``type=local`` registry)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.manager.container_registry.base import (
+    RescanCounts,
+    all_updates,
+    concurrency_sema,
+    progress_reporter,
+    rescan_counts,
+)
+from ai.backend.manager.container_registry.local import LocalRegistry
+
+# A Docker Engine 29 (API 1.55) image-inspect response: `Config` carries no `Image` key,
+# and `ContainerConfig` is gone entirely.
+DOCKER_29_INSPECT: dict[str, Any] = {
+    "Id": "sha256:2140e699b3beaf7f96a0081fd9c9406bc3832b435cdb60dfa2d261f7d2f34a1c",
+    "RepoTags": ["ngc-pytorch:26.07-py3"],
+    "RepoDigests": [],
+    "Architecture": "amd64",
+    "Size": 10574521716,
+    "Config": {
+        "Env": ["CUDA_VERSION=13.3.1.008"],
+        "Labels": None,
+    },
+}
+
+# A pre-29 response, which still carries `Config.Image` and `ContainerConfig`.
+DOCKER_LEGACY_INSPECT: dict[str, Any] = {
+    **DOCKER_29_INSPECT,
+    "Config": {
+        **DOCKER_29_INSPECT["Config"],
+        "Image": "sha256:abcdef",
+    },
+    "ContainerConfig": {"Image": "sha256:abcdef"},
+}
+
+
+@pytest.fixture
+def scan_context() -> Iterator[None]:
+    """Bind the context variables that the scanner writes its results into."""
+    tokens = (
+        all_updates.set({}),
+        rescan_counts.set(RescanCounts()),
+        concurrency_sema.set(AsyncMock()),
+        progress_reporter.set(None),
+    )
+    try:
+        yield
+    finally:
+        all_updates.reset(tokens[0])
+        rescan_counts.reset(tokens[1])
+
+
+@pytest.fixture
+def registry() -> LocalRegistry:
+    db = MagicMock()
+
+    @asynccontextmanager
+    async def _begin_readonly_session() -> AsyncIterator[MagicMock]:
+        session = MagicMock()
+        session.scalar = AsyncMock(return_value=0)
+        yield session
+
+    db.begin_readonly_session = _begin_readonly_session
+
+    registry_info = MagicMock()
+    registry_info.url = "http://docker"
+    return LocalRegistry(db, "local", registry_info)
+
+
+def _session_returning(payload: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.json = AsyncMock(return_value=payload)
+
+    @asynccontextmanager
+    async def _get(_url: Any) -> AsyncIterator[MagicMock]:
+        yield response
+
+    session = MagicMock()
+    session.get = _get
+    return session
+
+
+class TestScanTagLocal:
+    @pytest.mark.parametrize(
+        ("label", "inspect_response"),
+        [
+            ("docker-29", DOCKER_29_INSPECT),
+            ("docker-legacy", DOCKER_LEGACY_INSPECT),
+        ],
+    )
+    async def test_scans_image_regardless_of_config_image_presence(
+        self,
+        registry: LocalRegistry,
+        scan_context: None,
+        label: str,
+        inspect_response: dict[str, Any],
+    ) -> None:
+        """`Config.Image` is absent on Docker Engine 29; the scan must not depend on it."""
+        await registry._scan_tag_local(
+            _session_returning(inspect_response), {}, "ngc-pytorch", "26.07-py3"
+        )
+
+        updates = all_updates.get()
+        assert rescan_counts.get().skipped == 0, label
+        assert len(updates) == 1, label
+        (key,) = updates
+        assert key.canonical == "local/ngc-pytorch:26.07-py3"
+        assert key.architecture == "x86_64"
+
+    async def test_vanilla_image_allows_every_accelerator(
+        self,
+        registry: LocalRegistry,
+        scan_context: None,
+    ) -> None:
+        """An image without Backend.AI labels is registered with an unrestricted accel set."""
+        await registry._scan_tag_local(
+            _session_returning(DOCKER_29_INSPECT), {}, "ngc-pytorch", "26.07-py3"
+        )
+
+        (update,) = all_updates.get().values()
+        assert update["accels"] == "*"
+        assert update["labels"] == {}
+        assert update["size_bytes"] == DOCKER_29_INSPECT["Size"]
+
+    async def test_image_already_known_from_a_remote_registry_is_skipped(
+        self,
+        registry: LocalRegistry,
+        scan_context: None,
+    ) -> None:
+        """The same config digest coming from a remote registry wins over the local copy."""
+
+        @asynccontextmanager
+        async def _begin_readonly_session() -> AsyncIterator[MagicMock]:
+            session = MagicMock()
+            session.scalar = AsyncMock(return_value=1)
+            yield session
+
+        setattr(registry.db, "begin_readonly_session", _begin_readonly_session)
+
+        await registry._scan_tag_local(
+            _session_returning(DOCKER_29_INSPECT), {}, "ngc-pytorch", "26.07-py3"
+        )
+
+        assert all_updates.get() == {}
+        assert rescan_counts.get().skipped == 1


### PR DESCRIPTION
## Summary

Three defects made images registered from a `type=local` container registry unusable end to end. All three are present on `main`, `26.8` and `26.4`.

- `LocalRegistry._scan_tag_local` read `data["Config"]["Image"]`, which Docker Engine 29 (API 1.55) no longer returns — every local image scan raised `KeyError` and the rescan registered nothing (`scanned:0 skipped:0 errors:N`).
- `AbstractAgent.check_and_pull` lacked the `not img_ref.is_local` guard that `create_kernel` already has, so local images were pulled from a registry and the session was cancelled with `pull access denied for local/<image>`.
- `DockerAgent.resolve_image_distro` created the `ldd --version` probe container with `image["canonical"]` (`local/<image>:<tag>`) instead of `image_ref.short`, so sessions on label-less (vanilla) images failed in `init_kernel_context` with a 404. Other call sites in the same file already branch on `is_local`.

## Test plan

- [x] `tests/unit/manager/container_registry/test_local.py` — Docker 29 and legacy inspect payloads both scan; a label-less image registers with `accels="*"`; a digest already known from a remote registry is skipped.
- [x] `tests/unit/agent/test_local_image_handling.py` — a local image is neither checked nor pulled but still emits `ImagePullFinishedEvent`; a remote image is still pulled.
- [x] `tests/unit/agent/docker/test_resolve_image_distro.py` — a local image is probed as `ngc-pytorch:26.07-py3`, a remote one keeps its canonical name, and a `base-distro`-labelled image skips the probe entirely.
- [x] Each new test was confirmed to fail against the unpatched code.
- [x] Verified live: `nvcr.io/nvidia/pytorch:26.07-py3` registered through a `type=local` registry, six concurrent fractional-GPU batch sessions (2x `cuda.shares=0.5`, 4x `cuda.shares=0.2`) started and ran a PyTorch workload to completion.

Resolves #14264 (BA-7692)