### PR TITLE
refactor(BA-7710): read one resource preset through a get

### DIFF
--- a/changes/14335.enhance.md
+++ b/changes/14335.enhance.md
@@ -1,0 +1,1 @@
+Read a single resource preset through a get keyed by its id instead of a system-wide search.

--- a/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
@@ -33,14 +33,13 @@ from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.resource_preset.types import ResourcePresetData
+from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.errors.resource import ResourcePresetNotFound
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
 from ai.backend.manager.models.resource_preset.conditions import ResourcePresetConditions
 from ai.backend.manager.models.resource_preset.orders import ResourcePresetOrders
 from ai.backend.manager.models.resource_preset.row import ResourcePresetRow
-from ai.backend.manager.models.specs.pagination import OffsetPagination
-from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.base.creator import Creator
 from ai.backend.manager.repositories.base.updater import Updater
 from ai.backend.manager.repositories.resource_preset.creators import ResourcePresetCreatorSpec
@@ -50,6 +49,9 @@ from ai.backend.manager.services.resource_preset.actions.create_preset import (
 )
 from ai.backend.manager.services.resource_preset.actions.delete_preset import (
     DeleteResourcePresetAction,
+)
+from ai.backend.manager.services.resource_preset.actions.get_preset import (
+    GetResourcePresetAction,
 )
 from ai.backend.manager.services.resource_preset.actions.search_presets import (
     SearchResourcePresetsV2Action,
@@ -118,16 +120,15 @@ class ResourcePresetAdapter(BaseAdapter):
 
     async def get(self, preset_id: UUID) -> ResourcePresetNode:
         """Get a single resource preset by ID."""
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=1),
-            conditions=[lambda: ResourcePresetRow.id == preset_id],
-        )
-        result = await self._processors.resource_preset.search_presets_v2.run(
-            SearchResourcePresetsV2Action(querier=querier)
-        )
-        if not result.presets:
-            raise ResourcePresetNotFound()
-        return self._data_to_node(result.presets[0])
+        try:
+            result = await self._processors.resource_preset.get_preset.run(
+                GetResourcePresetAction(preset_id=ResourcePresetID(preset_id))
+            )
+        except EntityNotFoundError as e:
+            # The generic repository names no domain; the route answered with the
+            # preset's own error before and keeps doing so.
+            raise ResourcePresetNotFound() from e
+        return self._data_to_node(result.data)
 
     async def create(
         self,

--- a/src/ai/backend/manager/models/resource_preset/queriers.py
+++ b/src/ai/backend/manager/models/resource_preset/queriers.py
@@ -1,0 +1,36 @@
+"""DataQuerier implementations for the resource presets table."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.resource_preset import ResourcePresetID
+from ai.backend.manager.data.resource_preset.types import ResourcePresetData
+from ai.backend.manager.models.resource_preset.row import ResourcePresetRow
+from ai.backend.manager.models.specs.querier import DataQuerier
+
+
+@dataclass
+class ResourcePresetQuerier(DataQuerier[ResourcePresetRow, ResourcePresetData]):
+    """Reads the preset an id names."""
+
+    preset_id: ResourcePresetID
+
+    @override
+    def row_class(self) -> type[ResourcePresetRow]:
+        return ResourcePresetRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return ResourcePresetRow.id
+
+    @override
+    def entity_id_value(self) -> ResourcePresetID:
+        return self.preset_id
+
+    @override
+    def to_data(self, row: ResourcePresetRow) -> ResourcePresetData:
+        return row.to_dataclass()

--- a/src/ai/backend/manager/services/resource_preset/actions/check_presets.py
+++ b/src/ai/backend/manager/services/resource_preset/actions/check_presets.py
@@ -16,6 +16,12 @@ from ai.backend.manager.services.resource_preset.actions.base import ResourcePre
 
 @dataclass
 class CheckResourcePresetsAction(ResourcePresetAction):
+    """List the presets a resource group offers, against the caller's own limits.
+
+    Public for the reason the listing beside it is, and the occupancy it adds is
+    the caller's own: the keypair, group and domain it reports on are theirs.
+    """
+
     access_key: AccessKey
     resource_policy: Mapping[str, Any]
     domain_name: str

--- a/src/ai/backend/manager/services/resource_preset/actions/get_preset.py
+++ b/src/ai/backend/manager/services/resource_preset/actions/get_preset.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.resource_preset import ResourcePresetID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import GetSingleEntityOpsAction
+from ai.backend.manager.data.resource_preset.types import ResourcePresetData
+from ai.backend.manager.models.resource_preset.queriers import ResourcePresetQuerier
+from ai.backend.manager.models.resource_preset.row import ResourcePresetRow
+
+
+@dataclass
+class GetResourcePresetAction(GetSingleEntityOpsAction[ResourcePresetRow, ResourcePresetData]):
+    """Read the preset an id names.
+
+    Single-entity rather than global: the read starts from the preset's id, the same
+    end the update and the delete beside it start from. The catalog reads that answer
+    a session launcher start from a resource group name instead and stay global and
+    public -- ``global_list_resource_presets`` and ``global_check_resource_presets``.
+    """
+
+    preset_id: ResourcePresetID
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "get_resource_preset"
+
+    @override
+    def entity_id(self) -> EntityIdentifier:
+        return self.preset_id
+
+    @override
+    def to_querier(self) -> ResourcePresetQuerier:
+        return ResourcePresetQuerier(preset_id=self.preset_id)

--- a/src/ai/backend/manager/services/resource_preset/actions/list_presets.py
+++ b/src/ai/backend/manager/services/resource_preset/actions/list_presets.py
@@ -7,6 +7,13 @@ from ai.backend.manager.services.resource_preset.actions.base import ResourcePre
 
 @dataclass
 class ListResourcePresetsAction(ResourcePresetAction):
+    """List the presets a resource group offers.
+
+    Public: a session launcher shows these for the user to pick from, so every
+    authenticated caller reads them. The catalog holds no owner and no secret --
+    a name, its resource slots and its shared memory.
+    """
+
     access_key: str
     resource_group: str | None
 

--- a/src/ai/backend/manager/services/resource_preset/processors.py
+++ b/src/ai/backend/manager/services/resource_preset/processors.py
@@ -5,7 +5,7 @@ from ai.backend.manager.actions.v2.global_scope.processor import (
     PublicActionProcessor,
 )
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
-from ai.backend.manager.actions.v2.ops.result import LookupOpsResult
+from ai.backend.manager.actions.v2.ops.result import EntityOpsResult, LookupOpsResult
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.resource_preset.types import ResourcePresetData
 from ai.backend.manager.services.resource_preset.actions.check_presets import (
@@ -19,6 +19,9 @@ from ai.backend.manager.services.resource_preset.actions.create_preset import (
 from ai.backend.manager.services.resource_preset.actions.delete_preset import (
     DeleteResourcePresetAction,
     DeleteResourcePresetActionResult,
+)
+from ai.backend.manager.services.resource_preset.actions.get_preset import (
+    GetResourcePresetAction,
 )
 from ai.backend.manager.services.resource_preset.actions.list_presets import (
     ListResourcePresetsAction,
@@ -49,6 +52,9 @@ class ResourcePresetProcessors:
     delete_preset: SingleEntityActionProcessor[
         DeleteResourcePresetAction, DeleteResourcePresetActionResult
     ]
+    get_preset: SingleEntityActionProcessor[
+        GetResourcePresetAction, EntityOpsResult[ResourcePresetData]
+    ]
     list_presets: PublicActionProcessor[ListResourcePresetsAction, ListResourcePresetsResult]
     check_presets: PublicActionProcessor[
         CheckResourcePresetsAction, CheckResourcePresetsActionResult
@@ -64,6 +70,7 @@ class ResourcePresetProcessors:
         self.create_preset = group.global_scope(CreateResourcePresetAction, service.create_preset)
         self.update_preset = group.single_entity(UpdateResourcePresetAction, service.update_preset)
         self.delete_preset = group.single_entity(DeleteResourcePresetAction, service.delete_preset)
+        self.get_preset = group.single_get_ops(GetResourcePresetAction)
         self.list_presets = group.public(ListResourcePresetsAction, service.list_presets)
         self.check_presets = group.public(CheckResourcePresetsAction, service.check_presets)
         self.search_presets_v2 = group.global_scope(

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -169,6 +169,15 @@ from ai.backend.manager.services.prometheus_query_preset_category.processors imp
     PrometheusQueryPresetCategoryProcessors,
 )
 from ai.backend.manager.services.resource_group.processors import ResourceGroupProcessors
+from ai.backend.manager.services.resource_preset.actions.check_presets import (
+    CheckResourcePresetsAction,
+)
+from ai.backend.manager.services.resource_preset.actions.get_preset import (
+    GetResourcePresetAction,
+)
+from ai.backend.manager.services.resource_preset.actions.list_presets import (
+    ListResourcePresetsAction,
+)
 from ai.backend.manager.services.resource_preset.processors import ResourcePresetProcessors
 from ai.backend.manager.services.resource_slot.processors import ResourceSlotProcessors
 from ai.backend.manager.services.retention_policy.processors import RetentionPolicyProcessors
@@ -434,6 +443,42 @@ def test_action_name_is_unique_across_v2_actions() -> None:
             f"{cls.__module__}.{cls.__qualname__} and {holder.__module__}.{holder.__qualname__} "
             f"both record as {name!r}; declare a distinct action_name() on one of them."
         )
+
+
+def test_resource_preset_reads_keep_their_judged_gates() -> None:
+    """Pins the three preset reads BA-7710 ruled on, so a rewiring has to restate them.
+
+    A preset is a catalog: its name, resource slots and shared memory hold no owner
+    and no secret. The two reads a session launcher makes start from a resource group
+    name and stay public; the read the admin route makes starts from the preset's id,
+    so it is judged on that entity like the update and the delete beside it.
+    """
+    registry = _ops_registry()
+    ResourcePresetProcessors(registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)), MagicMock())
+
+    judged = {
+        ListResourcePresetsAction: (
+            RESOURCE_PRESET_ENTITY_TYPE,
+            ActionKind.GLOBAL,
+            ActionGate.PUBLIC,
+        ),
+        CheckResourcePresetsAction: (
+            RESOURCE_PRESET_ENTITY_TYPE,
+            ActionKind.GLOBAL,
+            ActionGate.PUBLIC,
+        ),
+        GetResourcePresetAction: (
+            RESOURCE_PRESET_ENTITY_TYPE,
+            ActionKind.SINGLE_ENTITY,
+            ActionGate.PERMISSION,
+        ),
+    }
+    recorded = {
+        record.action_cls: (record.entity_type, record.kind, record.gate)
+        for record in registry.wired_processors()
+        if record.action_cls in judged
+    }
+    assert recorded == judged
 
 
 def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:


### PR DESCRIPTION
## Summary
- `GET /v2/resource-presets/{preset_id}` ran a global search with a limit of one and an id condition, so a read that starts from an entity id was recorded as a system-wide search. It now runs a get keyed by that id, judged on the preset like the `PATCH` and the `DELETE` beside it on the same route.
- The two catalog reads a session launcher makes — `GET /resource/presets` and `POST /resource/check-presets` — start from a resource group name instead, and their docstrings now record why they stay public. The registry catalog test pins all three judgments.
- The generic ops repository raises its own not-found error, so the adapter turns it back into `ResourcePresetNotFound` and the route answers exactly as before.
- Every route keeps its middleware: the six v2 preset routes stay `superadmin_required`, the two v1 reads stay `auth_required`. Request and response shapes, and the SDK path, are unchanged.

## Test plan
- [ ] `GET /v2/resource-presets/{id}` as a super admin returns the same body as before
- [ ] The same call with an unknown id still answers 404 with the resource-preset not-found error
- [ ] A non-super-admin is still refused by the route
- [ ] `GET /resource/presets` and `POST /resource/check-presets` are unchanged for a regular user

Resolves BA-7710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnDWcwrgQsmcAQbAd56kfh
