### PR TITLE
refactor(BA-7709): answer for a deployment's field rows through the deployment

### DIFF
--- a/changes/14314.enhance.md
+++ b/changes/14314.enhance.md
@@ -1,0 +1,1 @@
+Decide access to a deployment revision, replica or access token by the deployment that owns it, and remove those rows with it.

--- a/src/ai/backend/common/data/entity/deployment_token.py
+++ b/src/ai/backend/common/data/entity/deployment_token.py
@@ -4,7 +4,7 @@ from typing import override
 
 from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
 
-__all__ = ("DeploymentTokenID",)
+__all__ = ("DEPLOYMENT_TOKEN_FIELD_TYPE", "DeploymentTokenID")
 
 
 DEPLOYMENT_TOKEN_FIELD_TYPE = FieldType("deployment_token")

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -1326,12 +1326,12 @@ class DeploymentAdapter(BaseAdapter):
         input: AdminSearchRevisionsInput,
     ) -> AdminSearchRevisionsPayload:
         """Search model revisions without scope (admin, all deployments)."""
-        querier = self._build_revision_querier(input)
+        searcher = self._build_revision_searcher(input)
         action_result = await self._processors.deployment.global_search_revisions.run(
-            GlobalSearchRevisionsAction(querier=querier)
+            GlobalSearchRevisionsAction(searcher=searcher)
         )
         return AdminSearchRevisionsPayload(
-            items=[self._revision_data_to_dto(item) for item in action_result.data],
+            items=[self._revision_data_to_dto(item) for item in action_result.items],
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -1479,15 +1479,15 @@ class DeploymentAdapter(BaseAdapter):
         """
         if not revision_ids:
             return []
-        querier = BatchQuerier(
+        searcher = ModelRevisionSearcher(
             pagination=OffsetPagination(limit=len(revision_ids)),
             conditions=[RevisionConditions.by_ids(revision_ids)],
         )
         action_result = await self._processors.deployment.global_search_revisions.run(
-            GlobalSearchRevisionsAction(querier=querier)
+            GlobalSearchRevisionsAction(searcher=searcher)
         )
         revision_map: dict[uuid.UUID, RevisionNode] = {
-            data.id: self._revision_data_to_dto(data) for data in action_result.data
+            data.id: self._revision_data_to_dto(data) for data in action_result.items
         }
         return [revision_map.get(revision_id) for revision_id in revision_ids]
 
@@ -1543,14 +1543,14 @@ class DeploymentAdapter(BaseAdapter):
         """
         if not token_ids:
             return []
-        querier = BatchQuerier(
+        searcher = DeploymentAccessTokenSearcher(
             pagination=OffsetPagination(limit=len(token_ids)),
             conditions=[AccessTokenConditions.by_ids(token_ids)],
         )
         action_result = await self._processors.deployment.global_search_access_tokens.run(
-            GlobalSearchAccessTokensAction(querier=querier)
+            GlobalSearchAccessTokensAction(searcher=searcher)
         )
-        token_map = {data.id: self._access_token_data_to_dto(data) for data in action_result.data}
+        token_map = {data.id: self._access_token_data_to_dto(data) for data in action_result.items}
         return [token_map.get(token_id) for token_id in token_ids]
 
     async def batch_load_auto_scaling_rules_by_ids(
@@ -1842,26 +1842,6 @@ class DeploymentAdapter(BaseAdapter):
                 if sub_conditions:
                     conditions.append(negate_conditions(sub_conditions))
         return conditions
-
-    def _build_revision_querier(self, input: AdminSearchRevisionsInput) -> BatchQuerier:
-        conditions: list[QueryCondition] = []
-        if input.filter:
-            f = input.filter
-            if f.deployment_id is not None:
-                conditions.append(RevisionConditions.by_deployment_id(f.deployment_id))
-            conditions.extend(self._convert_revision_filter(f))
-        orders: list[QueryOrder] = self._convert_revision_orders(input.order) if input.order else []
-        return self._build_querier(
-            conditions=conditions,
-            orders=orders,
-            pagination_spec=_get_revision_pagination_spec(),
-            first=input.first,
-            after=input.after,
-            last=input.last,
-            before=input.before,
-            limit=input.limit,
-            offset=input.offset,
-        )
 
     def _build_revision_searcher(self, input: AdminSearchRevisionsInput) -> ModelRevisionSearcher:
         """The filters and page of a revision search whose deployment the action scopes."""

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -25,7 +25,9 @@ from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.common.data.entity.runtime_variant_preset import RuntimeVariantPresetID
 from ai.backend.common.data.model_deployment.types import (
     DeploymentStrategy,
@@ -213,6 +215,7 @@ from ai.backend.manager.models.deployment_policy.upserters import DeploymentPoli
 from ai.backend.manager.models.deployment_revision import DeploymentRevisionRow
 from ai.backend.manager.models.deployment_revision.conditions import RevisionConditions
 from ai.backend.manager.models.deployment_revision.orders import RevisionOrders
+from ai.backend.manager.models.deployment_revision.searchers import ModelRevisionSearcher
 from ai.backend.manager.models.endpoint import (
     EndpointAutoScalingRuleRow,
     EndpointRow,
@@ -228,6 +231,7 @@ from ai.backend.manager.models.endpoint.orders import (
     AutoScalingRuleOrders,
     DeploymentOrders,
 )
+from ai.backend.manager.models.endpoint.searchers import DeploymentAccessTokenSearcher
 from ai.backend.manager.models.endpoint.updaters import DeploymentUpdater
 from ai.backend.manager.models.resource_slot.conditions import RevisionResourceSlotConditions
 from ai.backend.manager.models.resource_slot.orders import (
@@ -239,6 +243,7 @@ from ai.backend.manager.models.resource_slot.orders import (
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.routing.conditions import RouteConditions
 from ai.backend.manager.models.routing.orders import RouteOrders
+from ai.backend.manager.models.routing.searchers import ModelReplicaSearcher
 from ai.backend.manager.models.specs.pagination import NoPagination, OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.deployment.actions.access_token.bulk_delete_access_tokens import (
@@ -300,10 +305,7 @@ from ai.backend.manager.services.deployment.actions.global_search_replicas impor
     GlobalSearchReplicasAction,
 )
 from ai.backend.manager.services.deployment.actions.lookup_owner import (
-    LookupAccessTokenDeploymentAction,
     LookupAutoScalingRuleDeploymentAction,
-    LookupRevisionDeploymentAction,
-    LookupRouteDeploymentAction,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
@@ -933,27 +935,9 @@ class DeploymentAdapter(BaseAdapter):
     # Access token operations
     # ------------------------------------------------------------------
 
-    async def _access_token_deployment(self, token_id: UUID) -> DeploymentID:
-        result = await self._processors.deployment.lookup_access_token_deployment.run(
-            LookupAccessTokenDeploymentAction(access_token_id=token_id)
-        )
-        return DeploymentID(result.entity_id())
-
     async def _auto_scaling_rule_deployment(self, rule_id: UUID) -> DeploymentID:
         result = await self._processors.deployment.lookup_auto_scaling_rule_deployment.run(
             LookupAutoScalingRuleDeploymentAction(rule_id=rule_id)
-        )
-        return DeploymentID(result.entity_id())
-
-    async def _route_deployment(self, route_id: UUID) -> DeploymentID:
-        result = await self._processors.deployment.lookup_route_deployment.run(
-            LookupRouteDeploymentAction(route_id=route_id)
-        )
-        return DeploymentID(result.entity_id())
-
-    async def _revision_deployment(self, revision_id: DeploymentRevisionID) -> DeploymentID:
-        result = await self._processors.deployment.lookup_revision_deployment.run(
-            LookupRevisionDeploymentAction(revision_id=revision_id)
         )
         return DeploymentID(result.entity_id())
 
@@ -981,10 +965,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> GetAccessTokenPayload:
         """Get a single access token by ID."""
         action_result = await self._processors.deployment.get_access_token.run(
-            GetAccessTokenAction(
-                deployment_id=await self._access_token_deployment(token_id),
-                access_token_id=token_id,
-            )
+            GetAccessTokenAction(access_token_id=DeploymentTokenID(token_id))
         )
         return GetAccessTokenPayload(
             access_token=self._access_token_data_to_dto(action_result.data)
@@ -996,10 +977,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> DeleteAccessTokenPayload:
         """Delete an access token."""
         action_result = await self._processors.deployment.delete_access_token.run(
-            DeleteAccessTokenAction(
-                deployment_id=await self._access_token_deployment(input.id),
-                access_token_id=input.id,
-            )
+            DeleteAccessTokenAction(access_token_id=DeploymentTokenID(input.id))
         )
         if not action_result.success:
             raise EndpointTokenNotFound(f"Access token {input.id} not found")
@@ -1021,14 +999,14 @@ class DeploymentAdapter(BaseAdapter):
         input: SearchAccessTokensInput,
     ) -> SearchAccessTokensPayload:
         """Search access tokens scoped to a specific deployment."""
-        querier = self._build_access_token_querier(input, scope=scope)
+        searcher = self._build_access_token_searcher(input)
         action_result = await self._processors.deployment.search_access_tokens.run(
             SearchAccessTokensAction(
-                deployment_id=DeploymentID(scope.deployment_id), querier=querier
+                deployment_id=DeploymentID(scope.deployment_id), searcher=searcher
             )
         )
         return SearchAccessTokensPayload(
-            items=[self._access_token_data_to_dto(item) for item in action_result.data],
+            items=[self._access_token_data_to_dto(item) for item in action_result.items],
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -1320,10 +1298,7 @@ class DeploymentAdapter(BaseAdapter):
     async def get_revision(self, revision_id: DeploymentRevisionID) -> RevisionNode:
         """Retrieve a single revision by ID."""
         action_result = await self._processors.deployment.get_revision_by_id.run(
-            GetRevisionByIdAction(
-                deployment_id=await self._revision_deployment(revision_id),
-                revision_id=revision_id,
-            )
+            GetRevisionByIdAction(revision_id=revision_id)
         )
         return self._revision_data_to_dto(action_result.data)
 
@@ -1333,12 +1308,14 @@ class DeploymentAdapter(BaseAdapter):
         input: AdminSearchRevisionsInput,
     ) -> AdminSearchRevisionsPayload:
         """Search model revisions scoped to a specific deployment."""
-        querier = self._build_revision_querier(input, scope=scope)
+        searcher = self._build_revision_searcher(input)
         action_result = await self._processors.deployment.search_revisions.run(
-            SearchRevisionsAction(deployment_id=DeploymentID(scope.deployment_id), querier=querier)
+            SearchRevisionsAction(
+                deployment_id=DeploymentID(scope.deployment_id), searcher=searcher
+            )
         )
         return AdminSearchRevisionsPayload(
-            items=[self._revision_data_to_dto(item) for item in action_result.data],
+            items=[self._revision_data_to_dto(item) for item in action_result.items],
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -1418,12 +1395,12 @@ class DeploymentAdapter(BaseAdapter):
         input: SearchReplicasInput,
     ) -> SearchReplicasPayload:
         """Search replicas scoped to a specific deployment."""
-        querier = self._build_replica_querier(input, scope=scope)
+        searcher = self._build_replica_searcher(input)
         action_result = await self._processors.deployment.search_replicas.run(
-            SearchReplicasAction(deployment_id=DeploymentID(scope.deployment_id), querier=querier)
+            SearchReplicasAction(deployment_id=DeploymentID(scope.deployment_id), searcher=searcher)
         )
         return SearchReplicasPayload(
-            items=[self._replica_data_to_dto(item) for item in action_result.data],
+            items=[self._replica_data_to_dto(item) for item in action_result.items],
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -1434,12 +1411,12 @@ class DeploymentAdapter(BaseAdapter):
         input: SearchReplicasInput,
     ) -> SearchReplicasPayload:
         """Search replicas without scope (admin, all deployments)."""
-        querier = self._build_replica_querier(input)
+        searcher = self._build_replica_searcher(input)
         action_result = await self._processors.deployment.global_search_replicas.run(
-            GlobalSearchReplicasAction(querier=querier)
+            GlobalSearchReplicasAction(searcher=searcher)
         )
         return SearchReplicasPayload(
-            items=[self._replica_data_to_dto(item) for item in action_result.data],
+            items=[self._replica_data_to_dto(item) for item in action_result.items],
             total_count=action_result.total_count,
             has_next_page=action_result.has_next_page,
             has_previous_page=action_result.has_previous_page,
@@ -1448,13 +1425,8 @@ class DeploymentAdapter(BaseAdapter):
     async def get_replica(self, replica_id: UUID) -> ReplicaNode | None:
         """Retrieve a single replica by ID."""
         action_result = await self._processors.deployment.get_replica_by_id.run(
-            GetReplicaByIdAction(
-                deployment_id=await self._route_deployment(replica_id),
-                replica_id=replica_id,
-            )
+            GetReplicaByIdAction(replica_id=ReplicaID(replica_id))
         )
-        if action_result.data is None:
-            return None
         return self._replica_data_to_dto(action_result.data)
 
     async def update_route_traffic(
@@ -1465,8 +1437,7 @@ class DeploymentAdapter(BaseAdapter):
         """Update the traffic status of a route."""
         action_result = await self._processors.deployment.update_route_traffic_status.run(
             UpdateRouteTrafficStatusAction(
-                deployment_id=await self._route_deployment(route_id),
-                route_id=route_id,
+                route_id=ReplicaID(route_id),
                 traffic_status=ManagerRouteTrafficStatus(traffic_status.value),
             )
         )
@@ -1530,14 +1501,14 @@ class DeploymentAdapter(BaseAdapter):
         """
         if not replica_ids:
             return []
-        querier = BatchQuerier(
+        searcher = ModelReplicaSearcher(
             pagination=OffsetPagination(limit=len(replica_ids)),
             conditions=[RouteConditions.by_ids(replica_ids)],
         )
         action_result = await self._processors.deployment.global_search_replicas.run(
-            GlobalSearchReplicasAction(querier=querier)
+            GlobalSearchReplicasAction(searcher=searcher)
         )
-        replica_map = {data.id: self._replica_data_to_dto(data) for data in action_result.data}
+        replica_map = {data.id: self._replica_data_to_dto(data) for data in action_result.items}
         return [replica_map.get(replica_id) for replica_id in replica_ids]
 
     async def batch_load_routes_by_ids(
@@ -1872,21 +1843,34 @@ class DeploymentAdapter(BaseAdapter):
                     conditions.append(negate_conditions(sub_conditions))
         return conditions
 
-    def _build_revision_querier(
-        self,
-        input: AdminSearchRevisionsInput,
-        scope: RevisionOperationScope | None = None,
-    ) -> BatchQuerier:
+    def _build_revision_querier(self, input: AdminSearchRevisionsInput) -> BatchQuerier:
         conditions: list[QueryCondition] = []
-        if scope is not None:
-            conditions.append(RevisionConditions.by_deployment_id(scope.deployment_id))
         if input.filter:
             f = input.filter
-            if scope is None and f.deployment_id is not None:
+            if f.deployment_id is not None:
                 conditions.append(RevisionConditions.by_deployment_id(f.deployment_id))
             conditions.extend(self._convert_revision_filter(f))
         orders: list[QueryOrder] = self._convert_revision_orders(input.order) if input.order else []
         return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_get_revision_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _build_revision_searcher(self, input: AdminSearchRevisionsInput) -> ModelRevisionSearcher:
+        """The filters and page of a revision search whose deployment the action scopes."""
+        conditions: list[QueryCondition] = (
+            self._convert_revision_filter(input.filter) if input.filter else []
+        )
+        orders: list[QueryOrder] = self._convert_revision_orders(input.order) if input.order else []
+        return self._build_searcher(
+            ModelRevisionSearcher,
             conditions=conditions,
             orders=orders,
             pagination_spec=_get_revision_pagination_spec(),
@@ -2006,38 +1990,6 @@ class DeploymentAdapter(BaseAdapter):
                 if sub_conditions:
                     conditions.append(negate_conditions(sub_conditions))
         return conditions
-
-    def _build_access_token_querier(
-        self,
-        input: SearchAccessTokensInput,
-        scope: AccessTokenOperationScope | None = None,
-    ) -> BatchQuerier:
-        conditions: list[QueryCondition] = []
-        if scope is not None:
-            conditions.append(AccessTokenConditions.by_endpoint_id(scope.deployment_id))
-        elif input.filter and input.filter.deployment_id is not None:
-            conditions.append(AccessTokenConditions.by_endpoint_id(input.filter.deployment_id))
-        if input.filter:
-            conditions.extend(self._convert_access_token_filter(input.filter))
-        orders: list[QueryOrder] = (
-            [
-                AccessTokenOrders.created_at(ascending=o.direction == OrderDirection.ASC)
-                for o in input.order
-            ]
-            if input.order
-            else []
-        )
-        return self._build_querier(
-            conditions=conditions,
-            orders=orders,
-            pagination_spec=_get_access_token_pagination_spec(),
-            first=input.first,
-            after=input.after,
-            last=input.last,
-            before=input.before,
-            limit=input.limit,
-            offset=input.offset,
-        )
 
     def _convert_auto_scaling_rule_filter(self, f: AutoScalingRuleFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
@@ -2222,21 +2174,42 @@ class DeploymentAdapter(BaseAdapter):
                     conditions.append(negate_conditions(sub_conditions))
         return conditions
 
-    def _build_replica_querier(
-        self,
-        input: SearchReplicasInput,
-        scope: ReplicaOperationScope | None = None,
-    ) -> BatchQuerier:
-        conditions: list[QueryCondition] = []
-        if scope is not None:
-            conditions.append(RouteConditions.by_endpoint_id(scope.deployment_id))
-        if input.filter:
-            f = input.filter
-            if scope is None and f.deployment_id is not None:
-                conditions.append(RouteConditions.by_endpoint_id(f.deployment_id))
-            conditions.extend(self._convert_replica_filter(f))
+    def _build_access_token_searcher(
+        self, input: SearchAccessTokensInput
+    ) -> DeploymentAccessTokenSearcher:
+        """The filters and page of a token search whose deployment the action scopes."""
+        conditions: list[QueryCondition] = (
+            self._convert_access_token_filter(input.filter) if input.filter else []
+        )
+        orders: list[QueryOrder] = (
+            [
+                AccessTokenOrders.created_at(ascending=o.direction == OrderDirection.ASC)
+                for o in input.order
+            ]
+            if input.order
+            else []
+        )
+        return self._build_searcher(
+            DeploymentAccessTokenSearcher,
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_get_access_token_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
+
+    def _build_replica_searcher(self, input: SearchReplicasInput) -> ModelReplicaSearcher:
+        """The filters and page of a replica search whose deployment the action scopes."""
+        conditions: list[QueryCondition] = (
+            self._convert_replica_filter(input.filter) if input.filter else []
+        )
         orders: list[QueryOrder] = self._convert_replica_orders(input.order) if input.order else []
-        return self._build_querier(
+        return self._build_searcher(
+            ModelReplicaSearcher,
             conditions=conditions,
             orders=orders,
             pagination_spec=_get_replica_pagination_spec(),

--- a/src/ai/backend/manager/api/rest/deployment/adapter.py
+++ b/src/ai/backend/manager/api/rest/deployment/adapter.py
@@ -79,6 +79,7 @@ from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.deployment_policy.upserters import DeploymentPolicyUpserter
 from ai.backend.manager.models.deployment_revision.conditions import RevisionConditions
 from ai.backend.manager.models.deployment_revision.orders import RevisionOrders
+from ai.backend.manager.models.deployment_revision.searchers import ModelRevisionSearcher
 from ai.backend.manager.models.endpoint.conditions import DeploymentConditions
 from ai.backend.manager.models.endpoint.orders import DeploymentOrders
 from ai.backend.manager.models.routing.conditions import RouteConditions
@@ -283,21 +284,13 @@ class RevisionAdapter(BaseFilterAdapter):
             image_id=data.image_id,
         )
 
-    def build_querier(self, request: SearchRevisionsRequest) -> BatchQuerier:
-        """
-        Build a BatchQuerier for revisions from search request.
-
-        Args:
-            request: Search request containing filter, order, and pagination
-
-        Returns:
-            BatchQuerier object with converted conditions, orders, and pagination
-        """
+    def build_searcher(self, request: SearchRevisionsRequest) -> ModelRevisionSearcher:
+        """The filters and page of a revision search whose deployment the action scopes."""
         conditions = self._convert_filter(request.filter) if request.filter else []
         orders = [self._convert_order(request.order)] if request.order else []
         pagination = self._build_pagination(request.limit, request.offset)
 
-        return BatchQuerier(conditions=conditions, orders=orders, pagination=pagination)
+        return ModelRevisionSearcher(conditions=conditions, orders=orders, pagination=pagination)
 
     def _convert_filter(self, filter: RevisionFilter) -> list[QueryCondition]:
         """Convert revision filter to list of query conditions."""

--- a/src/ai/backend/manager/api/rest/deployment/handler.py
+++ b/src/ai/backend/manager/api/rest/deployment/handler.py
@@ -13,6 +13,7 @@ from ai.backend.common.api_handlers import APIResponse, BodyParam, PathParam
 from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
 from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.dto.manager.deployment import (
     ActivateRevisionResponse,
@@ -32,7 +33,6 @@ from ai.backend.common.dto.manager.deployment import (
     ListRevisionsResponse,
     ListRoutesResponse,
     PaginationInfo,
-    RevisionFilter,
     RevisionPathParam,
     RouteFilter,
     RoutePathParam,
@@ -323,24 +323,16 @@ class DeploymentAPIHandler:
         body: BodyParam[SearchRevisionsRequest],
     ) -> APIResponse:
         """Search revisions for a deployment with filters, orders, and pagination."""
-        # Build querier using adapter, adding deployment filter
-        if body.parsed.filter is None:
-            body.parsed.filter = RevisionFilter(deployment_id=path.parsed.deployment_id)
-        else:
-            body.parsed.filter.deployment_id = path.parsed.deployment_id
+        searcher = self._revision_adapter.build_searcher(body.parsed)
 
-        querier = self._revision_adapter.build_querier(body.parsed)
-
-        # Call service action
         action_result = await self._deployment.search_revisions.run(
             SearchRevisionsAction(
-                deployment_id=DeploymentID(path.parsed.deployment_id), querier=querier
+                deployment_id=DeploymentID(path.parsed.deployment_id), searcher=searcher
             )
         )
 
-        # Build response
         resp = ListRevisionsResponse(
-            revisions=[await self._revision_dto(rev) for rev in action_result.data],
+            revisions=[await self._revision_dto(rev) for rev in action_result.items],
             pagination=PaginationInfo(
                 total=action_result.total_count,
                 offset=body.parsed.offset,
@@ -354,15 +346,10 @@ class DeploymentAPIHandler:
         path: PathParam[RevisionPathParam],
     ) -> APIResponse:
         """Get a specific revision."""
-        # Call service action - raises DeploymentRevisionNotFound if not found
         action_result = await self._deployment.get_revision_by_id.run(
-            GetRevisionByIdAction(
-                deployment_id=DeploymentID(path.parsed.deployment_id),
-                revision_id=DeploymentRevisionID(path.parsed.revision_id),
-            )
+            GetRevisionByIdAction(revision_id=DeploymentRevisionID(path.parsed.revision_id))
         )
 
-        # Build response
         resp = GetRevisionResponse(revision=await self._revision_dto(action_result.data))
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=resp)
 
@@ -437,8 +424,7 @@ class DeploymentAPIHandler:
         # Call service action
         action_result = await self._deployment.update_route_traffic_status.run(
             UpdateRouteTrafficStatusAction(
-                deployment_id=DeploymentID(path.parsed.deployment_id),
-                route_id=path.parsed.route_id,
+                route_id=ReplicaID(path.parsed.route_id),
                 traffic_status=manager_traffic_status,
             )
         )

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -996,7 +996,7 @@ class ModelDeploymentAccessTokenData(FieldData):
 
 
 @dataclass
-class ModelReplicaData:
+class ModelReplicaData(FieldData):
     id: UUID
     deployment_id: UUID
     revision_id: UUID

--- a/src/ai/backend/manager/models/alembic/versions/c1a7f3e0d94b_own_deployment_field_rows_by_their_endpoint.py
+++ b/src/ai/backend/manager/models/alembic/versions/c1a7f3e0d94b_own_deployment_field_rows_by_their_endpoint.py
@@ -1,0 +1,72 @@
+"""own deployment field rows by their endpoint
+
+Revision ID: c1a7f3e0d94b
+Revises: b4c2e7f19a30
+Create Date: 2026-09-07 16:10:00.000000
+
+Access tokens and revisions are field rows of a deployment, so each must name exactly
+one that exists. ``endpoint_tokens.endpoint`` had lost its foreign key and accepted
+NULL, and ``deployment_revisions.endpoint`` carried no foreign key either; rows whose
+endpoint is gone are unreachable and are deleted before the constraints go on.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1a7f3e0d94b"
+down_revision = "b4c2e7f19a30"
+branch_labels = None
+depends_on = None
+
+_TOKEN_FK = "fk_endpoint_tokens_endpoint_endpoints"
+_REVISION_FK = "fk_deployment_revisions_endpoint_endpoints"
+
+
+def _foreign_keys(table: str) -> set[str]:
+    inspector = sa.inspect(op.get_bind())
+    return {fk["name"] for fk in inspector.get_foreign_keys(table) if fk["name"]}
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "DELETE FROM endpoint_tokens WHERE endpoint IS NULL"
+            " OR endpoint NOT IN (SELECT id FROM endpoints)"
+        )
+    )
+    op.alter_column(
+        "endpoint_tokens", "endpoint", existing_type=sa.dialects.postgresql.UUID(), nullable=False
+    )
+    if _TOKEN_FK not in _foreign_keys("endpoint_tokens"):
+        op.create_foreign_key(
+            _TOKEN_FK,
+            "endpoint_tokens",
+            "endpoints",
+            ["endpoint"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    op.execute(
+        sa.text("DELETE FROM deployment_revisions WHERE endpoint NOT IN (SELECT id FROM endpoints)")
+    )
+    if _REVISION_FK not in _foreign_keys("deployment_revisions"):
+        op.create_foreign_key(
+            _REVISION_FK,
+            "deployment_revisions",
+            "endpoints",
+            ["endpoint"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    if _REVISION_FK in _foreign_keys("deployment_revisions"):
+        op.drop_constraint(_REVISION_FK, "deployment_revisions", type_="foreignkey")
+    if _TOKEN_FK in _foreign_keys("endpoint_tokens"):
+        op.drop_constraint(_TOKEN_FK, "endpoint_tokens", type_="foreignkey")
+    op.alter_column(
+        "endpoint_tokens", "endpoint", existing_type=sa.dialects.postgresql.UUID(), nullable=True
+    )

--- a/src/ai/backend/manager/models/artifact_revision/scopes.py
+++ b/src/ai/backend/manager/models/artifact_revision/scopes.py
@@ -1,0 +1,35 @@
+"""Operation scopes for artifact revisions."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.artifact import ArtifactID
+from ai.backend.manager.models.artifact_revision.row import ArtifactRevisionRow
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
+
+
+@dataclass(frozen=True)
+class ArtifactRevisionOperationScope(OperationScope):
+    """The revisions one artifact holds."""
+
+    artifact_id: ArtifactID
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        artifact_id = self.artifact_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ArtifactRevisionRow.artifact_id == artifact_id
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()

--- a/src/ai/backend/manager/models/deployment_revision/lookups.py
+++ b/src/ai/backend/manager/models/deployment_revision/lookups.py
@@ -1,0 +1,32 @@
+"""Lookup specs for the deployment_revisions table."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.specs.lookup import FieldOwnerLookup
+
+
+@dataclass
+class DeploymentRevisionOwnerLookup(FieldOwnerLookup[DeploymentRevisionID, DeploymentID]):
+    """The deployment a revision was taken of."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[DeploymentRevisionID]
+    ) -> sa.sql.Select[tuple[DeploymentRevisionID, DeploymentID]]:
+        return sa.select(DeploymentRevisionRow.id, DeploymentRevisionRow.endpoint).where(
+            DeploymentRevisionRow.id.in_(field_ids)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> DeploymentID:
+        return DeploymentID(value)

--- a/src/ai/backend/manager/models/deployment_revision/queriers.py
+++ b/src/ai/backend/manager/models/deployment_revision/queriers.py
@@ -1,0 +1,34 @@
+"""FieldQuerier implementations for deployment revisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
+from ai.backend.manager.data.deployment.types import ModelRevisionData
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.specs.querier import FieldQuerier
+
+
+@dataclass
+class ModelRevisionQuerier(FieldQuerier[DeploymentRevisionRow, ModelRevisionData]):
+    revision_id: DeploymentRevisionID
+
+    @override
+    def row_class(self) -> type[DeploymentRevisionRow]:
+        return DeploymentRevisionRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return DeploymentRevisionRow.id
+
+    @override
+    def target_id_value(self) -> DeploymentRevisionID:
+        return self.revision_id
+
+    @override
+    def to_data(self, row: DeploymentRevisionRow) -> ModelRevisionData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/deployment_revision/row.py
+++ b/src/ai/backend/manager/models/deployment_revision/row.py
@@ -91,7 +91,12 @@ class DeploymentRevisionRow(CreatedAtMixin, Base):
         primary_key=True,
         server_default=sa.text("uuid_generate_v7()"),
     )
-    endpoint: Mapped[DeploymentID] = mapped_column("endpoint", GUID(DeploymentID), nullable=False)
+    endpoint: Mapped[DeploymentID] = mapped_column(
+        "endpoint",
+        GUID(DeploymentID),
+        sa.ForeignKey("endpoints.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     revision_number: Mapped[int] = mapped_column("revision_number", sa.Integer, nullable=False)
 
     # Image configuration.

--- a/src/ai/backend/manager/models/deployment_revision/scopes.py
+++ b/src/ai/backend/manager/models/deployment_revision/scopes.py
@@ -1,0 +1,35 @@
+"""Operation scopes for deployment revisions."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
+
+
+@dataclass(frozen=True)
+class DeploymentRevisionOperationScope(OperationScope):
+    """The revisions one deployment holds."""
+
+    deployment_id: DeploymentID
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        deployment_id = self.deployment_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return DeploymentRevisionRow.endpoint == deployment_id
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()

--- a/src/ai/backend/manager/models/deployment_revision/searchers.py
+++ b/src/ai/backend/manager/models/deployment_revision/searchers.py
@@ -1,0 +1,23 @@
+"""Searcher spec for the deployment_revisions table."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.deployment.types import ModelRevisionData
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.specs.searcher import Searcher
+
+
+@dataclass
+class ModelRevisionSearcher(Searcher[DeploymentRevisionRow, ModelRevisionData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(DeploymentRevisionRow)
+
+    @override
+    def to_data(self, row: DeploymentRevisionRow) -> ModelRevisionData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/endpoint/lookups.py
+++ b/src/ai/backend/manager/models/endpoint/lookups.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 from uuid import UUID
@@ -9,10 +10,9 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.deployment import DeploymentID
-from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.manager.models.endpoint.row import EndpointAutoScalingRuleRow, EndpointTokenRow
-from ai.backend.manager.models.routing.row import RoutingRow
-from ai.backend.manager.models.specs.lookup import FieldOwnerKeyLookup
+from ai.backend.manager.models.specs.lookup import FieldOwnerKeyLookup, FieldOwnerLookup
 
 
 @dataclass
@@ -33,47 +33,15 @@ class AutoScalingRuleDeploymentLookup(FieldOwnerKeyLookup[DeploymentID]):
 
 
 @dataclass
-class AccessTokenDeploymentLookup(FieldOwnerKeyLookup[DeploymentID]):
-    """Reads the deployment an access token grants access to."""
-
-    access_token_id: UUID
+class DeploymentAccessTokenOwnerLookup(FieldOwnerLookup[DeploymentTokenID, DeploymentID]):
+    """The deployment an access token grants access to."""
 
     @override
-    def build_query(self) -> sa.sql.Select[Any]:
-        return sa.select(EndpointTokenRow.endpoint).where(
-            EndpointTokenRow.id == self.access_token_id
-        )
-
-    @override
-    def to_entity_id(self, value: UUID) -> DeploymentID:
-        return DeploymentID(value)
-
-
-@dataclass
-class RouteDeploymentLookup(FieldOwnerKeyLookup[DeploymentID]):
-    """Reads the deployment a route belongs to."""
-
-    route_id: UUID
-
-    @override
-    def build_query(self) -> sa.sql.Select[Any]:
-        return sa.select(RoutingRow.endpoint).where(RoutingRow.id == self.route_id)
-
-    @override
-    def to_entity_id(self, value: UUID) -> DeploymentID:
-        return DeploymentID(value)
-
-
-@dataclass
-class RevisionDeploymentLookup(FieldOwnerKeyLookup[DeploymentID]):
-    """Reads the deployment a revision was taken of."""
-
-    revision_id: UUID
-
-    @override
-    def build_query(self) -> sa.sql.Select[Any]:
-        return sa.select(DeploymentRevisionRow.endpoint).where(
-            DeploymentRevisionRow.id == self.revision_id
+    def build_query(
+        self, field_ids: Sequence[DeploymentTokenID]
+    ) -> sa.sql.Select[tuple[DeploymentTokenID, DeploymentID]]:
+        return sa.select(EndpointTokenRow.id, EndpointTokenRow.endpoint).where(
+            EndpointTokenRow.id.in_(field_ids)
         )
 
     @override

--- a/src/ai/backend/manager/models/endpoint/queriers.py
+++ b/src/ai/backend/manager/models/endpoint/queriers.py
@@ -1,0 +1,34 @@
+"""FieldQuerier implementations for endpoint tokens."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
+from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
+from ai.backend.manager.models.endpoint.row import EndpointTokenRow
+from ai.backend.manager.models.specs.querier import FieldQuerier
+
+
+@dataclass
+class DeploymentAccessTokenQuerier(FieldQuerier[EndpointTokenRow, ModelDeploymentAccessTokenData]):
+    access_token_id: DeploymentTokenID
+
+    @override
+    def row_class(self) -> type[EndpointTokenRow]:
+        return EndpointTokenRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return EndpointTokenRow.id
+
+    @override
+    def target_id_value(self) -> DeploymentTokenID:
+        return self.access_token_id
+
+    @override
+    def to_data(self, row: EndpointTokenRow) -> ModelDeploymentAccessTokenData:
+        return row.to_access_token_data()

--- a/src/ai/backend/manager/models/endpoint/row.py
+++ b/src/ai/backend/manager/models/endpoint/row.py
@@ -64,6 +64,7 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentPolicyData,
     DeploymentState,
     DeploymentSummaryData,
+    ModelDeploymentAccessTokenData,
     ModelDeploymentAutoScalingRuleData,
     ModelRevisionData,
     ReplicaData,
@@ -906,8 +907,11 @@ class EndpointTokenRow(Base):
         server_default=sa.text("uuid_generate_v7()"),
     )
     token: Mapped[str] = mapped_column("token", sa.String(), nullable=False)
-    endpoint: Mapped[DeploymentID | None] = mapped_column(
-        "endpoint", GUID(DeploymentID), nullable=True
+    endpoint: Mapped[DeploymentID] = mapped_column(
+        "endpoint",
+        GUID(DeploymentID),
+        sa.ForeignKey("endpoints.id", ondelete="CASCADE"),
+        nullable=False,
     )
     session_owner: Mapped[UserID] = mapped_column("session_owner", GUID(UserID), nullable=False)
     domain: Mapped[str] = mapped_column(
@@ -1014,10 +1018,18 @@ class EndpointTokenRow(Base):
         return EndpointTokenData(
             id=self.id,
             token=self.token,
-            endpoint=self.endpoint or uuid.UUID(int=0),
+            endpoint=self.endpoint,
             domain=self.domain,
             project=self.project,
             session_owner=self.session_owner,
+            created_at=self.created_at,
+        )
+
+    def to_access_token_data(self) -> ModelDeploymentAccessTokenData:
+        return ModelDeploymentAccessTokenData(
+            id=self.id,
+            token=self.token,
+            expires_at=self.expires_at,
             created_at=self.created_at,
         )
 

--- a/src/ai/backend/manager/models/endpoint/scopes.py
+++ b/src/ai/backend/manager/models/endpoint/scopes.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import Any, override
 from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.manager.errors.resource import ProjectNotFound
 from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.endpoint.row import EndpointRow
+from ai.backend.manager.models.endpoint.row import EndpointRow, EndpointTokenRow
 from ai.backend.manager.models.project.row import ProjectRow
 from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
 
@@ -44,3 +45,24 @@ class ProjectDeploymentOperationScope(OperationScope):
                 error=ProjectNotFound(str(self.project_id)),
             ),
         ]
+
+
+@dataclass(frozen=True)
+class DeploymentAccessTokenOperationScope(OperationScope):
+    """The access tokens one deployment holds."""
+
+    deployment_id: DeploymentID
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        deployment_id = self.deployment_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return EndpointTokenRow.endpoint == deployment_id
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()

--- a/src/ai/backend/manager/models/endpoint/searchers.py
+++ b/src/ai/backend/manager/models/endpoint/searchers.py
@@ -1,0 +1,23 @@
+"""Searcher spec for the endpoint_tokens table."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
+from ai.backend.manager.models.endpoint.row import EndpointTokenRow
+from ai.backend.manager.models.specs.searcher import Searcher
+
+
+@dataclass
+class DeploymentAccessTokenSearcher(Searcher[EndpointTokenRow, ModelDeploymentAccessTokenData]):
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(EndpointTokenRow)
+
+    @override
+    def to_data(self, row: EndpointTokenRow) -> ModelDeploymentAccessTokenData:
+        return row.to_access_token_data()

--- a/src/ai/backend/manager/models/routing/lookups.py
+++ b/src/ai/backend/manager/models/routing/lookups.py
@@ -1,0 +1,30 @@
+"""Lookup specs for the routings table."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.models.specs.lookup import FieldOwnerLookup
+
+
+@dataclass
+class ReplicaOwnerLookup(FieldOwnerLookup[ReplicaID, DeploymentID]):
+    """The deployment a replica serves."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[ReplicaID]
+    ) -> sa.sql.Select[tuple[ReplicaID, DeploymentID]]:
+        return sa.select(RoutingRow.id, RoutingRow.endpoint).where(RoutingRow.id.in_(field_ids))
+
+    @override
+    def to_entity_id(self, value: UUID) -> DeploymentID:
+        return DeploymentID(value)

--- a/src/ai/backend/manager/models/routing/queriers.py
+++ b/src/ai/backend/manager/models/routing/queriers.py
@@ -1,0 +1,34 @@
+"""FieldQuerier implementations for routings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.manager.data.deployment.types import ModelReplicaData
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.models.specs.querier import FieldQuerier
+
+
+@dataclass
+class ModelReplicaQuerier(FieldQuerier[RoutingRow, ModelReplicaData]):
+    replica_id: ReplicaID
+
+    @override
+    def row_class(self) -> type[RoutingRow]:
+        return RoutingRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return RoutingRow.id
+
+    @override
+    def target_id_value(self) -> ReplicaID:
+        return self.replica_id
+
+    @override
+    def to_data(self, row: RoutingRow) -> ModelReplicaData:
+        return row.to_replica_data()

--- a/src/ai/backend/manager/models/routing/row.py
+++ b/src/ai/backend/manager/models/routing/row.py
@@ -20,9 +20,15 @@ from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.common.data.entity.replica_group import ReplicaGroupID
 from ai.backend.common.data.entity.session import SessionID
 from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.model_deployment.types import (
+    ActivenessStatus,
+    LivenessStatus,
+    ReadinessStatus,
+)
 from ai.backend.common.types import SessionId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.deployment.types import (
+    ModelReplicaData,
     RouteHealthStatus,
     RouteInfo,
     RouteStatus,
@@ -280,6 +286,42 @@ class RoutingRow(Base):
             created_at=self.created_at,
             error_data=self.error_data or {},
         )
+
+    def to_replica_data(self) -> ModelReplicaData:
+        readiness = self._readiness_status()
+        liveness = LivenessStatus(self.health_status.value)
+        return ModelReplicaData(
+            id=self.id,
+            deployment_id=self.endpoint,
+            revision_id=self.revision,
+            session_id=self.session,
+            readiness_status=readiness,
+            liveness_status=liveness,
+            activeness_status=self._activeness_status(readiness, liveness),
+            status=self.status,
+            traffic_status=self.traffic_status,
+            health_status=self.health_status,
+            detail=self.error_data or {},
+            created_at=self.created_at,
+        )
+
+    def _readiness_status(self) -> ReadinessStatus:
+        """The health status as readiness, which has no DEGRADED of its own."""
+        if self.health_status is RouteHealthStatus.DEGRADED:
+            return ReadinessStatus.UNHEALTHY
+        return ReadinessStatus(self.health_status.value)
+
+    def _activeness_status(
+        self, readiness: ReadinessStatus, liveness: LivenessStatus
+    ) -> ActivenessStatus:
+        """ACTIVE only when traffic is enabled and both health axes are HEALTHY."""
+        if self.traffic_status != RouteTrafficStatus.ACTIVE:
+            return ActivenessStatus.INACTIVE
+        if readiness != ReadinessStatus.HEALTHY:
+            return ActivenessStatus.INACTIVE
+        if liveness != LivenessStatus.HEALTHY:
+            return ActivenessStatus.INACTIVE
+        return ActivenessStatus.ACTIVE
 
     def to_route_info(self) -> RouteInfo:
         return RouteInfo(

--- a/src/ai/backend/manager/models/routing/scopes.py
+++ b/src/ai/backend/manager/models/routing/scopes.py
@@ -1,0 +1,35 @@
+"""Operation scopes for routings."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
+
+
+@dataclass(frozen=True)
+class DeploymentReplicaOperationScope(OperationScope):
+    """The replicas one deployment holds."""
+
+    deployment_id: DeploymentID
+
+    @override
+    def to_condition(self) -> QueryCondition:
+        deployment_id = self.deployment_id
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return RoutingRow.endpoint == deployment_id
+
+        return inner
+
+    @property
+    @override
+    def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
+        return ()

--- a/src/ai/backend/manager/models/routing/searchers.py
+++ b/src/ai/backend/manager/models/routing/searchers.py
@@ -1,0 +1,25 @@
+"""Searcher spec for the routings table."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+import sqlalchemy as sa
+
+from ai.backend.manager.data.deployment.types import ModelReplicaData
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.models.specs.searcher import Searcher
+
+
+@dataclass
+class ModelReplicaSearcher(Searcher[RoutingRow, ModelReplicaData]):
+    """Routing rows read as replicas."""
+
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(RoutingRow)
+
+    @override
+    def to_data(self, row: RoutingRow) -> ModelReplicaData:
+        return row.to_replica_data()

--- a/src/ai/backend/manager/repositories/artifact/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/artifact/db_source/db_source.py
@@ -81,14 +81,6 @@ class ArtifactDBSource:
                 raise ArtifactRevisionNotFoundError(f"Revision {revision} not found")
             return row.to_dataclass()
 
-    async def list_artifact_revisions(self, artifact_id: uuid.UUID) -> list[ArtifactRevisionData]:
-        async with self._db.begin_readonly_session_read_committed() as db_sess:
-            result = await db_sess.execute(
-                sa.select(ArtifactRevisionRow).where(ArtifactRevisionRow.artifact_id == artifact_id)
-            )
-            rows = list(result.scalars().all())
-            return [row.to_dataclass() for row in rows]
-
     async def associate_artifact_with_storage(
         self,
         artifact_revision_id: uuid.UUID,

--- a/src/ai/backend/manager/repositories/artifact/repository.py
+++ b/src/ai/backend/manager/repositories/artifact/repository.py
@@ -96,10 +96,6 @@ class ArtifactRepository:
             return data
 
     @artifact_repository_resilience.apply()
-    async def list_artifact_revisions(self, artifact_id: uuid.UUID) -> list[ArtifactRevisionData]:
-        return await self._db_source.list_artifact_revisions(artifact_id)
-
-    @artifact_repository_resilience.apply()
     async def upsert_artifacts(
         self,
         artifacts: list[ArtifactData],

--- a/src/ai/backend/manager/services/artifact/actions/get_revisions.py
+++ b/src/ai/backend/manager/services/artifact/actions/get_revisions.py
@@ -1,24 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE, ArtifactID
+from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.artifact.types import ArtifactRevisionData
-from ai.backend.manager.services.artifact.actions.base import ArtifactSingleEntityAction
+from ai.backend.manager.models.artifact_revision.row import ArtifactRevisionRow
+from ai.backend.manager.models.artifact_revision.scopes import ArtifactRevisionOperationScope
+from ai.backend.manager.models.artifact_revision.searchers import ArtifactRevisionSearcher
+from ai.backend.manager.models.scopes import OperationScope
 
 
 @dataclass
-class GetArtifactRevisionsAction(ArtifactSingleEntityAction):
+class GetArtifactRevisionsAction(
+    OperationScopeOpsAction[ArtifactRevisionRow, ArtifactRevisionData]
+):
+    """Page through the revisions of one artifact.
+
+    The artifact is the scope, so ops applies that condition.
+    """
+
+    artifact_id: ArtifactID
+    searcher: ArtifactRevisionSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return ARTIFACT_ENTITY_TYPE
+
     @override
     @classmethod
     def action_name(cls) -> str:
         return "get_artifact_revisions"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return (ScopeRef(scope_type=ScopeType(ARTIFACT_ENTITY_TYPE), scope_id=self.artifact_id),)
 
+    @override
+    def operation_scopes(self) -> Sequence[OperationScope]:
+        return (ArtifactRevisionOperationScope(artifact_id=self.artifact_id),)
 
-@dataclass
-class GetArtifactRevisionsActionResult:
-    revisions: list[ArtifactRevisionData]
+    @override
+    def to_searcher(self) -> ArtifactRevisionSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/artifact/processors.py
+++ b/src/ai/backend/manager/services/artifact/processors.py
@@ -1,7 +1,10 @@
+from ai.backend.manager.actions.registry.field import FieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
+from ai.backend.manager.actions.v2.ops.result import ScopedFieldsOpsResult
+from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
-from ai.backend.manager.data.artifact.types import ArtifactData
+from ai.backend.manager.data.artifact.types import ArtifactData, ArtifactRevisionData
 from ai.backend.manager.services.artifact.actions.delegate_scan import (
     DelegateScanArtifactsAction,
     DelegateScanArtifactsActionResult,
@@ -16,7 +19,6 @@ from ai.backend.manager.services.artifact.actions.get import (
 )
 from ai.backend.manager.services.artifact.actions.get_revisions import (
     GetArtifactRevisionsAction,
-    GetArtifactRevisionsActionResult,
 )
 from ai.backend.manager.services.artifact.actions.restore_multi import (
     RestoreArtifactsAction,
@@ -64,8 +66,8 @@ class ArtifactProcessors:
     search_artifacts_with_revisions: GlobalActionProcessor[
         SearchArtifactsWithRevisionsAction, SearchArtifactsWithRevisionsActionResult
     ]
-    get_revisions: SingleEntityActionProcessor[
-        GetArtifactRevisionsAction, GetArtifactRevisionsActionResult
+    get_revisions: ScopeActionProcessor[
+        GetArtifactRevisionsAction, ScopedFieldsOpsResult[ArtifactRevisionData]
     ]
     update: SingleEntityActionProcessor[UpdateArtifactAction, UpdateArtifactActionResult]
     upsert_artifacts_with_revisions: GlobalActionProcessor[
@@ -85,6 +87,7 @@ class ArtifactProcessors:
     def __init__(
         self,
         group: ProcessorGroup[ArtifactData],
+        revisions: FieldGroup[ArtifactRevisionData],
         revision: ArtifactRevisionProcessors,
         service: ArtifactService,
     ) -> None:
@@ -96,7 +99,7 @@ class ArtifactProcessors:
         self.search_artifacts_with_revisions = group.global_scope(
             SearchArtifactsWithRevisionsAction, service.search_with_revisions
         )
-        self.get_revisions = group.single_entity(GetArtifactRevisionsAction, service.get_revisions)
+        self.get_revisions = revisions.search_ops(GetArtifactRevisionsAction)
         self.update = group.single_entity(UpdateArtifactAction, service.update)
         self.upsert_artifacts_with_revisions = group.global_scope(
             UpsertArtifactsAction, service.upsert_artifacts_with_revisions

--- a/src/ai/backend/manager/services/artifact/service.py
+++ b/src/ai/backend/manager/services/artifact/service.py
@@ -63,10 +63,6 @@ from ai.backend.manager.services.artifact.actions.get import (
     GetArtifactAction,
     GetArtifactActionResult,
 )
-from ai.backend.manager.services.artifact.actions.get_revisions import (
-    GetArtifactRevisionsAction,
-    GetArtifactRevisionsActionResult,
-)
 from ai.backend.manager.services.artifact.actions.restore_multi import (
     RestoreArtifactsAction,
     RestoreArtifactsActionResult,
@@ -366,12 +362,6 @@ class ArtifactService:
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
         )
-
-    async def get_revisions(
-        self, action: GetArtifactRevisionsAction
-    ) -> GetArtifactRevisionsActionResult:
-        revisions = await self._artifact_repository.list_artifact_revisions(action.artifact_id)
-        return GetArtifactRevisionsActionResult(revisions=revisions)
 
     async def update(self, action: UpdateArtifactAction) -> UpdateArtifactActionResult:
         updated_artifact = await self._artifact_repository.update_artifact(action.updater)

--- a/src/ai/backend/manager/services/deployment/actions/access_token/delete_access_token.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/delete_access_token.py
@@ -14,7 +14,12 @@ from ai.backend.manager.services.deployment.actions.lookup_owner import (
 
 @dataclass
 class DeleteAccessTokenAction(BaseSingleFieldAction[DeploymentTokenID, DeploymentID]):
-    """Remove one access token, authorized against the deployment it grants access to."""
+    """Remove one access token, authorized against the deployment it grants access to.
+
+    Declares ``UPDATE`` like every other write to a field row: a field path carries
+    ``READ|UPDATE`` and nothing else, so a delete bit there is not expressible and the
+    check would fall back on the deployment's own deletion right.
+    """
 
     access_token_id: DeploymentTokenID
 
@@ -26,7 +31,7 @@ class DeleteAccessTokenAction(BaseSingleFieldAction[DeploymentTokenID, Deploymen
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.DELETE
+        return ActionOperationType.UPDATE
 
     @override
     def to_owner_lookup_action(self) -> LookupDeploymentAccessTokenOwnerAction:

--- a/src/ai/backend/manager/services/deployment/actions/access_token/delete_access_token.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/delete_access_token.py
@@ -1,16 +1,22 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import override
-from uuid import UUID
 
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.services.deployment.actions.access_token.base import (
-    DeploymentAccessTokenBaseAction,
+from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupDeploymentAccessTokenOwnerAction,
 )
 
 
 @dataclass
-class DeleteAccessTokenAction(DeploymentAccessTokenBaseAction):
-    access_token_id: UUID
+class DeleteAccessTokenAction(BaseSingleFieldAction[DeploymentTokenID, DeploymentID]):
+    """Remove one access token, authorized against the deployment it grants access to."""
+
+    access_token_id: DeploymentTokenID
 
     @override
     @classmethod
@@ -21,6 +27,10 @@ class DeleteAccessTokenAction(DeploymentAccessTokenBaseAction):
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.DELETE
+
+    @override
+    def to_owner_lookup_action(self) -> LookupDeploymentAccessTokenOwnerAction:
+        return LookupDeploymentAccessTokenOwnerAction(access_token_id=self.access_token_id)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/deployment/actions/access_token/get_access_token.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/get_access_token.py
@@ -1,17 +1,28 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import override
-from uuid import UUID
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
+from ai.backend.manager.actions.v2.field.ops import GetFieldOpsAction
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
-from ai.backend.manager.services.deployment.actions.access_token.base import (
-    DeploymentAccessTokenBaseAction,
+from ai.backend.manager.models.endpoint.queriers import DeploymentAccessTokenQuerier
+from ai.backend.manager.models.endpoint.row import EndpointTokenRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupDeploymentAccessTokenOwnerAction,
 )
 
 
 @dataclass
-class GetAccessTokenAction(DeploymentAccessTokenBaseAction):
-    access_token_id: UUID
+class GetAccessTokenAction(
+    GetFieldOpsAction[
+        DeploymentTokenID, DeploymentID, EndpointTokenRow, ModelDeploymentAccessTokenData
+    ]
+):
+    """Read one access token, authorized against the deployment it grants access to."""
+
+    access_token_id: DeploymentTokenID
 
     @override
     @classmethod
@@ -19,11 +30,9 @@ class GetAccessTokenAction(DeploymentAccessTokenBaseAction):
         return "get_access_token"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.GET
+    def to_owner_lookup_action(self) -> LookupDeploymentAccessTokenOwnerAction:
+        return LookupDeploymentAccessTokenOwnerAction(access_token_id=self.access_token_id)
 
-
-@dataclass
-class GetAccessTokenActionResult:
-    data: ModelDeploymentAccessTokenData
+    @override
+    def to_querier(self) -> DeploymentAccessTokenQuerier:
+        return DeploymentAccessTokenQuerier(access_token_id=self.access_token_id)

--- a/src/ai/backend/manager/services/deployment/actions/access_token/global_search_access_tokens.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/global_search_access_tokens.py
@@ -3,17 +3,26 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
-from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.services.deployment.actions.base import DeploymentGlobalAction
+from ai.backend.manager.models.endpoint.row import EndpointTokenRow
+from ai.backend.manager.models.endpoint.searchers import DeploymentAccessTokenSearcher
 
 
 @dataclass
-class GlobalSearchAccessTokensAction(DeploymentGlobalAction):
+class GlobalSearchAccessTokensAction(
+    SearchGlobalOpsAction[EndpointTokenRow, ModelDeploymentAccessTokenData]
+):
     """Page through access tokens across every deployment."""
 
-    querier: BatchQuerier
+    searcher: DeploymentAccessTokenSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
 
     @override
     @classmethod
@@ -21,14 +30,5 @@ class GlobalSearchAccessTokensAction(DeploymentGlobalAction):
         return "global_search_access_tokens"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
-
-
-@dataclass
-class GlobalSearchAccessTokensActionResult:
-    data: list[ModelDeploymentAccessTokenData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
+    def to_searcher(self) -> DeploymentAccessTokenSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/deployment/actions/access_token/search_access_tokens.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/search_access_tokens.py
@@ -1,17 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
-from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.services.deployment.actions.access_token.base import (
-    DeploymentAccessTokenBaseAction,
-)
+from ai.backend.manager.models.endpoint.row import EndpointTokenRow
+from ai.backend.manager.models.endpoint.scopes import DeploymentAccessTokenOperationScope
+from ai.backend.manager.models.endpoint.searchers import DeploymentAccessTokenSearcher
+from ai.backend.manager.models.scopes import OperationScope
 
 
 @dataclass
-class SearchAccessTokensAction(DeploymentAccessTokenBaseAction):
-    querier: BatchQuerier
+class SearchAccessTokensAction(
+    OperationScopeOpsAction[EndpointTokenRow, ModelDeploymentAccessTokenData]
+):
+    """Page through the access tokens of one deployment.
+
+    The deployment is the scope, so ops applies that condition. Reading every
+    deployment's tokens is the global variant, which says so in its shape.
+    """
+
+    deployment_id: DeploymentID
+    searcher: DeploymentAccessTokenSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
 
     @override
     @classmethod
@@ -19,14 +38,15 @@ class SearchAccessTokensAction(DeploymentAccessTokenBaseAction):
         return "search_access_tokens"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return (
+            ScopeRef(scope_type=ScopeType(DEPLOYMENT_ENTITY_TYPE), scope_id=self.deployment_id),
+        )
 
+    @override
+    def operation_scopes(self) -> Sequence[OperationScope]:
+        return (DeploymentAccessTokenOperationScope(deployment_id=self.deployment_id),)
 
-@dataclass
-class SearchAccessTokensActionResult:
-    data: list[ModelDeploymentAccessTokenData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
+    @override
+    def to_searcher(self) -> DeploymentAccessTokenSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/deployment/actions/get_replica_by_id.py
+++ b/src/ai/backend/manager/services/deployment/actions/get_replica_by_id.py
@@ -1,15 +1,26 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import override
-from uuid import UUID
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.manager.actions.v2.field.ops import GetFieldOpsAction
 from ai.backend.manager.data.deployment.types import ModelReplicaData
-from ai.backend.manager.services.deployment.actions.replica.base import DeploymentReplicaBaseAction
+from ai.backend.manager.models.routing.queriers import ModelReplicaQuerier
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupReplicaOwnerAction,
+)
 
 
 @dataclass
-class GetReplicaByIdAction(DeploymentReplicaBaseAction):
-    replica_id: UUID
+class GetReplicaByIdAction(
+    GetFieldOpsAction[ReplicaID, DeploymentID, RoutingRow, ModelReplicaData]
+):
+    """Read one replica, authorized against the deployment it serves."""
+
+    replica_id: ReplicaID
 
     @override
     @classmethod
@@ -17,11 +28,9 @@ class GetReplicaByIdAction(DeploymentReplicaBaseAction):
         return "get_replica_by_id"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.GET
+    def to_owner_lookup_action(self) -> LookupReplicaOwnerAction:
+        return LookupReplicaOwnerAction(replica_id=self.replica_id)
 
-
-@dataclass
-class GetReplicaByIdActionResult:
-    data: ModelReplicaData | None
+    @override
+    def to_querier(self) -> ModelReplicaQuerier:
+        return ModelReplicaQuerier(replica_id=self.replica_id)

--- a/src/ai/backend/manager/services/deployment/actions/global_search_replicas.py
+++ b/src/ai/backend/manager/services/deployment/actions/global_search_replicas.py
@@ -1,17 +1,26 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment.types import ModelReplicaData
-from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.services.deployment.actions.base import DeploymentGlobalAction
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.models.routing.searchers import ModelReplicaSearcher
 
 
 @dataclass
-class GlobalSearchReplicasAction(DeploymentGlobalAction):
+class GlobalSearchReplicasAction(SearchGlobalOpsAction[RoutingRow, ModelReplicaData]):
     """Page through replicas across every deployment."""
 
-    querier: BatchQuerier
+    searcher: ModelReplicaSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
 
     @override
     @classmethod
@@ -19,14 +28,5 @@ class GlobalSearchReplicasAction(DeploymentGlobalAction):
         return "global_search_replicas"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
-
-
-@dataclass
-class GlobalSearchReplicasActionResult:
-    data: list[ModelReplicaData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
+    def to_searcher(self) -> ModelReplicaSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/deployment/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/deployment/actions/lookup_owner.py
@@ -2,20 +2,28 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 from uuid import UUID
 
 from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
+from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerByKeyOpsAction
-from ai.backend.manager.actions.v2.lookup.base import LookupKey
-from ai.backend.manager.models.endpoint.lookups import (
-    AccessTokenDeploymentLookup,
-    AutoScalingRuleDeploymentLookup,
-    RevisionDeploymentLookup,
-    RouteDeploymentLookup,
+from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.field.lookup import (
+    LookupFieldOwnerByKeyOpsAction,
+    LookupFieldOwnerOpsAction,
 )
+from ai.backend.manager.actions.v2.lookup.base import LookupKey
+from ai.backend.manager.models.deployment_revision.lookups import DeploymentRevisionOwnerLookup
+from ai.backend.manager.models.endpoint.lookups import (
+    AutoScalingRuleDeploymentLookup,
+    DeploymentAccessTokenOwnerLookup,
+)
+from ai.backend.manager.models.routing.lookups import ReplicaOwnerLookup
 
 
 @dataclass(frozen=True)
@@ -59,25 +67,27 @@ class LookupAutoScalingRuleDeploymentAction(LookupFieldOwnerByKeyOpsAction[Deplo
 
 
 @dataclass(frozen=True)
-class AccessTokenKey(LookupKey):
-    """The access token a request names, which its deployment is read from."""
+class DeploymentRevisionIDLookupKey(LookupKey):
+    """A revision's id, resolved into the deployment it belongs to."""
 
-    access_token_id: UUID
+    revision_id: DeploymentRevisionID
 
     @override
     def kind(self) -> str:
-        return "access_token_id"
+        return "deployment_revision_id"
 
     @override
     def to_dict(self) -> dict[str, Any]:
-        return {"access_token_id": str(self.access_token_id)}
+        return {"id": str(self.revision_id)}
 
 
 @dataclass
-class LookupAccessTokenDeploymentAction(LookupFieldOwnerByKeyOpsAction[DeploymentID]):
-    """Resolve the access token's id into the deployment it belongs to."""
+class LookupDeploymentRevisionOwnerAction(
+    LookupFieldOwnerOpsAction[DeploymentRevisionID, DeploymentID]
+):
+    """The deployment a revision was taken of."""
 
-    access_token_id: UUID
+    revision_id: DeploymentRevisionID
 
     @override
     @classmethod
@@ -87,37 +97,72 @@ class LookupAccessTokenDeploymentAction(LookupFieldOwnerByKeyOpsAction[Deploymen
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "lookup_access_token_deployment"
+        return "lookup_deployment_revision_owner"
 
     @override
-    def lookup_key(self) -> AccessTokenKey:
-        return AccessTokenKey(access_token_id=self.access_token_id)
+    def lookup_key(self) -> LookupKey:
+        return DeploymentRevisionIDLookupKey(self.revision_id)
 
     @override
-    def to_owner_lookup(self) -> AccessTokenDeploymentLookup:
-        return AccessTokenDeploymentLookup(access_token_id=self.access_token_id)
+    def field_id(self) -> DeploymentRevisionID:
+        return self.revision_id
+
+    @override
+    def to_owner_lookup(self) -> DeploymentRevisionOwnerLookup:
+        return DeploymentRevisionOwnerLookup()
+
+
+@dataclass
+class LookupBulkDeploymentRevisionOwnerAction(
+    LookupBulkFieldOwnerOpsAction[DeploymentRevisionID, DeploymentID]
+):
+    """The deployments several revisions were taken of."""
+
+    revision_ids: Sequence[DeploymentRevisionID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_deployment_revision_owner"
+
+    @override
+    def to_lookup_key(self, field_id: DeploymentRevisionID) -> LookupKey:
+        return DeploymentRevisionIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentRevisionID]:
+        return tuple(self.revision_ids)
+
+    @override
+    def to_owner_lookup(self) -> DeploymentRevisionOwnerLookup:
+        return DeploymentRevisionOwnerLookup()
 
 
 @dataclass(frozen=True)
-class RouteKey(LookupKey):
-    """The route a request names, which its deployment is read from."""
+class ReplicaIDLookupKey(LookupKey):
+    """A replica's id, resolved into the deployment it serves."""
 
-    route_id: UUID
+    replica_id: ReplicaID
 
     @override
     def kind(self) -> str:
-        return "route_id"
+        return "replica_id"
 
     @override
     def to_dict(self) -> dict[str, Any]:
-        return {"route_id": str(self.route_id)}
+        return {"id": str(self.replica_id)}
 
 
 @dataclass
-class LookupRouteDeploymentAction(LookupFieldOwnerByKeyOpsAction[DeploymentID]):
-    """Resolve the route's id into the deployment it belongs to."""
+class LookupReplicaOwnerAction(LookupFieldOwnerOpsAction[ReplicaID, DeploymentID]):
+    """The deployment a replica serves."""
 
-    route_id: UUID
+    replica_id: ReplicaID
 
     @override
     @classmethod
@@ -127,37 +172,72 @@ class LookupRouteDeploymentAction(LookupFieldOwnerByKeyOpsAction[DeploymentID]):
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "lookup_route_deployment"
+        return "lookup_replica_owner"
 
     @override
-    def lookup_key(self) -> RouteKey:
-        return RouteKey(route_id=self.route_id)
+    def lookup_key(self) -> LookupKey:
+        return ReplicaIDLookupKey(self.replica_id)
 
     @override
-    def to_owner_lookup(self) -> RouteDeploymentLookup:
-        return RouteDeploymentLookup(route_id=self.route_id)
+    def field_id(self) -> ReplicaID:
+        return self.replica_id
+
+    @override
+    def to_owner_lookup(self) -> ReplicaOwnerLookup:
+        return ReplicaOwnerLookup()
+
+
+@dataclass
+class LookupBulkReplicaOwnerAction(LookupBulkFieldOwnerOpsAction[ReplicaID, DeploymentID]):
+    """The deployments several replicas serve."""
+
+    replica_ids: Sequence[ReplicaID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_replica_owner"
+
+    @override
+    def to_lookup_key(self, field_id: ReplicaID) -> LookupKey:
+        return ReplicaIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[ReplicaID]:
+        return tuple(self.replica_ids)
+
+    @override
+    def to_owner_lookup(self) -> ReplicaOwnerLookup:
+        return ReplicaOwnerLookup()
 
 
 @dataclass(frozen=True)
-class RevisionKey(LookupKey):
-    """The revision a request names, which its deployment is read from."""
+class DeploymentTokenIDLookupKey(LookupKey):
+    """An access token's id, resolved into the deployment it grants access to."""
 
-    revision_id: UUID
+    access_token_id: DeploymentTokenID
 
     @override
     def kind(self) -> str:
-        return "revision_id"
+        return "deployment_token_id"
 
     @override
     def to_dict(self) -> dict[str, Any]:
-        return {"revision_id": str(self.revision_id)}
+        return {"id": str(self.access_token_id)}
 
 
 @dataclass
-class LookupRevisionDeploymentAction(LookupFieldOwnerByKeyOpsAction[DeploymentID]):
-    """Resolve the revision's id into the deployment it belongs to."""
+class LookupDeploymentAccessTokenOwnerAction(
+    LookupFieldOwnerOpsAction[DeploymentTokenID, DeploymentID]
+):
+    """The deployment an access token grants access to."""
 
-    revision_id: UUID
+    access_token_id: DeploymentTokenID
 
     @override
     @classmethod
@@ -167,12 +247,47 @@ class LookupRevisionDeploymentAction(LookupFieldOwnerByKeyOpsAction[DeploymentID
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "lookup_revision_deployment"
+        return "lookup_deployment_access_token_owner"
 
     @override
-    def lookup_key(self) -> RevisionKey:
-        return RevisionKey(revision_id=self.revision_id)
+    def lookup_key(self) -> LookupKey:
+        return DeploymentTokenIDLookupKey(self.access_token_id)
 
     @override
-    def to_owner_lookup(self) -> RevisionDeploymentLookup:
-        return RevisionDeploymentLookup(revision_id=self.revision_id)
+    def field_id(self) -> DeploymentTokenID:
+        return self.access_token_id
+
+    @override
+    def to_owner_lookup(self) -> DeploymentAccessTokenOwnerLookup:
+        return DeploymentAccessTokenOwnerLookup()
+
+
+@dataclass
+class LookupBulkDeploymentAccessTokenOwnerAction(
+    LookupBulkFieldOwnerOpsAction[DeploymentTokenID, DeploymentID]
+):
+    """The deployments several access tokens grant access to."""
+
+    access_token_ids: Sequence[DeploymentTokenID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_deployment_access_token_owner"
+
+    @override
+    def to_lookup_key(self, field_id: DeploymentTokenID) -> LookupKey:
+        return DeploymentTokenIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentTokenID]:
+        return tuple(self.access_token_ids)
+
+    @override
+    def to_owner_lookup(self) -> DeploymentAccessTokenOwnerLookup:
+        return DeploymentAccessTokenOwnerLookup()

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/get_revision_by_id.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/get_revision_by_id.py
@@ -1,18 +1,25 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
-from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.deployment.types import (
-    ModelRevisionData,
-)
-from ai.backend.manager.services.deployment.actions.model_revision.base import (
-    ModelRevisionBaseAction,
+from ai.backend.manager.actions.v2.field.ops import GetFieldOpsAction
+from ai.backend.manager.data.deployment.types import ModelRevisionData
+from ai.backend.manager.models.deployment_revision.queriers import ModelRevisionQuerier
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupDeploymentRevisionOwnerAction,
 )
 
 
 @dataclass
-class GetRevisionByIdAction(ModelRevisionBaseAction):
+class GetRevisionByIdAction(
+    GetFieldOpsAction[DeploymentRevisionID, DeploymentID, DeploymentRevisionRow, ModelRevisionData]
+):
+    """Read one revision, authorized against the deployment it was taken of."""
+
     revision_id: DeploymentRevisionID
 
     @override
@@ -21,11 +28,9 @@ class GetRevisionByIdAction(ModelRevisionBaseAction):
         return "get_revision_by_id"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.GET
+    def to_owner_lookup_action(self) -> LookupDeploymentRevisionOwnerAction:
+        return LookupDeploymentRevisionOwnerAction(revision_id=self.revision_id)
 
-
-@dataclass
-class GetRevisionByIdActionResult:
-    data: ModelRevisionData
+    @override
+    def to_querier(self) -> ModelRevisionQuerier:
+        return ModelRevisionQuerier(revision_id=self.revision_id)

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/global_search_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/global_search_revisions.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment.types import ModelRevisionData
-from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.services.deployment.actions.base import DeploymentGlobalAction
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision.searchers import ModelRevisionSearcher
 
 
 @dataclass
-class GlobalSearchRevisionsAction(DeploymentGlobalAction):
+class GlobalSearchRevisionsAction(SearchGlobalOpsAction[DeploymentRevisionRow, ModelRevisionData]):
     """Page through model revisions across every deployment."""
 
-    querier: BatchQuerier
+    searcher: ModelRevisionSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
 
     @override
     @classmethod
@@ -21,14 +28,5 @@ class GlobalSearchRevisionsAction(DeploymentGlobalAction):
         return "global_search_revisions"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
-
-
-@dataclass
-class GlobalSearchRevisionsActionResult:
-    data: list[ModelRevisionData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
+    def to_searcher(self) -> ModelRevisionSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/search_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/search_revisions.py
@@ -1,19 +1,36 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelRevisionData
-from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.services.deployment.actions.model_revision.base import (
-    ModelRevisionBaseAction,
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.models.deployment_revision.scopes import (
+    DeploymentRevisionOperationScope,
 )
+from ai.backend.manager.models.deployment_revision.searchers import ModelRevisionSearcher
+from ai.backend.manager.models.scopes import OperationScope
 
 
 @dataclass
-class SearchRevisionsAction(ModelRevisionBaseAction):
-    querier: BatchQuerier
+class SearchRevisionsAction(OperationScopeOpsAction[DeploymentRevisionRow, ModelRevisionData]):
+    """Page through the revisions of one deployment.
+
+    The deployment is the scope, so ops applies that condition. Reading every
+    deployment's revisions is the global variant, which says so in its shape.
+    """
+
+    deployment_id: DeploymentID
+    searcher: ModelRevisionSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
 
     @override
     @classmethod
@@ -21,14 +38,15 @@ class SearchRevisionsAction(ModelRevisionBaseAction):
         return "search_revisions"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return (
+            ScopeRef(scope_type=ScopeType(DEPLOYMENT_ENTITY_TYPE), scope_id=self.deployment_id),
+        )
 
+    @override
+    def operation_scopes(self) -> Sequence[OperationScope]:
+        return (DeploymentRevisionOperationScope(deployment_id=self.deployment_id),)
 
-@dataclass
-class SearchRevisionsActionResult:
-    data: list[ModelRevisionData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
+    @override
+    def to_searcher(self) -> ModelRevisionSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/deployment/actions/route/update_route_traffic_status.py
+++ b/src/ai/backend/manager/services/deployment/actions/route/update_route_traffic_status.py
@@ -4,19 +4,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import override
-from uuid import UUID
 
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
 from ai.backend.manager.data.deployment.types import RouteInfo, RouteTrafficStatus
-
-from .base import RouteBaseAction
+from ai.backend.manager.services.deployment.actions.lookup_owner import LookupReplicaOwnerAction
 
 
 @dataclass
-class UpdateRouteTrafficStatusAction(RouteBaseAction):
-    """Action to update traffic status of a route."""
+class UpdateRouteTrafficStatusAction(BaseSingleFieldAction[ReplicaID, DeploymentID]):
+    """Set one route's traffic status, authorized against the deployment it serves."""
 
-    route_id: UUID
+    route_id: ReplicaID
     traffic_status: RouteTrafficStatus
 
     @override
@@ -28,6 +29,10 @@ class UpdateRouteTrafficStatusAction(RouteBaseAction):
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.UPDATE
+
+    @override
+    def to_owner_lookup_action(self) -> LookupReplicaOwnerAction:
+        return LookupReplicaOwnerAction(replica_id=self.route_id)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/deployment/actions/search_replicas.py
+++ b/src/ai/backend/manager/services/deployment/actions/search_replicas.py
@@ -1,15 +1,34 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelReplicaData
-from ai.backend.manager.repositories.base import BatchQuerier
-from ai.backend.manager.services.deployment.actions.replica.base import DeploymentReplicaBaseAction
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.models.routing.scopes import DeploymentReplicaOperationScope
+from ai.backend.manager.models.routing.searchers import ModelReplicaSearcher
+from ai.backend.manager.models.scopes import OperationScope
 
 
 @dataclass
-class SearchReplicasAction(DeploymentReplicaBaseAction):
-    querier: BatchQuerier
+class SearchReplicasAction(OperationScopeOpsAction[RoutingRow, ModelReplicaData]):
+    """Page through the replicas of one deployment.
+
+    The deployment is the scope, so ops applies that condition. Reading every
+    deployment's replicas is the global variant, which says so in its shape.
+    """
+
+    deployment_id: DeploymentID
+    searcher: ModelReplicaSearcher
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
 
     @override
     @classmethod
@@ -17,14 +36,15 @@ class SearchReplicasAction(DeploymentReplicaBaseAction):
         return "search_replicas"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.SEARCH
+    def scope_targets(self) -> Sequence[ScopeRef]:
+        return (
+            ScopeRef(scope_type=ScopeType(DEPLOYMENT_ENTITY_TYPE), scope_id=self.deployment_id),
+        )
 
+    @override
+    def operation_scopes(self) -> Sequence[OperationScope]:
+        return (DeploymentReplicaOperationScope(deployment_id=self.deployment_id),)
 
-@dataclass
-class SearchReplicasActionResult:
-    data: list[ModelReplicaData]
-    total_count: int
-    has_next_page: bool
-    has_previous_page: bool
+    @override
+    def to_searcher(self) -> ModelReplicaSearcher:
+        return self.searcher

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -4,13 +4,29 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ai.backend.common.data.entity.deployment_revision import DEPLOYMENT_REVISION_FIELD_TYPE
+from ai.backend.common.data.entity.deployment_token import DEPLOYMENT_TOKEN_FIELD_TYPE
+from ai.backend.common.data.entity.replica import REPLICA_FIELD_TYPE
+from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.registry.types import FieldGroupMeta
+from ai.backend.manager.actions.v2.field.processor import SingleFieldActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
-from ai.backend.manager.actions.v2.ops.result import FieldOwnerLookupOpsResult
+from ai.backend.manager.actions.v2.ops.result import (
+    BatchOpsResult,
+    EntityOpsResult,
+    FieldOwnerLookupOpsResult,
+    ScopedFieldsOpsResult,
+)
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
-from ai.backend.manager.data.deployment.types import ModelDeploymentData
+from ai.backend.manager.data.deployment.types import (
+    ModelDeploymentAccessTokenData,
+    ModelDeploymentData,
+    ModelReplicaData,
+    ModelRevisionData,
+)
 from ai.backend.manager.services.deployment.actions.access_token.bulk_delete_access_tokens import (
     BulkDeleteAccessTokensAction,
     BulkDeleteAccessTokensActionResult,
@@ -25,7 +41,6 @@ from ai.backend.manager.services.deployment.actions.access_token.delete_access_t
 )
 from ai.backend.manager.services.deployment.actions.access_token.get_access_token import (
     GetAccessTokenAction,
-    GetAccessTokenActionResult,
 )
 from ai.backend.manager.services.deployment.actions.access_token.global_search_access_tokens import (
     GlobalSearchAccessTokensAction,
@@ -33,7 +48,6 @@ from ai.backend.manager.services.deployment.actions.access_token.global_search_a
 )
 from ai.backend.manager.services.deployment.actions.access_token.search_access_tokens import (
     SearchAccessTokensAction,
-    SearchAccessTokensActionResult,
 )
 from ai.backend.manager.services.deployment.actions.auto_scaling_rule.bulk_delete_auto_scaling_rules import (
     BulkDeleteAutoScalingRulesAction,
@@ -89,17 +103,18 @@ from ai.backend.manager.services.deployment.actions.get_legacy_deployment_by_id 
 )
 from ai.backend.manager.services.deployment.actions.get_replica_by_id import (
     GetReplicaByIdAction,
-    GetReplicaByIdActionResult,
 )
 from ai.backend.manager.services.deployment.actions.global_search_replicas import (
     GlobalSearchReplicasAction,
-    GlobalSearchReplicasActionResult,
 )
 from ai.backend.manager.services.deployment.actions.lookup_owner import (
-    LookupAccessTokenDeploymentAction,
     LookupAutoScalingRuleDeploymentAction,
-    LookupRevisionDeploymentAction,
-    LookupRouteDeploymentAction,
+    LookupBulkDeploymentAccessTokenOwnerAction,
+    LookupBulkDeploymentRevisionOwnerAction,
+    LookupBulkReplicaOwnerAction,
+    LookupDeploymentAccessTokenOwnerAction,
+    LookupDeploymentRevisionOwnerAction,
+    LookupReplicaOwnerAction,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
@@ -107,7 +122,6 @@ from ai.backend.manager.services.deployment.actions.model_revision.add_model_rev
 )
 from ai.backend.manager.services.deployment.actions.model_revision.get_revision_by_id import (
     GetRevisionByIdAction,
-    GetRevisionByIdActionResult,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.global_search_revisions import (
     GlobalSearchRevisionsAction,
@@ -119,7 +133,6 @@ from ai.backend.manager.services.deployment.actions.model_revision.search_revisi
 )
 from ai.backend.manager.services.deployment.actions.model_revision.search_revisions import (
     SearchRevisionsAction,
-    SearchRevisionsActionResult,
 )
 from ai.backend.manager.services.deployment.actions.refresh_deployment_revisions import (
     GlobalRefreshDeploymentRevisionsAction,
@@ -153,7 +166,6 @@ from ai.backend.manager.services.deployment.actions.search_legacy_deployments im
 )
 from ai.backend.manager.services.deployment.actions.search_replicas import (
     SearchReplicasAction,
-    SearchReplicasActionResult,
 )
 from ai.backend.manager.services.deployment.actions.sync_replicas import (
     SyncReplicaAction,
@@ -173,15 +185,6 @@ class DeploymentProcessors:
 
     lookup_auto_scaling_rule_deployment: LookupActionProcessor[
         LookupAutoScalingRuleDeploymentAction, FieldOwnerLookupOpsResult
-    ]
-    lookup_access_token_deployment: LookupActionProcessor[
-        LookupAccessTokenDeploymentAction, FieldOwnerLookupOpsResult
-    ]
-    lookup_route_deployment: LookupActionProcessor[
-        LookupRouteDeploymentAction, FieldOwnerLookupOpsResult
-    ]
-    lookup_revision_deployment: LookupActionProcessor[
-        LookupRevisionDeploymentAction, FieldOwnerLookupOpsResult
     ]
 
     # Deployment CRUD
@@ -228,11 +231,11 @@ class DeploymentProcessors:
     add_model_revision: SingleEntityActionProcessor[
         AddModelRevisionAction, AddModelRevisionActionResult
     ]
-    get_revision_by_id: SingleEntityActionProcessor[
-        GetRevisionByIdAction, GetRevisionByIdActionResult
+    get_revision_by_id: SingleFieldActionProcessor[
+        GetRevisionByIdAction, EntityOpsResult[ModelRevisionData]
     ]
-    search_revisions: SingleEntityActionProcessor[
-        SearchRevisionsAction, SearchRevisionsActionResult
+    search_revisions: ScopeActionProcessor[
+        SearchRevisionsAction, ScopedFieldsOpsResult[ModelRevisionData]
     ]
     search_revision_resource_slots: GlobalActionProcessor[
         SearchRevisionResourceSlotsAction, SearchRevisionResourceSlotsActionResult
@@ -247,13 +250,17 @@ class DeploymentProcessors:
     # Route operations
     sync_replicas: SingleEntityActionProcessor[SyncReplicaAction, SyncReplicaActionResult]
     search_routes: GlobalActionProcessor[SearchRoutesAction, SearchRoutesActionResult]
-    update_route_traffic_status: SingleEntityActionProcessor[
+    update_route_traffic_status: SingleFieldActionProcessor[
         UpdateRouteTrafficStatusAction, UpdateRouteTrafficStatusActionResult
     ]
 
     # Replica operations
-    get_replica_by_id: SingleEntityActionProcessor[GetReplicaByIdAction, GetReplicaByIdActionResult]
-    search_replicas: SingleEntityActionProcessor[SearchReplicasAction, SearchReplicasActionResult]
+    get_replica_by_id: SingleFieldActionProcessor[
+        GetReplicaByIdAction, EntityOpsResult[ModelReplicaData]
+    ]
+    search_replicas: ScopeActionProcessor[
+        SearchReplicasAction, ScopedFieldsOpsResult[ModelReplicaData]
+    ]
 
     # Auto-scaling rules
     create_auto_scaling_rule: SingleEntityActionProcessor[
@@ -279,19 +286,21 @@ class DeploymentProcessors:
     create_access_token: SingleEntityActionProcessor[
         CreateAccessTokenAction, CreateAccessTokenActionResult
     ]
-    get_access_token: SingleEntityActionProcessor[GetAccessTokenAction, GetAccessTokenActionResult]
-    delete_access_token: SingleEntityActionProcessor[
+    get_access_token: SingleFieldActionProcessor[
+        GetAccessTokenAction, EntityOpsResult[ModelDeploymentAccessTokenData]
+    ]
+    delete_access_token: SingleFieldActionProcessor[
         DeleteAccessTokenAction, DeleteAccessTokenActionResult
     ]
     bulk_delete_access_tokens: GlobalActionProcessor[
         BulkDeleteAccessTokensAction, BulkDeleteAccessTokensActionResult
     ]
-    search_access_tokens: SingleEntityActionProcessor[
-        SearchAccessTokensAction, SearchAccessTokensActionResult
+    search_access_tokens: ScopeActionProcessor[
+        SearchAccessTokensAction, ScopedFieldsOpsResult[ModelDeploymentAccessTokenData]
     ]
 
     global_search_replicas: GlobalActionProcessor[
-        GlobalSearchReplicasAction, GlobalSearchReplicasActionResult
+        GlobalSearchReplicasAction, BatchOpsResult[ModelReplicaData]
     ]
     global_search_revisions: GlobalActionProcessor[
         GlobalSearchRevisionsAction, GlobalSearchRevisionsActionResult
@@ -303,17 +312,28 @@ class DeploymentProcessors:
     def __init__(
         self, group: ProcessorGroup[ModelDeploymentData], service: DeploymentService
     ) -> None:
+        revisions: LookupFieldGroup[ModelRevisionData] = group.field_group(
+            FieldGroupMeta(DEPLOYMENT_REVISION_FIELD_TYPE),
+            ModelRevisionData,
+            LookupDeploymentRevisionOwnerAction,
+            LookupBulkDeploymentRevisionOwnerAction,
+        )
+        replicas: LookupFieldGroup[ModelReplicaData] = group.field_group(
+            FieldGroupMeta(REPLICA_FIELD_TYPE),
+            ModelReplicaData,
+            LookupReplicaOwnerAction,
+            LookupBulkReplicaOwnerAction,
+        )
+        access_tokens: LookupFieldGroup[ModelDeploymentAccessTokenData] = group.field_group(
+            FieldGroupMeta(DEPLOYMENT_TOKEN_FIELD_TYPE),
+            ModelDeploymentAccessTokenData,
+            LookupDeploymentAccessTokenOwnerAction,
+            LookupBulkDeploymentAccessTokenOwnerAction,
+        )
         self.lookup_auto_scaling_rule_deployment = group.key_owner_lookup_ops(
             LookupAutoScalingRuleDeploymentAction
         )
-        self.lookup_access_token_deployment = group.key_owner_lookup_ops(
-            LookupAccessTokenDeploymentAction
-        )
-        self.lookup_route_deployment = group.key_owner_lookup_ops(LookupRouteDeploymentAction)
-        self.lookup_revision_deployment = group.key_owner_lookup_ops(LookupRevisionDeploymentAction)
-        self.global_search_replicas = group.global_scope(
-            GlobalSearchReplicasAction, service.global_search_replicas
-        )
+        self.global_search_replicas = replicas.global_search_ops(GlobalSearchReplicasAction)
         self.global_search_revisions = group.global_scope(
             GlobalSearchRevisionsAction, service.global_search_revisions
         )
@@ -363,10 +383,8 @@ class DeploymentProcessors:
         self.add_model_revision = group.single_entity(
             AddModelRevisionAction, service.add_model_revision
         )
-        self.get_revision_by_id = group.single_entity(
-            GetRevisionByIdAction, service.get_revision_by_id
-        )
-        self.search_revisions = group.single_entity(SearchRevisionsAction, service.search_revisions)
+        self.get_revision_by_id = revisions.get_ops(GetRevisionByIdAction)
+        self.search_revisions = revisions.search_ops(SearchRevisionsAction)
         self.search_revision_resource_slots = group.global_scope(
             SearchRevisionResourceSlotsAction, service.search_revision_resource_slots
         )
@@ -380,15 +398,13 @@ class DeploymentProcessors:
         # Route operations
         self.sync_replicas = group.single_entity(SyncReplicaAction, service.sync_replicas)
         self.search_routes = group.global_scope(SearchRoutesAction, service.search_routes)
-        self.update_route_traffic_status = group.single_entity(
+        self.update_route_traffic_status = replicas.single_field(
             UpdateRouteTrafficStatusAction, service.update_route_traffic_status
         )
 
         # Replica operations
-        self.get_replica_by_id = group.single_entity(
-            GetReplicaByIdAction, service.get_replica_by_id
-        )
-        self.search_replicas = group.single_entity(SearchReplicasAction, service.search_replicas)
+        self.get_replica_by_id = replicas.get_ops(GetReplicaByIdAction)
+        self.search_replicas = replicas.search_ops(SearchReplicasAction)
 
         # Auto-scaling rules
         self.create_auto_scaling_rule = group.single_entity(
@@ -414,13 +430,11 @@ class DeploymentProcessors:
         self.create_access_token = group.single_entity(
             CreateAccessTokenAction, service.create_access_token
         )
-        self.get_access_token = group.single_entity(GetAccessTokenAction, service.get_access_token)
-        self.delete_access_token = group.single_entity(
+        self.get_access_token = access_tokens.get_ops(GetAccessTokenAction)
+        self.delete_access_token = access_tokens.single_field(
             DeleteAccessTokenAction, service.delete_access_token
         )
         self.bulk_delete_access_tokens = group.global_scope(
             BulkDeleteAccessTokensAction, service.bulk_delete_access_tokens
         )
-        self.search_access_tokens = group.single_entity(
-            SearchAccessTokensAction, service.search_access_tokens
-        )
+        self.search_access_tokens = access_tokens.search_ops(SearchAccessTokensAction)

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -44,7 +44,6 @@ from ai.backend.manager.services.deployment.actions.access_token.get_access_toke
 )
 from ai.backend.manager.services.deployment.actions.access_token.global_search_access_tokens import (
     GlobalSearchAccessTokensAction,
-    GlobalSearchAccessTokensActionResult,
 )
 from ai.backend.manager.services.deployment.actions.access_token.search_access_tokens import (
     SearchAccessTokensAction,
@@ -125,7 +124,6 @@ from ai.backend.manager.services.deployment.actions.model_revision.get_revision_
 )
 from ai.backend.manager.services.deployment.actions.model_revision.global_search_revisions import (
     GlobalSearchRevisionsAction,
-    GlobalSearchRevisionsActionResult,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.search_revision_resource_slots import (
     SearchRevisionResourceSlotsAction,
@@ -303,10 +301,10 @@ class DeploymentProcessors:
         GlobalSearchReplicasAction, BatchOpsResult[ModelReplicaData]
     ]
     global_search_revisions: GlobalActionProcessor[
-        GlobalSearchRevisionsAction, GlobalSearchRevisionsActionResult
+        GlobalSearchRevisionsAction, BatchOpsResult[ModelRevisionData]
     ]
     global_search_access_tokens: GlobalActionProcessor[
-        GlobalSearchAccessTokensAction, GlobalSearchAccessTokensActionResult
+        GlobalSearchAccessTokensAction, BatchOpsResult[ModelDeploymentAccessTokenData]
     ]
 
     def __init__(
@@ -334,11 +332,9 @@ class DeploymentProcessors:
             LookupAutoScalingRuleDeploymentAction
         )
         self.global_search_replicas = replicas.global_search_ops(GlobalSearchReplicasAction)
-        self.global_search_revisions = group.global_scope(
-            GlobalSearchRevisionsAction, service.global_search_revisions
-        )
-        self.global_search_access_tokens = group.global_scope(
-            GlobalSearchAccessTokensAction, service.global_search_access_tokens
+        self.global_search_revisions = revisions.global_search_ops(GlobalSearchRevisionsAction)
+        self.global_search_access_tokens = access_tokens.global_search_ops(
+            GlobalSearchAccessTokensAction
         )
         # Deployment CRUD
         self.create_deployment = group.scope(CreateDeploymentAction, service.create_deployment)

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -10,11 +10,8 @@ from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.model_deployment.types import (
-    ActivenessStatus,
     DeploymentStrategy,
-    LivenessStatus,
     ModelDeploymentStatus,
-    ReadinessStatus,
 )
 from ai.backend.common.dto.appproxy_coordinator.v2.endpoint.request import (
     MintEndpointTokenRequest,
@@ -31,16 +28,11 @@ from ai.backend.manager.data.deployment.types import (
     LegacyDeploymentData,
     ModelDeploymentData,
     ModelDeploymentMetadataInfo,
-    ModelReplicaData,
     ModelRevisionData,
     MountInfo,
     ReplicaStateData,
     ResourceSpec,
     RevisionRefreshResult,
-    RouteHealthStatus,
-    RouteInfo,
-    RouteStatus,
-    RouteTrafficStatus,
 )
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.service import RoutingNotFound
@@ -68,17 +60,9 @@ from ai.backend.manager.services.deployment.actions.access_token.delete_access_t
     DeleteAccessTokenAction,
     DeleteAccessTokenActionResult,
 )
-from ai.backend.manager.services.deployment.actions.access_token.get_access_token import (
-    GetAccessTokenAction,
-    GetAccessTokenActionResult,
-)
 from ai.backend.manager.services.deployment.actions.access_token.global_search_access_tokens import (
     GlobalSearchAccessTokensAction,
     GlobalSearchAccessTokensActionResult,
-)
-from ai.backend.manager.services.deployment.actions.access_token.search_access_tokens import (
-    SearchAccessTokensAction,
-    SearchAccessTokensActionResult,
 )
 from ai.backend.manager.services.deployment.actions.auto_scaling_rule.bulk_delete_auto_scaling_rules import (
     BulkDeleteAutoScalingRulesAction,
@@ -132,21 +116,9 @@ from ai.backend.manager.services.deployment.actions.get_legacy_deployment_by_id 
     GetLegacyDeploymentByIdAction,
     GetLegacyDeploymentByIdActionResult,
 )
-from ai.backend.manager.services.deployment.actions.get_replica_by_id import (
-    GetReplicaByIdAction,
-    GetReplicaByIdActionResult,
-)
-from ai.backend.manager.services.deployment.actions.global_search_replicas import (
-    GlobalSearchReplicasAction,
-    GlobalSearchReplicasActionResult,
-)
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
     AddModelRevisionActionResult,
-)
-from ai.backend.manager.services.deployment.actions.model_revision.get_revision_by_id import (
-    GetRevisionByIdAction,
-    GetRevisionByIdActionResult,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.global_search_revisions import (
     GlobalSearchRevisionsAction,
@@ -155,10 +127,6 @@ from ai.backend.manager.services.deployment.actions.model_revision.global_search
 from ai.backend.manager.services.deployment.actions.model_revision.search_revision_resource_slots import (
     SearchRevisionResourceSlotsAction,
     SearchRevisionResourceSlotsActionResult,
-)
-from ai.backend.manager.services.deployment.actions.model_revision.search_revisions import (
-    SearchRevisionsAction,
-    SearchRevisionsActionResult,
 )
 from ai.backend.manager.services.deployment.actions.refresh_deployment_revisions import (
     GlobalRefreshDeploymentRevisionsAction,
@@ -189,10 +157,6 @@ from ai.backend.manager.services.deployment.actions.search_deployments_in_projec
 from ai.backend.manager.services.deployment.actions.search_legacy_deployments import (
     GlobalSearchLegacyDeploymentsAction,
     GlobalSearchLegacyDeploymentsActionResult,
-)
-from ai.backend.manager.services.deployment.actions.search_replicas import (
-    SearchReplicasAction,
-    SearchReplicasActionResult,
 )
 from ai.backend.manager.services.deployment.actions.sync_replicas import (
     SyncReplicaAction,
@@ -306,63 +270,6 @@ def _convert_deployment_info_to_legacy_data(info: DeploymentInfo) -> LegacyDeplo
         created_user_id=info.metadata.created_user,
         policy=info.policy,
         sub_step=info.sub_step,
-    )
-
-
-_HEALTH_STATUS_TO_READINESS: dict[RouteHealthStatus, ReadinessStatus] = {
-    RouteHealthStatus.HEALTHY: ReadinessStatus.HEALTHY,
-    RouteHealthStatus.UNHEALTHY: ReadinessStatus.UNHEALTHY,
-    RouteHealthStatus.DEGRADED: ReadinessStatus.UNHEALTHY,
-    RouteHealthStatus.NOT_CHECKED: ReadinessStatus.NOT_CHECKED,
-}
-
-_ROUTE_STATUS_TO_LIVENESS: dict[RouteStatus, LivenessStatus] = {
-    RouteStatus.RUNNING: LivenessStatus.HEALTHY,
-    RouteStatus.PROVISIONING: LivenessStatus.NOT_CHECKED,
-    RouteStatus.TERMINATING: LivenessStatus.DEGRADED,
-    RouteStatus.TERMINATED: LivenessStatus.UNHEALTHY,
-    RouteStatus.FAILED_TO_START: LivenessStatus.UNHEALTHY,
-}
-
-
-def _resolve_activeness(
-    traffic_status: RouteTrafficStatus,
-    readiness: ReadinessStatus,
-    liveness: LivenessStatus,
-) -> ActivenessStatus:
-    """Determine activeness from traffic_status, readiness, and liveness.
-
-    A replica is ACTIVE only when:
-    - traffic_status is ACTIVE (admin hasn't disabled it), AND
-    - readiness is HEALTHY (health check passed), AND
-    - liveness is HEALTHY (container is running)
-    """
-    if traffic_status != RouteTrafficStatus.ACTIVE:
-        return ActivenessStatus.INACTIVE
-    if readiness != ReadinessStatus.HEALTHY:
-        return ActivenessStatus.INACTIVE
-    if liveness != LivenessStatus.HEALTHY:
-        return ActivenessStatus.INACTIVE
-    return ActivenessStatus.ACTIVE
-
-
-def _convert_route_info_to_replica_data(route: RouteInfo) -> ModelReplicaData:
-    """Convert RouteInfo to ModelReplicaData."""
-    readiness = _HEALTH_STATUS_TO_READINESS.get(route.health_status) or ReadinessStatus.NOT_CHECKED
-    liveness = _ROUTE_STATUS_TO_LIVENESS.get(route.status) or LivenessStatus.NOT_CHECKED
-    return ModelReplicaData(
-        id=route.route_id,
-        deployment_id=route.deployment_id,
-        revision_id=route.revision_id,
-        session_id=route.session_id,
-        readiness_status=readiness,
-        liveness_status=liveness,
-        activeness_status=_resolve_activeness(route.traffic_status, readiness, liveness),
-        status=route.status,
-        traffic_status=route.traffic_status,
-        health_status=route.health_status,
-        detail=route.error_data,
-        created_at=route.created_at,
     )
 
 
@@ -699,29 +606,6 @@ class DeploymentService:
         )
         return AddModelRevisionActionResult(revision=revision_data)
 
-    async def get_revision_by_id(
-        self, action: GetRevisionByIdAction
-    ) -> GetRevisionByIdActionResult:
-        revision = await self._deployment_repository.get_revision(action.revision_id)
-        return GetRevisionByIdActionResult(data=revision)
-
-    async def search_revisions(self, action: SearchRevisionsAction) -> SearchRevisionsActionResult:
-        """Search revisions with filtering and pagination.
-
-        Args:
-            action: Action containing BatchQuerier for filtering and pagination
-
-        Returns:
-            SearchRevisionsActionResult: Result containing list of revisions and pagination info
-        """
-        result = await self._deployment_repository.search_revisions(action.querier)
-        return SearchRevisionsActionResult(
-            data=result.items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
     async def global_search_revisions(
         self, action: GlobalSearchRevisionsAction
     ) -> GlobalSearchRevisionsActionResult:
@@ -1056,11 +940,6 @@ class DeploymentService:
         )
         return CreateAccessTokenActionResult(data=data)
 
-    async def get_access_token(self, action: GetAccessTokenAction) -> GetAccessTokenActionResult:
-        """Get an access token by ID."""
-        data = await self._deployment_repository.get_access_token(action.access_token_id)
-        return GetAccessTokenActionResult(data=data)
-
     async def delete_access_token(
         self, action: DeleteAccessTokenAction
     ) -> DeleteAccessTokenActionResult:
@@ -1079,38 +958,7 @@ class DeploymentService:
 
     # ========== Replica Operations ==========
 
-    async def get_replica_by_id(self, action: GetReplicaByIdAction) -> GetReplicaByIdActionResult:
-        """Get a replica by ID."""
-        route = await self._deployment_repository.get_route(action.replica_id)
-        if route is None:
-            return GetReplicaByIdActionResult(data=None)
-        return GetReplicaByIdActionResult(data=_convert_route_info_to_replica_data(route))
-
     # ========== Search Operations ==========
-
-    async def search_replicas(self, action: SearchReplicasAction) -> SearchReplicasActionResult:
-        """Search replicas with pagination, ordering, and filtering."""
-        result = await self._deployment_repository.search_routes(action.querier)
-        replicas = [_convert_route_info_to_replica_data(route) for route in result.items]
-        return SearchReplicasActionResult(
-            data=replicas,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
-    async def global_search_replicas(
-        self, action: GlobalSearchReplicasAction
-    ) -> GlobalSearchReplicasActionResult:
-        """Search replicas across every deployment."""
-        result = await self._deployment_repository.search_routes(action.querier)
-        replicas = [_convert_route_info_to_replica_data(route) for route in result.items]
-        return GlobalSearchReplicasActionResult(
-            data=replicas,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
 
     async def global_search_access_tokens(
         self, action: GlobalSearchAccessTokensAction
@@ -1118,18 +966,6 @@ class DeploymentService:
         """Search access tokens across every deployment."""
         result = await self._deployment_repository.search_access_tokens(action.querier)
         return GlobalSearchAccessTokensActionResult(
-            data=result.items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
-    async def search_access_tokens(
-        self, action: SearchAccessTokensAction
-    ) -> SearchAccessTokensActionResult:
-        """Search access tokens with pagination and ordering."""
-        result = await self._deployment_repository.search_access_tokens(action.querier)
-        return SearchAccessTokensActionResult(
             data=result.items,
             total_count=result.total_count,
             has_next_page=result.has_next_page,

--- a/src/ai/backend/manager/services/deployment/service.py
+++ b/src/ai/backend/manager/services/deployment/service.py
@@ -60,10 +60,6 @@ from ai.backend.manager.services.deployment.actions.access_token.delete_access_t
     DeleteAccessTokenAction,
     DeleteAccessTokenActionResult,
 )
-from ai.backend.manager.services.deployment.actions.access_token.global_search_access_tokens import (
-    GlobalSearchAccessTokensAction,
-    GlobalSearchAccessTokensActionResult,
-)
 from ai.backend.manager.services.deployment.actions.auto_scaling_rule.bulk_delete_auto_scaling_rules import (
     BulkDeleteAutoScalingRulesAction,
     BulkDeleteAutoScalingRulesActionResult,
@@ -119,10 +115,6 @@ from ai.backend.manager.services.deployment.actions.get_legacy_deployment_by_id 
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
     AddModelRevisionActionResult,
-)
-from ai.backend.manager.services.deployment.actions.model_revision.global_search_revisions import (
-    GlobalSearchRevisionsAction,
-    GlobalSearchRevisionsActionResult,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.search_revision_resource_slots import (
     SearchRevisionResourceSlotsAction,
@@ -606,18 +598,6 @@ class DeploymentService:
         )
         return AddModelRevisionActionResult(revision=revision_data)
 
-    async def global_search_revisions(
-        self, action: GlobalSearchRevisionsAction
-    ) -> GlobalSearchRevisionsActionResult:
-        """Search revisions across every deployment."""
-        result = await self._deployment_repository.search_revisions(action.querier)
-        return GlobalSearchRevisionsActionResult(
-            data=result.items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
-
     async def activate_revision(
         self, action: ActivateRevisionAction
     ) -> ActivateRevisionActionResult:
@@ -959,18 +939,6 @@ class DeploymentService:
     # ========== Replica Operations ==========
 
     # ========== Search Operations ==========
-
-    async def global_search_access_tokens(
-        self, action: GlobalSearchAccessTokensAction
-    ) -> GlobalSearchAccessTokensActionResult:
-        """Search access tokens across every deployment."""
-        result = await self._deployment_repository.search_access_tokens(action.querier)
-        return GlobalSearchAccessTokensActionResult(
-            data=result.items,
-            total_count=result.total_count,
-            has_next_page=result.has_next_page,
-            has_previous_page=result.has_previous_page,
-        )
 
     async def search_auto_scaling_rules(
         self, action: SearchAutoScalingRulesAction

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -734,6 +734,7 @@ def create_processors(
         ),
         artifact=ArtifactProcessors(
             artifact_groups.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            artifact_revisions,
             ArtifactRevisionProcessors(
                 artifact_groups.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
                 artifact_revisions,

--- a/tests/component/artifact/conftest.py
+++ b/tests/component/artifact/conftest.py
@@ -98,16 +98,18 @@ def artifact_processors(
         storage_manager=storage_manager,
         config_provider=config_provider,
     )
+    artifact_revisions = processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
+        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        ArtifactRevisionData,
+        LookupArtifactRevisionOwnerAction,
+        LookupBulkArtifactRevisionOwnerAction,
+    )
     return ArtifactProcessors(
         processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        artifact_revisions,
         ArtifactRevisionProcessors(
             processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-                FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
-                ArtifactRevisionData,
-                LookupArtifactRevisionOwnerAction,
-                LookupBulkArtifactRevisionOwnerAction,
-            ),
+            artifact_revisions,
             MagicMock(),
         ),
         service,

--- a/tests/component/artifact_registry/conftest.py
+++ b/tests/component/artifact_registry/conftest.py
@@ -105,16 +105,18 @@ def artifact_processors(
         storage_manager=storage_manager,
         config_provider=config_provider,
     )
+    artifact_revisions = processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
+        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        ArtifactRevisionData,
+        LookupArtifactRevisionOwnerAction,
+        LookupBulkArtifactRevisionOwnerAction,
+    )
     return ArtifactProcessors(
         processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        artifact_revisions,
         ArtifactRevisionProcessors(
             processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-                FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
-                ArtifactRevisionData,
-                LookupArtifactRevisionOwnerAction,
-                LookupBulkArtifactRevisionOwnerAction,
-            ),
+            artifact_revisions,
             MagicMock(),
         ),
         service,

--- a/tests/component/artifact_revision/conftest.py
+++ b/tests/component/artifact_revision/conftest.py
@@ -103,16 +103,18 @@ def artifact_processors(
         storage_manager=storage_manager,
         config_provider=config_provider,
     )
+    artifact_revisions = processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
+        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        ArtifactRevisionData,
+        LookupArtifactRevisionOwnerAction,
+        LookupBulkArtifactRevisionOwnerAction,
+    )
     return ArtifactProcessors(
         processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        artifact_revisions,
         ArtifactRevisionProcessors(
             processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-                FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
-                ArtifactRevisionData,
-                LookupArtifactRevisionOwnerAction,
-                LookupBulkArtifactRevisionOwnerAction,
-            ),
+            artifact_revisions,
             MagicMock(),
         ),
         service,

--- a/tests/unit/manager/actions/test_lookup_permission_gate.py
+++ b/tests/unit/manager/actions/test_lookup_permission_gate.py
@@ -46,10 +46,7 @@ from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 from ai.backend.manager.services.deployment.actions.lookup_owner import (
-    LookupAccessTokenDeploymentAction,
     LookupAutoScalingRuleDeploymentAction,
-    LookupRevisionDeploymentAction,
-    LookupRouteDeploymentAction,
 )
 from ai.backend.manager.services.resource_slot.actions.lookup_kernel_owner import (
     LookupKernelOwnerAction,
@@ -263,12 +260,6 @@ _KEY_OWNER_LOOKUP_ACTIONS: list[tuple[LookupFieldOwnerByKeyOpsAction[Any], Entit
         LookupAutoScalingRuleDeploymentAction(rule_id=uuid.uuid4()),
         DeploymentID(uuid.uuid4()),
     ),
-    (
-        LookupAccessTokenDeploymentAction(access_token_id=uuid.uuid4()),
-        DeploymentID(uuid.uuid4()),
-    ),
-    (LookupRouteDeploymentAction(route_id=uuid.uuid4()), DeploymentID(uuid.uuid4())),
-    (LookupRevisionDeploymentAction(revision_id=uuid.uuid4()), DeploymentID(uuid.uuid4())),
 ]
 
 

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -347,6 +347,7 @@ def test_every_defined_v2_action_is_wired() -> None:
     ResourceGroupProcessors(registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), MagicMock())
     ArtifactProcessors(
         registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        artifact_revisions,
         ArtifactRevisionProcessors(
             registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
             artifact_revisions,

--- a/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
+++ b/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
@@ -413,22 +413,6 @@ class TestArtifactRevisionRepository:
         assert revision.version == "main"
 
     # =========================================================================
-    # Tests - List
-    # =========================================================================
-
-    async def test_list_artifact_revisions(
-        self,
-        artifact_repository: ArtifactRepository,
-        sample_artifact_id: uuid.UUID,
-        sample_revision_id: uuid.UUID,
-    ) -> None:
-        """Test listing artifact revisions"""
-        revisions = await artifact_repository.list_artifact_revisions(sample_artifact_id)
-
-        assert len(revisions) == 1
-        assert revisions[0].id == sample_revision_id
-
-    # =========================================================================
     # Tests - Search with filtering
     # =========================================================================
 

--- a/tests/unit/manager/repositories/deployment/test_deployment_repository.py
+++ b/tests/unit/manager/repositories/deployment/test_deployment_repository.py
@@ -972,6 +972,7 @@ class TestDeploymentRepositoryFetchRouteServiceDiscoveryInfo:
                     lifecycle_stage=EndpointLifecycle.READY,
                 )
                 db_sess.add(endpoint)
+                await db_sess.flush()
                 attach_primary_replica_group(db_sess, endpoint, current_revision_id=revision_id)
                 revision = DeploymentRevisionRow(
                     id=revision_id,

--- a/tests/unit/manager/repositories/retention/test_retention_repository.py
+++ b/tests/unit/manager/repositories/retention/test_retention_repository.py
@@ -1060,11 +1060,14 @@ class TestDeploymentsRetention:
     async def test_endpoint_tokens_purged_by_expiry(
         self, db: ExtendedAsyncSAEngine, scope: _Scope
     ) -> None:
-        # endpoint id is irrelevant to expiry-based purge; use throwaway ids.
-        await self._add_token(db, scope, endpoint_id=DeploymentID(uuid.uuid4()), expires_at=_OLD)
-        await self._add_token(db, scope, endpoint_id=DeploymentID(uuid.uuid4()), expires_at=_NEW)
+        # Which endpoint a token belongs to is irrelevant to expiry-based purge.
+        endpoint_id = await self._add_endpoint(
+            db, scope, lifecycle=EndpointLifecycle.READY, destroyed_at=None
+        )
+        await self._add_token(db, scope, endpoint_id=endpoint_id, expires_at=_OLD)
+        await self._add_token(db, scope, endpoint_id=endpoint_id, expires_at=_NEW)
         # A never-expiring token (NULL expires_at) is preserved.
-        await self._add_token(db, scope, endpoint_id=DeploymentID(uuid.uuid4()), expires_at=None)
+        await self._add_token(db, scope, endpoint_id=endpoint_id, expires_at=None)
 
         spec = RetentionDrain(EndpointTokenRow, EndpointTokenRow.expires_at, _THRESHOLD)
         async with RetentionOpsProvider(db).write_ops() as w:
@@ -1076,9 +1079,8 @@ class TestDeploymentsRetention:
     async def test_fk_less_child_deleted_by_destroyed_endpoint(
         self, db: ExtendedAsyncSAEngine, scope: _Scope
     ) -> None:
-        # endpoint_tokens stand in for deployment_revisions: an FK-less child
-        # keyed by endpoint id, deleted when its parent endpoint is DESTROYED and
-        # past the boundary.
+        # A soft-deleted endpoint keeps its row, so ON DELETE CASCADE never fires:
+        # its children are deleted when it is DESTROYED and past the boundary.
         destroyed_id = await self._add_endpoint(
             db, scope, lifecycle=EndpointLifecycle.DESTROYED, destroyed_at=_OLD
         )

--- a/tests/unit/manager/services/artifact/test_artifact_service.py
+++ b/tests/unit/manager/services/artifact/test_artifact_service.py
@@ -60,9 +60,6 @@ from ai.backend.manager.services.artifact.actions.delete_multi import (
 from ai.backend.manager.services.artifact.actions.get import (
     GetArtifactAction,
 )
-from ai.backend.manager.services.artifact.actions.get_revisions import (
-    GetArtifactRevisionsAction,
-)
 from ai.backend.manager.services.artifact.actions.restore_multi import (
     RestoreArtifactsAction,
 )
@@ -1273,72 +1270,6 @@ class TestRetrieveModelsAction:
 
         assert len(result.result) == 2
         mock_storage_client.retrieve_huggingface_models.assert_called_once()
-
-
-class TestGetArtifactRevisionsAction:
-    """Test cases for GetArtifactRevisionsAction"""
-
-    @pytest.fixture
-    def mock_artifact_repository(self) -> MagicMock:
-        return MagicMock(spec=ArtifactRepository)
-
-    @pytest.fixture
-    def artifact_service(self, mock_artifact_repository: MagicMock) -> ArtifactService:
-        return ArtifactService(
-            artifact_repository=mock_artifact_repository,
-            artifact_registry_repository=MagicMock(spec=ArtifactRegistryRepository),
-            object_storage_repository=MagicMock(spec=ObjectStorageRepository),
-            vfs_storage_repository=MagicMock(spec=VFSStorageRepository),
-            huggingface_registry_repository=MagicMock(spec=HuggingFaceRepository),
-            reservoir_registry_repository=MagicMock(spec=ReservoirRegistryRepository),
-            storage_manager=MagicMock(),
-            config_provider=MagicMock(),
-        )
-
-    async def test_artifact_with_multiple_versions(
-        self,
-        artifact_service: ArtifactService,
-        mock_artifact_repository: MagicMock,
-    ) -> None:
-        """Artifact with multiple versions returns sorted revision list"""
-        now = datetime.now(UTC)
-        artifact_id = uuid4()
-        revisions = [
-            ArtifactRevisionData(
-                id=ArtifactRevisionID(uuid4()),
-                artifact_id=ArtifactID(artifact_id),
-                version=f"v{i}",
-                readme=None,
-                size=1000 * i,
-                status=ArtifactStatus.AVAILABLE,
-                remote_status=None,
-                created_at=now,
-                updated_at=now,
-                digest=None,
-                verification_result=None,
-            )
-            for i in range(3)
-        ]
-        mock_artifact_repository.list_artifact_revisions = AsyncMock(return_value=revisions)
-
-        action = GetArtifactRevisionsAction(artifact_id=ArtifactID(artifact_id))
-        result = await artifact_service.get_revisions(action)
-
-        assert len(result.revisions) == 3
-        mock_artifact_repository.list_artifact_revisions.assert_called_once_with(artifact_id)
-
-    async def test_no_revisions_returns_empty(
-        self,
-        artifact_service: ArtifactService,
-        mock_artifact_repository: MagicMock,
-    ) -> None:
-        """No revisions returns empty list"""
-        mock_artifact_repository.list_artifact_revisions = AsyncMock(return_value=[])
-
-        action = GetArtifactRevisionsAction(artifact_id=ArtifactID(uuid4()))
-        result = await artifact_service.get_revisions(action)
-
-        assert result.revisions == []
 
 
 class TestSearchArtifactsWithRevisionsAction:

--- a/tests/unit/manager/services/artifact_revision/test_artifact_revision_service.py
+++ b/tests/unit/manager/services/artifact_revision/test_artifact_revision_service.py
@@ -52,9 +52,6 @@ from ai.backend.manager.repositories.reservoir_registry.repository import (
 from ai.backend.manager.repositories.storage_namespace.repository import StorageNamespaceRepository
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.repositories.vfs_storage.repository import VFSStorageRepository
-from ai.backend.manager.services.artifact.actions.get_revisions import (
-    GetArtifactRevisionsAction,
-)
 from ai.backend.manager.services.artifact.actions.upsert_multi import (
     UpsertArtifactsAction,
 )
@@ -507,27 +504,6 @@ class TestArtifactServiceRevisionOperations:
             updated_at=now,
             digest=None,
             verification_result=None,
-        )
-
-    async def test_get_artifact_revisions(
-        self,
-        artifact_service: ArtifactService,
-        mock_artifact_repository: MagicMock,
-        mock_revision_ops: MagicMock,
-        sample_artifact_data: ArtifactData,
-        sample_artifact_revision: ArtifactRevisionData,
-    ) -> None:
-        """Test getting artifact revisions via ArtifactService"""
-        mock_artifact_repository.list_artifact_revisions = AsyncMock(
-            return_value=[sample_artifact_revision]
-        )
-
-        action = GetArtifactRevisionsAction(artifact_id=sample_artifact_data.id)
-        result = await artifact_service.get_revisions(action)
-
-        assert result.revisions == [sample_artifact_revision]
-        mock_artifact_repository.list_artifact_revisions.assert_called_once_with(
-            sample_artifact_data.id
         )
 
     async def test_upsert_artifacts_with_revisions(

--- a/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
+++ b/tests/unit/manager/services/deployment/test_deployment_crud_actions.py
@@ -1,8 +1,7 @@
 """
 Mock-based unit tests for DeploymentService CRUD and replica/revision actions.
 
-Tests cover: CreateLegacyDeployment, DestroyDeployment, GetReplicaById,
-SearchReplicas, SearchAccessTokens, SyncReplica, GetRevisionById.
+Tests cover: CreateLegacyDeployment, DestroyDeployment, SyncReplica.
 """
 
 from __future__ import annotations
@@ -22,15 +21,9 @@ from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.replica_group import ReplicaGroupID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
-from ai.backend.common.data.model_deployment.types import (
-    ActivenessStatus,
-    LivenessStatus,
-    ReadinessStatus,
-)
-from ai.backend.common.types import ClusterMode, MountPermission, ResourceSlot, SessionId
+from ai.backend.common.types import ClusterMode, MountPermission, ResourceSlot
 from ai.backend.manager.clients.appproxy.client import AppProxyClientPool
 from ai.backend.manager.data.deployment.types import (
-    AccessTokenSearchResult,
     ClusterConfigData,
     DeploymentInfo,
     DeploymentMetadata,
@@ -38,39 +31,21 @@ from ai.backend.manager.data.deployment.types import (
     DeploymentOptions,
     DeploymentState,
     ExecutionData,
-    ModelDeploymentAccessTokenData,
     ModelMountConfigData,
     ModelRevisionData,
     ModelRuntimeConfigData,
     PresetAttributionData,
     ReplicaData,
     ResourceConfigData,
-    RouteHealthStatus,
-    RouteInfo,
-    RouteSearchResult,
-    RouteStatus,
-    RouteTrafficStatus,
 )
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.deployment import DeploymentRepository
-from ai.backend.manager.services.deployment.actions.access_token.search_access_tokens import (
-    SearchAccessTokensAction,
-)
 from ai.backend.manager.services.deployment.actions.create_legacy_deployment import (
     CreateLegacyDeploymentAction,
 )
 from ai.backend.manager.services.deployment.actions.destroy_deployment import (
     DestroyDeploymentAction,
-)
-from ai.backend.manager.services.deployment.actions.get_replica_by_id import (
-    GetReplicaByIdAction,
-)
-from ai.backend.manager.services.deployment.actions.model_revision.get_revision_by_id import (
-    GetRevisionByIdAction,
-)
-from ai.backend.manager.services.deployment.actions.search_replicas import (
-    SearchReplicasAction,
 )
 from ai.backend.manager.services.deployment.actions.sync_replicas import (
     SyncReplicaAction,
@@ -352,280 +327,6 @@ class TestDestroyDeployment(DeploymentCRUDBaseFixtures):
         mock_deployment_controller.destroy_deployment.assert_called_once_with(endpoint_id)
 
 
-class TestGetReplicaById(DeploymentCRUDBaseFixtures):
-    """Tests for DeploymentService.get_replica_by_id"""
-
-    @pytest.fixture
-    def route_info(self, endpoint_id: uuid.UUID) -> RouteInfo:
-        return RouteInfo(
-            route_id=uuid.uuid4(),
-            deployment_id=DeploymentID(endpoint_id),
-            session_id=SessionId(uuid.uuid4()),
-            status=RouteStatus.RUNNING,
-            health_status=RouteHealthStatus.HEALTHY,
-            traffic_ratio=0.5,
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            revision_id=uuid.uuid4(),
-            traffic_status=RouteTrafficStatus.ACTIVE,
-            health_check=None,
-        )
-
-    async def test_existing_replica_returns_data(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        route_info: RouteInfo,
-    ) -> None:
-        """Existing replica_id returns ModelReplicaData with readiness/liveness/activeness."""
-        mock_deployment_repository.get_route = AsyncMock(return_value=route_info)
-
-        action = GetReplicaByIdAction(
-            deployment_id=DeploymentID(uuid.uuid4()), replica_id=route_info.route_id
-        )
-        result = await deployment_service.get_replica_by_id(action)
-
-        assert result.data is not None
-        assert result.data.id == route_info.route_id
-        assert result.data.deployment_id == route_info.deployment_id
-        assert result.data.readiness_status == ReadinessStatus.HEALTHY
-        assert result.data.liveness_status == LivenessStatus.HEALTHY
-        assert result.data.activeness_status == ActivenessStatus.ACTIVE
-
-    async def test_non_existent_replica_returns_none(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-    ) -> None:
-        """Non-existent ID returns data=None."""
-        mock_deployment_repository.get_route = AsyncMock(return_value=None)
-
-        action = GetReplicaByIdAction(
-            deployment_id=DeploymentID(uuid.uuid4()), replica_id=uuid.uuid4()
-        )
-        result = await deployment_service.get_replica_by_id(action)
-
-        assert result.data is None
-
-    async def test_zero_weight_traffic_inactive(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        endpoint_id: uuid.UUID,
-    ) -> None:
-        """traffic_status=INACTIVE returned correctly."""
-        inactive_route = RouteInfo(
-            route_id=uuid.uuid4(),
-            deployment_id=DeploymentID(endpoint_id),
-            session_id=SessionId(uuid.uuid4()),
-            status=RouteStatus.RUNNING,
-            health_status=RouteHealthStatus.HEALTHY,
-            traffic_ratio=0.0,
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            revision_id=uuid.uuid4(),
-            traffic_status=RouteTrafficStatus.INACTIVE,
-            health_check=None,
-        )
-        mock_deployment_repository.get_route = AsyncMock(return_value=inactive_route)
-
-        action = GetReplicaByIdAction(
-            deployment_id=DeploymentID(uuid.uuid4()), replica_id=inactive_route.route_id
-        )
-        result = await deployment_service.get_replica_by_id(action)
-
-        assert result.data is not None
-        assert result.data.activeness_status == ActivenessStatus.INACTIVE
-
-    async def test_unassigned_session_id_is_none(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        endpoint_id: uuid.UUID,
-    ) -> None:
-        """Regression for BA-5838: a route without a compute session must yield
-        ``session_id=None``, not a fallback to ``route_id``."""
-        route = RouteInfo(
-            route_id=uuid.uuid4(),
-            deployment_id=DeploymentID(endpoint_id),
-            session_id=None,
-            status=RouteStatus.PROVISIONING,
-            health_status=RouteHealthStatus.NOT_CHECKED,
-            traffic_ratio=1.0,
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            revision_id=uuid.uuid4(),
-            traffic_status=RouteTrafficStatus.ACTIVE,
-            health_check=None,
-        )
-        mock_deployment_repository.get_route = AsyncMock(return_value=route)
-
-        action = GetReplicaByIdAction(
-            deployment_id=DeploymentID(uuid.uuid4()), replica_id=route.route_id
-        )
-        result = await deployment_service.get_replica_by_id(action)
-
-        assert result.data is not None
-        assert result.data.session_id is None
-
-
-class TestSearchReplicas(DeploymentCRUDBaseFixtures):
-    """Tests for DeploymentService.search_replicas"""
-
-    @pytest.fixture
-    def route_info(self, endpoint_id: uuid.UUID) -> RouteInfo:
-        return RouteInfo(
-            route_id=uuid.uuid4(),
-            deployment_id=DeploymentID(endpoint_id),
-            session_id=SessionId(uuid.uuid4()),
-            status=RouteStatus.RUNNING,
-            health_status=RouteHealthStatus.HEALTHY,
-            traffic_ratio=1.0,
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            revision_id=uuid.uuid4(),
-            traffic_status=RouteTrafficStatus.ACTIVE,
-            health_check=None,
-        )
-
-    async def test_default_pagination(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        route_info: RouteInfo,
-        default_querier: BatchQuerier,
-    ) -> None:
-        """Default pagination returns list/total_count/has_next_page/has_previous_page."""
-        mock_deployment_repository.search_routes = AsyncMock(
-            return_value=RouteSearchResult(
-                items=[route_info],
-                total_count=1,
-                has_next_page=False,
-                has_previous_page=False,
-            )
-        )
-
-        action = SearchReplicasAction(
-            deployment_id=DeploymentID(uuid.uuid4()), querier=default_querier
-        )
-        result = await deployment_service.search_replicas(action)
-
-        assert len(result.data) == 1
-        assert result.total_count == 1
-        assert result.has_next_page is False
-        assert result.has_previous_page is False
-
-    async def test_empty_result(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        default_querier: BatchQuerier,
-    ) -> None:
-        """Empty result returns data=[]/total_count=0."""
-        mock_deployment_repository.search_routes = AsyncMock(
-            return_value=RouteSearchResult(
-                items=[],
-                total_count=0,
-                has_next_page=False,
-                has_previous_page=False,
-            )
-        )
-
-        action = SearchReplicasAction(
-            deployment_id=DeploymentID(uuid.uuid4()), querier=default_querier
-        )
-        result = await deployment_service.search_replicas(action)
-
-        assert result.data == []
-        assert result.total_count == 0
-
-    async def test_pagination_with_next_page(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        route_info: RouteInfo,
-    ) -> None:
-        """Pagination with has_next_page returns correctly."""
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=1, offset=0),
-            conditions=[],
-            orders=[],
-        )
-        mock_deployment_repository.search_routes = AsyncMock(
-            return_value=RouteSearchResult(
-                items=[route_info],
-                total_count=5,
-                has_next_page=True,
-                has_previous_page=False,
-            )
-        )
-
-        action = SearchReplicasAction(deployment_id=DeploymentID(uuid.uuid4()), querier=querier)
-        result = await deployment_service.search_replicas(action)
-
-        assert result.total_count == 5
-        assert result.has_next_page is True
-
-
-class TestSearchAccessTokens(DeploymentCRUDBaseFixtures):
-    """Tests for DeploymentService.search_access_tokens"""
-
-    @pytest.fixture
-    def token_data(self) -> ModelDeploymentAccessTokenData:
-        return ModelDeploymentAccessTokenData(
-            id=uuid.uuid4(),
-            token="test-token-abc123",
-            expires_at=datetime(2025, 12, 31, tzinfo=UTC),
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-        )
-
-    async def test_pagination_returns_tokens(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        token_data: ModelDeploymentAccessTokenData,
-        default_querier: BatchQuerier,
-    ) -> None:
-        """Pagination returns ModelDeploymentAccessTokenData list."""
-        mock_deployment_repository.search_access_tokens = AsyncMock(
-            return_value=AccessTokenSearchResult(
-                items=[token_data],
-                total_count=1,
-                has_next_page=False,
-                has_previous_page=False,
-            )
-        )
-
-        action = SearchAccessTokensAction(
-            deployment_id=DeploymentID(uuid.uuid4()), querier=default_querier
-        )
-        result = await deployment_service.search_access_tokens(action)
-
-        assert len(result.data) == 1
-        assert result.data[0] == token_data
-        assert result.total_count == 1
-
-    async def test_no_tokens_returns_empty(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        default_querier: BatchQuerier,
-    ) -> None:
-        """No tokens returns empty list/total_count=0."""
-        mock_deployment_repository.search_access_tokens = AsyncMock(
-            return_value=AccessTokenSearchResult(
-                items=[],
-                total_count=0,
-                has_next_page=False,
-                has_previous_page=False,
-            )
-        )
-
-        action = SearchAccessTokensAction(
-            deployment_id=DeploymentID(uuid.uuid4()), querier=default_querier
-        )
-        result = await deployment_service.search_access_tokens(action)
-
-        assert result.data == []
-        assert result.total_count == 0
-
-
 class TestSyncReplica(DeploymentCRUDBaseFixtures):
     """Tests for DeploymentService.sync_replicas"""
 
@@ -662,78 +363,3 @@ class TestSyncReplica(DeploymentCRUDBaseFixtures):
         mock_deployment_controller.mark_lifecycle_needed.assert_called_once_with(
             DeploymentLifecycleType.CHECK_REPLICA
         )
-
-
-class TestGetRevisionById(DeploymentCRUDBaseFixtures):
-    """Tests for DeploymentService.get_revision_by_id"""
-
-    @pytest.fixture
-    def revision_data(self) -> ModelRevisionData:
-        return ModelRevisionData(
-            id=DeploymentRevisionID(uuid.uuid4()),
-            deployment_id=DeploymentID(uuid.uuid4()),
-            revision_number=1,
-            cluster_config=ClusterConfigData(
-                mode=ClusterMode.SINGLE_NODE,
-                size=1,
-            ),
-            resource_config=ResourceConfigData(
-                resource_group_name="default",
-                resource_slot=ResourceSlot({"cpu": "4", "mem": "8g"}),
-            ),
-            model_runtime_config=ModelRuntimeConfigData(
-                runtime_variant_id=RuntimeVariantID(uuid.uuid4()),
-            ),
-            model_mount_config=ModelMountConfigData(
-                vfolder_id=VFolderUUID(uuid.uuid4()),
-                mount_destination="/models",
-                definition_path="model-definition.yaml",
-                extra_mounts=[],
-                model_mount_perm=MountPermission.READ_ONLY,
-            ),
-            image_id=ImageID(uuid.uuid4()),
-            created_at=datetime(2024, 1, 1, tzinfo=UTC),
-            execution=ExecutionData(
-                startup_command=None,
-                bootstrap_script=None,
-                callback_url=None,
-            ),
-            revision_preset=PresetAttributionData(preset_id=None, values=[]),
-        )
-
-    async def test_existing_revision_returns_data(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-        revision_data: ModelRevisionData,
-    ) -> None:
-        """Existing revision returns ModelRevisionData with cluster_config/resource_config/image_id/extra_mounts."""
-        mock_deployment_repository.get_revision = AsyncMock(return_value=revision_data)
-
-        action = GetRevisionByIdAction(
-            deployment_id=DeploymentID(uuid.uuid4()), revision_id=revision_data.id
-        )
-        result = await deployment_service.get_revision_by_id(action)
-
-        assert result.data == revision_data
-        assert result.data.cluster_config.mode == ClusterMode.SINGLE_NODE
-        assert result.data.resource_config.resource_group_name == "default"
-        assert result.data.image_id == revision_data.image_id
-        assert result.data.model_mount_config.extra_mounts == []
-        mock_deployment_repository.get_revision.assert_called_once_with(revision_data.id)
-
-    async def test_non_existent_revision_raises(
-        self,
-        deployment_service: DeploymentService,
-        mock_deployment_repository: MagicMock,
-    ) -> None:
-        """Non-existent revision raises DeploymentRevisionNotFound."""
-        mock_deployment_repository.get_revision = AsyncMock(
-            side_effect=Exception("DeploymentRevisionNotFound")
-        )
-
-        action = GetRevisionByIdAction(
-            deployment_id=DeploymentID(uuid.uuid4()), revision_id=DeploymentRevisionID(uuid.uuid4())
-        )
-        with pytest.raises(Exception, match="DeploymentRevisionNotFound"):
-            await deployment_service.get_revision_by_id(action)


### PR DESCRIPTION
## Summary

- A read that names a deployment and comes back with several of the rows under it started from the deployment, so it names where to look rather than what to touch. The revision, replica and access-token searches, and the artifact revision search, become owner-scoped field searches backed by ops; the global counterparts read through the same searchers.
- The three deployment field kinds get a field group with the owner lookups every row-named operation runs first. The get, delete and traffic-status operations go through it, so the adapter no longer resolves an owner by hand and passes it beside the row's id.
- `endpoint_tokens.endpoint` and `deployment_revisions.endpoint` name the endpoint that owns the row, so both carry a cascading foreign key and the token column is no longer nullable. Rows whose endpoint is gone are unreachable and are deleted before the constraints go on.
- A replica's readiness and liveness derive from its route's health status alone; the route-status table that stood behind liveness is gone.
- Removing an access token asks for `UPDATE`, like every other write to a field row: a field path carries `READ|UPDATE` and nothing else, so a delete bit there is not expressible and the check would otherwise fall back on the deployment's own soft-delete right.

## Test plan

- [ ] `pants lint check test --changed-since=origin/main --changed-dependents=direct`
- [ ] Migration `c1a7f3e0d94b` applies on a database holding tokens whose endpoint is gone, and downgrades
- [ ] Revision / replica / access-token search, scoped and admin, over REST v2 and GraphQL
- [ ] Revision, replica and access-token reads by id, and the token delete, as a non-superadmin who may reach the deployment
- [ ] The same as a caller who may not reach the deployment: refused at the owner lookup
- [ ] Replica readiness / liveness / activeness over a route in each health status

Resolves BA-7709
