### PR TITLE
refactor(BA-7714): add a bulk entity key lookup and wire the agent name bulk lookup

### DIFF
--- a/changes/14333.enhance.md
+++ b/changes/14333.enhance.md
@@ -1,0 +1,1 @@
+Add a bulk entity key lookup to the v2 ops and wire the agent name bulk lookup through it.

--- a/src/ai/backend/manager/actions/AGENTS.md
+++ b/src/ai/backend/manager/actions/AGENTS.md
@@ -16,7 +16,7 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
 | `bulk` | several entities |
 | `scope` | the scope itself — searches within it, and creates |
 | `global` | none (system-wide) |
-| `lookup` / `bulk_lookup` | an external key into an internal id |
+| `lookup` / `bulk_lookup` | an external key into an internal id, one or several |
 | `single_field` / `bulk_field` | field rows |
 | `relation` | two entities, linked or unlinked |
 
@@ -181,14 +181,16 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
 - A gated action wired to a REST route with no auth middleware fails at request time
   with no context to check. Decide the route's middleware and the action's gate
   together.
-- `lookup` and `bulk_lookup` check authentication first and the permission on whatever
-  the key resolved to after. The check splits in two because the entity a key names is
-  not known until the run produces it. The second half takes the `single_entity` and
-  `bulk` validators respectively — `LOOKUP` is a read, so it asks for read on that
-  entity.
+- `lookup_ops` and `bulk_lookup_ops` check authentication first and the permission on
+  whatever the key resolved to after. The check splits in two because the entity a key
+  names is not known until the run produces it. The second half takes the
+  `single_entity` and `atomic_bulk` validators respectively — `LOOKUP` is a read, so it
+  asks for read on that entity.
 - A key that named nothing offers no entity to check. It is one failed key.
-- Wiring through `public_lookup_ops` leaves the second half empty, so every
-  authenticated caller may resolve.
+- Wiring through `public_lookup_ops` / `public_bulk_lookup_ops` leaves the second half
+  empty, so every authenticated caller may resolve. A bulk lookup feeding a
+  `partial_bulk_get_ops` read is wired public: the read answers per entity, and a
+  lookup refusing the whole batch over one entity would take that away.
 - A lookup with post-validators answers a key naming nothing and a key the caller may
   not reach with one exception, so no status code says whether the key exists. The
   processor merges them; adapters must not split them apart again. The audit record

--- a/src/ai/backend/manager/actions/KNOWLEDGE.md
+++ b/src/ai/backend/manager/actions/KNOWLEDGE.md
@@ -106,8 +106,10 @@ which is why handlers call processors, not services.
   distinct descriptions and would not collapse anyway, and volume is a retention
   problem.
 - The batch owner read is a lookup action too. Going straight to the repository leaves
-  that read unrecorded and a missing row unmentioned. `bulk_lookup` answers per key,
-  and a key that named nothing is a failed key rather than a failed run.
+  that read unrecorded and a missing row unmentioned. The bulk lookup processor
+  (`field_group` builds it for owners; `bulk_lookup_ops` / `public_bulk_lookup_ops` for
+  entity keys) answers per key, and a key that named nothing is a failed key rather
+  than a failed run.
 
 ## Many-row writes: the failure mode is named, never an argument
 

--- a/src/ai/backend/manager/actions/registry/group.py
+++ b/src/ai/backend/manager/actions/registry/group.py
@@ -76,6 +76,7 @@ from ai.backend.manager.actions.v2.global_scope.processor import (
 )
 from ai.backend.manager.actions.v2.global_scope.validator import GlobalActionValidator
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction, BaseLookupActionResult
+from ai.backend.manager.actions.v2.lookup.bulk_monitor import BulkLookupActionMonitor
 from ai.backend.manager.actions.v2.lookup.bulk_processor import BulkLookupActionProcessor
 from ai.backend.manager.actions.v2.lookup.monitor import LookupActionMonitor
 from ai.backend.manager.actions.v2.lookup.processor import (
@@ -92,6 +93,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     BatchPurgeScopeOpsAction,
     BatchUpdateGlobalOpsAction,
     BatchUpdateScopeOpsAction,
+    BulkLookupEntityOpsAction,
     CreateEntityOpsAction,
     CreateEntityWithFieldsOpsAction,
     CreateGlobalOpsAction,
@@ -122,6 +124,7 @@ from ai.backend.manager.actions.v2.ops.base import (
 )
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
+    BulkLookupOpsResult,
     CreatedEntityOpsResult,
     CreatedEntityWithFieldsOpsResult,
     EntitiesOpsResult,
@@ -148,6 +151,7 @@ from ai.backend.manager.services.ops.service import (
     BatchPurgeService,
     BatchUpdateService,
     BulkFieldOwnerLookupService,
+    BulkLookupService,
     DeleteService,
     EntityAtomicCreateService,
     EntityAtomicUpsertService,
@@ -492,6 +496,35 @@ class ProcessorGroup[TData: EntityData]:
             LookupService(self._deps.repository).execute,
             monitors=(*self._deps.monitors.lookup, *monitors),
             validators=(*self._deps.validators.lookup, *validators),
+        )
+
+    def bulk_lookup_ops[TAction: BulkLookupEntityOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        monitors: Sequence[BulkLookupActionMonitor] = (),
+    ) -> BulkLookupActionProcessor[TAction, BulkLookupOpsResult[Any, Any]]:
+        """Several keys resolved at once, each answered for; the entities they named
+        are then checked together, as a bulk read of them would be."""
+        self._record(action_cls, ActionKind.LOOKUP, ActionGate.PERMISSION, ActionBacking.GENERIC)
+        return BulkLookupActionProcessor(
+            BulkLookupService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.bulk_lookup, *monitors),
+            post_validators=self._deps.validators.atomic_bulk,
+        )
+
+    def public_bulk_lookup_ops[TAction: BulkLookupEntityOpsAction[Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        monitors: Sequence[BulkLookupActionMonitor] = (),
+    ) -> BulkLookupActionProcessor[TAction, BulkLookupOpsResult[Any, Any]]:
+        """Keys every authenticated caller may resolve: no post-validators, so the
+        resolved entities carry no permission."""
+        self._record(action_cls, ActionKind.LOOKUP, ActionGate.PUBLIC, ActionBacking.GENERIC)
+        return BulkLookupActionProcessor(
+            BulkLookupService(self._deps.repository).execute,
+            monitors=(*self._deps.monitors.bulk_lookup, *monitors),
         )
 
     def key_owner_lookup_ops[TAction: LookupFieldOwnerByKeyOpsAction[Any]](

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -7,7 +7,8 @@ from ai.backend.common.data.entity.types import EntityIdentifier as OwnerEntityI
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction, BasePartialBulkAction
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
-from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction
+from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction, LookupKey
+from ai.backend.manager.actions.v2.lookup.bulk_base import BaseBulkLookupAction
 from ai.backend.manager.actions.v2.ops.backend import OpsBackendAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -20,7 +21,7 @@ from ai.backend.manager.models.specs.creator import (
     RoleManagedEntityCreator,
     RoleManagedGlobalEntityCreator,
 )
-from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 from ai.backend.manager.models.specs.purger import (
     EntityBatchPurger,
     EntityPurger,
@@ -49,6 +50,7 @@ __all__ = (
     "GetOpsAction",
     "FieldGetOpsAction",
     "LookupOpsAction",
+    "BulkLookupOpsAction",
     "SearchOpsAction",
     "GlobalSearchOpsAction",
     "GlobalEntityCreateOpsAction",
@@ -196,6 +198,24 @@ class LookupOpsAction[TRow: Base, TEntityID: EntityIdentifier](OpsBackendAction)
 
     @abstractmethod
     def to_lookup(self) -> DataLookup[TRow, TEntityID]:
+        """Return the key-resolution spec this action executes."""
+        raise NotImplementedError
+
+
+class BulkLookupOpsAction[TKey, TEntityID: EntityIdentifier](OpsBackendAction):
+    """A read of several entities' ids by keys that are not those ids.
+
+    The plural of :class:`LookupOpsAction`: the keys are the caller's, so the action
+    carries them and the spec says how they resolve.
+    """
+
+    @abstractmethod
+    def keys(self) -> Sequence[TKey]:
+        """Return the keys being resolved."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_lookup(self) -> BulkDataLookup[TKey, TEntityID]:
         """Return the key-resolution spec this action executes."""
         raise NotImplementedError
 
@@ -597,6 +617,25 @@ class LookupEntityOpsAction[TRow: Base, TEntityID: EntityIdentifier](
     Declares nothing further — the shape fixes the operation, and the spec carries
     the key's columns and the conversion.
     """
+
+
+class BulkLookupEntityOpsAction[TKey, TEntityID: EntityIdentifier](
+    BaseBulkLookupAction, BulkLookupOpsAction[TKey, TEntityID], ABC
+):
+    """A bulk key resolution backed by ops: the bulk lookup shape paired with its spec.
+
+    ``lookup_keys()`` is derived from ``keys()``, so a key and its record cannot come
+    apart.
+    """
+
+    @abstractmethod
+    def to_lookup_key(self, key: TKey) -> LookupKey:
+        """Return the record's name for one key."""
+        raise NotImplementedError
+
+    @override
+    def lookup_keys(self) -> Sequence[LookupKey]:
+        return tuple(self.to_lookup_key(key) for key in self.keys())
 
 
 class GetSingleEntityOpsAction[TRow: Base, TData](

--- a/src/ai/backend/manager/actions/v2/ops/result.py
+++ b/src/ai/backend/manager/actions/v2/ops/result.py
@@ -23,6 +23,10 @@ from ai.backend.common.data.entity.types import (
     FieldIdentifier,
 )
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupActionResult
+from ai.backend.manager.actions.v2.lookup.bulk_base import (
+    BaseBulkLookupActionResult,
+    BulkLookupKeyResult,
+)
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
 
 __all__ = (
@@ -30,6 +34,7 @@ __all__ = (
     "CreatedEntityOpsResult",
     "CreatedEntityWithFieldsOpsResult",
     "LookupOpsResult",
+    "BulkLookupOpsResult",
     "OwnedFieldsOpsResult",
     "CreatedFieldOpsResult",
     "FieldsOpsResult",
@@ -97,6 +102,33 @@ class LookupOpsResult[TEntityID: EntityIdentifier](BaseLookupActionResult):
     @override
     def entity_id(self) -> TEntityID:
         return self.resolved_entity_id
+
+
+class BulkLookupOpsResult[TKey, TEntityID: EntityIdentifier](BaseBulkLookupActionResult):
+    """The id each key of a bulk lookup names, and which keys named nothing.
+
+    A key that named nothing is one failed key, so the operation that follows can
+    answer for it beside the rest rather than being refused as a whole.
+    """
+
+    _resolved: Mapping[TKey, TEntityID]
+    _key_results: Sequence[BulkLookupKeyResult]
+
+    def __init__(
+        self,
+        resolved: Mapping[TKey, TEntityID],
+        key_results: Sequence[BulkLookupKeyResult],
+    ) -> None:
+        self._resolved = resolved
+        self._key_results = key_results
+
+    @property
+    def resolved(self) -> Mapping[TKey, TEntityID]:
+        return self._resolved
+
+    @override
+    def key_results(self) -> Sequence[BulkLookupKeyResult]:
+        return self._key_results
 
 
 @dataclass

--- a/src/ai/backend/manager/models/agent/lookups.py
+++ b/src/ai/backend/manager/models/agent/lookups.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import Any, override
+from uuid import UUID
+
+import sqlalchemy as sa
 
 from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.types import AgentId
 from ai.backend.manager.models.agent.row import AgentRow
 from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 
 
 @dataclass
@@ -33,3 +36,15 @@ class AgentNameLookup(DataLookup[AgentRow, AgentUUID]):
     @override
     def to_entity_id(self, row: AgentRow) -> AgentUUID:
         return row.uuid
+
+
+class AgentNamesLookup(BulkDataLookup[AgentId, AgentUUID]):
+    """Resolves several operator-facing agent ids into the agents they name."""
+
+    @override
+    def build_query(self, keys: Sequence[AgentId]) -> sa.sql.Select[Any]:
+        return sa.select(AgentRow.id, AgentRow.uuid).where(AgentRow.id.in_(keys))
+
+    @override
+    def to_entity_id(self, value: UUID) -> AgentUUID:
+        return AgentUUID(value)

--- a/src/ai/backend/manager/models/specs/lookup.py
+++ b/src/ai/backend/manager/models/specs/lookup.py
@@ -1,4 +1,4 @@
-"""Lookup specs of the v2 lineage: read one entity by an external key."""
+"""Lookup specs of the v2 lineage: read one entity, or several, by an external key."""
 
 from __future__ import annotations
 
@@ -70,6 +70,34 @@ class DataLookup[TRow: Base, TEntityID: EntityIdentifier](ABC):
     @abstractmethod
     def to_entity_id(self, row: TRow) -> TEntityID:
         """Return the id of the entity the matched row is."""
+        raise NotImplementedError
+
+
+class BulkDataLookup[TKey, TEntityID: EntityIdentifier](ABC):
+    """Resolves several external keys into the ids of the entities they name.
+
+    The plural :class:`DataLookup`. A query rather than conditions, for the same reason
+    :class:`FieldOwnerLookup` is one: it selects the pair, so which entity each key
+    named survives the batch. A key matching no row is absent from the answer.
+
+    Example:
+        class AgentNamesLookup(BulkDataLookup[AgentId, AgentUUID]):
+            def build_query(self, keys):
+                return sa.select(AgentRow.id, AgentRow.uuid).where(AgentRow.id.in_(keys))
+
+            def to_entity_id(self, value: UUID) -> AgentUUID:
+                return AgentUUID(value)
+    """
+
+    @abstractmethod
+    def build_query(self, keys: Sequence[TKey]) -> sa.sql.Select[Any]:
+        """Build the query selecting each key and the id of the entity it names, in
+        that order."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_entity_id(self, value: UUID) -> TEntityID:
+        """Convert the selected value into the entity's identifier."""
         raise NotImplementedError
 
 

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -30,6 +30,7 @@ from ai.backend.manager.models.specs.creator import (
     RoleManagedGlobalEntityCreator,
 )
 from ai.backend.manager.models.specs.lookup import (
+    BulkDataLookup,
     DataLookup,
     FieldKeyLookup,
     FieldOwnerKeyLookup,
@@ -121,6 +122,13 @@ class OpsRepository[TData]:
             if entity_id is None:
                 raise EntityNotFoundError(f"No {lookup.row_class().__name__} matches the given key")
             return entity_id
+
+    async def bulk_lookup[TKey, TEntityID: EntityIdentifier](
+        self, lookup: BulkDataLookup[TKey, TEntityID], keys: Sequence[TKey]
+    ) -> Mapping[TKey, TEntityID]:
+        """Resolve several keys into the ids they name; a key naming nothing is absent."""
+        async with self._ops.read_ops() as r:
+            return await r.lookup_entity_ids(lookup, keys)
 
     async def owned_fields[TOwnerID: EntityIdentifier, TFieldData: FieldData](
         self,

--- a/src/ai/backend/manager/repositories/ops/v2/read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/read.py
@@ -22,6 +22,7 @@ from ai.backend.manager.errors.repository import (
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.models.specs.lookup import (
+    BulkDataLookup,
     DataLookup,
     FieldKeyLookup,
     FieldOwnerKeyLookup,
@@ -101,6 +102,20 @@ class V2ReadOps(V2GraphReadOpsBase):
                 f"The given key matches more than one {row_class.__name__}"
             )
         return lookup.to_entity_id(rows[0])
+
+    async def lookup_entity_ids[TKey, TEntityID: EntityIdentifier](
+        self, lookup: BulkDataLookup[TKey, TEntityID], keys: Sequence[TKey]
+    ) -> Mapping[TKey, TEntityID]:
+        """Resolve several keys into the ids of the entities they name.
+
+        A key matching no row is absent from the mapping rather than an error: the
+        caller decides whether that is a miss or one failed item among many.
+        """
+        if not keys:
+            return {}
+        rows = (await self._sess.execute(lookup.build_query(keys))).all()
+        resolved = {row[0]: lookup.to_entity_id(row[1]) for row in rows}
+        return {key: resolved[key] for key in keys if key in resolved}
 
     async def lookup_field_owners(
         self, lookup: FieldOwnerLookup[Any, Any], field_ids: Sequence[FieldIdentifier]

--- a/src/ai/backend/manager/services/agent/actions/bulk_lookup.py
+++ b/src/ai/backend/manager/services/agent/actions/bulk_lookup.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE, AgentUUID
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.types import AgentId
+from ai.backend.manager.actions.v2.ops.base import BulkLookupEntityOpsAction
+from ai.backend.manager.models.agent.lookups import AgentNamesLookup
+from ai.backend.manager.services.agent.actions.lookup import AgentNameKey
+
+
+@dataclass
+class BulkLookupAgentsAction(BulkLookupEntityOpsAction[AgentId, AgentUUID]):
+    """Resolve several operator-facing agent ids into the agents they name.
+
+    Every authenticated caller may resolve the keys, as with the single lookup: the
+    read that follows is checked against each agent on its own.
+    """
+
+    agent_ids: Sequence[AgentId]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return AGENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_lookup_agents"
+
+    @override
+    def keys(self) -> Sequence[AgentId]:
+        return tuple(self.agent_ids)
+
+    @override
+    def to_lookup_key(self, key: AgentId) -> AgentNameKey:
+        return AgentNameKey(agent_id=key)
+
+    @override
+    def to_lookup(self) -> AgentNamesLookup:
+        return AgentNamesLookup()

--- a/src/ai/backend/manager/services/agent/processors.py
+++ b/src/ai/backend/manager/services/agent/processors.py
@@ -1,13 +1,16 @@
 from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.v2.global_scope.processor import (
     GlobalActionProcessor,
     PublicActionProcessor,
 )
+from ai.backend.manager.actions.v2.lookup.bulk_processor import BulkLookupActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
-from ai.backend.manager.actions.v2.ops.result import LookupOpsResult
+from ai.backend.manager.actions.v2.ops.result import BulkLookupOpsResult, LookupOpsResult
 from ai.backend.manager.data.agent.types import AgentData
+from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
     GetTotalResourcesActionResult,
@@ -54,6 +57,9 @@ from ai.backend.manager.services.agent.service import AgentService
 
 class AgentProcessors:
     lookup: LookupActionProcessor[LookupAgentAction, LookupOpsResult[AgentUUID]]
+    bulk_lookup: BulkLookupActionProcessor[
+        BulkLookupAgentsAction, BulkLookupOpsResult[AgentId, AgentUUID]
+    ]
     sync_agent_registry: GlobalActionProcessor[
         SyncAgentRegistryAction, SyncAgentRegistryActionResult
     ]
@@ -84,6 +90,7 @@ class AgentProcessors:
         action_monitors: list[ActionMonitor],
     ) -> None:
         self.lookup = group.public_lookup_ops(LookupAgentAction)
+        self.bulk_lookup = group.public_bulk_lookup_ops(BulkLookupAgentsAction)
         self.sync_agent_registry = group.global_scope(
             SyncAgentRegistryAction, service.sync_agent_registry
         )

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -37,6 +37,7 @@ from ai.backend.manager.actions.v2.ops.base import (
     BatchPurgeOpsAction,
     BatchUpdateOpsAction,
     BulkGetOwnedFieldOpsAction,
+    BulkLookupEntityOpsAction,
     EntityAtomicCreateOpsAction,
     EntityAtomicUpsertOpsAction,
     EntityCreateOpsAction,
@@ -73,6 +74,7 @@ from ai.backend.manager.actions.v2.ops.base import (
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
     BulkFieldOpsResult,
+    BulkLookupOpsResult,
     CreatedEntityOpsResult,
     CreatedEntityWithFieldsOpsResult,
     CreatedFieldOpsResult,
@@ -237,6 +239,35 @@ class LookupService[TData: EntityData]:
 
     async def execute(self, action: LookupOpsAction[Any, Any]) -> LookupOpsResult[Any]:
         return LookupOpsResult(resolved_entity_id=await self._repository.lookup(action.to_lookup()))
+
+
+class BulkLookupService:
+    """Resolves the keys an action names into entity ids, answering per key."""
+
+    _repository: OpsRepository[Any]
+
+    def __init__(self, repository: OpsRepository[Any]) -> None:
+        self._repository = repository
+
+    async def execute(
+        self, action: BulkLookupEntityOpsAction[Any, Any]
+    ) -> BulkLookupOpsResult[Any, Any]:
+        keys = action.keys()
+        resolved = await self._repository.bulk_lookup(action.to_lookup(), keys)
+        found = ActionRunStatus.success()
+        key_results = [
+            BulkLookupKeyResult(
+                key=action.to_lookup_key(key),
+                status=found.status if key in resolved else OperationStatus.ERROR,
+                description=found.description
+                if key in resolved
+                else "No entity matches the given key.",
+                error_code=None,
+                entity_id=resolved.get(key),
+            )
+            for key in keys
+        ]
+        return BulkLookupOpsResult(resolved=resolved, key_results=key_results)
 
 
 class FieldOwnerLookupService:

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -106,6 +106,7 @@ from ai.backend.manager.data.artifact.types import ArtifactRevisionData
 from ai.backend.manager.data.audit_log.types import AuditLogData
 from ai.backend.manager.data.entity_label.types import EntityLabelData
 from ai.backend.manager.repositories.ops.repository import OpsRepository
+from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
 )
@@ -476,6 +477,7 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
         SearchAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PUBLIC),
         # The lookup carries no permission; the read that follows it is checked.
         LookupAgentAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),
+        BulkLookupAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),
     }
     recorded = {
         record.action_cls: (record.entity_type, record.kind, record.gate)

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -54,7 +54,7 @@ from ai.backend.manager.models.rbac_models.role_preset.updaters import (
 )
 from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
 from ai.backend.manager.models.specs.creator import GlobalEntityCreator
-from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.specs.purger import EntityBatchPurger
 from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
@@ -182,6 +182,18 @@ class _PresetBulkQuerier(BulkEntityQuerier[RolePresetRow, RolePresetData]):
     @override
     def to_data(self, row: RolePresetRow) -> RolePresetData:
         return row.to_data()
+
+
+class _PresetsByName(BulkDataLookup[str, EntityIdentifier]):
+    """The plural key resolution: the names come with the call."""
+
+    @override
+    def build_query(self, keys: Sequence[str]) -> sa.sql.Select[Any]:
+        return sa.select(RolePresetRow.name, RolePresetRow.id).where(RolePresetRow.name.in_(keys))
+
+    @override
+    def to_entity_id(self, value: uuid.UUID) -> EntityIdentifier:
+        return RolePresetID(value)
 
 
 @dataclass
@@ -408,6 +420,31 @@ class TestLookup:
 
         with pytest.raises(AmbiguousEntityKeyError):
             await repository.lookup(_PresetByName(name="default"))
+
+
+class TestBulkLookup:
+    async def test_every_named_key_comes_back_keyed_by_itself(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        other = await repository.create_global_entity(
+            _PresetCreator(name="analysts", scope_type=RBACScopeType.PROJECT)
+        )
+
+        found = await repository.bulk_lookup(_PresetsByName(), ["default", "analysts"])
+
+        assert found == {"default": preset.id, "analysts": other.id}
+
+    async def test_a_key_naming_nothing_is_absent_rather_than_raising(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        found = await repository.bulk_lookup(_PresetsByName(), ["default", "absent"])
+
+        assert list(found) == ["default"]
+
+    async def test_no_keys_reads_nothing(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        assert await repository.bulk_lookup(_PresetsByName(), []) == {}
 
 
 class TestUpdate:

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -37,7 +37,7 @@ from ai.backend.common.data.entity.types import (
     ScopeType,
 )
 from ai.backend.common.data.user.types import UserData, UserRole
-from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction, LookupKey
@@ -45,6 +45,7 @@ from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.base import (
     BatchPurgeOpsAction,
     BatchUpdateOpsAction,
+    BulkLookupEntityOpsAction,
     EntityAtomicCreateOpsAction,
     EntityCreateOpsAction,
     EntityPartialBulkPurgeOpsAction,
@@ -87,7 +88,7 @@ from ai.backend.manager.models.specs.creator import (
     GlobalEntityCreator,
     RoleManagedEntityCreator,
 )
-from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.specs.purger import (
     EntityBatchPurger,
@@ -111,6 +112,7 @@ from ai.backend.manager.repositories.ops.repository import OpsRepository
 from ai.backend.manager.services.ops.service import (
     BatchPurgeService,
     BatchUpdateService,
+    BulkLookupService,
     DeleteService,
     EntityAtomicCreateService,
     EntityCreateService,
@@ -318,6 +320,16 @@ class _PresetPurger(EntityPurger[RolePresetRow, _PresetData]):
     @override
     def to_data(self, row: RolePresetRow) -> _PresetData:
         return _PresetData(id=row.id, name=row.name)
+
+
+class _PresetsByName(BulkDataLookup[str, EntityIdentifier]):
+    @override
+    def build_query(self, keys: Sequence[str]) -> sa.sql.Select[Any]:
+        return sa.select(RolePresetRow.name, RolePresetRow.id).where(RolePresetRow.name.in_(keys))
+
+    @override
+    def to_entity_id(self, value: uuid.UUID) -> EntityIdentifier:
+        return _EntityID(value)
 
 
 @dataclass
@@ -760,6 +772,33 @@ class _NameKey(LookupKey):
     @override
     def to_dict(self) -> dict[str, Any]:
         return {"name": self.name}
+
+
+@dataclass
+class _BulkLookupAction(BulkLookupEntityOpsAction[str, EntityIdentifier]):
+    names: Sequence[str]
+
+    @override
+    def keys(self) -> Sequence[str]:
+        return tuple(self.names)
+
+    @override
+    def to_lookup_key(self, key: str) -> LookupKey:
+        return _NameKey(name=key)
+
+    @override
+    def to_lookup(self) -> BulkDataLookup[str, EntityIdentifier]:
+        return _PresetsByName()
+
+    @classmethod
+    @override
+    def entity_type(cls) -> EntityType:
+        return _ENTITY_TYPE
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "bulk_lookup_role_presets"
 
 
 @dataclass
@@ -1386,6 +1425,24 @@ async def test_lookup_forwards_the_action_s_lookup_spec(
 
     assert result.entity_id() == stored.id
     repository.lookup.assert_awaited_once_with(lookup)
+
+
+async def test_bulk_lookup_answers_for_every_named_key(
+    repository: MagicMock, stored: _PresetData
+) -> None:
+    service = BulkLookupService(repository)
+    repository.bulk_lookup = AsyncMock(return_value={"default": stored.id})
+
+    result = await service.execute(_BulkLookupAction(names=["default", "absent"]))
+
+    # A key naming nothing is one failed key, not a failed run.
+    assert result.resolved == {"default": stored.id}
+    assert [(r.key, r.status, r.entity_id) for r in result.key_results()] == [
+        (_NameKey(name="default"), OperationStatus.SUCCESS, stored.id),
+        (_NameKey(name="absent"), OperationStatus.ERROR, None),
+    ]
+    repository.bulk_lookup.assert_awaited_once()
+    assert repository.bulk_lookup.await_args.args[1] == ("default", "absent")
 
 
 async def test_lookup_runs_under_the_lookup_processor(


### PR DESCRIPTION
## Summary
- Add a bulk key lookup to the v2 ops lineage: `BulkDataLookup` spec, `bulk_lookup` on the ops repository, `BulkLookupService`, the `BulkLookupEntityOpsAction` base and `BulkLookupOpsResult`. A key naming nothing is one failed key rather than a failed run.
- Add the `bulk_lookup_ops` / `public_bulk_lookup_ops` factories to `ProcessorGroup`; the public one leaves the resolved entities unchecked so the partial bulk get that follows answers per entity.
- Wire `BulkLookupAgentsAction` (agent names to uuids) through `public_bulk_lookup_ops`, mirroring the single `LookupAgentAction`. The agent bulk get and the DataLoader move are follow-ups.

## Test plan
- [x] `tests/unit/manager/repositories/ops/test_ops_repository.py` — bulk lookup answers every key, leaves a missing key absent, reads nothing for no keys
- [x] `tests/unit/manager/services/ops/test_generic_services.py` — `BulkLookupService` answers per key
- [x] `tests/unit/manager/actions/test_registry_catalog.py` — `BulkLookupAgentsAction` recorded as (agent, LOOKUP, PUBLIC)
- [x] `pants fmt fix lint check test --changed-since=origin/main`

Resolves BA-7714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9CzWeuzWUXTXuK3HXiouu
