### PR TITLE
fix: align the entity_shares migration with the model

### DIFF
--- a/src/ai/backend/manager/models/alembic/versions/b6f2c1e94a30_rename_entity_invitations_to_shares.py
+++ b/src/ai/backend/manager/models/alembic/versions/b6f2c1e94a30_rename_entity_invitations_to_shares.py
@@ -64,6 +64,9 @@ def upgrade() -> None:
     op.drop_index(_OLD_TARGET_INDEX, table_name="entity_invitations")
     op.drop_index(_OLD_PENDING_INDEX, table_name="entity_invitations")
     op.rename_table("entity_invitations", "entity_shares")
+    op.execute(
+        "ALTER TABLE entity_shares RENAME CONSTRAINT pk_entity_invitations TO pk_entity_shares"
+    )
     op.alter_column("entity_shares", "inviter_user_id", new_column_name="sharer_user_id")
     op.drop_constraint(
         op.f("fk_entity_invitations_inviter_user_id_users"), "entity_shares", type_="foreignkey"
@@ -151,8 +154,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute(sa.text("DELETE FROM entity_shares WHERE recipient_email IS NULL"))
-    op.drop_constraint(op.f("fk_entity_shares_recipient"), "entity_shares", type_="foreignkey")
-    op.drop_constraint(op.f("fk_entity_shares_target"), "entity_shares", type_="foreignkey")
+    op.drop_constraint("recipient", "entity_shares", type_="foreignkey")
+    op.drop_constraint("target", "entity_shares", type_="foreignkey")
     op.drop_index(_RECIPIENT_INDEX, table_name="entity_shares")
     op.drop_index(_EMAIL_INDEX, table_name="entity_shares")
     op.drop_index(_TARGET_INDEX, table_name="entity_shares")
@@ -168,18 +171,21 @@ def downgrade() -> None:
     op.alter_column(
         "entity_shares", "recipient_email", new_column_name="invitee_email", nullable=False
     )
-    op.drop_constraint(op.f("fk_entity_shares_sharer_user_id"), "entity_shares", type_="foreignkey")
+    op.drop_constraint("sharer_user_id", "entity_shares", type_="foreignkey")
     op.execute(sa.text("DELETE FROM entity_shares WHERE sharer_user_id IS NULL"))
     op.alter_column("entity_shares", "sharer_user_id", nullable=False)
     op.alter_column("entity_shares", "sharer_user_id", new_column_name="inviter_user_id")
     op.create_foreign_key(
-        "inviter_user_id",
+        op.f("fk_entity_invitations_inviter_user_id_users"),
         "entity_shares",
         "users",
         ["inviter_user_id"],
         ["uuid"],
         onupdate="CASCADE",
         ondelete="CASCADE",
+    )
+    op.execute(
+        "ALTER TABLE entity_shares RENAME CONSTRAINT pk_entity_shares TO pk_entity_invitations"
     )
     op.rename_table("entity_shares", "entity_invitations")
     op.create_index(

--- a/src/ai/backend/manager/models/alembic/versions/b6f2c1e94a30_rename_entity_invitations_to_shares.py
+++ b/src/ai/backend/manager/models/alembic/versions/b6f2c1e94a30_rename_entity_invitations_to_shares.py
@@ -40,6 +40,7 @@ _EMAIL_INDEX: Final = "ix_entity_shares_recipient_email"
 _RECIPIENT_INDEX: Final = "ix_entity_shares_recipient"
 
 _ADDRESSED: Final = "addressed"
+_ACCEPTED_DOES_NOT_EXPIRE: Final = "accepted_does_not_expire"
 
 _BACKFILL_RECIPIENT: Final = sa.text("""
     UPDATE entity_shares s
@@ -113,21 +114,38 @@ def upgrade() -> None:
         "entity_shares",
         "recipient_entity_type IS NOT NULL OR recipient_email IS NOT NULL",
     )
+    op.create_check_constraint(
+        _ACCEPTED_DOES_NOT_EXPIRE,
+        "entity_shares",
+        "status <> 'accepted' OR expires_at IS NULL",
+    )
     op.create_index(
         _LIVE_EMAIL_INDEX,
         "entity_shares",
         ["recipient_email", "target_entity_type", "target_entity_id"],
         unique=True,
-        postgresql_where=sa.text("status = 'pending' AND recipient_email IS NOT NULL"),
+        postgresql_where=sa.text(
+            "status IN ('pending', 'accepted') AND recipient_email IS NOT NULL"
+        ),
     )
     op.create_index(
         _LIVE_RECIPIENT_INDEX,
         "entity_shares",
-        ["recipient_virtual_entity_id", "target_entity_type", "target_entity_id"],
+        [
+            "recipient_entity_type",
+            "recipient_entity_id",
+            "target_entity_type",
+            "target_entity_id",
+        ],
         unique=True,
-        postgresql_where=sa.text("status = 'pending' AND recipient_virtual_entity_id IS NOT NULL"),
+        postgresql_where=sa.text(
+            "status IN ('pending', 'accepted') AND recipient_entity_type IS NOT NULL"
+        ),
     )
     op.create_index(_TARGET_INDEX, "entity_shares", ["target_entity_type", "target_entity_id"])
+    op.create_index(
+        _RECIPIENT_INDEX, "entity_shares", ["recipient_entity_type", "recipient_entity_id"]
+    )
     op.create_index(_EMAIL_INDEX, "entity_shares", ["recipient_email"])
 
 
@@ -140,6 +158,9 @@ def downgrade() -> None:
     op.drop_index(_TARGET_INDEX, table_name="entity_shares")
     op.drop_index(_LIVE_RECIPIENT_INDEX, table_name="entity_shares")
     op.drop_index(_LIVE_EMAIL_INDEX, table_name="entity_shares")
+    op.drop_constraint(
+        op.f(f"ck_entity_shares_{_ACCEPTED_DOES_NOT_EXPIRE}"), "entity_shares", type_="check"
+    )
     op.drop_constraint(op.f(f"ck_entity_shares_{_ADDRESSED}"), "entity_shares", type_="check")
     op.drop_column("entity_shares", "expires_at")
     op.drop_column("entity_shares", "recipient_entity_id")


### PR DESCRIPTION
The rename migration (`b6f2c1e94a30`) was written against an earlier shape of the recipient and never caught up with the model, so `alembic upgrade head` stops on a column that is never created. Its downgrade names three foreign keys that never existed under those names.

### Upgrade

| | Migration | `EntityShareRow` |
|---|---|---|
| `uq_entity_shares_live_recipient` columns | `recipient_virtual_entity_id` (no such column) | `recipient_entity_type`, `recipient_entity_id` |
| Live index predicate | `status = 'pending'` | `status IN ('pending', 'accepted')` |
| `ix_entity_shares_recipient` | dropped on downgrade, never created | present |
| `accepted_does_not_expire` check | absent | present |
| Primary key | stays `pk_entity_invitations` through the rename | `pk_entity_shares` |

### Downgrade

`target`, `recipient` and `sharer_user_id` are created under those names, not `fk_entity_shares_*`, so every drop raised `UndefinedObjectError`. Restoring `inviter_user_id` also has to put back the convention name the original table carried.

### Verification

A 26.8 `mgr schema oneshot` database, seeded with a domain, resource policies, three users and their invitations, run through `alembic upgrade head` (64 revisions), then all the way back down to the 26.8 head:

- `compare_metadata` against the models reports **0 differences** across the whole schema.
- The accepted invitation is backfilled to its recipient's personal project; the pending one keeps an email and no recipient; both rows whose target has no `virtual_entities` row are dropped.
- The downgrade restores `entity_invitations` with its original constraint names, and the full `downgrade b93d1c47af52` lands back on 99 tables with the main-only ones gone.

Fixed in place rather than in a follow-up revision: `b6f2c1e94a30` is unreleased and currently cannot be applied at all, so stacking a revision on top would leave `upgrade head` broken.

No changelog fragment — nothing here ever shipped.

Backport: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA656UnMDVeLAFdmy1HsuL
