### PR TITLE
refactor(BA-7708): judge each model card of a bulk delete on its own

### DIFF
--- a/changes/14322.enhance.md
+++ b/changes/14322.enhance.md
@@ -1,0 +1,1 @@
+Judge every model card of a bulk delete on its own permission instead of the caller being a super admin.

--- a/src/ai/backend/manager/api/adapters/model_card/adapter.py
+++ b/src/ai/backend/manager/api/adapters/model_card/adapter.py
@@ -89,7 +89,6 @@ from ai.backend.manager.services.model_card.actions.available_presets import (
 )
 from ai.backend.manager.services.model_card.actions.bulk_delete import (
     BulkDeleteModelCardAction,
-    BulkDeleteModelCardActionResult,
 )
 from ai.backend.manager.services.model_card.actions.create import CreateModelCardAction
 from ai.backend.manager.services.model_card.actions.delete import DeleteModelCardAction
@@ -427,25 +426,18 @@ class ModelCardAdapter(BaseAdapter):
         options: DeleteModelCardOptions,
     ) -> BulkDeleteModelCardsPayload:
         """Bulk-delete model cards and surface per-card success/failure breakdown."""
-        result = await self._run_bulk_delete(input.ids, options)
-        return BulkDeleteModelCardsPayload(
-            successes=list(result.data.successes),
-            failed=[
-                BulkDeleteModelCardV2Error(card_id=failure.card_id, message=failure.message)
-                for failure in result.data.failures
-            ],
-        )
-
-    async def _run_bulk_delete(
-        self,
-        card_ids: list[UUID],
-        options: DeleteModelCardOptions,
-    ) -> BulkDeleteModelCardActionResult:
-        return await self._processors.model_card.bulk_delete.run(
+        result = await self._processors.model_card.bulk_delete.run(
             BulkDeleteModelCardAction(
-                purgers=[ModelCardPurger(card_id=ModelCardID(card_id)) for card_id in card_ids],
+                ids=[ModelCardID(card_id) for card_id in input.ids],
                 options=options,
             )
+        )
+        return BulkDeleteModelCardsPayload(
+            successes=[UUID(str(card_id)) for card_id in result.values()],
+            failed=[
+                BulkDeleteModelCardV2Error(card_id=UUID(str(card_id)), message=str(error))
+                for card_id, error in result.errors().items()
+            ],
         )
 
     async def scan_project(self, project_id: UUID) -> ScanProjectModelCardsPayload:

--- a/src/ai/backend/manager/data/model_card/types.py
+++ b/src/ai/backend/manager/data/model_card/types.py
@@ -62,10 +62,10 @@ class ModelCardData(EntityData):
 
 @dataclass(frozen=True)
 class BulkModelCardDeleteFailure:
-    """Error info for a single failed model card delete inside a bulk operation."""
+    """The error one model card's delete raised inside a bulk operation."""
 
     card_id: UUID
-    message: str
+    error: Exception
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/model_card/db_source/db_source.py
@@ -176,9 +176,7 @@ class ModelCardDBSource:
                         deleted_id = await self._delete_card(sp, purger, options)
                     successes.append(deleted_id)
                 except Exception as exc:
-                    failures.append(
-                        BulkModelCardDeleteFailure(card_id=purger.card_id, message=str(exc))
-                    )
+                    failures.append(BulkModelCardDeleteFailure(card_id=purger.card_id, error=exc))
         return BulkModelCardDeleteResultData(successes=successes, failures=failures)
 
     async def _delete_card(

--- a/src/ai/backend/manager/services/model_card/actions/bulk_delete.py
+++ b/src/ai/backend/manager/services/model_card/actions/bulk_delete.py
@@ -1,16 +1,23 @@
-from dataclasses import dataclass
-from typing import override
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
 
+from ai.backend.common.data.entity.model_card import ModelCardID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.dto.manager.v2.model_card.request import DeleteModelCardOptions
 from ai.backend.manager.actions.types import ActionOperationType
-from ai.backend.manager.data.model_card.types import BulkModelCardDeleteResultData
-from ai.backend.manager.models.model_card.purgers import ModelCardPurger
-from ai.backend.manager.services.model_card.actions.base import ModelCardAction
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
 
 
 @dataclass
-class BulkDeleteModelCardAction(ModelCardAction):
-    purgers: list[ModelCardPurger]
+class BulkDeleteModelCardAction(BasePartialBulkAction):
+    """Delete the named model cards, answering for each one.
+
+    ``PURGE`` because the row is removed rather than marked deleted, which is also
+    what the cascade behind ``options`` acts on.
+    """
+
+    ids: Sequence[ModelCardID]
     options: DeleteModelCardOptions
 
     @override
@@ -21,9 +28,13 @@ class BulkDeleteModelCardAction(ModelCardAction):
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.DELETE
+        return ActionOperationType.PURGE
 
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
 
-@dataclass
-class BulkDeleteModelCardActionResult:
-    data: BulkModelCardDeleteResultData
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[card_id for card_id in self.ids if card_id in allowed])

--- a/src/ai/backend/manager/services/model_card/actions/delete.py
+++ b/src/ai/backend/manager/services/model_card/actions/delete.py
@@ -10,6 +10,12 @@ from ai.backend.manager.services.model_card.actions.base import ModelCardSingleE
 
 @dataclass
 class DeleteModelCardAction(ModelCardSingleEntityAction):
+    """Delete one model card.
+
+    ``PURGE`` because the row is removed rather than marked deleted, matching the
+    bulk form of the same operation.
+    """
+
     purger: ModelCardPurger
     options: DeleteModelCardOptions
 
@@ -21,7 +27,7 @@ class DeleteModelCardAction(ModelCardSingleEntityAction):
     @override
     @classmethod
     def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.DELETE
+        return ActionOperationType.PURGE
 
 
 @dataclass

--- a/src/ai/backend/manager/services/model_card/processors.py
+++ b/src/ai/backend/manager/services/model_card/processors.py
@@ -1,11 +1,13 @@
 from typing import Any
 
+from ai.backend.common.data.entity.model_card import ModelCardID
 from ai.backend.common.data.entity.model_card_resource_requirement import (
     MODEL_CARD_RESOURCE_REQUIREMENT_FIELD_TYPE,
 )
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.registry.types import FieldGroupMeta
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
@@ -27,7 +29,6 @@ from ai.backend.manager.services.model_card.actions.available_presets import (
 )
 from ai.backend.manager.services.model_card.actions.bulk_delete import (
     BulkDeleteModelCardAction,
-    BulkDeleteModelCardActionResult,
 )
 from ai.backend.manager.services.model_card.actions.create import CreateModelCardAction
 from ai.backend.manager.services.model_card.actions.delete import (
@@ -66,7 +67,7 @@ class ModelCardProcessors:
     ]
     update: SingleEntityActionProcessor[UpdateModelCardAction, UpdateModelCardActionResult]
     delete: SingleEntityActionProcessor[DeleteModelCardAction, DeleteModelCardActionResult]
-    bulk_delete: GlobalActionProcessor[BulkDeleteModelCardAction, BulkDeleteModelCardActionResult]
+    bulk_delete: PartialBulkActionProcessor[BulkDeleteModelCardAction, ModelCardID]
     get: SingleEntityActionProcessor[GetModelCardAction, EntityOpsResult[ModelCardData]]
     global_search: GlobalActionProcessor[
         GlobalSearchModelCardsAction, BatchOpsResult[ModelCardData]
@@ -85,7 +86,7 @@ class ModelCardProcessors:
         self.create = group.entity_create_with_fields_ops(CreateModelCardAction)
         self.update = group.single_entity(UpdateModelCardAction, service.update)
         self.delete = group.single_entity(DeleteModelCardAction, service.delete)
-        self.bulk_delete = group.global_scope(BulkDeleteModelCardAction, service.bulk_delete)
+        self.bulk_delete = group.partial_bulk(BulkDeleteModelCardAction, service.bulk_delete)
         self.get = group.single_get_ops(GetModelCardAction)
         self.global_search = group.global_search_ops(GlobalSearchModelCardsAction)
         self.search_in_project = group.scope_search_ops(SearchModelCardsInProjectAction)

--- a/src/ai/backend/manager/services/model_card/service.py
+++ b/src/ai/backend/manager/services/model_card/service.py
@@ -4,11 +4,18 @@ from uuid import UUID
 from ruamel.yaml import YAML
 
 from ai.backend.common.config import ModelDefinition
+from ai.backend.common.data.entity.model_card import ModelCardID
 from ai.backend.common.types import VFolderID
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.v2.bulk.result import (
+    PartialBulkEntityResult,
+    PartialBulkResult,
+)
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
 from ai.backend.manager.data.model_card.types import ResourceRequirementEntry, VFolderScanData
+from ai.backend.manager.errors.resource import ModelCardNotFound
 from ai.backend.manager.errors.storage import ModelCardParseError
+from ai.backend.manager.models.model_card.purgers import ModelCardPurger
 from ai.backend.manager.models.model_card.upserters import ModelCardScanUpserter
 from ai.backend.manager.repositories.model_card.repository import ModelCardRepository
 from ai.backend.manager.services.model_card.actions.available_presets import (
@@ -17,7 +24,6 @@ from ai.backend.manager.services.model_card.actions.available_presets import (
 )
 from ai.backend.manager.services.model_card.actions.bulk_delete import (
     BulkDeleteModelCardAction,
-    BulkDeleteModelCardActionResult,
 )
 from ai.backend.manager.services.model_card.actions.delete import (
     DeleteModelCardAction,
@@ -61,9 +67,21 @@ class ModelCardService:
 
     async def bulk_delete(
         self, action: BulkDeleteModelCardAction
-    ) -> BulkDeleteModelCardActionResult:
-        data = await self._repository.bulk_delete(action.purgers, action.options)
-        return BulkDeleteModelCardActionResult(data=data)
+    ) -> PartialBulkResult[ModelCardID]:
+        purgers = [ModelCardPurger(card_id=card_id) for card_id in action.ids]
+        data = await self._repository.bulk_delete(purgers, action.options)
+        deleted = {ModelCardID(card_id) for card_id in data.successes}
+        errors = {ModelCardID(failure.card_id): failure.error for failure in data.failures}
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[ModelCardID].succeeded(card_id, card_id)
+                if card_id in deleted
+                else PartialBulkEntityResult[ModelCardID].failed(
+                    card_id, errors.get(card_id, ModelCardNotFound())
+                )
+                for card_id in action.ids
+            ]
+        )
 
     async def available_presets(
         self, action: AvailablePresetsAction

--- a/tests/unit/manager/services/model_card/BUILD
+++ b/tests/unit/manager/services/model_card/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests")

--- a/tests/unit/manager/services/model_card/test_model_card_bulk_delete.py
+++ b/tests/unit/manager/services/model_card/test_model_card_bulk_delete.py
@@ -1,0 +1,97 @@
+"""Tests for the per-card answer `ModelCardService.bulk_delete` returns."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.common.data.entity.model_card import ModelCardID
+from ai.backend.common.dto.manager.v2.model_card.request import DeleteModelCardOptions
+from ai.backend.manager.data.model_card.types import (
+    BulkModelCardDeleteFailure,
+    BulkModelCardDeleteResultData,
+)
+from ai.backend.manager.errors.resource import ModelCardNotFound
+from ai.backend.manager.repositories.model_card.repository import ModelCardRepository
+from ai.backend.manager.services.model_card.actions.bulk_delete import BulkDeleteModelCardAction
+from ai.backend.manager.services.model_card.service import ModelCardService
+
+
+@pytest.fixture
+def mock_repository() -> MagicMock:
+    return MagicMock(spec=ModelCardRepository)
+
+
+@pytest.fixture
+def model_card_service(mock_repository: MagicMock) -> ModelCardService:
+    return ModelCardService(repository=mock_repository, storage_manager=MagicMock())
+
+
+def _action(*card_ids: ModelCardID) -> BulkDeleteModelCardAction:
+    return BulkDeleteModelCardAction(ids=list(card_ids), options=DeleteModelCardOptions())
+
+
+class TestBulkDeleteModelCard:
+    async def test_every_card_deleted_is_answered_for(
+        self,
+        model_card_service: ModelCardService,
+        mock_repository: MagicMock,
+    ) -> None:
+        first, second = ModelCardID(uuid.uuid4()), ModelCardID(uuid.uuid4())
+        mock_repository.bulk_delete = AsyncMock(
+            return_value=BulkModelCardDeleteResultData(successes=[first, second], failures=[])
+        )
+
+        result = await model_card_service.bulk_delete(_action(first, second))
+
+        assert [item.entity_id for item in result.items] == [first, second]
+        assert result.values() == {first: first, second: second}
+        assert result.errors() == {}
+
+    async def test_a_failed_card_carries_the_error_it_raised(
+        self,
+        model_card_service: ModelCardService,
+        mock_repository: MagicMock,
+    ) -> None:
+        deleted, missing = ModelCardID(uuid.uuid4()), ModelCardID(uuid.uuid4())
+        error = ModelCardNotFound()
+        mock_repository.bulk_delete = AsyncMock(
+            return_value=BulkModelCardDeleteResultData(
+                successes=[deleted],
+                failures=[BulkModelCardDeleteFailure(card_id=missing, error=error)],
+            )
+        )
+
+        result = await model_card_service.bulk_delete(_action(deleted, missing))
+
+        assert result.values() == {deleted: deleted}
+        assert result.errors() == {missing: error}
+
+    async def test_the_purger_of_every_named_card_reaches_the_repository(
+        self,
+        model_card_service: ModelCardService,
+        mock_repository: MagicMock,
+    ) -> None:
+        first, second = ModelCardID(uuid.uuid4()), ModelCardID(uuid.uuid4())
+        mock_repository.bulk_delete = AsyncMock(
+            return_value=BulkModelCardDeleteResultData(successes=[first, second], failures=[])
+        )
+
+        await model_card_service.bulk_delete(_action(first, second))
+
+        purgers, options = mock_repository.bulk_delete.call_args.args
+        assert [purger.card_id for purger in purgers] == [first, second]
+        assert options.delete_associated_vfolder is False
+
+
+class TestBulkDeleteModelCardAction:
+    def test_narrowing_keeps_the_allowed_cards_in_order(self) -> None:
+        first, second, third = (ModelCardID(uuid.uuid4()) for _ in range(3))
+        action = _action(first, second, third)
+
+        narrowed = action.narrowed_to([third, first])
+
+        assert list(narrowed.ids) == [first, third]
+        assert narrowed.options is action.options


### PR DESCRIPTION
## Summary
- `bulk_delete_model_card` was wired to `global_scope`, so the super-admin check was the only gate it passed and no individual card was judged. It is now a partial bulk action whose run names the cards it deletes, and the bulk RBAC validator asks for the permission on every one of them.
- Both model card delete actions declare `PURGE`, the operation they actually perform — the row is removed rather than marked deleted, which is also what the `delete_associated_vfolder` cascade acts on.
- A card's failure is carried as the exception it was raised as instead of a flattened string, so the audit row keeps its error code. The GraphQL payload still reports the message text.
- The route, the `admin_bulk_delete_model_cards_v2` super-admin contract and the `successes` / `failed` payload are unchanged.

## Test plan
- [ ] Bulk-deleting several model cards as a super admin still reports every deleted id in `successes`
- [ ] A batch mixing a deletable card with a missing one, and with one whose VFolder is mounted, still reports the rest as deleted and the failure in `failed` with its message
- [ ] `delete_associated_vfolder: true` still moves the VFolder to trash and purges the sibling cards on it
- [ ] Deleting one card through the single-card mutation is unchanged

Resolves BA-7708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnDWcwrgQsmcAQbAd56kfh
