### PR TITLE
fix(BA-7726): grant every user's self role the keypair permissions it owns

### DIFF
--- a/changes/14326.fix.md
+++ b/changes/14326.fix.md
@@ -1,0 +1,1 @@
+Grant a user's self role the permissions on the keypairs it owns, so a user created after the keypair RBAC migration is no longer refused on /auth/ssh-keypair.

--- a/fixtures/manager/example-roles.json
+++ b/fixtures/manager/example-roles.json
@@ -6314,6 +6314,51 @@
             "entity_id": "5e96b4ee-2296-495b-90b4-0fc845d13c67",
             "registered_at": "2025-09-12 09:51:58.265582+00",
             "relation_type": "auto"
+        },
+        {
+            "id": "7c85ff00-e5c2-5627-9d4a-75c48255e733",
+            "scope_type": "user",
+            "scope_id": "f38dea23-50fa-42a0-b5ae-338f5f4693f4",
+            "entity_type": "keypair",
+            "entity_id": "AKIAIOSFODNN7EXAMPLE",
+            "registered_at": "2025-09-12 09:51:58.265582+00",
+            "relation_type": "auto"
+        },
+        {
+            "id": "5953ba19-5290-525b-a691-21691b8c51f8",
+            "scope_type": "user",
+            "scope_id": "4f13d193-f646-425a-a340-270c4d2b9860",
+            "entity_type": "keypair",
+            "entity_id": "AKIAHUKCHDEZGEXAMPLE",
+            "registered_at": "2025-09-12 09:51:58.265582+00",
+            "relation_type": "auto"
+        },
+        {
+            "id": "ee04bdf2-5fc7-5f99-a5c9-dc8093bf9bca",
+            "scope_type": "user",
+            "scope_id": "dfa9da54-4b28-432f-be29-c0d680c7a412",
+            "entity_type": "keypair",
+            "entity_id": "AKIANABBDUSEREXAMPLE",
+            "registered_at": "2025-09-12 09:51:58.265582+00",
+            "relation_type": "auto"
+        },
+        {
+            "id": "3cfa4002-0d5a-529c-95c5-ea5b7ab692d8",
+            "scope_type": "user",
+            "scope_id": "009fb1a4-487c-4f6e-9b1b-228b94b1d040",
+            "entity_type": "keypair",
+            "entity_id": "AKIANATWOUSEREXAMPLE",
+            "registered_at": "2025-09-12 09:51:58.265582+00",
+            "relation_type": "auto"
+        },
+        {
+            "id": "8534b805-f576-54bf-acad-e5cbe083cede",
+            "scope_type": "user",
+            "scope_id": "2e10157d-20ca-4bd0-9806-3f909cbcd0e6",
+            "entity_type": "keypair",
+            "entity_id": "AKIANAMONITOREXAMPLE",
+            "registered_at": "2025-09-12 09:51:58.265582+00",
+            "relation_type": "auto"
         }
     ],
     "role_presets": [
@@ -6423,6 +6468,41 @@
             "role_preset_id": "06057849-3534-546f-b74c-b79d5d3ecf5e",
             "entity_type": "model_deployment",
             "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "bbc6fc69-63c3-59c7-93f0-f83ce26e7d1d",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "keypair",
+            "operation": "create",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "025ee359-2400-5577-bfeb-9a1189ac8209",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "keypair",
+            "operation": "hard-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "fbbac31d-709f-51a5-b3a5-49f05d909db8",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "keypair",
+            "operation": "read",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "db16eb2f-39e0-5b90-85aa-f3c3eac84177",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "keypair",
+            "operation": "soft-delete",
+            "created_at": "2025-09-12 09:51:58.265582+00"
+        },
+        {
+            "id": "42a1d35d-784d-5061-8ed0-9388dc7e3153",
+            "role_preset_id": "776c1366-dcf3-5abd-b8de-bc3ad3b759ad",
+            "entity_type": "keypair",
+            "operation": "update",
             "created_at": "2025-09-12 09:51:58.265582+00"
         },
         {

--- a/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
+++ b/src/ai/backend/manager/models/alembic/versions/2d6443ac0d4a_create_app_config_allow_list_table.py
@@ -20,7 +20,7 @@ from ai.backend.manager.models.base import IDColumn
 
 # revision identifiers, used by Alembic.
 revision = "2d6443ac0d4a"
-down_revision = "bd1bf0524350"
+down_revision = "e1b7f3d20a94"
 # Part of: 26.5.0
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/857c4d02c4b9_rekey_domain_rbac_rows_to_domain_uuid.py
+++ b/src/ai/backend/manager/models/alembic/versions/857c4d02c4b9_rekey_domain_rbac_rows_to_domain_uuid.py
@@ -28,7 +28,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "857c4d02c4b9"
-down_revision = "b93d1c47af52"
+down_revision = "f4a2b7c9e105"
 # Part of: NEXT_RELEASE_VERSION
 branch_labels = None
 depends_on = None

--- a/src/ai/backend/manager/models/alembic/versions/e1b7f3d20a94_grant_self_roles_keypair_permissions.py
+++ b/src/ai/backend/manager/models/alembic/versions/e1b7f3d20a94_grant_self_roles_keypair_permissions.py
@@ -1,0 +1,74 @@
+"""grant every user's self role the permissions on the keypairs it owns
+
+The self role a user creation provisions covers only the resource entity types, which
+leave out ``keypair``, so a user created after 21159a293dfb holds no permission on its
+own keypairs and is refused on ``/auth/ssh-keypair``. Backfills those rows, together
+with the keypair AUTO edges a keypair created outside the RBAC creator never got, so
+the scope chain resolves a keypair to its owner.
+
+Spliced in at the 26.4 release head; f4a2b7c9e105 repeats it at the 26.8 one. No repeat
+follows on the main head: there a keypair is a field of its owner, so the permission an
+operation on it reads is the one on the ``user`` entity, which the self role already
+holds. Idempotent via ``ON CONFLICT DO NOTHING``.
+
+Revision ID: e1b7f3d20a94
+Revises: bd1bf0524350
+Create Date: 2026-09-07 22:30:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e1b7f3d20a94"
+down_revision = "bd1bf0524350"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+# A role its holder carries on that same holder's user scope: the self role. Derived
+# from the permissions the role already holds, so both the data-migrated roles
+# (``role_user_<username>``) and the runtime ones (``user-<id8>``) match.
+_SELF_ROLES = """
+    SELECT DISTINCT p.role_id, p.scope_id
+    FROM permissions p
+    JOIN user_roles ur ON ur.role_id = p.role_id AND ur.user_id::text = p.scope_id
+    JOIN roles r ON r.id = p.role_id
+    WHERE p.scope_type = 'user'
+      AND r.status = 'active'
+"""
+
+# The owner operation set 21159a293dfb gave every non-member role. grant:* carries no bit.
+_GRANT_KEYPAIR_PERMISSIONS = sa.text(f"""
+    INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation, permission)
+    SELECT self_role.role_id, 'user', self_role.scope_id, 'keypair',
+           owner_op.operation, owner_op.permission
+    FROM ({_SELF_ROLES}) AS self_role
+    CROSS JOIN (VALUES
+        ('create', 4), ('read', 1), ('update', 2),
+        ('soft-delete', 8), ('hard-delete', 16),
+        ('grant:all', 0), ('grant:read', 0), ('grant:update', 0),
+        ('grant:soft-delete', 0), ('grant:hard-delete', 0)
+    ) AS owner_op(operation, permission)
+    ON CONFLICT DO NOTHING
+""")
+
+# INSERT ... SELECT binds no per-row parameter, so the keypair count needs no chunking.
+_BIND_KEYPAIRS_TO_OWNERS = sa.text("""
+    INSERT INTO association_scopes_entities
+        (scope_type, scope_id, entity_type, entity_id, relation_type)
+    SELECT 'user', k."user"::text, 'keypair', k.access_key, 'auto'
+    FROM keypairs k
+    ON CONFLICT DO NOTHING
+""")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(_GRANT_KEYPAIR_PERMISSIONS)
+    conn.execute(_BIND_KEYPAIRS_TO_OWNERS)
+
+
+def downgrade() -> None:
+    pass

--- a/src/ai/backend/manager/models/alembic/versions/e1b7f3d20a94_grant_self_roles_keypair_permissions.py
+++ b/src/ai/backend/manager/models/alembic/versions/e1b7f3d20a94_grant_self_roles_keypair_permissions.py
@@ -23,19 +23,20 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "e1b7f3d20a94"
 down_revision = "bd1bf0524350"
-# Part of: NEXT_RELEASE_VERSION
+# Part of: 26.4.11 (backport), 26.8.4 (backport), 26.9.0 (main)
 branch_labels = None
 depends_on = None
 
-# A role its holder carries on that same holder's user scope: the self role. Derived
-# from the permissions the role already holds, so both the data-migrated roles
-# (``role_user_<username>``) and the runtime ones (``user-<id8>``) match.
+# A system role its holder carries on that same holder's user scope: the self role.
+# Custom roles are left out: one may be assigned to several people, so a keypair grant
+# on it would reach everyone holding it rather than the scope's owner.
 _SELF_ROLES = """
     SELECT DISTINCT p.role_id, p.scope_id
     FROM permissions p
     JOIN user_roles ur ON ur.role_id = p.role_id AND ur.user_id::text = p.scope_id
     JOIN roles r ON r.id = p.role_id
     WHERE p.scope_type = 'user'
+      AND r.source = 'system'
       AND r.status = 'active'
 """
 

--- a/src/ai/backend/manager/models/alembic/versions/f4a2b7c9e105_grant_self_roles_keypair_permissions_followup.py
+++ b/src/ai/backend/manager/models/alembic/versions/f4a2b7c9e105_grant_self_roles_keypair_permissions_followup.py
@@ -19,19 +19,20 @@ from alembic import op
 # revision identifiers, used by Alembic.
 revision = "f4a2b7c9e105"
 down_revision = "b93d1c47af52"
-# Part of: NEXT_RELEASE_VERSION
+# Part of: 26.8.4 (backport), 26.9.0 (main)
 branch_labels = None
 depends_on = None
 
-# A role its holder carries on that same holder's user scope: the self role. Derived
-# from the permissions the role already holds, so both the data-migrated roles
-# (``role_user_<username>``) and the runtime ones (``user-<id8>``) match.
+# A system role its holder carries on that same holder's user scope: the self role.
+# Custom roles are left out: one may be assigned to several people, so a keypair grant
+# on it would reach everyone holding it rather than the scope's owner.
 _SELF_ROLES = """
     SELECT DISTINCT p.role_id, p.scope_id
     FROM permissions p
     JOIN user_roles ur ON ur.role_id = p.role_id AND ur.user_id::text = p.scope_id
     JOIN roles r ON r.id = p.role_id
     WHERE p.scope_type = 'user'
+      AND r.source = 'system'
       AND r.status = 'active'
 """
 

--- a/src/ai/backend/manager/models/alembic/versions/f4a2b7c9e105_grant_self_roles_keypair_permissions_followup.py
+++ b/src/ai/backend/manager/models/alembic/versions/f4a2b7c9e105_grant_self_roles_keypair_permissions_followup.py
@@ -1,0 +1,70 @@
+"""grant every user's self role the permissions on the keypairs it owns (26.8 followup)
+
+Repeat of e1b7f3d20a94 appended on the 26.8 release head, which the 26.4 splice sits
+behind: a database already past that point never walks e1b7f3d20a94, so it needs the
+backfill issued again here. A no-op on databases that did apply it.
+
+The chain carries no third repeat on the main head, where a keypair is a field of its
+owner and the permission an operation on it reads is the one on the ``user`` entity.
+
+Revision ID: f4a2b7c9e105
+Revises: b93d1c47af52
+Create Date: 2026-09-07 22:30:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f4a2b7c9e105"
+down_revision = "b93d1c47af52"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+# A role its holder carries on that same holder's user scope: the self role. Derived
+# from the permissions the role already holds, so both the data-migrated roles
+# (``role_user_<username>``) and the runtime ones (``user-<id8>``) match.
+_SELF_ROLES = """
+    SELECT DISTINCT p.role_id, p.scope_id
+    FROM permissions p
+    JOIN user_roles ur ON ur.role_id = p.role_id AND ur.user_id::text = p.scope_id
+    JOIN roles r ON r.id = p.role_id
+    WHERE p.scope_type = 'user'
+      AND r.status = 'active'
+"""
+
+# The owner operation set 21159a293dfb gave every non-member role. grant:* carries no bit.
+_GRANT_KEYPAIR_PERMISSIONS = sa.text(f"""
+    INSERT INTO permissions (role_id, scope_type, scope_id, entity_type, operation, permission)
+    SELECT self_role.role_id, 'user', self_role.scope_id, 'keypair',
+           owner_op.operation, owner_op.permission
+    FROM ({_SELF_ROLES}) AS self_role
+    CROSS JOIN (VALUES
+        ('create', 4), ('read', 1), ('update', 2),
+        ('soft-delete', 8), ('hard-delete', 16),
+        ('grant:all', 0), ('grant:read', 0), ('grant:update', 0),
+        ('grant:soft-delete', 0), ('grant:hard-delete', 0)
+    ) AS owner_op(operation, permission)
+    ON CONFLICT DO NOTHING
+""")
+
+# INSERT ... SELECT binds no per-row parameter, so the keypair count needs no chunking.
+_BIND_KEYPAIRS_TO_OWNERS = sa.text("""
+    INSERT INTO association_scopes_entities
+        (scope_type, scope_id, entity_type, entity_id, relation_type)
+    SELECT 'user', k."user"::text, 'keypair', k.access_key, 'auto'
+    FROM keypairs k
+    ON CONFLICT DO NOTHING
+""")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(_GRANT_KEYPAIR_PERMISSIONS)
+    conn.execute(_BIND_KEYPAIRS_TO_OWNERS)
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- A user created after the keypair RBAC migration (`21159a293dfb`) gets a self role covering only the resource entity types, which leave out `keypair`. It therefore holds no permission on its own keypairs and is refused on `/auth/ssh-keypair` with `NotEnoughPermission(403)`. Neither the user-scope permission presets nor the project member roles cover the gap.
- Backfills the missing permission rows at both maintained release heads, together with the keypair AUTO edges a keypair created outside the RBAC creator never got, so the scope chain resolves a keypair to its owner. Both migrations are idempotent via `ON CONFLICT DO NOTHING` and leave `downgrade()` empty.
- No repeat follows on the main head. There a keypair is a field of its owner (`KeyPairID` is a `FieldIdentifier`), so the permission an operation on it reads is the one on the `user` entity, which the self role already holds — the rows would be inert.
- The roles fixture gains the same data: the keypair AUTO edges the runtime creator writes, and `keypair` on the user-scope permission preset.

## Migration chain

```
… → bd1bf0524350 → e1b7f3d20a94 → 2d6443ac0d4a → …     (26.4 head)
… → b93d1c47af52 → f4a2b7c9e105 → 857c4d02c4b9 → …     (26.8 head)
… → b4c2e7f19a30                                        (main head, unchanged)
```

Both splice points sit before `5c1e7a2d9b40` drops `permissions.operation` and before `b44c240c7680` adds `all_fields`, and after `c6648c039bd4` adds `permissions.permission`, so both migrations write the release-branch column set.

## Backport notes

Default `fix:` backporting already targets exactly `26.8` and `26.4`, so no `Backport:` trailer is set.

- **26.8** cherry-picks cleanly: `bd1bf0524350 → e1b7f3d20a94 → 2d6443ac0d4a → … → b93d1c47af52 → f4a2b7c9e105`, single head, the second migration a no-op after the first.
- **26.4** will conflict — `2d6443ac0d4a`, `857c4d02c4b9` and `b93d1c47af52` are all past its head. Keep `e1b7f3d20a94` and the fixture change; drop `f4a2b7c9e105` and both `down_revision` repoints.

## Test plan

- [x] Ran both statements against a local halfstack DB inside a transaction, rolled back: 26.x variant produced 200 user-scope keypair rows (20 self roles × 10 operations), main-schema variant 100 (20 × 5 bits); rerun of each was `INSERT 0 0`.
- [x] The ASE backfill inserted 3 missing keypair edges on that DB — keypairs issued after `21159a293dfb` that had no edge.
- [x] Alembic graph resolves to a single head with no dangling `down_revision`; column availability verified at both splice positions.
- [x] `pants fmt` / `fix` / `lint` / `check` on every touched file.
- [x] CI migration replay on a fresh database.

Resolves BA-7726

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JN3jEjobnMrFzdAjrtnPz5
