### PR TITLE
refactor(BA-7711): read artifact registry metas as a partial bulk get

### DIFF
--- a/changes/14337.enhance.md
+++ b/changes/14337.enhance.md
@@ -1,0 +1,1 @@
+Read artifact registry metas as a partial bulk get so non-superadmin callers get the registries they may read

--- a/src/ai/backend/manager/api/adapters/artifact_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact_registry/adapter.py
@@ -55,11 +55,17 @@ class ArtifactRegistryAdapter(BaseAdapter):
     async def get_registry_metas(
         self, registry_ids: list[uuid.UUID]
     ) -> list[ArtifactRegistryGQLNode]:
-        """Get metadata for multiple artifact registries by IDs."""
-        action_result = await self._processors.artifact_registry.get_registry_metas.run(
-            GetArtifactRegistryMetasAction(registry_ids=registry_ids)
+        """Get metadata for the named artifact registries.
+
+        An id the caller may not read is left out beside one matching no row, so the
+        caller cannot tell a denied registry from an absent one.
+        """
+        result = await self._processors.artifact_registry.get_registry_metas.run(
+            GetArtifactRegistryMetasAction(
+                registry_ids=[ArtifactRegistryID(registry_id) for registry_id in registry_ids]
+            )
         )
-        return [self._data_to_dto(item) for item in action_result.result]
+        return [self._data_to_dto(item.value) for item in result.items if item.value is not None]
 
     async def batch_load_by_ids(
         self, ids: Sequence[uuid.UUID]

--- a/src/ai/backend/manager/models/artifact_registries/queriers.py
+++ b/src/ai/backend/manager/models/artifact_registries/queriers.py
@@ -1,0 +1,27 @@
+"""Read specs for the artifact registry repository."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.manager.data.artifact_registries.types import ArtifactRegistryData
+from ai.backend.manager.models.artifact_registries.row import ArtifactRegistryRow
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier
+
+
+class BulkArtifactRegistryQuerier(BulkEntityQuerier[ArtifactRegistryRow, ArtifactRegistryData]):
+    """The artifact registries the caller named, keyed by the registry id the single get keys on."""
+
+    @override
+    def row_class(self) -> type[ArtifactRegistryRow]:
+        return ArtifactRegistryRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return ArtifactRegistryRow.registry_id
+
+    @override
+    def to_data(self, row: ArtifactRegistryRow) -> ArtifactRegistryData:
+        return row.to_dataclass()

--- a/src/ai/backend/manager/repositories/artifact_registry/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/artifact_registry/db_source/db_source.py
@@ -39,21 +39,6 @@ class ArtifactRegistryDBSource:
                 raise ArtifactRegistryNotFoundError(f"Registry with name {registry_name} not found")
             return row.to_dataclass()
 
-    async def get_artifact_registry_datas(
-        self, registry_ids: list[uuid.UUID]
-    ) -> list[ArtifactRegistryData]:
-        """
-        Get multiple artifact registry entries by their IDs in a single query.
-        """
-        async with self._db.begin_readonly_session_read_committed() as session:
-            result = await session.execute(
-                sa.select(ArtifactRegistryRow).where(
-                    ArtifactRegistryRow.registry_id.in_(registry_ids)
-                )
-            )
-            rows = result.scalars().all()
-            return [row.to_dataclass() for row in rows]
-
     async def get_artifact_registry_type(self, registry_id: uuid.UUID) -> ArtifactRegistryType:
         async with self._db.begin_readonly_session_read_committed() as session:
             result = await session.execute(

--- a/src/ai/backend/manager/repositories/artifact_registry/repository.py
+++ b/src/ai/backend/manager/repositories/artifact_registry/repository.py
@@ -53,11 +53,6 @@ class ArtifactRegistryRepository:
         return await self._db_source.get_artifact_registry_data_by_name(registry_name)
 
     @artifact_registry_repository_resilience.apply()
-    async def get_artifact_registry_datas(
-        self, registry_ids: list[uuid.UUID]
-    ) -> list[ArtifactRegistryData]:
-        return await self._db_source.get_artifact_registry_datas(registry_ids)
-
     @artifact_registry_repository_resilience.apply()
     async def get_artifact_registry_type(self, registry_id: uuid.UUID) -> ArtifactRegistryType:
         return await self._db_source.get_artifact_registry_type(registry_id)

--- a/src/ai/backend/manager/services/artifact_registry/actions/common/__init__.py
+++ b/src/ai/backend/manager/services/artifact_registry/actions/common/__init__.py
@@ -1,12 +1,11 @@
 from .get_meta import GetArtifactRegistryMetaAction, GetArtifactRegistryMetaActionResult
-from .get_multi import GetArtifactRegistryMetasAction, GetArtifactRegistryMetasActionResult
+from .get_multi import GetArtifactRegistryMetasAction
 from .search import SearchArtifactRegistriesAction, SearchArtifactRegistriesActionResult
 
 __all__ = [
     "GetArtifactRegistryMetaAction",
     "GetArtifactRegistryMetaActionResult",
     "GetArtifactRegistryMetasAction",
-    "GetArtifactRegistryMetasActionResult",
     "SearchArtifactRegistriesAction",
     "SearchArtifactRegistriesActionResult",
 ]

--- a/src/ai/backend/manager/services/artifact_registry/actions/common/get_multi.py
+++ b/src/ai/backend/manager/services/artifact_registry/actions/common/get_multi.py
@@ -1,15 +1,24 @@
-import uuid
-from dataclasses import dataclass
-from typing import override
+from __future__ import annotations
 
-from ai.backend.manager.actions.types import ActionOperationType
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
 from ai.backend.manager.data.artifact_registries.types import ArtifactRegistryData
-from ai.backend.manager.services.artifact_registry.actions.base import ArtifactRegistryAction
+from ai.backend.manager.models.artifact_registries.queriers import BulkArtifactRegistryQuerier
+from ai.backend.manager.models.artifact_registries.row import ArtifactRegistryRow
 
 
 @dataclass
-class GetArtifactRegistryMetasAction(ArtifactRegistryAction):
-    registry_ids: list[uuid.UUID]
+class GetArtifactRegistryMetasAction(
+    PartialBulkGetEntityOpsAction[ArtifactRegistryRow, ArtifactRegistryData]
+):
+    """Read the artifact registries the caller named, answering for each id."""
+
+    registry_ids: Sequence[ArtifactRegistryID]
 
     @override
     @classmethod
@@ -17,11 +26,14 @@ class GetArtifactRegistryMetasAction(ArtifactRegistryAction):
         return "get_artifact_registry_metas"
 
     @override
-    @classmethod
-    def operation_type(cls) -> ActionOperationType:
-        return ActionOperationType.GET
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.registry_ids)
 
+    @override
+    def to_querier(self) -> BulkArtifactRegistryQuerier:
+        return BulkArtifactRegistryQuerier()
 
-@dataclass
-class GetArtifactRegistryMetasActionResult:
-    result: list[ArtifactRegistryData]
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, registry_ids=[rid for rid in self.registry_ids if rid in allowed])

--- a/src/ai/backend/manager/services/artifact_registry/processors.py
+++ b/src/ai/backend/manager/services/artifact_registry/processors.py
@@ -1,5 +1,6 @@
 from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryID
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import LookupOpsResult
@@ -11,7 +12,6 @@ from ai.backend.manager.services.artifact_registry.actions.common.get_meta impor
 )
 from ai.backend.manager.services.artifact_registry.actions.common.get_multi import (
     GetArtifactRegistryMetasAction,
-    GetArtifactRegistryMetasActionResult,
 )
 from ai.backend.manager.services.artifact_registry.actions.common.search import (
     SearchArtifactRegistriesAction,
@@ -127,8 +127,8 @@ class ArtifactRegistryProcessors:
     get_registry_meta: SingleEntityActionProcessor[
         GetArtifactRegistryMetaAction, GetArtifactRegistryMetaActionResult
     ]
-    get_registry_metas: GlobalActionProcessor[
-        GetArtifactRegistryMetasAction, GetArtifactRegistryMetasActionResult
+    get_registry_metas: PartialBulkActionProcessor[
+        GetArtifactRegistryMetasAction, ArtifactRegistryData
     ]
     search_artifact_registries: GlobalActionProcessor[
         SearchArtifactRegistriesAction, SearchArtifactRegistriesActionResult
@@ -184,6 +184,7 @@ class ArtifactRegistryProcessors:
         self.get_registry_meta = group.single_entity(
             GetArtifactRegistryMetaAction, service.get_registry_meta
         )
+        self.get_registry_metas = group.partial_bulk_get_ops(GetArtifactRegistryMetasAction)
 
         # Internal/batch actions without RBAC
         self.get_huggingface_registries = group.global_scope(
@@ -191,7 +192,4 @@ class ArtifactRegistryProcessors:
         )
         self.get_reservoir_registries = group.global_scope(
             GetReservoirRegistriesAction, service.get_reservoir_registries
-        )
-        self.get_registry_metas = group.global_scope(
-            GetArtifactRegistryMetasAction, service.get_registry_metas
         )

--- a/src/ai/backend/manager/services/artifact_registry/service.py
+++ b/src/ai/backend/manager/services/artifact_registry/service.py
@@ -10,10 +10,6 @@ from ai.backend.manager.services.artifact_registry.actions.common.get_meta impor
     GetArtifactRegistryMetaAction,
     GetArtifactRegistryMetaActionResult,
 )
-from ai.backend.manager.services.artifact_registry.actions.common.get_multi import (
-    GetArtifactRegistryMetasAction,
-    GetArtifactRegistryMetasActionResult,
-)
 from ai.backend.manager.services.artifact_registry.actions.common.search import (
     SearchArtifactRegistriesAction,
     SearchArtifactRegistriesActionResult,
@@ -262,15 +258,6 @@ class ArtifactRegistryService:
             action.registry_id
         )
         return GetArtifactRegistryMetaActionResult(result=registry_meta)
-
-    async def get_registry_metas(
-        self, action: GetArtifactRegistryMetasAction
-    ) -> GetArtifactRegistryMetasActionResult:
-        log.info("Getting {} artifact registry metas", len(action.registry_ids))
-        registry_metas = await self._artifact_registry_repository.get_artifact_registry_datas(
-            action.registry_ids
-        )
-        return GetArtifactRegistryMetasActionResult(result=registry_metas)
 
     async def search_artifact_registries(
         self, action: SearchArtifactRegistriesAction

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -121,6 +121,9 @@ from ai.backend.manager.services.artifact.revision.actions.lookup_owner import (
     LookupBulkArtifactRevisionOwnerAction,
 )
 from ai.backend.manager.services.artifact.revision.processors import ArtifactRevisionProcessors
+from ai.backend.manager.services.artifact_registry.actions.common.get_multi import (
+    GetArtifactRegistryMetasAction,
+)
 from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
 from ai.backend.manager.services.audit_log.processors import AuditLogProcessors
 from ai.backend.manager.services.auth.processors import AuthProcessors
@@ -493,6 +496,24 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
         if record.action_cls in judged
     }
     assert recorded == judged
+
+
+def test_artifact_registry_metas_read_is_a_partial_bulk_permission_read() -> None:
+    """The named registries are read one permission check per registry, not superadmin-only."""
+    registry = _ops_registry()
+    ArtifactRegistryProcessors(
+        registry.group(GroupMeta(ARTIFACT_REGISTRY_ENTITY_TYPE)), MagicMock()
+    )
+
+    recorded = {
+        record.action_cls: (record.entity_type, record.kind, record.gate)
+        for record in registry.wired_processors()
+    }
+    assert recorded[GetArtifactRegistryMetasAction] == (
+        ARTIFACT_REGISTRY_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
 
 
 def test_rg_domain_read_is_a_scoped_permission_read() -> None:

--- a/tests/unit/manager/repositories/artifact_registry/test_artifact_registry_repository.py
+++ b/tests/unit/manager/repositories/artifact_registry/test_artifact_registry_repository.py
@@ -204,35 +204,6 @@ class TestArtifactRegistryRepository:
             )
 
     # =========================================================================
-    # Tests - Get Multiple
-    # =========================================================================
-
-    async def test_get_artifact_registry_datas(
-        self,
-        artifact_registry_repository: ArtifactRegistryRepository,
-        sample_registries_for_ordering: list[uuid.UUID],
-    ) -> None:
-        """Test retrieving multiple artifact registries by IDs"""
-        registry_ids = sample_registries_for_ordering[:2]
-        retrieved_registries = await artifact_registry_repository.get_artifact_registry_datas(
-            registry_ids
-        )
-
-        assert len(retrieved_registries) == 2
-        retrieved_ids = [r.registry_id for r in retrieved_registries]
-        for registry_id in registry_ids:
-            assert registry_id in retrieved_ids
-
-    async def test_get_artifact_registry_datas_empty(
-        self,
-        artifact_registry_repository: ArtifactRegistryRepository,
-    ) -> None:
-        """Test retrieving multiple artifact registries with empty list returns empty"""
-        retrieved_registries = await artifact_registry_repository.get_artifact_registry_datas([])
-
-        assert len(retrieved_registries) == 0
-
-    # =========================================================================
     # Tests - Get Type
     # =========================================================================
 

--- a/tests/unit/manager/services/artifact_registry/test_artifact_registry_service.py
+++ b/tests/unit/manager/services/artifact_registry/test_artifact_registry_service.py
@@ -883,80 +883,17 @@ class TestGetArtifactRegistryMetaAction:
 
 
 class TestGetArtifactRegistryMetasAction:
-    @pytest.fixture
-    def mock_artifact_registry_repository(self) -> MagicMock:
-        return MagicMock(spec=ArtifactRegistryRepository)
-
-    @pytest.fixture
-    def service(self, mock_artifact_registry_repository: MagicMock) -> ArtifactRegistryService:
-        return ArtifactRegistryService(
-            huggingface_registry_repository=MagicMock(spec=HuggingFaceRepository),
-            reservoir_repository=MagicMock(spec=ReservoirRegistryRepository),
-            artifact_registry_repository=mock_artifact_registry_repository,
-        )
-
-    async def test_get_registry_metas_multiple(
-        self,
-        service: ArtifactRegistryService,
-        mock_artifact_registry_repository: MagicMock,
-    ) -> None:
-        id1, id2 = uuid4(), uuid4()
-        items = [
-            ArtifactRegistryData(
-                id=ArtifactRegistryID(uuid4()),
-                registry_id=id1,
-                name="reg-1",
-                type=ArtifactRegistryType.HUGGINGFACE,
-            ),
-            ArtifactRegistryData(
-                id=ArtifactRegistryID(uuid4()),
-                registry_id=id2,
-                name="reg-2",
-                type=ArtifactRegistryType.RESERVOIR,
-            ),
-        ]
-        mock_artifact_registry_repository.get_artifact_registry_datas = AsyncMock(
-            return_value=items
-        )
-
+    def test_entity_ids_are_the_named_registries(self) -> None:
+        id1, id2 = ArtifactRegistryID(uuid4()), ArtifactRegistryID(uuid4())
         action = GetArtifactRegistryMetasAction(registry_ids=[id1, id2])
-        result = await service.get_registry_metas(action)
 
-        assert result.result == items
-        assert len(result.result) == 2
+        assert action.entity_ids() == (id1, id2)
 
-    async def test_get_registry_metas_partially_missing_skipped(
-        self,
-        service: ArtifactRegistryService,
-        mock_artifact_registry_repository: MagicMock,
-    ) -> None:
-        id1 = uuid4()
-        id_missing = uuid4()
-        items = [
-            ArtifactRegistryData(
-                id=ArtifactRegistryID(uuid4()),
-                registry_id=id1,
-                name="reg-1",
-                type=ArtifactRegistryType.HUGGINGFACE,
-            ),
-        ]
-        mock_artifact_registry_repository.get_artifact_registry_datas = AsyncMock(
-            return_value=items
-        )
+    def test_narrowed_to_keeps_only_the_allowed_ids_in_order(self) -> None:
+        id1, id2, id3 = (ArtifactRegistryID(uuid4()) for _ in range(3))
+        action = GetArtifactRegistryMetasAction(registry_ids=[id1, id2, id3])
 
-        action = GetArtifactRegistryMetasAction(registry_ids=[id1, id_missing])
-        result = await service.get_registry_metas(action)
+        narrowed = action.narrowed_to([id3, id1])
 
-        assert len(result.result) == 1
-
-    async def test_get_registry_metas_empty_list(
-        self,
-        service: ArtifactRegistryService,
-        mock_artifact_registry_repository: MagicMock,
-    ) -> None:
-        mock_artifact_registry_repository.get_artifact_registry_datas = AsyncMock(return_value=[])
-
-        action = GetArtifactRegistryMetasAction(registry_ids=[])
-        result = await service.get_registry_metas(action)
-
-        assert result.result == []
+        assert narrowed.entity_ids() == (id1, id3)
+        assert action.entity_ids() == (id1, id2, id3)


### PR DESCRIPTION
## Summary
- `GetArtifactRegistryMetasAction` was wired through `global_scope`, so any caller below superadmin was refused. It is now a `PartialBulkGetEntityOpsAction` wired through `partial_bulk_get_ops`: each named registry is permission-checked on its own, and the generic bulk get service reads it through the new `BulkArtifactRegistryQuerier`.
- The adapter returns only the registries that were delivered, so a denied id and an absent one are answered alike (no-leakage).
- The service method and the repository read it called are removed, along with their tests. API request and response shapes are unchanged.

## Test plan
- [x] `pants fmt fix lint check` pass
- [x] `tests/unit/manager/actions/test_registry_catalog.py`: pins the read as (artifact_registry, BULK, PERMISSION)
- [x] `tests/unit/manager/services/artifact_registry/test_artifact_registry_service.py`: `entity_ids` and `narrowed_to` of the action
- [x] artifact registry repository and service test suites pass

Resolves BA-7711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJY916kVKaa6oaQFnexg8t