### PR TITLE
refactor(BA-7715): move the agent DataLoaders onto the bulk get and close the agent search gate

### DIFF
--- a/changes/14339.enhance.md
+++ b/changes/14339.enhance.md
@@ -1,0 +1,1 @@
+Read agents for the GraphQL DataLoaders through a per-agent bulk get and gate the agent search on superadmin.

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 
+from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.v2.agent.request import (
     AdminSearchAgentsInput,
@@ -34,6 +36,7 @@ from ai.backend.common.types import AgentId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.agent.types import AgentDetailData, AgentStatus
+from ai.backend.manager.data.resource_slot.types import AgentResourceData
 from ai.backend.manager.models.agent.conditions import AgentConditions
 from ai.backend.manager.models.agent.orders import (
     DEFAULT_BACKWARD_ORDER,
@@ -43,14 +46,19 @@ from ai.backend.manager.models.agent.orders import (
 )
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
+from ai.backend.manager.models.resource_slot.searchers import AgentResourceSearcher
 from ai.backend.manager.models.specs.pagination import NoPagination
-from ai.backend.manager.repositories.base import BatchQuerier
+from ai.backend.manager.services.agent.actions.bulk_get import BulkGetAgentsAction
+from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
+    BulkLoadContainerCountsAction,
+)
+from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
     GetTotalResourcesActionResult,
 )
-from ai.backend.manager.services.agent.actions.load_container_counts import (
-    LoadContainerCountsAction,
+from ai.backend.manager.services.agent.actions.scoped_search_resources import (
+    ScopedSearchAgentResourcesAction,
 )
 from ai.backend.manager.services.agent.actions.search_agents import SearchAgentsAction
 from ai.backend.manager.services.agent.actions.update_resource_group import (
@@ -72,35 +80,99 @@ class AgentAdapter(BaseAdapter):
 
     # ------------------------------------------------------------------ batch load (DataLoader)
 
-    async def batch_load_by_ids(self, agent_ids: Sequence[AgentId]) -> list[AgentNode | None]:
-        """Batch load agents by ID for DataLoader use.
+    async def batch_load_by_ids(
+        self, agent_ids: Sequence[AgentId]
+    ) -> list[AgentNode | Exception | None]:
+        """Batch load agents by name for DataLoader use.
 
-        Returns AgentNode DTOs in the same order as the input agent_ids list.
+        One answer per name in the given order: the node, ``None`` for a name matching
+        no agent, and the denial for one the caller may not read. The names resolve
+        into uuids first, since that is what each agent is checked by; the slot rows
+        are a field read of the agents that passed.
         """
         if not agent_ids:
             return []
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[AgentConditions.by_ids(agent_ids)],
+        lookup = await self._processors.agent.bulk_lookup.run(
+            BulkLookupAgentsAction(agent_ids=agent_ids)
         )
-        action_result = await self._processors.agent.search_agents.run(
-            SearchAgentsAction(querier=querier)
+        uuids = [lookup.resolved[agent_id] for agent_id in agent_ids if agent_id in lookup.resolved]
+        got = await self._processors.agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
+        agents = got.values()
+        errors = got.errors()
+        resources = await self._load_resources([agent.uuid for agent in agents.values()])
+        nodes: list[AgentNode | Exception | None] = []
+        for agent_id in agent_ids:
+            uuid = lookup.resolved.get(agent_id)
+            if uuid is None:
+                nodes.append(None)
+                continue
+            agent = agents.get(uuid)
+            if agent is None:
+                nodes.append(self.batch_load_failure(errors.get(uuid)))
+                continue
+            nodes.append(
+                self._data_to_dto(
+                    AgentDetailData(
+                        agent=agent, resources=resources.get(agent.id, []), permissions=[]
+                    )
+                )
+            )
+        return nodes
+
+    async def _load_resources(
+        self, agent_uuids: Sequence[AgentUUID]
+    ) -> Mapping[AgentId, list[AgentResourceData]]:
+        """The slot rows of the named agents, keyed by the agent's name column."""
+        if not agent_uuids:
+            return {}
+        result = await self._processors.agent.scoped_search_resources.run(
+            ScopedSearchAgentResourcesAction(
+                agent_uuids=agent_uuids,
+                searcher=AgentResourceSearcher(pagination=NoPagination()),
+            )
         )
-        agent_map = {detail.agent.id: self._data_to_dto(detail) for detail in action_result.agents}
-        return [agent_map.get(agent_id) for agent_id in agent_ids]
+        resources: dict[AgentId, list[AgentResourceData]] = {}
+        for item in result.items:
+            resources.setdefault(AgentId(item.agent_id), []).append(item)
+        return resources
 
-    async def batch_load_container_counts(self, agent_ids: Sequence[AgentId]) -> list[int]:
-        """Batch load container counts for agents by ID for DataLoader use.
+    async def batch_load_container_counts(
+        self, agent_ids: Sequence[AgentId]
+    ) -> list[int | Exception]:
+        """Batch load container counts by agent name for DataLoader use.
 
-        Returns container counts in the same order as the input agent_ids list.
-        Returns 0 for agents not found.
+        One answer per name in the given order: the count, ``0`` for a name matching
+        no agent, and the denial for one the caller may not read. Checked the way the
+        agents themselves are: through the bulk get, per agent.
         """
         if not agent_ids:
             return []
-        action_result = await self._processors.agent.load_container_counts.run(
-            LoadContainerCountsAction(agent_ids=agent_ids)
+        lookup = await self._processors.agent.bulk_lookup.run(
+            BulkLookupAgentsAction(agent_ids=agent_ids)
         )
-        return list(action_result.container_counts)
+        uuids = [lookup.resolved[agent_id] for agent_id in agent_ids if agent_id in lookup.resolved]
+        got = await self._processors.agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
+        permitted = [uuid for uuid in uuids if uuid in got.values()]
+        counts: Mapping[EntityIdentifier, int] = {}
+        count_errors: Mapping[EntityIdentifier, Exception] = {}
+        if permitted:
+            counted = await self._processors.agent.bulk_load_container_counts.run(
+                BulkLoadContainerCountsAction(agent_uuids=permitted)
+            )
+            counts = counted.values()
+            count_errors = counted.errors()
+        answers: list[int | Exception] = []
+        for agent_id in agent_ids:
+            uuid = lookup.resolved.get(agent_id)
+            if uuid is None:
+                answers.append(0)
+                continue
+            error = self.batch_load_failure(got.errors().get(uuid) or count_errors.get(uuid))
+            if error is not None:
+                answers.append(error)
+                continue
+            answers.append(counts.get(uuid, 0))
+        return answers
 
     # ------------------------------------------------------------------ search
 

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -563,7 +563,7 @@ class DataLoaders:
     ) -> DataLoader[AgentId, int]:
         adapter = self._adapters.agent
 
-        async def load_fn(agent_ids: list[AgentId]) -> list[int]:
+        async def load_fn(agent_ids: list[AgentId]) -> list[int | Exception]:
             return await adapter.batch_load_container_counts(agent_ids)
 
         return DataLoader(load_fn=load_fn)
@@ -735,13 +735,16 @@ class DataLoaders:
     ) -> DataLoader[AgentId, AgentV2GQL | None]:
         adapter = self._adapters.agent
 
-        async def load_fn(agent_ids: list[AgentId]) -> list[AgentV2GQL | None]:
+        async def load_fn(agent_ids: list[AgentId]) -> list[AgentV2GQL | Exception | None]:
             from ai.backend.manager.api.gql.agent.types import (  # pants: no-infer-dep
                 AgentV2GQL as AG,
             )
 
             dtos = await adapter.batch_load_by_ids(agent_ids)
-            return [AG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else AG.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/models/agent/queriers.py
+++ b/src/ai/backend/manager/models/agent/queriers.py
@@ -1,0 +1,27 @@
+"""DataQuerier implementations for the agent table."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.manager.data.agent.types import AgentData
+from ai.backend.manager.models.agent.row import AgentRow
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier
+
+
+class BulkAgentQuerier(BulkEntityQuerier[AgentRow, AgentData]):
+    """The agents the caller named; the slot rows are a field read of their own."""
+
+    @override
+    def row_class(self) -> type[AgentRow]:
+        return AgentRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return AgentRow.uuid
+
+    @override
+    def to_data(self, row: AgentRow) -> AgentData:
+        return row.to_data()

--- a/src/ai/backend/manager/repositories/agent/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/agent/db_source/db_source.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection
+from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import sqlalchemy as sa
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import selectinload
 
+from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.exception import AgentNotFound
 from ai.backend.common.types import AgentId, ImageID
@@ -79,6 +80,20 @@ class AgentDBSource:
             for image_row in results:
                 images_data[ImageID(image_row.id)] = image_row.to_detailed_dataclass()
             return images_data
+
+    async def agent_names_by_uuid(
+        self, agent_uuids: Sequence[AgentUUID]
+    ) -> Mapping[AgentUUID, AgentId]:
+        """The name column of each named agent; an unknown uuid is absent."""
+        if not agent_uuids:
+            return {}
+        async with self._db.begin_readonly_session_read_committed() as db_session:
+            rows = (
+                await db_session.execute(
+                    sa.select(AgentRow.uuid, AgentRow.id).where(AgentRow.uuid.in_(agent_uuids))
+                )
+            ).all()
+        return {AgentUUID(row[0]): AgentId(row[1]) for row in rows}
 
     async def get_by_id(self, agent_id: AgentId) -> AgentData:
         async with self._db.begin_readonly_session_read_committed() as db_session:

--- a/src/ai/backend/manager/repositories/agent/repository.py
+++ b/src/ai/backend/manager/repositories/agent/repository.py
@@ -95,6 +95,20 @@ class AgentRepository:
         return await self._stateful_source.read_agent_container_counts(agent_ids)
 
     @agent_repository_resilience.apply()
+    async def load_container_counts_by_uuid(
+        self, agent_uuids: Sequence[AgentUUID]
+    ) -> Mapping[AgentUUID, int]:
+        """The container count of each named agent; an unknown uuid is absent."""
+        names = await self._db_source.agent_names_by_uuid(agent_uuids)
+        if not names:
+            return {}
+        uuids = list(names)
+        counts = await self._stateful_source.read_agent_container_counts([
+            names[uuid] for uuid in uuids
+        ])
+        return dict(zip(uuids, counts, strict=True))
+
+    @agent_repository_resilience.apply()
     async def get_by_id(self, agent_id: AgentId) -> AgentData:
         return await self._db_source.get_by_id(agent_id)
 

--- a/src/ai/backend/manager/services/agent/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/agent/actions/bulk_get.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.agent.types import AgentData
+from ai.backend.manager.models.agent.queriers import BulkAgentQuerier
+from ai.backend.manager.models.agent.row import AgentRow
+
+
+@dataclass
+class BulkGetAgentsAction(PartialBulkGetEntityOpsAction[AgentRow, AgentData]):
+    """Read the agents the caller named, answering for each id."""
+
+    ids: Sequence[AgentUUID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_agents"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkAgentQuerier:
+        return BulkAgentQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/agent/actions/bulk_load_container_counts.py
+++ b/src/ai/backend/manager/services/agent/actions/bulk_load_container_counts.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
+
+
+@dataclass
+class BulkLoadContainerCountsAction(BasePartialBulkAction):
+    """Read the container count of each agent the caller named.
+
+    Answered for by each agent, unlike the global load the admin search uses.
+    """
+
+    agent_uuids: Sequence[AgentUUID]
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_load_agent_container_counts"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.agent_uuids)
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, agent_uuids=[uuid for uuid in self.agent_uuids if uuid in allowed])

--- a/src/ai/backend/manager/services/agent/actions/load_container_counts.py
+++ b/src/ai/backend/manager/services/agent/actions/load_container_counts.py
@@ -13,7 +13,11 @@ from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
 @dataclass(frozen=True)
 class LoadContainerCountsAction(BaseGlobalAction):
-    """Action to load container counts."""
+    """Load the container counts the admin search shows, behind the SUPERADMIN gate.
+
+    A DataLoader reads them per named agent through
+    :class:`BulkLoadContainerCountsAction` instead.
+    """
 
     agent_ids: Sequence[AgentId]
 

--- a/src/ai/backend/manager/services/agent/actions/search_agents.py
+++ b/src/ai/backend/manager/services/agent/actions/search_agents.py
@@ -13,14 +13,10 @@ from ai.backend.manager.repositories.base import BatchQuerier
 
 @dataclass(frozen=True)
 class SearchAgentsAction(BaseGlobalAction):
-    """A page read across every agent.
+    """A page read across every agent, behind the SUPERADMIN gate.
 
-    The gate belongs on SUPERADMIN -- both surfaces already declare it -- but the
-    action stays public until the agent DataLoaders stop reaching for it. A
-    DataLoader must name its entities and be checked per entity
-    (``partial_bulk_get_ops``); reading them through this search is what forces
-    the gate open. Moving the loaders needs a bulk key lookup that does not exist
-    yet, so it is a change of its own.
+    The admin search surfaces are the only callers: the agent DataLoaders name
+    their entities and are checked per entity through the bulk get.
     """
 
     querier: BatchQuerier

--- a/src/ai/backend/manager/services/agent/processors.py
+++ b/src/ai/backend/manager/services/agent/processors.py
@@ -5,11 +5,9 @@ from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.registry.types import FieldGroupMeta
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
-from ai.backend.manager.actions.v2.global_scope.processor import (
-    GlobalActionProcessor,
-    PublicActionProcessor,
-)
+from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.lookup.bulk_processor import BulkLookupActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
@@ -19,6 +17,10 @@ from ai.backend.manager.actions.v2.ops.result import (
 )
 from ai.backend.manager.data.agent.types import AgentData
 from ai.backend.manager.data.resource_slot.types import AgentResourceData
+from ai.backend.manager.services.agent.actions.bulk_get import BulkGetAgentsAction
+from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
+    BulkLoadContainerCountsAction,
+)
 from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
@@ -76,6 +78,8 @@ class AgentProcessors:
     bulk_lookup: BulkLookupActionProcessor[
         BulkLookupAgentsAction, BulkLookupOpsResult[AgentId, AgentUUID]
     ]
+    bulk_get: PartialBulkActionProcessor[BulkGetAgentsAction, AgentData]
+    bulk_load_container_counts: PartialBulkActionProcessor[BulkLoadContainerCountsAction, int]
     scoped_search_resources: BulkActionProcessor[
         ScopedSearchAgentResourcesAction, ScopedFieldsOpsResult[AgentResourceData]
     ]
@@ -97,8 +101,8 @@ class AgentProcessors:
     get_total_resources: GlobalActionProcessor[
         GetTotalResourcesAction, GetTotalResourcesActionResult
     ]
-    search_agents: PublicActionProcessor[SearchAgentsAction, SearchAgentsActionResult]
-    load_container_counts: PublicActionProcessor[
+    search_agents: GlobalActionProcessor[SearchAgentsAction, SearchAgentsActionResult]
+    load_container_counts: GlobalActionProcessor[
         LoadContainerCountsAction, LoadContainerCountsActionResult
     ]
 
@@ -110,6 +114,10 @@ class AgentProcessors:
     ) -> None:
         self.lookup = group.public_lookup_ops(LookupAgentAction)
         self.bulk_lookup = group.public_bulk_lookup_ops(BulkLookupAgentsAction)
+        self.bulk_get = group.partial_bulk_get_ops(BulkGetAgentsAction)
+        self.bulk_load_container_counts = group.partial_bulk(
+            BulkLoadContainerCountsAction, service.bulk_load_container_counts
+        )
         resources: LookupFieldGroup[AgentResourceData] = group.field_group(
             FieldGroupMeta(AGENT_RESOURCE_FIELD_TYPE),
             AgentResourceData,
@@ -143,7 +151,7 @@ class AgentProcessors:
         self.get_total_resources = group.global_scope(
             GetTotalResourcesAction, service.get_total_resources
         )
-        self.search_agents = group.public(SearchAgentsAction, service.search_agents)
-        self.load_container_counts = group.public(
+        self.search_agents = group.global_scope(SearchAgentsAction, service.search_agents)
+        self.load_container_counts = group.global_scope(
             LoadContainerCountsAction, service.load_container_counts
         )

--- a/src/ai/backend/manager/services/agent/service.py
+++ b/src/ai/backend/manager/services/agent/service.py
@@ -19,11 +19,16 @@ from ai.backend.common.types import (
     SessionId,
 )
 from ai.backend.logging.utils import BraceStyleAdapter
+from ai.backend.manager.actions.v2.bulk.result import PartialBulkEntityResult, PartialBulkResult
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.errors.agent import ConflictingSessionRescheduleNotSupported
+from ai.backend.manager.errors.resource import AgentNotFound
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository
+from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
+    BulkLoadContainerCountsAction,
+)
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
     GetTotalResourcesActionResult,
@@ -264,6 +269,21 @@ class AgentService:
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,
+        )
+
+    async def bulk_load_container_counts(
+        self, action: BulkLoadContainerCountsAction
+    ) -> PartialBulkResult[int]:
+        counts = await self._agent_repository.load_container_counts_by_uuid(action.agent_uuids)
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[int].succeeded(uuid, counts[uuid], description="counted")
+                if uuid in counts
+                else PartialBulkEntityResult[int].failed(
+                    uuid, AgentNotFound(f"Agent {uuid} not found")
+                )
+                for uuid in action.agent_uuids
+            ]
         )
 
     async def load_container_counts(

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -107,9 +107,16 @@ from ai.backend.manager.data.artifact.types import ArtifactRevisionData
 from ai.backend.manager.data.audit_log.types import AuditLogData
 from ai.backend.manager.data.entity_label.types import EntityLabelData
 from ai.backend.manager.repositories.ops.repository import OpsRepository
+from ai.backend.manager.services.agent.actions.bulk_get import BulkGetAgentsAction
+from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
+    BulkLoadContainerCountsAction,
+)
 from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
+)
+from ai.backend.manager.services.agent.actions.load_container_counts import (
+    LoadContainerCountsAction,
 )
 from ai.backend.manager.services.agent.actions.lookup import LookupAgentAction
 from ai.backend.manager.services.agent.actions.lookup_resource_owner import (
@@ -536,8 +543,16 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
             ActionGate.PERMISSION,
         ),
         GetTotalResourcesAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
-        # Public until the agent DataLoaders stop reading agents through this search.
-        SearchAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PUBLIC),
+        # Admin search surfaces only: the DataLoaders read per named agent below.
+        SearchAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
+        LoadContainerCountsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
+        # What the DataLoaders read: checked per agent.
+        BulkGetAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.BULK, ActionGate.PERMISSION),
+        BulkLoadContainerCountsAction: (
+            AGENT_ENTITY_TYPE,
+            ActionKind.BULK,
+            ActionGate.PERMISSION,
+        ),
         # The lookup carries no permission; the read that follows it is checked.
         LookupAgentAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),
         BulkLookupAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),

--- a/tests/unit/manager/api/adapters/test_agent_adapter.py
+++ b/tests/unit/manager/api/adapters/test_agent_adapter.py
@@ -1,0 +1,146 @@
+"""The agent DataLoader paths: names resolve into uuids, each agent is answered for."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.agent_resource import AgentResourceID
+from ai.backend.common.types import AgentId
+from ai.backend.manager.actions.v2.bulk.result import PartialBulkEntityResult, PartialBulkResult
+from ai.backend.manager.actions.v2.ops.result import BulkLookupOpsResult, ScopedFieldsOpsResult
+from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
+from ai.backend.manager.data.agent.types import AgentData, AgentStatus
+from ai.backend.manager.data.resource_slot.types import AgentResourceData
+from ai.backend.manager.errors.common import GenericForbidden
+
+READABLE = AgentId("agent-readable")
+DENIED = AgentId("agent-denied")
+ABSENT = AgentId("agent-absent")
+
+
+def _agent(agent_id: AgentId) -> AgentData:
+    return AgentData(
+        uuid=AgentUUID(uuid.uuid4()),
+        id=agent_id,
+        status=AgentStatus.ALIVE,
+        status_changed=None,
+        region="local",
+        resource_group="default",
+        schedulable=True,
+        addr="tcp://127.0.0.1:6001",
+        public_host=None,
+        first_contact=None,
+        lost_at=None,
+        version="test",
+        architecture="x86_64",
+        compute_plugins={},
+        public_key=None,
+        auto_terminate_abusing_kernel=False,
+    )
+
+
+@pytest.fixture
+def readable() -> AgentData:
+    return _agent(READABLE)
+
+
+@pytest.fixture
+def denied() -> AgentData:
+    return _agent(DENIED)
+
+
+@pytest.fixture
+def denial() -> GenericForbidden:
+    return GenericForbidden("no read on this agent")
+
+
+@pytest.fixture
+def processors(readable: AgentData, denied: AgentData, denial: GenericForbidden) -> MagicMock:
+    processors = MagicMock()
+    processors.agent.bulk_lookup.run = AsyncMock(
+        return_value=BulkLookupOpsResult(
+            resolved={READABLE: readable.uuid, DENIED: denied.uuid}, key_results=[]
+        )
+    )
+    processors.agent.bulk_get.run = AsyncMock(
+        return_value=PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[AgentData].succeeded(readable.uuid, readable),
+                PartialBulkEntityResult[AgentData].denied(denied.uuid, denial),
+            ]
+        )
+    )
+    processors.agent.scoped_search_resources.run = AsyncMock(
+        return_value=ScopedFieldsOpsResult(
+            items=[
+                AgentResourceData(
+                    id=AgentResourceID(uuid.uuid4()),
+                    agent_id=READABLE,
+                    slot_name="cpu",
+                    capacity=Decimal(4),
+                    reserved=Decimal(0),
+                    used=Decimal(1),
+                )
+            ],
+            total_count=1,
+            has_next_page=False,
+            has_previous_page=False,
+        )
+    )
+    processors.agent.bulk_load_container_counts.run = AsyncMock(
+        return_value=PartialBulkResult(
+            items=[PartialBulkEntityResult[int].succeeded(readable.uuid, 3)]
+        )
+    )
+    return processors
+
+
+@pytest.fixture
+def adapter(processors: MagicMock) -> AgentAdapter:
+    return AgentAdapter(processors)
+
+
+async def test_batch_load_answers_per_name(
+    adapter: AgentAdapter,
+    processors: MagicMock,
+    readable: AgentData,
+    denial: GenericForbidden,
+) -> None:
+    nodes = await adapter.batch_load_by_ids([READABLE, DENIED, ABSENT])
+
+    node, refused, missing = nodes
+    assert node is not None and not isinstance(node, Exception)
+    assert node.id == READABLE
+    assert node.resource_info.capacity == {"cpu": "4"}
+    assert node.resource_info.used == {"cpu": "1"}
+    assert node.permissions == []
+    # A denial reaches the resolver; a name matching nothing stays None.
+    assert refused is denial
+    assert missing is None
+    # The slot rows are read for the agents that passed, and no other.
+    search_action = processors.agent.scoped_search_resources.run.await_args.args[0]
+    assert list(search_action.agent_uuids) == [readable.uuid]
+
+
+async def test_container_counts_answer_per_name(
+    adapter: AgentAdapter,
+    processors: MagicMock,
+    readable: AgentData,
+    denial: GenericForbidden,
+) -> None:
+    counts = await adapter.batch_load_container_counts([READABLE, DENIED, ABSENT])
+
+    assert counts == [3, denial, 0]
+    count_action = processors.agent.bulk_load_container_counts.run.await_args.args[0]
+    assert list(count_action.agent_uuids) == [readable.uuid]
+
+
+async def test_no_names_read_nothing(adapter: AgentAdapter, processors: MagicMock) -> None:
+    assert await adapter.batch_load_by_ids([]) == []
+    assert await adapter.batch_load_container_counts([]) == []
+    processors.agent.bulk_lookup.run.assert_not_awaited()

--- a/tests/unit/manager/services/agent/test_service.py
+++ b/tests/unit/manager/services/agent/test_service.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.exception import AgentWatcherResponseError
@@ -20,9 +21,13 @@ from ai.backend.manager.errors.agent import (
     AgentHasConflictingSessions,
     ConflictingSessionRescheduleNotSupported,
 )
+from ai.backend.manager.errors.resource import AgentNotFound
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository
+from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
+    BulkLoadContainerCountsAction,
+)
 from ai.backend.manager.services.agent.actions.get_watcher_status import (
     GetWatcherStatusAction,
 )
@@ -405,3 +410,23 @@ class TestUpdateResourceGroup:
 
         mock_agent_repository.update_resource_group.assert_not_called()
         mock_scheduling_controller.mark_sessions_for_termination.assert_not_called()
+
+
+class TestBulkLoadContainerCounts:
+    async def test_each_named_agent_is_answered_for(
+        self, agent_service: AgentService, mock_agent_repository: AsyncMock
+    ) -> None:
+        known = AgentUUID(uuid4())
+        unknown = AgentUUID(uuid4())
+        mock_agent_repository.load_container_counts_by_uuid.return_value = {known: 2}
+
+        result = await agent_service.bulk_load_container_counts(
+            BulkLoadContainerCountsAction(agent_uuids=[known, unknown])
+        )
+
+        assert result.values() == {known: 2}
+        assert isinstance(result.errors()[unknown], AgentNotFound)
+        mock_agent_repository.load_container_counts_by_uuid.assert_awaited_once_with([
+            known,
+            unknown,
+        ])


### PR DESCRIPTION
## Summary
- The agent DataLoaders (`KernelV2GQL.agent`, Relay `node(agent)`, `AgentV2GQL.container_count`) no longer read through the global agent search. The loader resolves names into uuids with the bulk lookup, reads the agents through `BulkGetAgentsAction` so each is checked on its own, and reads their slot rows as a field search of the agents that passed. A name matching nothing stays `None`; a denied agent raises at the resolver. `permissions` on these nodes is an empty list for now; filling it per caller is BA-7716.
- The container count loader takes the same path through a new per-agent `BulkLoadContainerCountsAction`. The adapter hands it only the uuids the bulk get let through, and the service resolves the names itself, so a caller cannot pair a permitted uuid with another agent's name. `AgentV2GQL.container_count` therefore stays visible to regular users; the global `LoadContainerCountsAction` now covers the admin search surface only.
- `SearchAgentsAction` and `LoadContainerCountsAction` move from `public` to `global_scope`. REST `search_agents` and GQL `agents_v2` / `agent_stats` already declared the superadmin gate at the handler; the action now enforces it too, so those surfaces are superadmin/monitor only from the action down.

## Test plan
- [x] `tests/unit/manager/api/adapters/test_agent_adapter.py` — one answer per name (node / denial / None), slot search and count action asked only for the agents that passed, empty input reads nothing
- [x] `tests/unit/manager/services/agent/test_service.py` — the count action answers per agent; an unknown uuid is a failed item
- [x] `tests/unit/manager/actions/test_registry_catalog.py` — the search and global count fixed at (agent, GLOBAL, PERMISSION); the bulk get and bulk count at (agent, BULK, PERMISSION)
- [x] `pants fmt fix lint check test` over the changed set

Resolves BA-7715

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9CzWeuzWUXTXuK3HXiouu
