### PR TITLE
refactor(BA-7713): unify the usage bucket scope fields into one scope item

### DIFF
--- a/changes/14334.enhance.md
+++ b/changes/14334.enhance.md
@@ -1,0 +1,1 @@
+Unify the usage bucket search scope fields into one scope item keyed by the resource group id

--- a/src/ai/backend/manager/api/adapters/resource_usage/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_usage/adapter.py
@@ -2,16 +2,15 @@
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Callable, Mapping
 from datetime import date
 from decimal import Decimal
 
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
     ResourceGroupName,
 )
-from ai.backend.common.data.entity.types import ScopeRef
 from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.dto.manager.query import DateFilter as DateFilterDTO
 from ai.backend.common.dto.manager.v2.fair_share.types import (
@@ -57,11 +56,6 @@ from ai.backend.manager.models.resource_usage_history.row import (
     ProjectUsageBucketRow,
     UserUsageBucketRow,
 )
-from ai.backend.manager.models.resource_usage_history.scopes import (
-    DomainUsageBucketOperationScope,
-    ProjectUsageBucketOperationScope,
-    UserUsageBucketOperationScope,
-)
 from ai.backend.manager.models.resource_usage_history.searchers import (
     DomainUsageBucketSearcher,
     ProjectUsageBucketSearcher,
@@ -89,6 +83,11 @@ from ai.backend.manager.services.resource_usage.actions.global_search_project_us
 )
 from ai.backend.manager.services.resource_usage.actions.global_search_user_usage_buckets import (
     GlobalSearchUserUsageBucketsAction,
+)
+from ai.backend.manager.services.resource_usage.actions.scope_items import (
+    DomainUsageBucketScopeItem,
+    ProjectUsageBucketScopeItem,
+    UserUsageBucketScopeItem,
 )
 from ai.backend.manager.services.resource_usage.actions.search_domain_usage_buckets import (
     SearchDomainUsageBucketsAction,
@@ -274,10 +273,6 @@ class ResourceUsageAdapter(BaseAdapter):
         """Search domain usage buckets scoped to a domain/resource-group."""
         limit = input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT
         offset = input.offset if input.offset is not None else 0
-        scope = DomainUsageBucketOperationScope(
-            domain_name=input.domain_name,
-            resource_group=input.resource_group,
-        )
         resource_group_id = await self._resource_group_id(input.resource_group)
         querier = BatchQuerier(
             conditions=[],
@@ -286,10 +281,12 @@ class ResourceUsageAdapter(BaseAdapter):
         )
         action_result = await self._processors.resource_usage.search_domain_usage_buckets.run(
             SearchDomainUsageBucketsAction(
-                scope_target=ScopeRef(
-                    scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id
-                ),
-                scope=scope,
+                items=[
+                    DomainUsageBucketScopeItem(
+                        resource_group_id=resource_group_id,
+                        domain_name=input.domain_name,
+                    )
+                ],
                 searcher=DomainUsageBucketSearcher(
                     pagination=querier.pagination,
                     conditions=querier.conditions,
@@ -312,11 +309,6 @@ class ResourceUsageAdapter(BaseAdapter):
         """Search project usage buckets scoped to a domain/resource-group/project."""
         limit = input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT
         offset = input.offset if input.offset is not None else 0
-        scope = ProjectUsageBucketOperationScope(
-            domain_name=input.domain_name,
-            resource_group=input.resource_group,
-            project_id=input.project_id,
-        )
         resource_group_id = await self._resource_group_id(input.resource_group)
         querier = BatchQuerier(
             conditions=[],
@@ -325,10 +317,13 @@ class ResourceUsageAdapter(BaseAdapter):
         )
         action_result = await self._processors.resource_usage.search_project_usage_buckets.run(
             SearchProjectUsageBucketsAction(
-                scope_target=ScopeRef(
-                    scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id
-                ),
-                scope=scope,
+                items=[
+                    ProjectUsageBucketScopeItem(
+                        resource_group_id=resource_group_id,
+                        domain_name=input.domain_name,
+                        project_id=input.project_id,
+                    )
+                ],
                 searcher=ProjectUsageBucketSearcher(
                     pagination=querier.pagination,
                     conditions=querier.conditions,
@@ -351,12 +346,6 @@ class ResourceUsageAdapter(BaseAdapter):
         """Search user usage buckets scoped to a domain/resource-group/project/user."""
         limit = input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT
         offset = input.offset if input.offset is not None else 0
-        scope = UserUsageBucketOperationScope(
-            domain_name=input.domain_name,
-            resource_group=input.resource_group,
-            project_id=input.project_id,
-            user_uuid=input.user_uuid,
-        )
         resource_group_id = await self._resource_group_id(input.resource_group)
         querier = BatchQuerier(
             conditions=[],
@@ -365,10 +354,14 @@ class ResourceUsageAdapter(BaseAdapter):
         )
         action_result = await self._processors.resource_usage.search_user_usage_buckets.run(
             SearchUserUsageBucketsAction(
-                scope_target=ScopeRef(
-                    scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id
-                ),
-                scope=scope,
+                items=[
+                    UserUsageBucketScopeItem(
+                        resource_group_id=resource_group_id,
+                        domain_name=input.domain_name,
+                        project_id=input.project_id,
+                        user_uuid=input.user_uuid,
+                    )
+                ],
                 searcher=UserUsageBucketSearcher(
                     pagination=querier.pagination,
                     conditions=querier.conditions,
@@ -389,7 +382,8 @@ class ResourceUsageAdapter(BaseAdapter):
 
     async def gql_search_domain_scoped(
         self,
-        scope: DomainUsageBucketOperationScope,
+        resource_group_name: str,
+        domain_name: str,
         filter: DomainUsageBucketFilter | None = None,
         order: list[DomainUsageBucketOrderBy] | None = None,
         first: int | None = None,
@@ -413,13 +407,15 @@ class ResourceUsageAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        resource_group_id = await self._resource_group_id(scope.resource_group)
+        resource_group_id = await self._resource_group_id(resource_group_name)
         action_result = await self._processors.resource_usage.search_domain_usage_buckets.run(
             SearchDomainUsageBucketsAction(
-                scope_target=ScopeRef(
-                    scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id
-                ),
-                scope=scope,
+                items=[
+                    DomainUsageBucketScopeItem(
+                        resource_group_id=resource_group_id,
+                        domain_name=domain_name,
+                    )
+                ],
                 searcher=DomainUsageBucketSearcher(
                     pagination=querier.pagination,
                     conditions=querier.conditions,
@@ -436,7 +432,9 @@ class ResourceUsageAdapter(BaseAdapter):
 
     async def gql_search_project_scoped(
         self,
-        scope: ProjectUsageBucketOperationScope,
+        resource_group_name: str,
+        domain_name: str,
+        project_id: uuid.UUID,
         filter: ProjectUsageBucketFilter | None = None,
         order: list[ProjectUsageBucketOrderBy] | None = None,
         first: int | None = None,
@@ -460,13 +458,16 @@ class ResourceUsageAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        resource_group_id = await self._resource_group_id(scope.resource_group)
+        resource_group_id = await self._resource_group_id(resource_group_name)
         action_result = await self._processors.resource_usage.search_project_usage_buckets.run(
             SearchProjectUsageBucketsAction(
-                scope_target=ScopeRef(
-                    scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id
-                ),
-                scope=scope,
+                items=[
+                    ProjectUsageBucketScopeItem(
+                        resource_group_id=resource_group_id,
+                        domain_name=domain_name,
+                        project_id=project_id,
+                    )
+                ],
                 searcher=ProjectUsageBucketSearcher(
                     pagination=querier.pagination,
                     conditions=querier.conditions,
@@ -483,7 +484,10 @@ class ResourceUsageAdapter(BaseAdapter):
 
     async def gql_search_user_scoped(
         self,
-        scope: UserUsageBucketOperationScope,
+        resource_group_name: str,
+        domain_name: str,
+        project_id: uuid.UUID,
+        user_uuid: uuid.UUID,
         filter: UserUsageBucketFilter | None = None,
         order: list[UserUsageBucketOrderBy] | None = None,
         first: int | None = None,
@@ -507,13 +511,17 @@ class ResourceUsageAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        resource_group_id = await self._resource_group_id(scope.resource_group)
+        resource_group_id = await self._resource_group_id(resource_group_name)
         action_result = await self._processors.resource_usage.search_user_usage_buckets.run(
             SearchUserUsageBucketsAction(
-                scope_target=ScopeRef(
-                    scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id
-                ),
-                scope=scope,
+                items=[
+                    UserUsageBucketScopeItem(
+                        resource_group_id=resource_group_id,
+                        domain_name=domain_name,
+                        project_id=project_id,
+                        user_uuid=user_uuid,
+                    )
+                ],
                 searcher=UserUsageBucketSearcher(
                     pagination=querier.pagination,
                     conditions=querier.conditions,

--- a/src/ai/backend/manager/api/gql/domain_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/domain_v2/types/node.py
@@ -164,17 +164,10 @@ class DomainV2GQL(PydanticNodeMixin[DomainNode]):
             DomainUsageBucketEdge,
             DomainUsageBucketGQL,
         )
-        from ai.backend.manager.models.resource_usage_history.scopes import (
-            DomainUsageBucketOperationScope,
-        )
-
-        repository_scope = DomainUsageBucketOperationScope(
-            resource_group=scope.resource_group_name,
-            domain_name=self.basic_info.name,
-        )
 
         payload = await info.context.adapters.resource_usage.gql_search_domain_scoped(
-            scope=repository_scope,
+            resource_group_name=scope.resource_group_name,
+            domain_name=self.basic_info.name,
             filter=filter.to_pydantic() if filter else None,
             order=[o.to_pydantic() for o in order_by] if order_by else None,
             first=first,

--- a/src/ai/backend/manager/api/gql/project_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/project_v2/types/node.py
@@ -160,17 +160,11 @@ class ProjectV2GQL(PydanticNodeMixin[ProjectNode]):
             ProjectUsageBucketEdge,
             ProjectUsageBucketGQL,
         )
-        from ai.backend.manager.models.resource_usage_history.scopes import (
-            ProjectUsageBucketOperationScope,
-        )
 
-        repository_scope = ProjectUsageBucketOperationScope(
-            resource_group=scope.resource_group_name,
+        payload = await info.context.adapters.resource_usage.gql_search_project_scoped(
+            resource_group_name=scope.resource_group_name,
             domain_name=self.organization.domain_name,
             project_id=UUID(str(self.id)),
-        )
-        payload = await info.context.adapters.resource_usage.gql_search_project_scoped(
-            scope=repository_scope,
             filter=filter.to_pydantic() if filter else None,
             order=[o.to_pydantic() for o in order_by] if order_by else None,
             first=first,

--- a/src/ai/backend/manager/api/gql/user/types/node.py
+++ b/src/ai/backend/manager/api/gql/user/types/node.py
@@ -156,20 +156,14 @@ class UserV2GQL(PydanticNodeMixin[UserNode]):
             UserUsageBucketEdge,
             UserUsageBucketGQL,
         )
-        from ai.backend.manager.models.resource_usage_history.scopes import (
-            UserUsageBucketOperationScope,
-        )
 
         if self.organization.domain_name is None:
             raise InvalidAPIParameters("User must belong to a domain to query usage buckets")
-        repository_scope = UserUsageBucketOperationScope(
-            resource_group=scope.resource_group_name,
+        payload = await info.context.adapters.resource_usage.gql_search_user_scoped(
+            resource_group_name=scope.resource_group_name,
             domain_name=self.organization.domain_name,
             project_id=scope.project_id,
             user_uuid=UUID(str(self.id)),
-        )
-        payload = await info.context.adapters.resource_usage.gql_search_user_scoped(
-            scope=repository_scope,
             filter=filter.to_pydantic() if filter else None,
             order=[o.to_pydantic() for o in order_by] if order_by else None,
             first=first,

--- a/src/ai/backend/manager/models/resource_usage_history/scopes.py
+++ b/src/ai/backend/manager/models/resource_usage_history/scopes.py
@@ -9,6 +9,7 @@ from typing import Any, override
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.manager.errors.resource import (
     DomainNotFound,
     ProjectNotFound,
@@ -32,18 +33,18 @@ from ai.backend.manager.models.user import UserRow
 class DomainUsageBucketOperationScope(OperationScope):
     """Scope for domain usage bucket queries."""
 
-    resource_group: str
+    resource_group_id: ResourceGroupID
     domain_name: str
 
     @override
     def to_condition(self) -> QueryCondition:
-        resource_group = self.resource_group
+        resource_group_id = self.resource_group_id
         domain_name = self.domain_name
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
                 DomainUsageBucketRow.domain_name == domain_name,
-                DomainUsageBucketRow.resource_group == resource_group,
+                DomainUsageBucketRow.resource_group_id == resource_group_id,
             )
 
         return inner
@@ -53,9 +54,11 @@ class DomainUsageBucketOperationScope(OperationScope):
     def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
         return [
             ExistenceCheck(
-                column=ResourceGroupRow.name,
-                value=self.resource_group,
-                error=ResourceGroupNotFound(self.resource_group),
+                column=ResourceGroupRow.id,
+                value=self.resource_group_id,
+                error=ResourceGroupNotFound(
+                    extra_data={"resource_group_id": str(self.resource_group_id)}
+                ),
             ),
             ExistenceCheck(
                 column=DomainRow.name,
@@ -69,13 +72,13 @@ class DomainUsageBucketOperationScope(OperationScope):
 class ProjectUsageBucketOperationScope(OperationScope):
     """Scope for project usage bucket queries."""
 
-    resource_group: str
+    resource_group_id: ResourceGroupID
     domain_name: str
     project_id: uuid.UUID
 
     @override
     def to_condition(self) -> QueryCondition:
-        resource_group = self.resource_group
+        resource_group_id = self.resource_group_id
         domain_name = self.domain_name
         project_id = self.project_id
 
@@ -83,7 +86,7 @@ class ProjectUsageBucketOperationScope(OperationScope):
             return sa.and_(
                 ProjectUsageBucketRow.domain_name == domain_name,
                 ProjectUsageBucketRow.project_id == project_id,
-                ProjectUsageBucketRow.resource_group == resource_group,
+                ProjectUsageBucketRow.resource_group_id == resource_group_id,
             )
 
         return inner
@@ -93,9 +96,11 @@ class ProjectUsageBucketOperationScope(OperationScope):
     def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
         return [
             ExistenceCheck(
-                column=ResourceGroupRow.name,
-                value=self.resource_group,
-                error=ResourceGroupNotFound(self.resource_group),
+                column=ResourceGroupRow.id,
+                value=self.resource_group_id,
+                error=ResourceGroupNotFound(
+                    extra_data={"resource_group_id": str(self.resource_group_id)}
+                ),
             ),
             ExistenceCheck(
                 column=DomainRow.name,
@@ -114,14 +119,14 @@ class ProjectUsageBucketOperationScope(OperationScope):
 class UserUsageBucketOperationScope(OperationScope):
     """Scope for user usage bucket queries."""
 
-    resource_group: str
+    resource_group_id: ResourceGroupID
     domain_name: str
     project_id: uuid.UUID
     user_uuid: uuid.UUID
 
     @override
     def to_condition(self) -> QueryCondition:
-        resource_group = self.resource_group
+        resource_group_id = self.resource_group_id
         domain_name = self.domain_name
         project_id = self.project_id
         user_uuid = self.user_uuid
@@ -131,7 +136,7 @@ class UserUsageBucketOperationScope(OperationScope):
                 UserUsageBucketRow.domain_name == domain_name,
                 UserUsageBucketRow.project_id == project_id,
                 UserUsageBucketRow.user_uuid == user_uuid,
-                UserUsageBucketRow.resource_group == resource_group,
+                UserUsageBucketRow.resource_group_id == resource_group_id,
             )
 
         return inner
@@ -141,9 +146,11 @@ class UserUsageBucketOperationScope(OperationScope):
     def existence_checks(self) -> Sequence[ExistenceCheck[Any]]:
         return [
             ExistenceCheck(
-                column=ResourceGroupRow.name,
-                value=self.resource_group,
-                error=ResourceGroupNotFound(self.resource_group),
+                column=ResourceGroupRow.id,
+                value=self.resource_group_id,
+                error=ResourceGroupNotFound(
+                    extra_data={"resource_group_id": str(self.resource_group_id)}
+                ),
             ),
             ExistenceCheck(
                 column=DomainRow.name,

--- a/src/ai/backend/manager/services/resource_usage/actions/scope_items.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/scope_items.py
@@ -1,0 +1,94 @@
+"""The resource-group scopes a usage bucket read is answered for."""
+
+from __future__ import annotations
+
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE, ResourceGroupID
+from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.manager.models.resource_usage_history.scopes import (
+    DomainUsageBucketOperationScope,
+    ProjectUsageBucketOperationScope,
+    UserUsageBucketOperationScope,
+)
+from ai.backend.manager.models.scopes import OperationScope
+
+__all__ = (
+    "DomainUsageBucketScopeItem",
+    "ProjectUsageBucketScopeItem",
+    "UsageBucketScopeItem",
+    "UserUsageBucketScopeItem",
+)
+
+
+class UsageBucketScopeItem(ABC):
+    """One resource group a usage bucket read is answered for.
+
+    The scope the read is authorized against and the rows it is restricted to name
+    the same resource group id, so a read cannot be authorized for one and served
+    another.
+    """
+
+    resource_group_id: ResourceGroupID
+
+    def scope_ref(self) -> ScopeRef:
+        return ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id)
+
+    @abstractmethod
+    def operation_scope(self) -> OperationScope:
+        """The rows the read is restricted to."""
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class DomainUsageBucketScopeItem(UsageBucketScopeItem):
+    """The domain usage buckets of one resource group."""
+
+    resource_group_id: ResourceGroupID
+    domain_name: str
+
+    @override
+    def operation_scope(self) -> DomainUsageBucketOperationScope:
+        return DomainUsageBucketOperationScope(
+            resource_group_id=self.resource_group_id,
+            domain_name=self.domain_name,
+        )
+
+
+@dataclass(frozen=True)
+class ProjectUsageBucketScopeItem(UsageBucketScopeItem):
+    """The project usage buckets of one resource group."""
+
+    resource_group_id: ResourceGroupID
+    domain_name: str
+    project_id: uuid.UUID
+
+    @override
+    def operation_scope(self) -> ProjectUsageBucketOperationScope:
+        return ProjectUsageBucketOperationScope(
+            resource_group_id=self.resource_group_id,
+            domain_name=self.domain_name,
+            project_id=self.project_id,
+        )
+
+
+@dataclass(frozen=True)
+class UserUsageBucketScopeItem(UsageBucketScopeItem):
+    """The user usage buckets of one resource group."""
+
+    resource_group_id: ResourceGroupID
+    domain_name: str
+    project_id: uuid.UUID
+    user_uuid: uuid.UUID
+
+    @override
+    def operation_scope(self) -> UserUsageBucketOperationScope:
+        return UserUsageBucketOperationScope(
+            resource_group_id=self.resource_group_id,
+            domain_name=self.domain_name,
+            project_id=self.project_id,
+            user_uuid=self.user_uuid,
+        )

--- a/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
@@ -9,21 +9,22 @@ from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import DomainUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import DomainUsageBucketRow
-from ai.backend.manager.models.resource_usage_history.scopes import DomainUsageBucketOperationScope
 from ai.backend.manager.models.resource_usage_history.searchers import (
     DomainUsageBucketSearcher,
 )
 from ai.backend.manager.models.scopes import OperationScope
+from ai.backend.manager.services.resource_usage.actions.scope_items import (
+    DomainUsageBucketScopeItem,
+)
 
 
 @dataclass
 class SearchDomainUsageBucketsAction(
     OperationScopeOpsAction[DomainUsageBucketRow, DomainUsageBucketData]
 ):
-    """Page through the domain usage buckets of one scope."""
+    """Page through the domain usage buckets the named resource groups hold, combined with OR."""
 
-    scope_target: ScopeRef
-    scope: DomainUsageBucketOperationScope
+    items: Sequence[DomainUsageBucketScopeItem]
     searcher: DomainUsageBucketSearcher
 
     @override
@@ -38,11 +39,11 @@ class SearchDomainUsageBucketsAction(
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
-        return (self.scope_target,)
+        return [item.scope_ref() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:
-        return (self.scope,)
+        return [item.operation_scope() for item in self.items]
 
     @override
     def to_searcher(self) -> DomainUsageBucketSearcher:

--- a/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
@@ -9,21 +9,22 @@ from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import ProjectUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import ProjectUsageBucketRow
-from ai.backend.manager.models.resource_usage_history.scopes import ProjectUsageBucketOperationScope
 from ai.backend.manager.models.resource_usage_history.searchers import (
     ProjectUsageBucketSearcher,
 )
 from ai.backend.manager.models.scopes import OperationScope
+from ai.backend.manager.services.resource_usage.actions.scope_items import (
+    ProjectUsageBucketScopeItem,
+)
 
 
 @dataclass
 class SearchProjectUsageBucketsAction(
     OperationScopeOpsAction[ProjectUsageBucketRow, ProjectUsageBucketData]
 ):
-    """Page through the project usage buckets of one scope."""
+    """Page through the project usage buckets the named resource groups hold, combined with OR."""
 
-    scope_target: ScopeRef
-    scope: ProjectUsageBucketOperationScope
+    items: Sequence[ProjectUsageBucketScopeItem]
     searcher: ProjectUsageBucketSearcher
 
     @override
@@ -38,11 +39,11 @@ class SearchProjectUsageBucketsAction(
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
-        return (self.scope_target,)
+        return [item.scope_ref() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:
-        return (self.scope,)
+        return [item.operation_scope() for item in self.items]
 
     @override
     def to_searcher(self) -> ProjectUsageBucketSearcher:

--- a/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
@@ -9,21 +9,22 @@ from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import UserUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import UserUsageBucketRow
-from ai.backend.manager.models.resource_usage_history.scopes import UserUsageBucketOperationScope
 from ai.backend.manager.models.resource_usage_history.searchers import (
     UserUsageBucketSearcher,
 )
 from ai.backend.manager.models.scopes import OperationScope
+from ai.backend.manager.services.resource_usage.actions.scope_items import (
+    UserUsageBucketScopeItem,
+)
 
 
 @dataclass
 class SearchUserUsageBucketsAction(
     OperationScopeOpsAction[UserUsageBucketRow, UserUsageBucketData]
 ):
-    """Page through the user usage buckets of one scope."""
+    """Page through the user usage buckets the named resource groups hold, combined with OR."""
 
-    scope_target: ScopeRef
-    scope: UserUsageBucketOperationScope
+    items: Sequence[UserUsageBucketScopeItem]
     searcher: UserUsageBucketSearcher
 
     @override
@@ -38,11 +39,11 @@ class SearchUserUsageBucketsAction(
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
-        return (self.scope_target,)
+        return [item.scope_ref() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:
-        return (self.scope,)
+        return [item.operation_scope() for item in self.items]
 
     @override
     def to_searcher(self) -> UserUsageBucketSearcher:

--- a/tests/unit/manager/services/resource_usage/BUILD
+++ b/tests/unit/manager/services/resource_usage/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py
+++ b/tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py
@@ -1,0 +1,61 @@
+"""The usage bucket scope items authorize and restrict against the same resource group."""
+
+from __future__ import annotations
+
+import uuid
+
+from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE, ResourceGroupID
+from ai.backend.manager.models.resource_usage_history.scopes import (
+    DomainUsageBucketOperationScope,
+    ProjectUsageBucketOperationScope,
+    UserUsageBucketOperationScope,
+)
+from ai.backend.manager.services.resource_usage.actions.scope_items import (
+    DomainUsageBucketScopeItem,
+    ProjectUsageBucketScopeItem,
+    UserUsageBucketScopeItem,
+)
+
+RESOURCE_GROUP_ID = ResourceGroupID(uuid.uuid4())
+PROJECT_ID = uuid.uuid4()
+USER_UUID = uuid.uuid4()
+
+
+def test_domain_item_is_read_for_the_resource_group() -> None:
+    item = DomainUsageBucketScopeItem(resource_group_id=RESOURCE_GROUP_ID, domain_name="default")
+    ref = item.scope_ref()
+    assert ref.scope_type == RESOURCE_GROUP_SCOPE_TYPE
+    assert ref.scope_id == RESOURCE_GROUP_ID
+    assert item.operation_scope() == DomainUsageBucketOperationScope(
+        resource_group_id=RESOURCE_GROUP_ID, domain_name="default"
+    )
+
+
+def test_project_item_is_read_for_the_resource_group() -> None:
+    item = ProjectUsageBucketScopeItem(
+        resource_group_id=RESOURCE_GROUP_ID, domain_name="default", project_id=PROJECT_ID
+    )
+    ref = item.scope_ref()
+    assert ref.scope_type == RESOURCE_GROUP_SCOPE_TYPE
+    assert ref.scope_id == RESOURCE_GROUP_ID
+    assert item.operation_scope() == ProjectUsageBucketOperationScope(
+        resource_group_id=RESOURCE_GROUP_ID, domain_name="default", project_id=PROJECT_ID
+    )
+
+
+def test_user_item_is_read_for_the_resource_group() -> None:
+    item = UserUsageBucketScopeItem(
+        resource_group_id=RESOURCE_GROUP_ID,
+        domain_name="default",
+        project_id=PROJECT_ID,
+        user_uuid=USER_UUID,
+    )
+    ref = item.scope_ref()
+    assert ref.scope_type == RESOURCE_GROUP_SCOPE_TYPE
+    assert ref.scope_id == RESOURCE_GROUP_ID
+    assert item.operation_scope() == UserUsageBucketOperationScope(
+        resource_group_id=RESOURCE_GROUP_ID,
+        domain_name="default",
+        project_id=PROJECT_ID,
+        user_uuid=USER_UUID,
+    )


### PR DESCRIPTION
## Summary
- The three usage bucket searches (domain/project/user) took a `ScopeRef` and an `OperationScope` as separate fields. They now take `items`, each a `UsageBucketScopeItem` that yields both from one resource group id, so a read cannot be authorized for one group and served another.
- The usage bucket operation scopes key on `resource_group_id` instead of the resource group name.
- The GQL nodes pass the raw scope values to the adapter, which resolves the resource group id and builds the scope item. API request and response shapes are unchanged.

## Test plan
- [x] `pants fmt fix lint check` pass
- [x] `tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py`: each item's scope type is the resource group and its operation scope carries the same id

Resolves BA-7713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJY916kVKaa6oaQFnexg8t