### PR TITLE
fix(BA-7706): scope the shared vfolder listing to the requester

### DIFF
--- a/changes/14319.fix.md
+++ b/changes/14319.fix.md
@@ -1,0 +1,1 @@
+Scope the shared vfolder listing to the requester, so a share on a folder the caller has no part in no longer appears.

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -173,6 +173,7 @@ from ai.backend.manager.services.vfolder.actions.invite import (
     UpdateInvitedVFolderMountPermissionAction,
 )
 from ai.backend.manager.services.vfolder.actions.sharing import (
+    GlobalListSharedVFoldersAction,
     ListSharedVFoldersAction,
     PublicListSharedVFoldersAction,
     ShareVFolderAction,
@@ -1212,7 +1213,6 @@ class VFolderHandler:
         )
         result = await self._vfolder_sharing.share.run(
             ShareVFolderAction(
-                user_uuid=vfctx.user_uuid,
                 vfolder_uuid=VFolderUUID(row["id"]),
                 resource_policy=req.request["keypair"]["resource_policy"],
                 permission=VFolderPermission(params.permission.value),
@@ -1244,7 +1244,6 @@ class VFolderHandler:
         )
         result = await self._vfolder_sharing.unshare.run(
             UnshareVFolderAction(
-                user_uuid=vfctx.user_uuid,
                 vfolder_uuid=VFolderUUID(row["id"]),
                 resource_policy=req.request["keypair"]["resource_policy"],
                 emails=params.emails,
@@ -1563,17 +1562,20 @@ class VFolderHandler:
     ) -> APIResponse:
         params = query.parsed
         target_vfid = params.vfolder_id
-        shared_rows = (
-            (
-                await self._vfolder_sharing.public_list_shared.run(PublicListSharedVFoldersAction())
-            ).shared
-            if target_vfid is None
-            else (
+        if target_vfid is not None:
+            shared_rows = (
                 await self._vfolder_sharing.list_shared.run(
                     ListSharedVFoldersAction(vfolder_uuid=VFolderUUID(target_vfid))
                 )
             ).shared
-        )
+        elif ctx.is_superadmin or ctx.user_role == UserRole.MONITOR:
+            shared_rows = (
+                await self._vfolder_sharing.global_list_shared.run(GlobalListSharedVFoldersAction())
+            ).shared
+        else:
+            shared_rows = (
+                await self._vfolder_sharing.public_list_shared.run(PublicListSharedVFoldersAction())
+            ).shared
         shared_info = []
         for shared in shared_rows:
             shared_info.append(

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -1901,11 +1901,16 @@ class VfolderRepository:
     @vfolder_repository_resilience.apply()
     async def list_shared_vfolder_permissions(
         self,
+        requester_id: UserID | None = None,
         vfolder_id: uuid.UUID | None = None,
     ) -> list[dict[str, Any]]:
         """
-        List all shared vfolder permission entries with vfolder and user info.
+        List shared vfolder permission entries with vfolder and user info.
         Returns list of dicts with vfolder/permission/user fields.
+
+        ``requester_id`` keeps the entries the user is party to: the share is granted
+        to them, or it stands on a folder they own, created, or reach through their
+        project membership. Omitting it lists every entry in the system.
         """
         async with self._db.begin_readonly_session_read_committed() as session:
             perm_table = VFolderPermissionRow.__table__
@@ -1926,6 +1931,17 @@ class VfolderRepository:
             ).select_from(j)
             if vfolder_id is not None:
                 db_query = db_query.where(vf_table.c.id == vfolder_id)
+            if requester_id is not None:
+                db_query = db_query.where(
+                    sa.or_(
+                        perm_table.c.user == requester_id,
+                        vf_table.c.user == requester_id,
+                        vf_table.c.creator_id == requester_id,
+                        user_scope_membership_exists(
+                            PROJECT_SCOPE_TYPE, vf_table.c.group, requester_id
+                        ),
+                    )
+                )
             result = await session.execute(db_query)
             return [dict(row._mapping) for row in result.fetchall()]
 

--- a/src/ai/backend/manager/services/vfolder/actions/sharing.py
+++ b/src/ai/backend/manager/services/vfolder/actions/sharing.py
@@ -29,7 +29,6 @@ class VFolderSharedInfo:
 class ShareVFolderAction(VFolderAction):
     """Share a group vfolder with users by granting permissions directly."""
 
-    user_uuid: uuid.UUID
     resource_policy: Mapping[str, Any]
     permission: VFolderPermission
     emails: list[str] = field(default_factory=list)
@@ -54,7 +53,6 @@ class ShareVFolderActionResult:
 class UnshareVFolderAction(VFolderAction):
     """Revoke direct sharing permissions from users."""
 
-    user_uuid: uuid.UUID
     resource_policy: Mapping[str, Any]
     emails: list[str] = field(default_factory=list)
 
@@ -119,9 +117,12 @@ class UpdateVFolderSharingStatusActionResult:
 
 @dataclass
 class PublicListSharedVFoldersAction(VFolderGlobalAction):
-    """List the sharing permissions granted across every vfolder.
+    """List the sharing permissions the requester is party to.
 
-    Read-only and open to any authenticated caller, as the legacy route was.
+    Read-only and open to any authenticated caller, as the legacy route was. The
+    requester bounds the rows, so no caller learns of a share on a folder they
+    neither hold, own, created, nor reach through their projects. The requester is
+    the user in context, never a field a caller fills in.
     """
 
     @override
@@ -137,4 +138,24 @@ class PublicListSharedVFoldersAction(VFolderGlobalAction):
 
 @dataclass
 class PublicListSharedVFoldersActionResult:
+    shared: list[VFolderSharedInfo] = field(default_factory=list)
+
+
+@dataclass
+class GlobalListSharedVFoldersAction(VFolderGlobalAction):
+    """List the sharing permissions granted across every vfolder."""
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.SEARCH
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "global_list_shared_vfolders"
+
+
+@dataclass
+class GlobalListSharedVFoldersActionResult:
     shared: list[VFolderSharedInfo] = field(default_factory=list)

--- a/src/ai/backend/manager/services/vfolder/processors/sharing.py
+++ b/src/ai/backend/manager/services/vfolder/processors/sharing.py
@@ -1,8 +1,13 @@
 from ai.backend.manager.actions.registry.group import ProcessorGroup
-from ai.backend.manager.actions.v2.global_scope.processor import PublicActionProcessor
+from ai.backend.manager.actions.v2.global_scope.processor import (
+    GlobalActionProcessor,
+    PublicActionProcessor,
+)
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.vfolder.types import VFolderData
 from ai.backend.manager.services.vfolder.actions.sharing import (
+    GlobalListSharedVFoldersAction,
+    GlobalListSharedVFoldersActionResult,
     ListSharedVFoldersAction,
     ListSharedVFoldersActionResult,
     PublicListSharedVFoldersAction,
@@ -26,6 +31,9 @@ class VFolderSharingProcessors:
     public_list_shared: PublicActionProcessor[
         PublicListSharedVFoldersAction, PublicListSharedVFoldersActionResult
     ]
+    global_list_shared: GlobalActionProcessor[
+        GlobalListSharedVFoldersAction, GlobalListSharedVFoldersActionResult
+    ]
     update_sharing_status: SingleEntityActionProcessor[
         UpdateVFolderSharingStatusAction, UpdateVFolderSharingStatusActionResult
     ]
@@ -38,6 +46,9 @@ class VFolderSharingProcessors:
         )
         self.public_list_shared = group.public(
             PublicListSharedVFoldersAction, service.public_list_shared_vfolders
+        )
+        self.global_list_shared = group.global_scope(
+            GlobalListSharedVFoldersAction, service.global_list_shared_vfolders
         )
         self.update_sharing_status = group.single_entity(
             UpdateVFolderSharingStatusAction, service.update_sharing_status

--- a/src/ai/backend/manager/services/vfolder/services/sharing.py
+++ b/src/ai/backend/manager/services/vfolder/services/sharing.py
@@ -1,9 +1,17 @@
+from typing import Any
+
+from ai.backend.common.contexts.user import current_user
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.user.types import UserData
+from ai.backend.common.exception import UnreachableError
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.errors.storage import VFolderNotFound
 from ai.backend.manager.models.vfolder import VFolderOwnershipType
 from ai.backend.manager.repositories.user.repository import UserRepository
 from ai.backend.manager.repositories.vfolder.repository import VfolderRepository
 from ai.backend.manager.services.vfolder.actions.sharing import (
+    GlobalListSharedVFoldersAction,
+    GlobalListSharedVFoldersActionResult,
     ListSharedVFoldersAction,
     ListSharedVFoldersActionResult,
     PublicListSharedVFoldersAction,
@@ -33,8 +41,15 @@ class VFolderSharingService:
         self._vfolder_repository = vfolder_repository
         self._user_repository = user_repository
 
+    def _requester(self) -> UserData:
+        me = current_user()
+        if me is None:
+            raise UnreachableError("User context is not available")
+        return me
+
     async def share(self, action: ShareVFolderAction) -> ShareVFolderActionResult:
-        user = await self._user_repository.get_user_by_uuid(action.user_uuid)
+        requester_id = self._requester().user_id
+        user = await self._user_repository.get_user_by_uuid(requester_id)
         if not user.domain_name:
             raise VFolderNotFound("User has no domain assigned")
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
@@ -51,7 +66,7 @@ class VFolderSharingService:
             vfolder_id=action.vfolder_uuid,
             vfolder_host=vfolder_data.host,
             vfolder_group=vfolder_data.group,
-            requester_uuid=action.user_uuid,
+            requester_uuid=requester_id,
             requester_email=user.email,
             domain_name=user.domain_name,
             resource_policy=action.resource_policy,
@@ -62,7 +77,8 @@ class VFolderSharingService:
         return ShareVFolderActionResult(shared_emails=shared_emails)
 
     async def unshare(self, action: UnshareVFolderAction) -> UnshareVFolderActionResult:
-        user = await self._user_repository.get_user_by_uuid(action.user_uuid)
+        requester_id = self._requester().user_id
+        user = await self._user_repository.get_user_by_uuid(requester_id)
         if not user.domain_name:
             raise VFolderNotFound("User has no domain assigned")
         vfolder_data = await self._vfolder_repository.get_by_id_validated(
@@ -78,7 +94,7 @@ class VFolderSharingService:
         unshared_emails = await self._vfolder_repository.unshare_vfolder_from_users(
             vfolder_id=action.vfolder_uuid,
             vfolder_host=vfolder_data.host,
-            requester_uuid=action.user_uuid,
+            requester_uuid=requester_id,
             domain_name=user.domain_name,
             resource_policy=action.resource_policy,
             emails=action.emails,
@@ -86,53 +102,47 @@ class VFolderSharingService:
         )
         return UnshareVFolderActionResult(unshared_emails=unshared_emails)
 
+    def _to_shared_info(self, rows: list[dict[str, Any]]) -> list[VFolderSharedInfo]:
+        shared_info = []
+        for row in rows:
+            is_project_folder = row["ownership_type"] == VFolderOwnershipType.GROUP
+            owner = row["group"] if is_project_folder else row["vfolder_user"]
+            folder_type = "project" if is_project_folder else "user"
+            shared_info.append(
+                VFolderSharedInfo(
+                    vfolder_id=row["vfolder_id"],
+                    vfolder_name=row["name"],
+                    status=row["status"],
+                    owner=str(owner),
+                    folder_type=folder_type,
+                    shared_user_uuid=row["user"],
+                    shared_user_email=row["email"],
+                    permission=row["permission"],
+                )
+            )
+        return shared_info
+
     async def list_shared_vfolders(
         self, action: ListSharedVFoldersAction
     ) -> ListSharedVFoldersActionResult:
         raw_list = await self._vfolder_repository.list_shared_vfolder_permissions(
-            action.vfolder_uuid
+            vfolder_id=action.vfolder_uuid
         )
-        shared_info = []
-        for row in raw_list:
-            is_project_folder = row["ownership_type"] == VFolderOwnershipType.GROUP
-            owner = row["group"] if is_project_folder else row["vfolder_user"]
-            folder_type = "project" if is_project_folder else "user"
-            shared_info.append(
-                VFolderSharedInfo(
-                    vfolder_id=row["vfolder_id"],
-                    vfolder_name=row["name"],
-                    status=row["status"],
-                    owner=str(owner),
-                    folder_type=folder_type,
-                    shared_user_uuid=row["user"],
-                    shared_user_email=row["email"],
-                    permission=row["permission"],
-                )
-            )
-        return ListSharedVFoldersActionResult(shared=shared_info)
+        return ListSharedVFoldersActionResult(shared=self._to_shared_info(raw_list))
 
     async def public_list_shared_vfolders(
         self, action: PublicListSharedVFoldersAction
     ) -> PublicListSharedVFoldersActionResult:
-        raw_list = await self._vfolder_repository.list_shared_vfolder_permissions(None)
-        shared_info = []
-        for row in raw_list:
-            is_project_folder = row["ownership_type"] == VFolderOwnershipType.GROUP
-            owner = row["group"] if is_project_folder else row["vfolder_user"]
-            folder_type = "project" if is_project_folder else "user"
-            shared_info.append(
-                VFolderSharedInfo(
-                    vfolder_id=row["vfolder_id"],
-                    vfolder_name=row["name"],
-                    status=row["status"],
-                    owner=str(owner),
-                    folder_type=folder_type,
-                    shared_user_uuid=row["user"],
-                    shared_user_email=row["email"],
-                    permission=row["permission"],
-                )
-            )
-        return PublicListSharedVFoldersActionResult(shared=shared_info)
+        raw_list = await self._vfolder_repository.list_shared_vfolder_permissions(
+            requester_id=UserID(self._requester().user_id)
+        )
+        return PublicListSharedVFoldersActionResult(shared=self._to_shared_info(raw_list))
+
+    async def global_list_shared_vfolders(
+        self, action: GlobalListSharedVFoldersAction
+    ) -> GlobalListSharedVFoldersActionResult:
+        raw_list = await self._vfolder_repository.list_shared_vfolder_permissions()
+        return GlobalListSharedVFoldersActionResult(shared=self._to_shared_info(raw_list))
 
     async def update_sharing_status(
         self, action: UpdateVFolderSharingStatusAction

--- a/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_sharing_service.py
@@ -5,13 +5,18 @@ Tests for VFolderSharingService and VFolderInviteService functionality.
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationID
+from ai.backend.common.data.user.types import UserData as ContextUserData
+from ai.backend.common.data.user.types import UserRole as ContextUserRole
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.data.vfolder.types import (
     VFolderData,
@@ -46,7 +51,9 @@ from ai.backend.manager.services.vfolder.actions.invite import (
     UpdateInvitedVFolderMountPermissionAction,
 )
 from ai.backend.manager.services.vfolder.actions.sharing import (
+    GlobalListSharedVFoldersAction,
     ListSharedVFoldersAction,
+    PublicListSharedVFoldersAction,
     ShareVFolderAction,
     UnshareVFolderAction,
     UpdateVFolderSharingStatusAction,
@@ -58,6 +65,22 @@ from ai.backend.manager.services.vfolder.services.sharing import VFolderSharingS
 @pytest.fixture
 def user_uuid() -> uuid.UUID:
     return uuid.uuid4()
+
+
+@pytest.fixture(autouse=True)
+def requester_context(user_uuid: uuid.UUID) -> Iterator[None]:
+    """The sharing service reads its requester from the user context."""
+    user = ContextUserData(
+        user_id=user_uuid,
+        is_authorized=True,
+        is_admin=False,
+        is_superadmin=False,
+        role=ContextUserRole.USER,
+        domain_name="default",
+        domain_id=DomainID(uuid.uuid4()),
+    )
+    with with_user(user):
+        yield
 
 
 @pytest.fixture
@@ -164,7 +187,6 @@ class TestShareVFolderAction:
         mock_vfolder_repo.share_vfolder_with_users = AsyncMock(return_value=emails)
 
         action = ShareVFolderAction(
-            user_uuid=user_uuid,
             vfolder_uuid=VFolderUUID(vfolder_uuid),
             resource_policy={},
             permission=VFolderMountPermission.READ_WRITE,
@@ -189,7 +211,6 @@ class TestShareVFolderAction:
         )
 
         action = ShareVFolderAction(
-            user_uuid=user_uuid,
             vfolder_uuid=VFolderUUID(vfolder_uuid),
             resource_policy={},
             permission=VFolderMountPermission.READ_WRITE,
@@ -211,7 +232,6 @@ class TestShareVFolderAction:
         )
 
         action = ShareVFolderAction(
-            user_uuid=user_uuid,
             vfolder_uuid=VFolderUUID(vfolder_uuid),
             resource_policy={},
             permission=VFolderMountPermission.READ_WRITE,
@@ -233,7 +253,6 @@ class TestShareVFolderAction:
         mock_vfolder_repo.get_by_id_validated = AsyncMock(side_effect=VFolderNotFound())
 
         action = ShareVFolderAction(
-            user_uuid=user_uuid,
             vfolder_uuid=VFolderUUID(vfolder_uuid),
             resource_policy={},
             permission=VFolderMountPermission.READ_WRITE,
@@ -266,7 +285,6 @@ class TestUnshareVFolderAction:
         mock_vfolder_repo.unshare_vfolder_from_users = AsyncMock(return_value=emails)
 
         action = UnshareVFolderAction(
-            user_uuid=user_uuid,
             vfolder_uuid=VFolderUUID(vfolder_uuid),
             resource_policy={},
             emails=emails,
@@ -289,7 +307,6 @@ class TestUnshareVFolderAction:
         )
 
         action = UnshareVFolderAction(
-            user_uuid=user_uuid,
             vfolder_uuid=VFolderUUID(vfolder_uuid),
             resource_policy={},
             emails=["a@test.com"],
@@ -349,7 +366,9 @@ class TestListSharedVFoldersAction:
         action = ListSharedVFoldersAction(vfolder_uuid=VFolderUUID(vfolder_uuid))
         await sharing_service.list_shared_vfolders(action)
 
-        mock_vfolder_repo.list_shared_vfolder_permissions.assert_called_once_with(vfolder_uuid)
+        mock_vfolder_repo.list_shared_vfolder_permissions.assert_called_once_with(
+            vfolder_id=vfolder_uuid
+        )
 
     async def test_no_permissions_returns_empty_list(
         self,
@@ -362,6 +381,60 @@ class TestListSharedVFoldersAction:
         result = await sharing_service.list_shared_vfolders(action)
 
         assert result.shared == []
+
+
+# ============================================================
+# PublicListSharedVFoldersAction / GlobalListSharedVFoldersAction tests
+# ============================================================
+
+
+class TestListSharedVFoldersWithoutTarget:
+    async def test_public_listing_is_bound_to_the_user_in_context(
+        self,
+        sharing_service: VFolderSharingService,
+        mock_vfolder_repo: MagicMock,
+        user_uuid: uuid.UUID,
+    ) -> None:
+        mock_vfolder_repo.list_shared_vfolder_permissions = AsyncMock(return_value=[])
+
+        result = await sharing_service.public_list_shared_vfolders(PublicListSharedVFoldersAction())
+
+        assert result.shared == []
+        mock_vfolder_repo.list_shared_vfolder_permissions.assert_called_once_with(
+            requester_id=user_uuid
+        )
+
+    async def test_global_listing_names_no_requester(
+        self,
+        sharing_service: VFolderSharingService,
+        mock_vfolder_repo: MagicMock,
+        vfolder_uuid: uuid.UUID,
+    ) -> None:
+        shared_user_uuid = uuid.uuid4()
+        owner_uuid = uuid.uuid4()
+        mock_vfolder_repo.list_shared_vfolder_permissions = AsyncMock(
+            return_value=[
+                {
+                    "vfolder_id": vfolder_uuid,
+                    "name": "shared-folder",
+                    "status": VFolderOperationStatus.READY,
+                    "group": None,
+                    "ownership_type": VFolderOwnershipType.USER,
+                    "vfolder_user": owner_uuid,
+                    "user": shared_user_uuid,
+                    "email": "shared@test.com",
+                    "permission": VFolderMountPermission.READ_ONLY,
+                }
+            ]
+        )
+
+        result = await sharing_service.global_list_shared_vfolders(GlobalListSharedVFoldersAction())
+
+        assert len(result.shared) == 1
+        info = result.shared[0]
+        assert info.owner == str(owner_uuid)
+        assert info.folder_type == "user"
+        mock_vfolder_repo.list_shared_vfolder_permissions.assert_called_once_with()
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- `GET /folders/_/shared` without a `vfolder_id` returned every sharing entry in the system — folder names, owner ids and grantee emails — to any authenticated caller. The listing now keeps the entries the requester is party to: granted to them, on a folder they own or created, or on a folder of a project they belong to. Project membership is read through the virtual-entity chain, not the sunset association tables.
- A super admin (and a monitor, which reads what a super admin reads) keeps the system-wide listing through a separate `GlobalListSharedVFoldersAction` wired to `global_scope`, so the privilege is enforced by `SuperAdminActionValidator` rather than a caller-supplied flag.
- The sharing service reads its requester from the user context, so `share`, `unshare` and the public listing no longer carry a caller-filled user id.
- The route, the request parameters and the response shape are unchanged.

## Test plan
- [ ] A regular user lists `GET /folders/_/shared` and sees only the shares granted to them, on their own folders, and on their projects' folders
- [ ] A folder owner still sees the grantees of their project folder and can revoke one through `POST /folders/_/shared`
- [ ] A super admin and a monitor still see the system-wide listing
- [ ] `GET /folders/_/shared?vfolder_id=…` is unchanged for every role

Backport: none

Resolves BA-7706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnDWcwrgQsmcAQbAd56kfh
