### PR TITLE
feat(BA-7654): report live mount and backend health from the storage proxy

### DIFF
--- a/changes/14272.feature.md
+++ b/changes/14272.feature.md
@@ -1,0 +1,1 @@
+Report live mount and backend appliance health from the storage proxy, so that a dropped mount is no longer indistinguishable from a healthy one.

--- a/src/ai/backend/common/data/storage/types.py
+++ b/src/ai/backend/common/data/storage/types.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import enum
+from typing import NewType
 
 from pydantic import ConfigDict
 
 from ai.backend.common.type_adapters import VFolderIDField
 from ai.backend.common.types import BackendAISchema
+
+# The operator-declared name of a storage volume, which is its configuration section key.
+VolumeName = NewType("VolumeName", str)
 
 
 class VFolderStorageTarget(BackendAISchema):

--- a/src/ai/backend/storage/backend/health/abc.py
+++ b/src/ai/backend/storage/backend/health/abc.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+
+from .types import BackendProbeResult
+
+
+class AbstractBackendProber(metaclass=ABCMeta):
+    """Answers whether one volume's backend appliance is reachable from this proxy."""
+
+    @abstractmethod
+    async def probe(self) -> BackendProbeResult:
+        raise NotImplementedError

--- a/src/ai/backend/storage/backend/health/probers.py
+++ b/src/ai/backend/storage/backend/health/probers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import ClassVar, override
+
+from ai.backend.storage.volumes.health.types import MountHealthRecord, MountStatus
+
+from .abc import AbstractBackendProber
+from .types import BackendProbeResult, BackendStatus
+
+
+class HealthyBackendProber(AbstractBackendProber):
+    """Reports an appliance that is always reachable, for volumes backed by none."""
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        return BackendProbeResult(status=BackendStatus.HEALTHY, checked_at=datetime.now(UTC))
+
+
+class MountDerivedBackendProber(AbstractBackendProber):
+    """
+    Reports the appliance of a local filesystem, which is the mount itself.
+
+    It reads the latest mount probe rather than running one, so that it costs no system
+    call and carries the time that mount was actually checked.
+    """
+
+    _STATUS_BY_MOUNT_STATUS: ClassVar[dict[MountStatus, BackendStatus]] = {
+        MountStatus.ALIVE: BackendStatus.HEALTHY,
+        MountStatus.DEVICE_CHANGED: BackendStatus.DEGRADED,
+        MountStatus.MARKER_MISSING: BackendStatus.DEGRADED,
+        MountStatus.MARKER_MISMATCH: BackendStatus.DEGRADED,
+        MountStatus.HUNG: BackendStatus.OFFLINE,
+        MountStatus.ERROR: BackendStatus.OFFLINE,
+    }
+
+    _record: MountHealthRecord
+
+    def __init__(self, record: MountHealthRecord) -> None:
+        self._record = record
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        result = self._record.latest
+        if result is None:
+            return BackendProbeResult(
+                status=BackendStatus.UNAVAILABLE,
+                checked_at=datetime.now(UTC),
+                status_info="the mount has not been probed yet",
+            )
+        return BackendProbeResult(
+            status=self._STATUS_BY_MOUNT_STATUS[result.status],
+            checked_at=result.checked_at,
+            status_info=result.detail,
+        )

--- a/src/ai/backend/storage/backend/health/tasks.py
+++ b/src/ai/backend/storage/backend/health/tasks.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import override
+
+from ai.backend.common.cron.base import PeriodicTask
+from ai.backend.common.data.storage.types import VolumeName
+from ai.backend.logging import BraceStyleAdapter
+
+from .abc import AbstractBackendProber
+from .types import BackendHealthRecord, BackendProbeResult, BackendStatus
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+@dataclass(frozen=True)
+class BackendProbeTaskArgs:
+    """What one appliance's probe loop needs to run and where it records."""
+
+    volume_name: VolumeName
+    prober: AbstractBackendProber
+    record: BackendHealthRecord
+    interval: float
+    timeout: float
+
+
+class BackendProbeTask(PeriodicTask):
+    """
+    Runs one volume's backend prober and records the result.
+
+    Kept on a cadence of its own because an appliance can answer its management API
+    while the mount has silently dropped.
+    """
+
+    _args: BackendProbeTaskArgs
+    _initial_delay: float
+
+    def __init__(self, args: BackendProbeTaskArgs) -> None:
+        self._args = args
+        self._initial_delay = random.uniform(0.0, args.interval)
+
+    @property
+    @override
+    def name(self) -> str:
+        return "backend_probe"
+
+    @property
+    @override
+    def interval(self) -> float:
+        return self._args.interval
+
+    @property
+    @override
+    def initial_delay(self) -> float:
+        return self._initial_delay
+
+    @property
+    @override
+    def run_timeout(self) -> float | None:
+        return None
+
+    @override
+    async def run(self) -> None:
+        timeout = self._args.timeout
+        try:
+            result = await asyncio.wait_for(self._args.prober.probe(), timeout=timeout)
+        except TimeoutError:
+            log.warning("Backend probe for {} timed out after {}s", self._args.volume_name, timeout)
+            result = BackendProbeResult(
+                status=BackendStatus.OFFLINE,
+                checked_at=datetime.now(UTC),
+                status_info=f"the probe timed out after {timeout}s",
+            )
+        except Exception as e:
+            log.exception("Backend probe for {} failed", self._args.volume_name)
+            result = BackendProbeResult(
+                status=BackendStatus.OFFLINE, checked_at=datetime.now(UTC), status_info=str(e)
+            )
+        self._args.record.latest = result

--- a/src/ai/backend/storage/backend/health/types.py
+++ b/src/ai/backend/storage/backend/health/types.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+
+class BackendStatus(enum.StrEnum):
+    """Reachability of a backend appliance, mirroring the hardware metadata statuses."""
+
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    OFFLINE = "offline"
+    UNAVAILABLE = "unavailable"
+
+    def to_hwinfo_status(self) -> Literal["healthy", "degraded", "offline", "unavailable"]:
+        match self:
+            case BackendStatus.HEALTHY:
+                return "healthy"
+            case BackendStatus.DEGRADED:
+                return "degraded"
+            case BackendStatus.OFFLINE:
+                return "offline"
+            case BackendStatus.UNAVAILABLE:
+                return "unavailable"
+
+
+@dataclass(frozen=True)
+class BackendProbeResult:
+    """The latest reachability of one volume's backend appliance from this proxy."""
+
+    status: BackendStatus
+    checked_at: datetime
+    status_info: str | None = None
+
+
+@dataclass
+class BackendHealthRecord:
+    """
+    Where one backend appliance's probe loop records its latest result.
+
+    A None result means the probe has not run yet, which the manager tells apart from a
+    stale result by the check time each result carries.
+    """
+
+    latest: BackendProbeResult | None = None

--- a/src/ai/backend/storage/cli/__main__.py
+++ b/src/ai/backend/storage/cli/__main__.py
@@ -69,3 +69,8 @@ def dependencies() -> None:
 @main.group(cls=LazyGroup, import_name="ai.backend.storage.cli.health:cli")
 def health() -> None:
     """Command set for health checking."""
+
+
+@main.group(cls=LazyGroup, import_name="ai.backend.storage.cli.volume:cli")
+def volume() -> None:
+    """Command set for volume management."""

--- a/src/ai/backend/storage/cli/volume.py
+++ b/src/ai/backend/storage/cli/volume.py
@@ -1,0 +1,92 @@
+"""Volume management CLI commands for Backend.AI Storage Proxy."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+import click
+
+from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.storage.config.loaders import load_local_config
+from ai.backend.storage.config.unified import VolumeInfoConfig
+from ai.backend.storage.volumes.health.types import MARKER_FILE_NAME
+
+from .context import CLIContext
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+@click.group()
+def cli() -> None:
+    """Volume management commands."""
+
+
+def _mark_one(volume_name: str, mount_path: Path) -> tuple[bool, str]:
+    """Writes the marker for one volume. Returns whether it succeeded, and why not."""
+    marker_path = mount_path / MARKER_FILE_NAME
+    try:
+        declared = marker_path.read_text().strip()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        return False, f"cannot read the existing marker: {e}"
+    else:
+        if declared == volume_name:
+            return True, "already marked"
+        return False, (
+            f"the marker already declares {declared!r}; "
+            "this path may be serving different storage than declared"
+        )
+
+    # Refuse to stamp the directory underneath a mount that has fallen off.
+    try:
+        mount_path.stat()
+        os.statvfs(mount_path)
+    except OSError as e:
+        return False, f"the mount is not usable: {e}"
+
+    try:
+        marker_path.write_text(f"{volume_name}\n")
+    except OSError as e:
+        return False, f"cannot write the marker: {e}"
+    return True, "marked"
+
+
+@cli.command()
+@click.argument("volume_name")
+@click.pass_obj
+def mark(cli_ctx: CLIContext, volume_name: str) -> None:
+    """
+    Write the volume marker that mount probes read to verify volume identity.
+
+    An existing marker is never overwritten, and a volume whose mount is not usable is
+    refused, so that the directory underneath a dropped mount is not stamped.
+    """
+    local_config = load_local_config(cli_ctx.config_path, log_level=cli_ctx.log_level)
+    if volume_name not in local_config.volume:
+        raise click.UsageError(f"No volume named {volume_name!r} in the configuration.")
+    _report({volume_name: local_config.volume[volume_name]})
+
+
+@cli.command(name="mark-all")
+@click.pass_obj
+def mark_all(cli_ctx: CLIContext) -> None:
+    """Write the volume marker for every volume declared in the configuration file."""
+    local_config = load_local_config(cli_ctx.config_path, log_level=cli_ctx.log_level)
+    _report(dict(local_config.volume))
+
+
+def _report(targets: Mapping[str, VolumeInfoConfig]) -> None:
+    failed = False
+    for name, volume_config in targets.items():
+        succeeded, reason = _mark_one(name, Path(volume_config.path))
+        if succeeded:
+            click.echo(f"{name}: {reason}")
+        else:
+            failed = True
+            click.echo(f"{name}: refused - {reason}", err=True)
+    if failed:
+        raise click.exceptions.Exit(1)

--- a/src/ai/backend/storage/config/unified.py
+++ b/src/ai/backend/storage/config/unified.py
@@ -23,7 +23,12 @@ from ai.backend.common.configs import (
 from ai.backend.common.data.artifact.types import ArtifactRegistryType
 from ai.backend.common.data.storage.types import ArtifactStorageType
 from ai.backend.common.exception import GenericNotImplementedError, InvalidConfigError
-from ai.backend.common.meta import BackendAIConfigMeta, CompositeType, ConfigExample
+from ai.backend.common.meta import (
+    NEXT_RELEASE_VERSION,
+    BackendAIConfigMeta,
+    CompositeType,
+    ConfigExample,
+)
 from ai.backend.common.typed_validators import (
     AutoDirectoryPath,
     GroupID,
@@ -473,6 +478,82 @@ class VolumeStatsConfig(BaseConfigSchema):
     ]
 
 
+class VolumeHealthConfig(BaseConfigSchema):
+    """Configuration for mount and backend appliance health probes."""
+
+    mount_probe_interval: Annotated[
+        float,
+        Field(
+            default=30.0,
+            ge=1.0,
+            validation_alias=AliasChoices("mount-probe-interval", "mount_probe_interval"),
+            serialization_alias="mount-probe-interval",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Interval in seconds between mount probes. Each volume is probed on its own "
+                "loop, staggered across this interval so that all mounts are not queried at "
+                "the same instant."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            example=ConfigExample(local="30.0", prod="30.0"),
+        ),
+    ]
+    mount_probe_timeout: Annotated[
+        float,
+        Field(
+            default=5.0,
+            ge=1.0,
+            validation_alias=AliasChoices("mount-probe-timeout", "mount_probe_timeout"),
+            serialization_alias="mount-probe-timeout",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Timeout in seconds for a single mount probe, and for the baseline capture "
+                "at startup. A dead network mount surfaces as a timeout instead of hanging "
+                "the caller; the volume is then reported as hung until the probe returns."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            example=ConfigExample(local="5.0", prod="5.0"),
+        ),
+    ]
+    backend_probe_interval: Annotated[
+        float,
+        Field(
+            default=60.0,
+            ge=1.0,
+            validation_alias=AliasChoices("backend-probe-interval", "backend_probe_interval"),
+            serialization_alias="backend-probe-interval",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Interval in seconds between backend appliance probes. Kept separate from the "
+                "mount probe interval because a vendor appliance can answer its management API "
+                "while a network mount has silently dropped."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            example=ConfigExample(local="60.0", prod="60.0"),
+        ),
+    ]
+    backend_probe_timeout: Annotated[
+        float,
+        Field(
+            default=10.0,
+            ge=1.0,
+            validation_alias=AliasChoices("backend-probe-timeout", "backend_probe_timeout"),
+            serialization_alias="backend-probe-timeout",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Timeout in seconds for a single backend appliance probe. On a timeout the "
+                "appliance is reported as offline from this proxy."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
+            example=ConfigExample(local="10.0", prod="10.0"),
+        ),
+    ]
+
+
 class StorageProxyConfig(BaseConfigSchema):
     ipc_base_path: Annotated[
         AutoDirectoryPath,
@@ -779,6 +860,21 @@ class StorageProxyConfig(BaseConfigSchema):
                 "storage volumes and caches them in Redis."
             ),
             added_version="25.12.0",
+        ),
+    ]
+    volume_health: Annotated[
+        VolumeHealthConfig,
+        Field(
+            default_factory=lambda: VolumeHealthConfig(),
+            validation_alias=AliasChoices("volume-health", "volume_health"),
+            serialization_alias="volume-health",
+        ),
+        BackendAIConfigMeta(
+            description=(
+                "Configuration for the mount and backend appliance health probes whose latest "
+                "results are kept in memory and shipped with the heartbeat."
+            ),
+            added_version=NEXT_RELEASE_VERSION,
         ),
     ]
 

--- a/src/ai/backend/storage/context.py
+++ b/src/ai/backend/storage/context.py
@@ -18,6 +18,7 @@ from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
 from ai.backend.common.clients.valkey_client.valkey_tus.client import (
     ValkeyTusClient,
 )
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import (
     EventDispatcher,
@@ -144,6 +145,8 @@ class RootContext:
             volume_obj = volume_cls(
                 local_config=self.local_config.model_dump(by_alias=True),
                 mount_path=Path(volume_config.path),
+                volume_name=VolumeName(name),
+                storage_proxy_config=self.local_config.storage_proxy,
                 options=volume_config.options or {},
                 etcd=self.etcd,
                 event_dispatcher=self.event_dispatcher,

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -737,7 +737,9 @@ async def server_main(
             volume_stats_state=volume_stats_state,
             backends={**DEFAULT_BACKENDS},
             volumes={
-                NOOP_STORAGE_VOLUME_NAME: init_noop_volume(etcd, event_dispatcher, event_producer)
+                NOOP_STORAGE_VOLUME_NAME: init_noop_volume(
+                    local_config.storage_proxy, etcd, event_dispatcher, event_producer
+                )
             },
             artifact_verifier_ctx=ArtifactVerifierContext(),
         )

--- a/src/ai/backend/storage/volumes/abc.py
+++ b/src/ai/backend/storage/volumes/abc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from abc import ABCMeta, abstractmethod
 from collections.abc import AsyncIterator, Mapping, Sequence
@@ -11,11 +12,14 @@ from typing import (
     final,
 )
 
+from ai.backend.common.cron.local_cron import LocalCron
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.defs import DEFAULT_VFOLDER_PERMISSION_MODE
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.errors import InvalidSubpathError, VFolderNotFoundError
 from ai.backend.storage.types import (
     CapacityUsage,
@@ -27,6 +31,12 @@ from ai.backend.storage.types import (
     VFolderID,
     VolumeInfo,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.tasks import BackendProbeTask, BackendProbeTaskArgs
+from ai.backend.storage.backend.health.types import BackendHealthRecord
+from ai.backend.storage.volumes.health.abc import AbstractMountProber
+from ai.backend.storage.volumes.health.tasks import MountProbeTask, MountProbeTaskArgs
+from ai.backend.storage.volumes.health.types import MountHealthRecord
 from ai.backend.storage.watcher import WatcherClient
 
 # Available capabilities of a volume implementation
@@ -190,16 +200,31 @@ class AbstractFSOpModel(metaclass=ABCMeta):
         raise NotImplementedError
 
 
-class AbstractVolume(metaclass=ABCMeta):
+class AbstractVolume[
+    TMountProber: AbstractMountProber = AbstractMountProber,
+    TBackendProber: AbstractBackendProber = AbstractBackendProber,
+](metaclass=ABCMeta):
     quota_model: AbstractQuotaModel
     fsop_model: AbstractFSOpModel
+    _mount_prober: TMountProber
+    _backend_prober: TBackendProber
     name: ClassVar[str] = "undefined"
+
+    volume_name: VolumeName
+    _storage_proxy_config: StorageProxyConfig
+    _mount_health: MountHealthRecord
+    _backend_health: BackendHealthRecord
+    _mount_probe_task: MountProbeTask
+    _backend_probe_task: BackendProbeTask
+    _health_cron: LocalCron
 
     def __init__(
         self,
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
@@ -209,17 +234,81 @@ class AbstractVolume(metaclass=ABCMeta):
         self.local_config = local_config
         self.mount_path = mount_path
         self.config = options or {}
+        self.volume_name = volume_name
+        self._storage_proxy_config = storage_proxy_config
+        self._mount_health = MountHealthRecord()
+        self._backend_health = BackendHealthRecord()
         self.etcd = etcd
         self.event_dispatcher = event_dispatcher
         self.event_producer = event_producer
         self.watcher = watcher
 
     async def init(self) -> None:
+        # After the subclass has set up its client, which its own init() does before
+        # delegating here, so that a backend prober can be handed one.
+        self._mount_prober = self.create_mount_prober()
+        self._backend_prober = self.create_backend_prober()
+        await self._capture_mount_baseline()
         self.fsop_model = await self.create_fsop_model()
         self.quota_model = await self.create_quota_model()
+        # The mount and the backend probe on separate loops, both independent of the
+        # heartbeat, so that a slow or hung probe never delays a heartbeat.
+        health_config = self._storage_proxy_config.volume_health
+        self._mount_probe_task = MountProbeTask(
+            MountProbeTaskArgs(
+                volume_name=self.volume_name,
+                prober=self._mount_prober,
+                record=self._mount_health,
+                interval=health_config.mount_probe_interval,
+                timeout=health_config.mount_probe_timeout,
+            )
+        )
+        self._backend_probe_task = BackendProbeTask(
+            BackendProbeTaskArgs(
+                volume_name=self.volume_name,
+                prober=self._backend_prober,
+                record=self._backend_health,
+                interval=health_config.backend_probe_interval,
+                timeout=health_config.backend_probe_timeout,
+            )
+        )
+        self._health_cron = LocalCron([self._mount_probe_task, self._backend_probe_task])
+        await self._health_cron.start()
 
     async def shutdown(self) -> None:
-        pass
+        await self._health_cron.stop()
+        # Stopping the cron cancels the await, not the thread the probe blocks in.
+        self._mount_probe_task.shutdown()
+
+    # ------ mount and backend health -------
+
+    @abstractmethod
+    def create_mount_prober(self) -> TMountProber:
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_backend_prober(self) -> TBackendProber:
+        raise NotImplementedError
+
+    async def _capture_mount_baseline(self) -> None:
+        """
+        Lets the mount prober record what its later probes compare against.
+        A failure is not fatal: the volume starts without a baseline and the first
+        successful probe adopts one.
+        """
+        timeout = self._storage_proxy_config.volume_health.mount_probe_timeout
+        try:
+            async with asyncio.timeout(timeout):
+                await asyncio.to_thread(self._mount_prober.capture_baseline)
+        except TimeoutError:
+            log.error(
+                "Timed out capturing the mount baseline of {} after {}s; "
+                "the volume starts without one",
+                self.mount_path,
+                timeout,
+            )
+        except OSError as e:
+            log.error("Failed to capture the mount baseline of {}: {}", self.mount_path, e)
 
     @abstractmethod
     def info(self) -> VolumeInfo:

--- a/src/ai/backend/storage/volumes/dellemc/__init__.py
+++ b/src/ai/backend/storage/volumes/dellemc/__init__.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast, override
 
 import aiofiles.os
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.types import HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.errors import QuotaDirectoryNotEmptyError
 from ai.backend.storage.types import CapacityUsage, FSPerfMetric, QuotaConfig, QuotaUsage
 from ai.backend.storage.volumes.abc import (
@@ -20,6 +23,8 @@ from ai.backend.storage.volumes.abc import (
     CAP_VFOLDER,
     AbstractQuotaModel,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.types import BackendProbeResult, BackendStatus
 from ai.backend.storage.volumes.vfs import BaseQuotaModel, BaseVolume
 from ai.backend.storage.watcher import WatcherClient
 
@@ -153,6 +158,20 @@ class DellEMCOneFSQuotaModel(BaseQuotaModel):
         await aiofiles.os.rmdir(qspath)
 
 
+class DellEMCBackendProber(AbstractBackendProber):
+    """Asks the OneFS API for its metadata, the cheapest call that proves reachability."""
+
+    _client: OneFSClient
+
+    def __init__(self, client: OneFSClient) -> None:
+        self._client = client
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        await self._client.get_metadata()
+        return BackendProbeResult(status=BackendStatus.HEALTHY, checked_at=datetime.now(UTC))
+
+
 class DellEMCOneFSVolume(BaseVolume):
     name = "dellemc-onefs"
     endpoint: str
@@ -164,6 +183,8 @@ class DellEMCOneFSVolume(BaseVolume):
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
@@ -173,6 +194,8 @@ class DellEMCOneFSVolume(BaseVolume):
         super().__init__(
             local_config,
             mount_path,
+            volume_name=volume_name,
+            storage_proxy_config=storage_proxy_config,
             etcd=etcd,
             options=options,
             event_dispatcher=event_dispatcher,
@@ -195,6 +218,7 @@ class DellEMCOneFSVolume(BaseVolume):
 
     @override
     async def shutdown(self) -> None:
+        await super().shutdown()
         await self.api_client.aclose()
 
     @override
@@ -207,6 +231,10 @@ class DellEMCOneFSVolume(BaseVolume):
     @override
     async def get_capabilities(self) -> frozenset[str]:
         return frozenset([CAP_FAST_FS_SIZE, CAP_VFOLDER, CAP_QUOTA, CAP_METRIC])
+
+    @override
+    def create_backend_prober(self) -> DellEMCBackendProber:
+        return DellEMCBackendProber(self.api_client)
 
     @override
     async def get_hwinfo(self) -> HardwareMetadata:

--- a/src/ai/backend/storage/volumes/gpfs/__init__.py
+++ b/src/ai/backend/storage/volumes/gpfs/__init__.py
@@ -1,13 +1,16 @@
 import logging
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal, override
+from typing import Any, Final, Literal, override
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.json import dump_json_str
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.types import CapacityUsage, FSPerfMetric, QuotaConfig, QuotaUsage
 from ai.backend.storage.volumes.abc import (
     CAP_FAST_FS_SIZE,
@@ -17,12 +20,16 @@ from ai.backend.storage.volumes.abc import (
     AbstractFSOpModel,
     AbstractQuotaModel,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.types import BackendProbeResult, BackendStatus
 from ai.backend.storage.volumes.vfs import BaseFSOpModel, BaseQuotaModel, BaseVolume
 from ai.backend.storage.watcher import WatcherClient
 
 from .exceptions import GPFSNoMetricError
 from .gpfs_client import GPFSAPIClient
 from .types import GPFSSystemHealthState
+
+_UNHEALTHY_NODE_STATES: Final = ("FAILED", "DEGRADED", "ERROR")
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -138,6 +145,35 @@ class GPFSOpModel(BaseFSOpModel):
         )
 
 
+class GPFSBackendProber(AbstractBackendProber):
+    """Asks the nodes for their health, without the reports `get_hwinfo()` also gathers."""
+
+    _client: GPFSAPIClient
+
+    def __init__(self, client: GPFSAPIClient) -> None:
+        self._client = client
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        degraded: GPFSSystemHealthState | None = None
+        for node in await self._client.list_nodes():
+            for node_health_status in await self._client.get_node_health(node):
+                if node_health_status.state in _UNHEALTHY_NODE_STATES:
+                    degraded = node_health_status
+                    break
+        if degraded is None:
+            return BackendProbeResult(status=BackendStatus.HEALTHY, checked_at=datetime.now(UTC))
+        return BackendProbeResult(
+            status=(
+                BackendStatus.DEGRADED
+                if degraded.state == "DEGRADED"
+                else BackendStatus.UNAVAILABLE
+            ),
+            checked_at=datetime.now(UTC),
+            status_info=f"node {degraded.component} reports {degraded.state}",
+        )
+
+
 class GPFSVolume(BaseVolume):
     name = "gpfs"
     api_client: GPFSAPIClient
@@ -149,6 +185,8 @@ class GPFSVolume(BaseVolume):
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
@@ -158,6 +196,8 @@ class GPFSVolume(BaseVolume):
         super().__init__(
             local_config,
             mount_path,
+            volume_name=volume_name,
+            storage_proxy_config=storage_proxy_config,
             etcd=etcd,
             options=options,
             event_dispatcher=event_dispatcher,
@@ -203,9 +243,13 @@ class GPFSVolume(BaseVolume):
         return frozenset([CAP_FAST_FS_SIZE, CAP_VFOLDER, CAP_QUOTA, CAP_METRIC])
 
     @override
+    def create_backend_prober(self) -> GPFSBackendProber:
+        return GPFSBackendProber(self.api_client)
+
+    @override
     async def get_hwinfo(self) -> HardwareMetadata:
         nodes = await self.api_client.list_nodes()
-        invalid_status = ["FAILED", "DEGRADED", "ERROR"]
+        invalid_status = _UNHEALTHY_NODE_STATES
         health_status: str | GPFSSystemHealthState = "HEALTHY"
 
         for node in nodes:

--- a/src/ai/backend/storage/volumes/hammerspace/volume/extended.py
+++ b/src/ai/backend/storage/volumes/hammerspace/volume/extended.py
@@ -13,11 +13,13 @@ from typing import (
 
 from yarl import URL
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.events.event_types.volume.broadcast import DoVolumeMountEvent
 from ai.backend.common.types import QuotaConfig, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.types import CapacityUsage, QuotaUsage
 from ai.backend.storage.volumes.abc import (
     CAP_QUOTA,
@@ -165,19 +167,25 @@ class HammerspaceVolume(BaseHammerspaceVolume):
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
         watcher: WatcherClient | None = None,
         options: Mapping[str, Any] | None = None,
     ) -> None:
-        self.local_config = local_config
-        self.mount_path = mount_path
-        self.config = options or {}
-        self.etcd = etcd
-        self.event_dispatcher = event_dispatcher
-        self.event_producer = event_producer
-        self.watcher = watcher
+        super().__init__(
+            local_config,
+            mount_path,
+            volume_name=volume_name,
+            storage_proxy_config=storage_proxy_config,
+            etcd=etcd,
+            event_dispatcher=event_dispatcher,
+            event_producer=event_producer,
+            watcher=watcher,
+            options=options,
+        )
 
         address = self.config.get("address")
         if address is None:

--- a/src/ai/backend/storage/volumes/health/abc.py
+++ b/src/ai/backend/storage/volumes/health/abc.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+
+from .types import MountProbeResult
+
+
+class AbstractMountProber(metaclass=ABCMeta):
+    """Answers whether one volume's mount is alive and serving the declared storage."""
+
+    def capture_baseline(self) -> None:
+        """
+        Records what later probes compare against, once at startup. Blocking, like
+        `probe()`. A prober that compares against nothing leaves this empty.
+        """
+
+    @abstractmethod
+    def probe(self) -> MountProbeResult:
+        """
+        Blocking on purpose: the probe task submits this to an executor of its own, so a
+        dead network mount surfaces as a timeout instead of stalling the event loop.
+        """
+        raise NotImplementedError

--- a/src/ai/backend/storage/volumes/health/probers.py
+++ b/src/ai/backend/storage/volumes/health/probers.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import override
+
+from ai.backend.common.data.storage.types import VolumeName
+
+from .abc import AbstractMountProber
+from .types import MARKER_FILE_NAME, MountProbeResult, MountStatus
+
+
+class PathMountProber(AbstractMountProber):
+    """
+    Checks a mount point by its device id, its filesystem statistics and its marker file.
+
+    The device id baseline cannot survive a restart, because the kernel assigns a device
+    number at mount time; the marker file is the check that does.
+    """
+
+    _volume_name: VolumeName
+    _mount_path: Path
+    _device_id: int | None
+    _marker_present_at_init: bool
+
+    def __init__(self, volume_name: VolumeName, mount_path: Path) -> None:
+        self._volume_name = volume_name
+        self._mount_path = mount_path
+        self._device_id = None
+        self._marker_present_at_init = False
+
+    @override
+    def capture_baseline(self) -> None:
+        self._device_id = self._mount_path.stat().st_dev
+        self._marker_present_at_init = (self._mount_path / MARKER_FILE_NAME).exists()
+
+    @override
+    def probe(self) -> MountProbeResult:
+        now = datetime.now(UTC)
+        try:
+            device_id = self._mount_path.stat().st_dev
+            if self._device_id is not None and device_id != self._device_id:
+                return MountProbeResult(
+                    status=MountStatus.DEVICE_CHANGED,
+                    checked_at=now,
+                    detail=f"the device id changed from {self._device_id} to {device_id}",
+                    device_id=device_id,
+                )
+            os.statvfs(self._mount_path)
+            status, detail = self._check_marker()
+        except OSError as e:
+            return MountProbeResult(status=MountStatus.ERROR, checked_at=now, detail=str(e))
+        if self._device_id is None:
+            self._device_id = device_id
+        return MountProbeResult(status=status, checked_at=now, detail=detail, device_id=device_id)
+
+    def _check_marker(self) -> tuple[MountStatus, str | None]:
+        try:
+            declared = (self._mount_path / MARKER_FILE_NAME).read_text().strip()
+        except FileNotFoundError:
+            if self._marker_present_at_init:
+                return MountStatus.MARKER_MISSING, "the volume marker disappeared after startup"
+            return MountStatus.ALIVE, "the volume marker is absent; identity is unverified"
+        if declared != self._volume_name:
+            return MountStatus.MARKER_MISMATCH, f"the volume marker declares {declared!r}"
+        return MountStatus.ALIVE, None
+
+
+class AliveMountProber(AbstractMountProber):
+    """Reports a mount that always answers, for volumes backed by no real mount."""
+
+    @override
+    def probe(self) -> MountProbeResult:
+        return MountProbeResult(status=MountStatus.ALIVE, checked_at=datetime.now(UTC))

--- a/src/ai/backend/storage/volumes/health/tasks.py
+++ b/src/ai/backend/storage/volumes/health/tasks.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import override
+
+from ai.backend.common.cron.base import PeriodicTask
+from ai.backend.common.data.storage.types import VolumeName
+from ai.backend.logging import BraceStyleAdapter
+
+from .abc import AbstractMountProber
+from .types import MountHealthRecord, MountProbeResult, MountStatus
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+@dataclass(frozen=True)
+class MountProbeTaskArgs:
+    """What one volume's mount probe loop needs to run and where it records."""
+
+    volume_name: VolumeName
+    prober: AbstractMountProber
+    record: MountHealthRecord
+    interval: float
+    timeout: float
+
+
+class MountProbeTask(PeriodicTask):
+    """
+    Runs one volume's mount prober in a thread of its own and records the result.
+
+    The pool is isolated per volume so that a probe left blocked in an uninterruptible
+    syscall on a dead mount cannot starve the file operations sharing the default one.
+    """
+
+    _args: MountProbeTaskArgs
+    _initial_delay: float
+    _executor: ThreadPoolExecutor
+    _inflight: Future[MountProbeResult] | None
+
+    def __init__(self, args: MountProbeTaskArgs) -> None:
+        self._args = args
+        self._initial_delay = random.uniform(0.0, args.interval)
+        self._executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=f"mount-probe-{args.volume_name}",
+        )
+        self._inflight = None
+
+    @property
+    @override
+    def name(self) -> str:
+        return "mount_probe"
+
+    @property
+    @override
+    def interval(self) -> float:
+        return self._args.interval
+
+    @property
+    @override
+    def initial_delay(self) -> float:
+        return self._initial_delay
+
+    @property
+    @override
+    def run_timeout(self) -> float | None:
+        return None
+
+    @override
+    async def run(self) -> None:
+        if self._inflight is not None and not self._inflight.done():
+            # Resubmitting would only queue behind the thread that is still blocked.
+            self._args.record.latest = MountProbeResult(
+                status=MountStatus.HUNG,
+                checked_at=datetime.now(UTC),
+                detail="the previous probe is still outstanding",
+            )
+            return
+
+        future = self._executor.submit(self._args.prober.probe)
+        self._inflight = future
+        timeout = self._args.timeout
+        try:
+            result = await asyncio.wait_for(asyncio.wrap_future(future), timeout=timeout)
+        except TimeoutError:
+            log.warning("Mount probe for {} timed out after {}s", self._args.volume_name, timeout)
+            result = MountProbeResult(
+                status=MountStatus.HUNG,
+                checked_at=datetime.now(UTC),
+                detail=f"the probe timed out after {timeout}s",
+            )
+        except Exception as e:
+            log.exception("Mount probe for {} failed", self._args.volume_name)
+            result = MountProbeResult(
+                status=MountStatus.ERROR, checked_at=datetime.now(UTC), detail=str(e)
+            )
+        self._args.record.latest = result
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False, cancel_futures=True)

--- a/src/ai/backend/storage/volumes/health/types.py
+++ b/src/ai/backend/storage/volumes/health/types.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Final
+
+MARKER_FILE_NAME: Final = ".backend.ai-volume"
+
+
+class MountStatus(enum.StrEnum):
+    """Outcome of a mount probe on a single volume."""
+
+    ALIVE = "alive"
+    DEVICE_CHANGED = "device-changed"
+    MARKER_MISSING = "marker-missing"
+    MARKER_MISMATCH = "marker-mismatch"
+    HUNG = "hung"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class MountProbeResult:
+    """The latest mount probe outcome for one volume."""
+
+    status: MountStatus
+    checked_at: datetime
+    detail: str | None = None
+    device_id: int | None = None
+
+
+@dataclass
+class MountHealthRecord:
+    """
+    Where one volume's mount probe loop records its latest result.
+
+    A None result means the probe has not run yet, which the manager tells apart from a
+    stale result by the check time each result carries.
+    """
+
+    latest: MountProbeResult | None = None

--- a/src/ai/backend/storage/volumes/netapp/__init__.py
+++ b/src/ai/backend/storage/volumes/netapp/__init__.py
@@ -9,8 +9,10 @@ import subprocess
 import time
 from collections.abc import AsyncIterator
 from contextlib import aclosing
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, override
+from uuid import UUID
 
 import aiofiles
 import aiofiles.os
@@ -57,6 +59,8 @@ from ai.backend.storage.volumes.abc import (
     AbstractFSOpModel,
     AbstractQuotaModel,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.types import BackendProbeResult, BackendStatus
 from ai.backend.storage.volumes.vfs import BaseFSOpModel, BaseQuotaModel, BaseVolume
 
 from .netappclient import JobResponseCode, NetAppClient, StorageID, VolumeID
@@ -435,6 +439,22 @@ class XCPFSOpModel(BaseFSOpModel):
         return BinarySize(usage.used_bytes)
 
 
+class NetAppBackendProber(AbstractBackendProber):
+    """Asks the ONTAP API for the volume, without the quota report `get_hwinfo()` gathers."""
+
+    _client: NetAppClient
+    _volume_id: UUID
+
+    def __init__(self, client: NetAppClient, volume_id: UUID) -> None:
+        self._client = client
+        self._volume_id = volume_id
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        await self._client.get_volume_by_id(self._volume_id, ["files"])
+        return BackendProbeResult(status=BackendStatus.HEALTHY, checked_at=datetime.now(UTC))
+
+
 class NetAppVolume(BaseVolume):
     name = "netapp"
     ontap_endpoint: str
@@ -442,7 +462,7 @@ class NetAppVolume(BaseVolume):
     netapp_password: str
     svm_name: str
     svm_id: StorageID
-    volume_name: str
+    netapp_volume_name: str
     volume_id: VolumeID
     nas_path: Path
 
@@ -488,8 +508,8 @@ class NetAppVolume(BaseVolume):
         )
         self.netapp_nfs_host = self.config["netapp_nfs_host"]
         self.netapp_xcp_cmd = self.config["netapp_xcp_cmd"]
-        self.volume_name = self.config["netapp_volume_name"]
-        volume_info = await self.netapp_client.get_volume_by_name(self.volume_name, ["svm"])
+        self.netapp_volume_name = self.config["netapp_volume_name"]
+        volume_info = await self.netapp_client.get_volume_by_name(self.netapp_volume_name, ["svm"])
         if "svm" not in volume_info:
             raise InvalidAPIParameters("Volume info does not contain svm data")
         self.volume_id = volume_info["uuid"]
@@ -520,11 +540,16 @@ class NetAppVolume(BaseVolume):
 
     @override
     async def shutdown(self) -> None:
+        await super().shutdown()
         await self.netapp_client.aclose()
 
     @override
     async def get_capabilities(self) -> frozenset[str]:
         return frozenset([CAP_VFOLDER, CAP_FAST_FS_SIZE, CAP_FAST_SIZE, CAP_QUOTA, CAP_METRIC])
+
+    @override
+    def create_backend_prober(self) -> NetAppBackendProber:
+        return NetAppBackendProber(self.netapp_client, self.volume_id)
 
     @override
     async def get_hwinfo(self) -> HardwareMetadata:

--- a/src/ai/backend/storage/volumes/noop/__init__.py
+++ b/src/ai/backend/storage/volumes/noop/__init__.py
@@ -3,10 +3,12 @@ from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, override
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.defs import DEFAULT_VFOLDER_PERMISSION_MODE, NOOP_STORAGE_BACKEND_TYPE
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.types import BinarySize, HardwareMetadata, QuotaScopeID
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.types import (
     CapacityUsage,
     DirEntry,
@@ -25,6 +27,8 @@ from ai.backend.storage.volumes.abc import (
     AbstractQuotaModel,
     AbstractVolume,
 )
+from ai.backend.storage.backend.health.probers import HealthyBackendProber
+from ai.backend.storage.volumes.health.probers import AliveMountProber
 
 
 async def _return_empty_dir_entry() -> AsyncIterator[DirEntry]:
@@ -131,8 +135,16 @@ class NoopFSOpModel(AbstractFSOpModel):
         return BinarySize(0)
 
 
-class NoopVolume(AbstractVolume):
+class NoopVolume(AbstractVolume[AliveMountProber, HealthyBackendProber]):
     name = NOOP_STORAGE_BACKEND_TYPE
+
+    @override
+    def create_mount_prober(self) -> AliveMountProber:
+        return AliveMountProber()
+
+    @override
+    def create_backend_prober(self) -> HealthyBackendProber:
+        return HealthyBackendProber()
 
     @override
     def info(self) -> VolumeInfo:
@@ -316,6 +328,7 @@ class NoopVolume(AbstractVolume):
 
 
 def init_noop_volume(
+    storage_proxy_config: StorageProxyConfig,
     etcd: AsyncEtcd,
     event_dispatcher: EventDispatcher,
     event_producer: EventProducer,
@@ -323,6 +336,8 @@ def init_noop_volume(
     return NoopVolume(
         {},
         Path(),
+        volume_name=VolumeName(NOOP_STORAGE_BACKEND_TYPE),
+        storage_proxy_config=storage_proxy_config,
         etcd=etcd,
         event_dispatcher=event_dispatcher,
         event_producer=event_producer,

--- a/src/ai/backend/storage/volumes/pool.py
+++ b/src/ai/backend/storage/volumes/pool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections.abc import AsyncIterator, Mapping
@@ -7,6 +8,7 @@ from contextlib import asynccontextmanager as actxmgr
 from pathlib import Path
 from typing import Self
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.types import VolumeID
@@ -79,29 +81,33 @@ class VolumePool:
             backends, local_config, etcd
         )
 
+        # Initialized concurrently: each volume's init probes its own mount under a
+        # timeout, so a sequential loop would sum those timeouts into the startup time.
+        raw_volume_ids = list(local_config.volume.keys())
+        initialized = await asyncio.gather(
+            *(
+                cls._init_volume(
+                    VolumeName(raw_volume_id),
+                    config,
+                    backends[config.backend],
+                    local_config,
+                    etcd,
+                    event_dispatcher,
+                    event_producer,
+                )
+                for raw_volume_id, config in local_config.volume.items()
+            )
+        )
+
         volumes: dict[VolumeID, AbstractVolume] = {}
         volumes_by_name: dict[str, AbstractVolume] = {}
-        for raw_volume_id, config in local_config.volume.items():
+        for raw_volume_id, volume in zip(raw_volume_ids, initialized, strict=False):
             try:
                 volume_id = VolumeID(uuid.UUID(raw_volume_id))
             except (ValueError, TypeError):
-                volumes_by_name[raw_volume_id] = await cls._init_volume(
-                    config,
-                    backends[config.backend],
-                    local_config,
-                    etcd,
-                    event_dispatcher,
-                    event_producer,
-                )
+                volumes_by_name[raw_volume_id] = volume
             else:
-                volumes[volume_id] = await cls._init_volume(
-                    config,
-                    backends[config.backend],
-                    local_config,
-                    etcd,
-                    event_dispatcher,
-                    event_producer,
-                )
+                volumes[volume_id] = volume
         return cls(
             volumes=volumes,
             volumes_by_name=volumes_by_name,
@@ -111,6 +117,7 @@ class VolumePool:
     @classmethod
     async def _init_volume(
         cls,
+        volume_name: VolumeName,
         volume_config: VolumeInfoConfig,
         volume_type: type[AbstractVolume],
         local_config: StorageProxyUnifiedConfig,
@@ -121,6 +128,8 @@ class VolumePool:
         volume_obj = volume_type(
             local_config=local_config.model_dump(by_alias=True),
             mount_path=Path(volume_config.path),
+            volume_name=volume_name,
+            storage_proxy_config=local_config.storage_proxy,
             etcd=etcd,
             event_dispatcher=event_dispatcher,
             event_producer=event_producer,
@@ -145,7 +154,7 @@ class VolumePool:
         return plugin_ctx
 
     async def shutdown(self) -> None:
-        for volume in self._volumes.values():
+        for volume in (*self._volumes.values(), *self._volumes_by_name.values()):
             await volume.shutdown()
         await self._storage_backend_plugin_ctx.cleanup()
 

--- a/src/ai/backend/storage/volumes/purestorage/__init__.py
+++ b/src/ai/backend/storage/volumes/purestorage/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import re
+from datetime import UTC, datetime
 from typing import Any, override
 
 from ai.backend.common.types import HardwareMetadata
@@ -21,6 +22,8 @@ from ai.backend.storage.volumes.abc import (
     CAP_VFOLDER,
     AbstractFSOpModel,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.types import BackendProbeResult, BackendStatus
 from ai.backend.storage.volumes.vfs import BaseVolume
 
 from .purity import PurityClient
@@ -31,6 +34,21 @@ FLASHBLADE_TOOLKIT_V2_VERSION_RE = re.compile(r"version p[a-zA-Z\d]+ \(RapidFile
 FLASHBLADE_TOOLKIT_V1_VERSION_RE = re.compile(r"p[a-zA-Z\d]+ \(RapidFile Toolkit\) (1\..+)")
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class PureStorageBackendProber(AbstractBackendProber):
+    """Asks the Purity API for its metadata, the cheapest call that proves reachability."""
+
+    _client: PurityClient
+
+    def __init__(self, client: PurityClient) -> None:
+        self._client = client
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        async with self._client as client:
+            await client.get_metadata()
+        return BackendProbeResult(status=BackendStatus.HEALTHY, checked_at=datetime.now(UTC))
 
 
 class FlashBladeVolume(BaseVolume):
@@ -105,6 +123,7 @@ class FlashBladeVolume(BaseVolume):
 
     @override
     async def shutdown(self) -> None:
+        await super().shutdown()
         await self.purity_client.aclose()
 
     @override
@@ -117,6 +136,10 @@ class FlashBladeVolume(BaseVolume):
                 CAP_FAST_SCAN,
             ],
         )
+
+    @override
+    def create_backend_prober(self) -> PureStorageBackendProber:
+        return PureStorageBackendProber(self.purity_client)
 
     @override
     async def get_hwinfo(self) -> HardwareMetadata:

--- a/src/ai/backend/storage/volumes/vast/__init__.py
+++ b/src/ai/backend/storage/volumes/vast/__init__.py
@@ -2,17 +2,20 @@ import asyncio
 import logging
 from collections.abc import Mapping
 from dataclasses import asdict
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final, Literal, cast, override
 
 import aiofiles
 import aiofiles.os
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.json import dump_json_str
 from ai.backend.common.types import HardwareMetadata, QuotaConfig, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.errors import (
     ExternalStorageServiceError,
     InvalidQuotaConfig,
@@ -27,6 +30,8 @@ from ai.backend.storage.volumes.abc import (
     CAP_QUOTA,
     CAP_VFOLDER,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.types import BackendProbeResult, BackendStatus
 from ai.backend.storage.volumes.vfs import BaseQuotaModel, BaseVolume
 from ai.backend.storage.watcher import WatcherClient
 
@@ -215,6 +220,41 @@ class VASTQuotaModel(BaseQuotaModel):
         await aiofiles.os.rmdir(qspath)
 
 
+class VASTBackendProber(AbstractBackendProber):
+    """Asks the cluster for its state, without the quota report `get_hwinfo()` gathers."""
+
+    _client: VASTAPIClient
+    _cluster_id: int
+
+    def __init__(self, client: VASTAPIClient, cluster_id: int) -> None:
+        self._client = client
+        self._cluster_id = cluster_id
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        now = datetime.now(UTC)
+        try:
+            cluster_info = await self._client.get_cluster_info(self._cluster_id)
+        except VASTUnknownError as e:
+            return BackendProbeResult(
+                status=BackendStatus.UNAVAILABLE, checked_at=now, status_info=str(e)
+            )
+        if cluster_info is None:
+            return BackendProbeResult(
+                status=BackendStatus.OFFLINE,
+                checked_at=now,
+                status_info=f"vast cluster not found. (id: {self._cluster_id})",
+            )
+        match cluster_info.state.lower():
+            case "online" | "healthy":
+                status = BackendStatus.HEALTHY
+            case "init":
+                status = BackendStatus.DEGRADED
+            case _:
+                status = BackendStatus.UNAVAILABLE
+        return BackendProbeResult(status=status, checked_at=now, status_info=cluster_info.state)
+
+
 class VASTVolume(BaseVolume):
     api_client: VASTAPIClient
 
@@ -225,6 +265,8 @@ class VASTVolume(BaseVolume):
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
@@ -234,6 +276,8 @@ class VASTVolume(BaseVolume):
         super().__init__(
             local_config,
             mount_path,
+            volume_name=volume_name,
+            storage_proxy_config=storage_proxy_config,
             etcd=etcd,
             options=options,
             event_dispatcher=event_dispatcher,
@@ -255,7 +299,7 @@ class VASTVolume(BaseVolume):
 
     @override
     async def shutdown(self) -> None:
-        pass
+        await super().shutdown()
 
     @override
     async def create_quota_model(self) -> VASTQuotaModel:
@@ -264,6 +308,10 @@ class VASTVolume(BaseVolume):
     @override
     async def get_capabilities(self) -> frozenset[str]:
         return frozenset([CAP_VFOLDER, CAP_METRIC, CAP_QUOTA, CAP_FAST_FS_SIZE, CAP_FAST_SIZE])
+
+    @override
+    def create_backend_prober(self) -> VASTBackendProber:
+        return VASTBackendProber(self.api_client, self.config["vast_cluster_id"])
 
     @override
     async def get_hwinfo(self) -> HardwareMetadata:

--- a/src/ai/backend/storage/volumes/vfs/__init__.py
+++ b/src/ai/backend/storage/volumes/vfs/__init__.py
@@ -53,6 +53,9 @@ from ai.backend.storage.volumes.abc import (
     AbstractQuotaModel,
     AbstractVolume,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.probers import MountDerivedBackendProber
+from ai.backend.storage.volumes.health.probers import PathMountProber
 from ai.backend.storage.watcher import DeletePathTask, WatcherClient
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
@@ -403,7 +406,7 @@ class BaseFSOpModel(AbstractFSOpModel):
         return BinarySize.finite_from_str(used_bytes)
 
 
-class BaseVolume(AbstractVolume):
+class BaseVolume(AbstractVolume[PathMountProber, AbstractBackendProber]):
     name = "vfs"
 
     @override
@@ -432,10 +435,20 @@ class BaseVolume(AbstractVolume):
         return frozenset([CAP_VFOLDER])
 
     @override
+    def create_mount_prober(self) -> PathMountProber:
+        return PathMountProber(self.volume_name, self.mount_path)
+
+    @override
+    def create_backend_prober(self) -> AbstractBackendProber:
+        # For a local filesystem the appliance is the mount itself.
+        return MountDerivedBackendProber(self._mount_health)
+
+    @override
     async def get_hwinfo(self) -> HardwareMetadata:
+        result = await self._backend_prober.probe()
         return {
-            "status": "healthy",
-            "status_info": None,
+            "status": result.status.to_hwinfo_status(),
+            "status_info": result.status_info,
             "metadata": {},
         }
 

--- a/src/ai/backend/storage/volumes/weka/__init__.py
+++ b/src/ai/backend/storage/volumes/weka/__init__.py
@@ -9,11 +9,13 @@ from typing import Any, override
 
 import aiofiles.os
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.json import dump_json_str
 from ai.backend.common.types import HardwareMetadata, QuotaConfig, QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.errors import VolumeNotInitializedError
 from ai.backend.storage.types import CapacityUsage, FSPerfMetric, QuotaUsage
 from ai.backend.storage.volumes.abc import (
@@ -23,6 +25,8 @@ from ai.backend.storage.volumes.abc import (
     CAP_VFOLDER,
     AbstractQuotaModel,
 )
+from ai.backend.storage.backend.health.abc import AbstractBackendProber
+from ai.backend.storage.backend.health.types import BackendProbeResult, BackendStatus
 from ai.backend.storage.volumes.vfs import BaseQuotaModel, BaseVolume
 from ai.backend.storage.watcher import WatcherClient
 
@@ -118,6 +122,26 @@ class WekaQuotaModel(BaseQuotaModel):
         await aiofiles.os.rmdir(qspath)
 
 
+class WekaBackendProber(AbstractBackendProber):
+    """Asks the cluster for its health, without the reports `get_hwinfo()` also gathers."""
+
+    _client: WekaAPIClient
+
+    def __init__(self, client: WekaAPIClient) -> None:
+        self._client = client
+
+    @override
+    async def probe(self) -> BackendProbeResult:
+        health_status = (await self._client.check_health()).lower()
+        if health_status == "ok":
+            return BackendProbeResult(status=BackendStatus.HEALTHY, checked_at=datetime.now(UTC))
+        return BackendProbeResult(
+            status=BackendStatus.DEGRADED,
+            checked_at=datetime.now(UTC),
+            status_info=health_status,
+        )
+
+
 class WekaVolume(BaseVolume):
     api_client: WekaAPIClient
 
@@ -130,6 +154,8 @@ class WekaVolume(BaseVolume):
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
@@ -139,6 +165,8 @@ class WekaVolume(BaseVolume):
         super().__init__(
             local_config,
             mount_path,
+            volume_name=volume_name,
+            storage_proxy_config=storage_proxy_config,
             etcd=etcd,
             options=options,
             event_dispatcher=event_dispatcher,
@@ -171,6 +199,10 @@ class WekaVolume(BaseVolume):
     @override
     async def get_capabilities(self) -> frozenset[str]:
         return frozenset([CAP_VFOLDER, CAP_QUOTA, CAP_METRIC, CAP_FAST_FS_SIZE])
+
+    @override
+    def create_backend_prober(self) -> WekaBackendProber:
+        return WekaBackendProber(self.api_client)
 
     @override
     async def get_hwinfo(self) -> HardwareMetadata:

--- a/src/ai/backend/storage/volumes/xfs/__init__.py
+++ b/src/ai/backend/storage/volumes/xfs/__init__.py
@@ -9,12 +9,14 @@ from typing import Any, override
 import aiofiles
 import aiofiles.os
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.exception import InvalidConfigError
 from ai.backend.common.lock import FileLock
 from ai.backend.common.types import QuotaScopeID
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.errors import (
     InvalidQuotaFormatError,
     InvalidQuotaScopeError,
@@ -302,6 +304,8 @@ class XfsVolume(BaseVolume):
         local_config: Mapping[str, Any],
         mount_path: Path,
         *,
+        volume_name: VolumeName,
+        storage_proxy_config: StorageProxyConfig,
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
@@ -311,6 +315,8 @@ class XfsVolume(BaseVolume):
         super().__init__(
             local_config,
             mount_path,
+            volume_name=volume_name,
+            storage_proxy_config=storage_proxy_config,
             etcd=etcd,
             event_dispatcher=event_dispatcher,
             event_producer=event_producer,

--- a/tests/unit/storage-proxy/conftest.py
+++ b/tests/unit/storage-proxy/conftest.py
@@ -10,12 +10,14 @@ import aioboto3
 import pytest
 from botocore.exceptions import ClientError
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.exception import ConfigurationError
 from ai.backend.common.types import HostPortPair, QuotaScopeID, QuotaScopeType
 from ai.backend.logging import LogLevel
 from ai.backend.storage.client.s3 import S3Client
 from ai.backend.storage.config.loaders import load_local_config
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.types import VFolderID
 from ai.backend.storage.volumes.abc import AbstractVolume
 from ai.backend.storage.volumes.cephfs import CephFSVolume
@@ -113,6 +115,11 @@ async def volume(
             raise RuntimeError(f"Unknown volume backend: {request.param}")
     mock_event_dispatcher = MagicMock()
     mock_event_producer = MagicMock()
+    storage_proxy_config = StorageProxyConfig.model_validate({
+        "node-id": "test-storage-proxy",
+        "secret": "test-secret",
+        "session-expire": "1h",
+    })
     volume = volume_cls(
         {
             "storage-proxy": {
@@ -120,6 +127,8 @@ async def volume(
             },
         },
         volume_path,
+        volume_name=VolumeName(request.param),
+        storage_proxy_config=storage_proxy_config,
         etcd=mock_etcd,
         options=backend_options,
         event_dispatcher=mock_event_dispatcher,

--- a/tests/unit/storage-proxy/volumes/test_vfs.py
+++ b/tests/unit/storage-proxy/volumes/test_vfs.py
@@ -9,7 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ai.backend.common.data.storage.types import VolumeName
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType
+from ai.backend.storage.config.unified import StorageProxyConfig
 from ai.backend.storage.errors import QuotaScopeCreationFailedError
 from ai.backend.storage.types import VFolderID
 from ai.backend.storage.volumes.vfs import BaseVolume
@@ -34,6 +36,11 @@ class TestBaseVolume:
     ) -> AsyncIterator[BaseVolume]:
         mock_event_dispatcher = MagicMock()
         mock_event_producer = MagicMock()
+        storage_proxy_config = StorageProxyConfig.model_validate({
+            "node-id": "test-storage-proxy",
+            "secret": "test-secret",
+            "session-expire": "1h",
+        })
         volume = BaseVolume(
             {
                 "storage-proxy": {
@@ -41,6 +48,8 @@ class TestBaseVolume:
                 },
             },
             temp_volume_path,
+            volume_name=VolumeName("test-volume"),
+            storage_proxy_config=storage_proxy_config,
             etcd=mock_etcd,
             options={},
             event_dispatcher=mock_event_dispatcher,


### PR DESCRIPTION
## Summary

- Each volume owns two probe loops on the local cron and records their latest results in a `VolumeHealthRecord`, which the heartbeat will read (BA-7630). Probe cadence and heartbeat cadence stay independent, so a slow or hung probe never delays a heartbeat.
- **Mount probe** — device id against the value captured at initialization, `statvfs` in a thread of its own under a timeout, and a marker file holding the volume name. One loop and one worker thread per volume, so a dead network mount cannot starve the others; a probe that timed out is not resubmitted while its thread is still blocked in the system call, because cancelling the await does not release it.
- **Backend probe** — a new `probe_backend()` implemented per backend with the cheapest call that proves reachability, on a cadence of its own because an appliance can answer its management API while a mount has silently dropped. `BaseVolume.get_hwinfo()` is no longer hardcoded to `healthy`; it reports what the probe found.
- **`backend.ai storage volume mark`** writes the volume marker. The proxy never writes it, and neither the CLI nor the proxy overwrites an existing one, so a wrong remount cannot be stamped as correct. An absent marker means identity is unverified, not broken, so installations upgrading into this feature do not all report unhealthy.

Design: [BEP-1078](https://github.com/lablup/backend.ai/blob/bep/1078-storage-proxy-enhancement/proposals/BEP-1078-storage-proxy-enhancement.md), phase 1. No heartbeat payload and no manager-side records here — those are BA-7630 and BA-7653.

## Test plan

- [ ] Unit tests for the probe matrix (alive / device-changed / marker-missing / marker-mismatch / hung / error), the in-flight guard, and `get_hwinfo()` derivation — scenarios to be agreed first
- [ ] Verify on a live storage proxy that volumes report `alive` and that a manually unmounted volume reports `device-changed`
- [ ] Verify `backend.ai storage volume mark` refuses an unusable mount and an existing marker

Resolves BA-7654