### PR TITLE
refactor(BA-7673): gate the resource, domain and agent reads on their entities

### DIFF
--- a/changes/14299.breaking.md
+++ b/changes/14299.breaking.md
@@ -1,0 +1,1 @@
+Require permission on the named entity to read a resource group's scheduling fit, a domain, or the cluster's total agent capacity, so these reads answer a superadmin only until role templates grant them.

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -377,9 +377,8 @@ class SessionAdapter(BaseAdapter):
         """Probe whether each kernel of a would-be session fits the target
         resource group's nodes, without provisioning.
 
-        A self-service query: the requesting user is resolved from the request
-        context and passed as ``user_uuid``. The service resolves that user's
-        default access key from it, so the adapter supplies no access key.
+        The read is answered for the named resource group, so the action carries
+        that group as its entity and the gate checks read on it.
         """
         cluster_mode = (
             ClusterMode.MULTI_NODE

--- a/src/ai/backend/manager/api/gql/agent/resolver.py
+++ b/src/ai/backend/manager/api/gql/agent/resolver.py
@@ -32,6 +32,7 @@ from ai.backend.manager.api.gql.utils import check_admin_only
     BackendAIGQLMeta(added_version="25.15.0", description="Get aggregate agent resource statistics")
 )  # type: ignore[misc]
 async def agent_stats(info: Info[StrawberryGQLContext]) -> AgentStatsGQL | None:
+    check_admin_only()
     total = await info.context.adapters.agent.get_total_resources()
     resource = AgentResourceGQL(
         free=cast(JSON, total.total_free_slots.to_json()),

--- a/src/ai/backend/manager/services/agent/actions/get_total_resources.py
+++ b/src/ai/backend/manager/services/agent/actions/get_total_resources.py
@@ -10,6 +10,13 @@ from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
 @dataclass(frozen=True)
 class GetTotalResourcesAction(BaseGlobalAction):
+    """Read the cluster-wide free, used and total agent capacity.
+
+    Operator state: it sums every agent regardless of which resource groups the
+    caller reaches, so SUPERADMIN is the gate. A caller's own occupancy is
+    answered by the scoped resource overviews instead.
+    """
+
     @override
     @classmethod
     def entity_type(cls) -> EntityType:

--- a/src/ai/backend/manager/services/agent/actions/lookup.py
+++ b/src/ai/backend/manager/services/agent/actions/lookup.py
@@ -29,7 +29,12 @@ class AgentNameKey(LookupKey):
 
 @dataclass
 class LookupAgentAction(LookupEntityOpsAction[AgentRow, AgentUUID]):
-    """Resolve the operator-facing agent id into the agent it names."""
+    """Resolve the operator-facing agent id into the agent it names.
+
+    Every authenticated caller may resolve the key: the lookup carries no
+    permission onto the agent, and the read that follows it is checked against
+    the agent itself.
+    """
 
     agent_id: AgentId
 

--- a/src/ai/backend/manager/services/agent/actions/search_agents.py
+++ b/src/ai/backend/manager/services/agent/actions/search_agents.py
@@ -13,6 +13,16 @@ from ai.backend.manager.repositories.base import BatchQuerier
 
 @dataclass(frozen=True)
 class SearchAgentsAction(BaseGlobalAction):
+    """A page read across every agent.
+
+    The gate belongs on SUPERADMIN -- both surfaces already declare it -- but the
+    action stays public until the agent DataLoaders stop reaching for it. A
+    DataLoader must name its entities and be checked per entity
+    (``partial_bulk_get_ops``); reading them through this search is what forces
+    the gate open. Moving the loaders needs a bulk key lookup that does not exist
+    yet, so it is a change of its own.
+    """
+
     querier: BatchQuerier
 
     @override

--- a/src/ai/backend/manager/services/agent/processors.py
+++ b/src/ai/backend/manager/services/agent/processors.py
@@ -69,7 +69,7 @@ class AgentProcessors:
     update_resource_group: GlobalActionProcessor[
         UpdateAgentResourceGroupAction, UpdateAgentResourceGroupActionResult
     ]
-    get_total_resources: PublicActionProcessor[
+    get_total_resources: GlobalActionProcessor[
         GetTotalResourcesAction, GetTotalResourcesActionResult
     ]
     search_agents: PublicActionProcessor[SearchAgentsAction, SearchAgentsActionResult]
@@ -105,7 +105,7 @@ class AgentProcessors:
         self.update_resource_group = group.global_scope(
             UpdateAgentResourceGroupAction, service.update_resource_group
         )
-        self.get_total_resources = group.public(
+        self.get_total_resources = group.global_scope(
             GetTotalResourcesAction, service.get_total_resources
         )
         self.search_agents = group.public(SearchAgentsAction, service.search_agents)

--- a/src/ai/backend/manager/services/agent/service.py
+++ b/src/ai/backend/manager/services/agent/service.py
@@ -254,7 +254,7 @@ class AgentService:
         return GetTotalResourcesActionResult(total_resources=total_resources)
 
     async def search_agents(self, action: SearchAgentsAction) -> SearchAgentsActionResult:
-        """Searches agents. It is used by superadmin only."""
+        """Searches agents."""
         result = await self._agent_repository.search_agents(
             querier=action.querier,
         )

--- a/src/ai/backend/manager/services/domain/actions/get.py
+++ b/src/ai/backend/manager/services/domain/actions/get.py
@@ -13,7 +13,12 @@ from ai.backend.manager.models.domain.row import DomainRow
 
 @dataclass(frozen=True)
 class GetDomainAction(GetSingleEntityOpsAction[DomainRow, DomainData]):
-    """Read one domain by its id."""
+    """Read one domain by its id.
+
+    Read on the domain is the gate, the same as the project read: a domain is an
+    RBAC entity, and the row carries resource limits, allowed vfolder hosts,
+    allowed registries and dotfiles, none of which every caller may see.
+    """
 
     domain_id: DomainID
 

--- a/src/ai/backend/manager/services/domain/processors.py
+++ b/src/ai/backend/manager/services/domain/processors.py
@@ -13,7 +13,6 @@ from ai.backend.manager.actions.v2.ops.result import (
     LookupOpsResult,
 )
 from ai.backend.manager.actions.v2.single_entity.processor import (
-    PublicSingleEntityActionProcessor,
     SingleEntityActionProcessor,
 )
 from ai.backend.manager.data.domain.types import DomainData
@@ -53,7 +52,7 @@ from ai.backend.manager.services.domain.service import DomainService
 
 
 class DomainProcessors:
-    get: PublicSingleEntityActionProcessor[GetDomainAction, EntityOpsResult[DomainData]]
+    get: SingleEntityActionProcessor[GetDomainAction, EntityOpsResult[DomainData]]
     lookup: LookupActionProcessor[LookupDomainAction, LookupOpsResult[DomainID]]
     global_search: GlobalActionProcessor[GlobalSearchDomainsAction, BatchOpsResult[DomainData]]
     public_search_rg_domains: PublicActionProcessor[
@@ -84,7 +83,7 @@ class DomainProcessors:
         service: DomainService,
         action_monitors: list[ActionMonitor],
     ) -> None:
-        self.get = group.public_get_ops(GetDomainAction)
+        self.get = group.single_get_ops(GetDomainAction)
         self.lookup = group.public_lookup_ops(LookupDomainAction)
         self.global_search = group.global_search_ops(GlobalSearchDomainsAction)
         self.public_search_rg_domains = group.public_search_ops(SearchRGDomainsAction)

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -609,6 +609,7 @@ def create_processors(
         ),
         session=SessionProcessors(
             session_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
             ResourceAllocationProcessors(
                 resource_group_groups.group(GroupMeta(USER_ENTITY_TYPE)),
                 resource_group_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),

--- a/src/ai/backend/manager/services/session/actions/compute_schedule.py
+++ b/src/ai/backend/manager/services/session/actions/compute_schedule.py
@@ -4,19 +4,26 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.types import AgentId, ClusterMode
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
 from ai.backend.manager.data.session.compute_schedule import (
     ComputeScheduleResult,
 )
 from ai.backend.manager.data.session.draft import KernelResourceInput
 from ai.backend.manager.data.session.options import AgentSelectionPolicy
-from ai.backend.manager.services.session.base import SessionGlobalAction
 
 
 @dataclass(frozen=True)
-class ComputeScheduleAction(SessionGlobalAction):
+class ComputeScheduleAction(BaseSingleEntityAction):
     """Compute a session's scheduling against a resource group without provisioning.
+
+    The answer describes the named group's nodes -- which kernels fit and how much
+    to subtract for the ones that do not -- so the read is answered for that group,
+    not for the session that does not exist yet. Read on the resource group is the
+    gate; ``DOMAIN/PROJECT/USER -> RESOURCE_GROUP`` is a scope-entity edge, so a
+    caller reaches the group through the scope it is bound to.
 
     The fields mirror the scheduler's selection criteria so the real selector can
     be driven directly: ``cluster_mode`` decides whether kernel slots are summed
@@ -31,6 +38,10 @@ class ComputeScheduleAction(SessionGlobalAction):
     resource_group_id: ResourceGroupID
     designated_agent_ids: list[AgentId] | None
     agent_selection_policy: AgentSelectionPolicy | None
+
+    @override
+    def entity_id(self) -> EntityIdentifier:
+        return self.resource_group_id
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/processors.py
+++ b/src/ai/backend/manager/services/session/processors.py
@@ -2,11 +2,11 @@ from ai.backend.common.data.entity.session import SessionID
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.field.bulk_processor import BulkFieldActionProcessor
-from ai.backend.manager.actions.v2.global_scope.processor import PublicActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import LookupOpsResult
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
+from ai.backend.manager.data.resource_group.types import ResourceGroupData
 from ai.backend.manager.data.resource_slot.types import ResourceAllocationAggregate
 from ai.backend.manager.data.session.types import SessionEntityData, SessionTerminationStatus
 from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
@@ -159,7 +159,9 @@ from ai.backend.manager.services.session.service import SessionService
 
 class SessionProcessors:
     commit_session: SingleEntityActionProcessor[CommitSessionAction, CommitSessionActionResult]
-    compute_schedule: PublicActionProcessor[ComputeScheduleAction, ComputeScheduleActionResult]
+    compute_schedule: SingleEntityActionProcessor[
+        ComputeScheduleAction, ComputeScheduleActionResult
+    ]
     complete: SingleEntityActionProcessor[CompleteAction, CompleteActionResult]
     convert_session_to_image: SingleEntityActionProcessor[
         ConvertSessionToImageAction, ConvertSessionToImageActionResult
@@ -232,6 +234,7 @@ class SessionProcessors:
     def __init__(
         self,
         group: ProcessorGroup[SessionEntityData],
+        resource_group: ProcessorGroup[ResourceGroupData],
         resource_allocation: ResourceAllocationProcessors,
         service: SessionService,
     ) -> None:
@@ -239,7 +242,9 @@ class SessionProcessors:
         # Actions without RBAC validation (internal/legacy)
         self.lookup = group.public_lookup_ops(LookupSessionAction)
         self.commit_session = group.single_entity(CommitSessionAction, service.commit_session)
-        self.compute_schedule = group.public(ComputeScheduleAction, service.compute_schedule)
+        self.compute_schedule = resource_group.single_entity(
+            ComputeScheduleAction, service.compute_schedule
+        )
         self.complete = group.single_entity(CompleteAction, service.complete)
         self.convert_session_to_image = group.single_entity(
             ConvertSessionToImageAction, service.convert_session_to_image

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -130,6 +130,7 @@ async def session_processors(
     groups = processor_registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
     return SessionProcessors(
         processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
         ResourceAllocationProcessors(
             groups.group(GroupMeta(USER_ENTITY_TYPE)),
             groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -167,6 +167,7 @@ async def session_processors(
     service = SessionService(args)
     return SessionProcessors(
         processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
         ResourceAllocationProcessors(
             processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
             processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)),
@@ -714,6 +715,7 @@ async def compute_session_processors(
     service = SessionService(args)
     return SessionProcessors(
         processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
         ResourceAllocationProcessors(
             processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
             processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)),

--- a/tests/component/session_v2/test_session_compute_schedule.py
+++ b/tests/component/session_v2/test_session_compute_schedule.py
@@ -173,21 +173,6 @@ class TestComputeSchedule:
         payload = await admin_v2_registry.session.compute_schedule(body)
         assert [result.success for result in payload.results] == [True, False]
 
-    async def test_regular_user_can_compute_schedule(
-        self,
-        user_v2_registry: V2ClientRegistry,
-        resource_group_id: ResourceGroupID,
-        compute_image_fixture: ImageID,
-        agent_factory: AgentFactoryFunc,
-    ) -> None:
-        await agent_factory({"cpu": "8", "mem": "34359738368"})
-        payload = await user_v2_registry.session.compute_schedule(
-            _single_kernel_input(
-                resource_group_id, compute_image_fixture, cpu="1", mem="1073741824"
-            )
-        )
-        assert payload.results[0].success is True
-
     async def test_unknown_resource_group_returns_not_found(
         self,
         admin_v2_registry: V2ClientRegistry,

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -87,6 +87,7 @@ from ai.backend.manager.actions.registry.types import (
     GroupMeta,
     ProcessorDependencies,
 )
+from ai.backend.manager.actions.types import ActionGate, ActionKind
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
 from ai.backend.manager.actions.v2.field.base import (
     BaseRuntimeSingleFieldAction,
@@ -104,6 +105,11 @@ from ai.backend.manager.data.artifact.types import ArtifactRevisionData
 from ai.backend.manager.data.audit_log.types import AuditLogData
 from ai.backend.manager.data.entity_label.types import EntityLabelData
 from ai.backend.manager.repositories.ops.repository import OpsRepository
+from ai.backend.manager.services.agent.actions.get_total_resources import (
+    GetTotalResourcesAction,
+)
+from ai.backend.manager.services.agent.actions.lookup import LookupAgentAction
+from ai.backend.manager.services.agent.actions.search_agents import SearchAgentsAction
 from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.app_config.processors import AppConfigProcessors
 from ai.backend.manager.services.artifact.processors import ArtifactProcessors
@@ -120,6 +126,7 @@ from ai.backend.manager.services.deployment.processors import DeploymentProcesso
 from ai.backend.manager.services.deployment_revision_preset.processors import (
     DeploymentPresetProcessors,
 )
+from ai.backend.manager.services.domain.actions.get import GetDomainAction
 from ai.backend.manager.services.domain.processors import DomainProcessors
 from ai.backend.manager.services.entity_label.actions.lookup_owner import (
     LookupBulkEntityLabelOwnerAction,
@@ -172,6 +179,9 @@ from ai.backend.manager.services.scheduling_history.processors import (
     SchedulingHistoryProcessors,
 )
 from ai.backend.manager.services.service_catalog.processors import ServiceCatalogProcessors
+from ai.backend.manager.services.session.actions.compute_schedule import (
+    ComputeScheduleAction,
+)
 from ai.backend.manager.services.session.processors import SessionProcessors
 from ai.backend.manager.services.session.resource_allocation.processors import (
     ResourceAllocationProcessors,
@@ -361,6 +371,7 @@ def test_every_defined_v2_action_is_wired() -> None:
     )
     SessionProcessors(
         registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        resource_allocation_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
         ResourceAllocationProcessors(
             resource_allocation_groups.group(GroupMeta(USER_ENTITY_TYPE)),
             resource_allocation_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
@@ -415,3 +426,53 @@ def test_action_name_is_unique_across_v2_actions() -> None:
             f"{cls.__module__}.{cls.__qualname__} and {holder.__module__}.{holder.__qualname__} "
             f"both record as {name!r}; declare a distinct action_name() on one of them."
         )
+
+
+def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
+    """Pins the five reads BA-7673 ruled on, so a rewiring has to restate the ruling.
+
+    The gate is decided by the factory a processor is wired through, not by the action
+    class, so the catalog record is what the assertion reads.
+    """
+    registry = _ops_registry()
+    resource_group_groups = registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
+    AgentProcessors(resource_group_groups.group(GroupMeta(AGENT_ENTITY_TYPE)), MagicMock(), [])
+    DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    SessionProcessors(
+        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+        ResourceAllocationProcessors(
+            resource_group_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            MagicMock(),
+        ),
+        MagicMock(),
+    )
+
+    judged = {
+        ComputeScheduleAction: (
+            RESOURCE_GROUP_ENTITY_TYPE,
+            ActionKind.SINGLE_ENTITY,
+            ActionGate.PERMISSION,
+        ),
+        GetDomainAction: (
+            DOMAIN_ENTITY_TYPE,
+            ActionKind.SINGLE_ENTITY,
+            ActionGate.PERMISSION,
+        ),
+        GetTotalResourcesAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
+        # Public until the agent DataLoaders stop reading agents through this search.
+        SearchAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PUBLIC),
+        # The lookup carries no permission; the read that follows it is checked.
+        LookupAgentAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),
+    }
+    recorded = {
+        record.action_cls: (record.entity_type, record.kind, record.gate)
+        for record in registry.wired_processors()
+        if record.action_cls in judged
+    }
+    assert recorded == judged


### PR DESCRIPTION
## Summary

- `ComputeScheduleAction` answers for the resource group it names, so it wires through that group's `single_entity` factory instead of the session group's public one. `GetDomainAction` moves to `single_get_ops`, matching the project read. `GetTotalResourcesAction` moves to `global_scope`, and the `agentStats` resolver states the same superadmin contract its REST counterpart already did.
- **This narrows access.** No role template grants read on a resource group, an agent or a domain, so `computeSchedule`, `domainV2`, `GET /domain-config/dotfiles` and `agentStats` now answer a superadmin only. Widening the templates is deliberately left out of this change and is not scheduled yet — please review with that in mind.
- `SearchAgentsAction` stays public on purpose: the agent DataLoaders read agents through it, and moving them to a bulk get needs an entity key lookup that does not exist yet (BA-7714, BA-7715). The verdict on all five reads is recorded on the actions and pinned by a new table in `test_registry_catalog.py`, so a rewiring has to restate the ruling.

## Test plan

- [x] `pants fmt` / `fix` / `lint`
- [x] `pants check --changed-dependents=transitive`
- [x] `pants test --changed-dependents=direct` — 14 targets
- [ ] Verify a superadmin still reaches `computeSchedule`, `domainV2` and `agentStats` on a live server

Resolves BA-7673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQ86b4QXHbiTcA8Gd3P12D
