### PR TITLE
refactor(BA-7716): answer the agent permissions for the caller

### DIFF
--- a/changes/14343.enhance.md
+++ b/changes/14343.enhance.md
@@ -1,0 +1,1 @@
+Show each caller the agent permissions they actually hold instead of the admin list.

--- a/src/ai/backend/manager/actions/v2/bulk/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/bulk/validator/rbac.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
@@ -38,26 +38,38 @@ class BulkOwnCheck:
         self._repository = repository
         self._config_provider = config_provider
 
-    async def check(self, meta: BulkActionTriggerMeta) -> Mapping[EntityIdentifier, bool]:
+    async def held(
+        self, entity_ids: Sequence[EntityIdentifier]
+    ) -> Mapping[EntityIdentifier, Permission]:
+        """The bits the caller holds on each entity, as this check sees them.
+
+        Enforcement off or a superadmin holds everything; anyone else holds what the
+        own check answers. What a domain shows as the caller's permissions is read
+        from here, so it cannot disagree with what the check would allow.
+        """
         if not self._config_provider.config.manager.rbac.enforcement_enabled:
-            return dict.fromkeys(meta.entity_ids, True)
+            return dict.fromkeys(entity_ids, Permission.full())
 
         user = current_user()
         if user is None:
             raise UnreachableError("User context is not available")
         if user.is_superadmin:
-            return dict.fromkeys(meta.entity_ids, True)
+            return dict.fromkeys(entity_ids, Permission.full())
 
         keys = [
             OwnCheckKey(
                 user_id=UserID(user.user_id),
                 entity=entity_id,
             )
-            for entity_id in meta.entity_ids
+            for entity_id in entity_ids
         ]
-        permission = meta.operation_type.to_permission()
         owned = await self._repository.owned_permissions(keys)
-        return {key.entity: owned.get(key, Permission.NONE).covers(permission) for key in keys}
+        return {key.entity: owned.get(key, Permission.NONE) for key in keys}
+
+    async def check(self, meta: BulkActionTriggerMeta) -> Mapping[EntityIdentifier, bool]:
+        permission = meta.operation_type.to_permission()
+        held = await self.held(meta.entity_ids)
+        return {entity_id: mask.covers(permission) for entity_id, mask in held.items()}
 
 
 class VirtualEntityAtomicBulkActionRBACValidator(AtomicBulkActionValidator):

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -36,6 +36,7 @@ from ai.backend.common.types import AgentId
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.agent.types import AgentDetailData, AgentStatus
+from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.data.resource_slot.types import AgentResourceData
 from ai.backend.manager.models.agent.conditions import AgentConditions
 from ai.backend.manager.models.agent.orders import (
@@ -51,6 +52,9 @@ from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.services.agent.actions.bulk_get import BulkGetAgentsAction
 from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
     BulkLoadContainerCountsAction,
+)
+from ai.backend.manager.services.agent.actions.bulk_load_permissions import (
+    BulkLoadAgentPermissionsAction,
 )
 from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
@@ -88,7 +92,7 @@ class AgentAdapter(BaseAdapter):
         One answer per name in the given order: the node, ``None`` for a name matching
         no agent, and the denial for one the caller may not read. The names resolve
         into uuids first, since that is what each agent is checked by; the slot rows
-        are a field read of the agents that passed.
+        and the caller's permissions are read for the agents that passed.
         """
         if not agent_ids:
             return []
@@ -99,7 +103,9 @@ class AgentAdapter(BaseAdapter):
         got = await self._processors.agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
         agents = got.values()
         errors = got.errors()
-        resources = await self._load_resources([agent.uuid for agent in agents.values()])
+        permitted = [agent.uuid for agent in agents.values()]
+        resources = await self._load_resources(permitted)
+        permissions = await self._load_permissions(permitted)
         nodes: list[AgentNode | Exception | None] = []
         for agent_id in agent_ids:
             uuid = lookup.resolved.get(agent_id)
@@ -113,11 +119,24 @@ class AgentAdapter(BaseAdapter):
             nodes.append(
                 self._data_to_dto(
                     AgentDetailData(
-                        agent=agent, resources=resources.get(agent.id, []), permissions=[]
+                        agent=agent,
+                        resources=resources.get(agent.id, []),
+                        permissions=permissions.get(uuid, []),
                     )
                 )
             )
         return nodes
+
+    async def _load_permissions(
+        self, agent_uuids: Sequence[AgentUUID]
+    ) -> Mapping[EntityIdentifier, list[AgentPermission]]:
+        """What the caller holds on each named agent."""
+        if not agent_uuids:
+            return {}
+        result = await self._processors.agent.bulk_load_permissions.run(
+            BulkLoadAgentPermissionsAction(agent_uuids=agent_uuids)
+        )
+        return result.values()
 
     async def _load_resources(
         self, agent_uuids: Sequence[AgentUUID]

--- a/src/ai/backend/manager/api/gql_legacy/agent.py
+++ b/src/ai/backend/manager/api/gql_legacy/agent.py
@@ -31,11 +31,9 @@ from ai.backend.manager.data.agent.types import AgentDetailData
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.models.agent import (
-    ADMIN_PERMISSIONS,
     AgentRow,
     AgentStatus,
     agents,
-    get_permission_ctx,
 )
 from ai.backend.manager.models.keypair import keypairs
 from ai.backend.manager.models.minilang import FieldSpecItem, OrderSpecItem
@@ -45,11 +43,13 @@ from ai.backend.manager.models.project import AssocGroupUserRow
 from ai.backend.manager.models.rbac import (
     ScopeType,
 )
-from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.resource_group import ResourceGroupRow
 from ai.backend.manager.models.resource_slot import AgentResourceRow
 from ai.backend.manager.models.user import UserRole, users
 from ai.backend.manager.repositories.agent.query import QueryConditions, QueryOrders
+from ai.backend.manager.services.agent.actions.bulk_load_permissions import (
+    BulkLoadAgentPermissionsAction,
+)
 from ai.backend.manager.services.agent.actions.update_resource_group import (
     UpdateAgentResourceGroupAction,
 )
@@ -308,35 +308,18 @@ class AgentNode(graphene.ObjectType):  # type: ignore[misc]
             before=before,
             last=last,
         )
-        async with graph_ctx.db.connect() as db_conn:
-            user = graph_ctx.user
-            if user["role"] != UserRole.SUPERADMIN:
-                client_ctx = ClientContext(
-                    graph_ctx.db, user["domain_name"], user["uuid"], user["role"]
-                )
-                permission_ctx = await get_permission_ctx(db_conn, client_ctx, scope, permission)
-                cond = permission_ctx.query_condition
-                if cond is None:
-                    return ConnectionResolverResult([], cursor, pagination_order, page_size, 0)
-                permission_getter = permission_ctx.calculate_final_permission
-                query = query.where(cond)
-                cnt_query = cnt_query.where(cond)
-            else:
-
-                async def all_permissions(row: AgentRow) -> frozenset[AgentPermission]:
-                    return ADMIN_PERMISSIONS
-
-                permission_getter = all_permissions  # type: ignore[assignment]
-            async with graph_ctx.db.begin_readonly_session(db_conn) as db_session:
-                agent_rows = (await db_session.scalars(query)).all()
-                total_cnt = await db_session.scalar(cnt_query)
-        agent_ids: list[AgentId] = []
-
-        agent_permissions: dict[AgentId, list[AgentPermission]] = {}
-        for row in agent_rows:
-            agent_ids.append(row.id)
-            permissions = await permission_getter(row)
-            agent_permissions[row.id] = list(permissions)
+        async with graph_ctx.db.begin_readonly_session() as db_session:
+            agent_rows = (await db_session.scalars(query)).all()
+            total_cnt = await db_session.scalar(cnt_query)
+        # What the caller holds on each agent is the service's to answer.
+        resolved = await graph_ctx.processors.agent.bulk_load_permissions.run(
+            BulkLoadAgentPermissionsAction(agent_uuids=[row.uuid for row in agent_rows])
+        )
+        held = resolved.values()
+        agent_ids: list[AgentId] = [row.id for row in agent_rows]
+        agent_permissions: dict[AgentId, list[AgentPermission]] = {
+            row.id: held.get(row.uuid, []) for row in agent_rows
+        }
         list_order = {agent_id: idx for idx, agent_id in enumerate(agent_ids)}
         condition = [QueryConditions.by_ids(agent_ids)]
         agent_list = await graph_ctx.agent_repository.list_data(condition)
@@ -805,7 +788,7 @@ class AgentSummary(graphene.ObjectType):  # type: ignore[misc]
                     AgentDetailData(
                         agent=agent.to_data(),
                         resources=agent.resources_by_rank(),
-                        permissions=list(ADMIN_PERMISSIONS),
+                        permissions=[],
                     )
                 )
                 for agent in agent_list

--- a/src/ai/backend/manager/data/permission/permission_defs.py
+++ b/src/ai/backend/manager/data/permission/permission_defs.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 import enum
+
+from ai.backend.common.data.permission.types import Permission
 
 
 class BasePermission(enum.StrEnum):
@@ -77,6 +81,23 @@ class AgentPermission(BasePermission):
 
     CREATE_COMPUTE_SESSION = enum.auto()
     CREATE_SERVICE = enum.auto()
+
+    @classmethod
+    def from_rbac(cls, mask: Permission) -> list[AgentPermission]:
+        """The agent permissions an RBAC mask stands for.
+
+        READ -> READ_ATTRIBUTE, UPDATE -> UPDATE_ATTRIBUTE, CREATE -> both
+        CREATE_COMPUTE_SESSION and CREATE_SERVICE; SOFT_DELETE and HARD_DELETE have
+        no counterpart.
+        """
+        permissions: list[AgentPermission] = []
+        if mask & Permission.READ:
+            permissions.append(cls.READ_ATTRIBUTE)
+        if mask & Permission.UPDATE:
+            permissions.append(cls.UPDATE_ATTRIBUTE)
+        if mask & Permission.CREATE:
+            permissions.extend((cls.CREATE_COMPUTE_SESSION, cls.CREATE_SERVICE))
+        return permissions
 
 
 class DomainPermission(BasePermission):

--- a/src/ai/backend/manager/models/agent/__init__.py
+++ b/src/ai/backend/manager/models/agent/__init__.py
@@ -1,19 +1,11 @@
 from ai.backend.manager.data.agent.types import AgentStatus
 
 from .row import (
-    ADMIN_PERMISSIONS as ADMIN_PERMISSIONS,
-)
-from .row import (
     AgentRow,
     agents,
     list_schedulable_agents_by_sgroup,
 )
-from .row import (
-    get_permission_ctx as get_permission_ctx,
-)
 
-# __all__ controls what gets exported with "from .agent import *"
-# Exclude ADMIN_PERMISSIONS to avoid conflicts with domain's in models/__init__.py
 __all__ = (
     "AgentRow",
     "AgentStatus",

--- a/src/ai/backend/manager/models/agent/row.py
+++ b/src/ai/backend/manager/models/agent/row.py
@@ -1,36 +1,27 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, cast, override
+from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
-from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import (
     Mapped,
-    joinedload,
-    load_only,
     mapped_column,
     relationship,
-    selectinload,
 )
 from sqlalchemy.sql.expression import false, true
 
 from ai.backend.common.auth import PublicKey
 from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.types import AccessKey, AgentId, ResourceSlot, SlotName, SlotTypes
+from ai.backend.common.types import AgentId, ResourceSlot, SlotName, SlotTypes
 from ai.backend.manager.data.agent.types import (
     AgentData,
     AgentDataForHeartbeatUpdate,
     AgentStatus,
-)
-from ai.backend.manager.data.permission.permission_defs import (
-    AgentPermission,
-    ResourceGroupPermission,
 )
 from ai.backend.manager.data.resource_slot.types import AgentResourceData
 from ai.backend.manager.models.base import (
@@ -39,17 +30,6 @@ from ai.backend.manager.models.base import (
     CurvePublicKeyColumn,
     EnumType,
 )
-from ai.backend.manager.models.keypair import KeyPairRow
-from ai.backend.manager.models.rbac import (
-    AbstractPermissionContext,
-    AbstractPermissionContextBuilder,
-    DomainScope,
-    ProjectScope,
-    ScopeType,
-    UserScope,
-    get_predefined_roles_in_scope,
-)
-from ai.backend.manager.models.rbac.context import ClientContext
 from ai.backend.manager.models.resource_slot import AgentResourceRow
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
@@ -210,277 +190,3 @@ async def list_schedulable_agents_by_sgroup(
 
     result = await db_sess.execute(query)
     return result.scalars().all()
-
-
-type WhereClauseType = sa.sql.expression.BinaryExpression[Any] | sa.sql.expression.BooleanClauseList
-# TypeAlias is deprecated since 3.12 but mypy does not follow up yet
-
-OWNER_PERMISSIONS: frozenset[AgentPermission] = frozenset([perm for perm in AgentPermission])
-ADMIN_PERMISSIONS: frozenset[AgentPermission] = frozenset([perm for perm in AgentPermission])
-MONITOR_PERMISSIONS: frozenset[AgentPermission] = frozenset([
-    AgentPermission.READ_ATTRIBUTE,
-    AgentPermission.UPDATE_ATTRIBUTE,
-])
-PRIVILEGED_MEMBER_PERMISSIONS: frozenset[AgentPermission] = frozenset([
-    AgentPermission.CREATE_COMPUTE_SESSION,
-    AgentPermission.CREATE_SERVICE,
-])
-MEMBER_PERMISSIONS: frozenset[AgentPermission] = frozenset([
-    AgentPermission.CREATE_COMPUTE_SESSION,
-    AgentPermission.CREATE_SERVICE,
-])
-
-
-@dataclass
-class AgentPermissionContext(AbstractPermissionContext[AgentPermission, AgentRow, AgentId]):
-    from ai.backend.manager.models.resource_group import ResourceGroupPermissionContext
-
-    sgroup_permission_ctx: ResourceGroupPermissionContext | None = None
-
-    @property
-    def query_condition(self) -> WhereClauseType | None:
-        cond: WhereClauseType | None = None
-
-        def _OR_coalesce(
-            base_cond: WhereClauseType | None,
-            _cond: sa.sql.expression.BinaryExpression[Any],
-        ) -> WhereClauseType:
-            return base_cond | _cond if base_cond is not None else _cond
-
-        if self.object_id_to_additional_permission_map:
-            cond = _OR_coalesce(
-                cond, AgentRow.id.in_(self.object_id_to_additional_permission_map.keys())
-            )
-        if self.object_id_to_overriding_permission_map:
-            cond = _OR_coalesce(
-                cond, AgentRow.id.in_(self.object_id_to_overriding_permission_map.keys())
-            )
-
-        if self.sgroup_permission_ctx is not None:
-            if cond is not None:
-                sgroup_names = self.sgroup_permission_ctx.sgroup_to_permissions_map.keys()
-                cond = cond & AgentRow.scaling_group.in_(sgroup_names)
-        return cond
-
-    def apply_sgroup_permission_ctx(
-        self, sgroup_permission_ctx: ResourceGroupPermissionContext
-    ) -> None:
-        self.sgroup_permission_ctx = sgroup_permission_ctx
-
-    @override
-    async def build_query(self) -> sa.sql.Select[Any] | None:
-        cond = self.query_condition
-        if cond is None:
-            return None
-        return sa.select(AgentRow).where(cond)
-
-    @override
-    async def calculate_final_permission(self, rbac_obj: AgentRow) -> frozenset[AgentPermission]:
-        agent_row = rbac_obj
-        agent_id = agent_row.id
-        permissions: set[AgentPermission] = set()
-
-        if (
-            overriding_perm := self.object_id_to_overriding_permission_map.get(agent_id)
-        ) is not None:
-            permissions = set(overriding_perm)
-        else:
-            permissions |= self.object_id_to_additional_permission_map.get(agent_id, set())
-
-        if self.sgroup_permission_ctx is not None:
-            sgroup_permission_map = self.sgroup_permission_ctx.sgroup_to_permissions_map
-            sgroup_perms = sgroup_permission_map.get(agent_row.scaling_group)
-            if (
-                sgroup_perms is None
-                or ResourceGroupPermission.AGENT_PERMISSIONS not in sgroup_perms
-            ):
-                permissions = set()
-
-        return frozenset(permissions)
-
-
-class AgentPermissionContextBuilder(
-    AbstractPermissionContextBuilder[AgentPermission, AgentPermissionContext]
-):
-    db_session: SASession
-
-    def __init__(self, db_session: SASession) -> None:
-        self.db_session = db_session
-
-    @override
-    async def calculate_permission(
-        self,
-        ctx: ClientContext,
-        target_scope: ScopeType,
-    ) -> frozenset[AgentPermission]:
-        roles = await get_predefined_roles_in_scope(ctx, target_scope, self.db_session)
-        return await self._calculate_permission_by_predefined_roles(roles)
-
-    @override
-    async def build_ctx_in_system_scope(
-        self,
-        ctx: ClientContext,
-    ) -> AgentPermissionContext:
-        from ai.backend.manager.models.domain import DomainRow
-
-        perm_ctx = AgentPermissionContext()
-        _domain_query_stmt = sa.select(DomainRow).options(load_only(DomainRow.name))
-        for row in await self.db_session.scalars(_domain_query_stmt):
-            to_be_merged = await self.build_ctx_in_domain_scope(ctx, DomainScope(row.name))
-            perm_ctx.merge(to_be_merged)
-        return perm_ctx
-
-    @override
-    async def build_ctx_in_domain_scope(
-        self,
-        ctx: ClientContext,
-        scope: DomainScope,
-    ) -> AgentPermissionContext:
-        from ai.backend.manager.models.domain import DomainRow
-        from ai.backend.manager.models.resource_group import (
-            ResourceGroupForDomainRow,
-            ResourceGroupRow,
-        )
-
-        permissions = await self.calculate_permission(ctx, scope)
-        aid_permission_map: dict[AgentId, frozenset[AgentPermission]] = {}
-
-        _stmt = (
-            sa.select(ResourceGroupForDomainRow)
-            .where(
-                ResourceGroupForDomainRow.domain_id
-                == sa.select(DomainRow.id)
-                .where(DomainRow.name == scope.domain_name)
-                .scalar_subquery()
-            )
-            .options(
-                joinedload(ResourceGroupForDomainRow.sgroup_row).options(
-                    selectinload(ResourceGroupRow.agents)
-                )
-            )
-        )
-        for row in await self.db_session.scalars(_stmt):
-            sg_row = row.sgroup_row
-            for ag in sg_row.agents:
-                aid_permission_map[AgentId(ag.id)] = permissions
-        return AgentPermissionContext(object_id_to_additional_permission_map=aid_permission_map)
-
-    @override
-    async def build_ctx_in_project_scope(
-        self,
-        ctx: ClientContext,
-        scope: ProjectScope,
-    ) -> AgentPermissionContext:
-        from ai.backend.manager.models.resource_group import (
-            ResourceGroupForProjectRow,
-            ResourceGroupRow,
-        )
-
-        permissions = await self.calculate_permission(ctx, scope)
-        aid_permission_map: dict[AgentId, frozenset[AgentPermission]] = {}
-
-        _stmt = (
-            sa.select(ResourceGroupForProjectRow)
-            .where(ResourceGroupForProjectRow.group == scope.project_id)
-            .options(
-                joinedload(ResourceGroupForProjectRow.sgroup_row).options(
-                    selectinload(ResourceGroupRow.agents)
-                )
-            )
-        )
-        for row in await self.db_session.scalars(_stmt):
-            sg_row = row.sgroup_row
-            for ag in sg_row.agents:
-                aid_permission_map[AgentId(ag.id)] = permissions
-        return AgentPermissionContext(object_id_to_additional_permission_map=aid_permission_map)
-
-    @override
-    async def build_ctx_in_user_scope(
-        self,
-        ctx: ClientContext,
-        scope: UserScope,
-    ) -> AgentPermissionContext:
-        from ai.backend.manager.models.resource_group import (
-            ResourceGroupForKeypairsRow,
-            ResourceGroupRow,
-        )
-
-        permissions = await self.calculate_permission(ctx, scope)
-        aid_permission_map: dict[AgentId, frozenset[AgentPermission]] = {}
-
-        _kp_stmt = (
-            sa.select(KeyPairRow)
-            .where(KeyPairRow.user == scope.user_id)
-            .options(load_only(KeyPairRow.access_key))
-        )
-        kp_rows = (await self.db_session.scalars(_kp_stmt)).all()
-        access_keys = cast(list[AccessKey], [r.access_key for r in kp_rows])
-
-        _stmt = (
-            sa.select(ResourceGroupForKeypairsRow)
-            .where(ResourceGroupForKeypairsRow.access_key.in_(access_keys))
-            .options(
-                joinedload(ResourceGroupForKeypairsRow.sgroup_row).options(
-                    selectinload(ResourceGroupRow.agents)
-                )
-            )
-        )
-        for row in await self.db_session.scalars(_stmt):
-            sg_row = row.sgroup_row
-            for ag in sg_row.agents:
-                aid_permission_map[AgentId(ag.id)] = permissions
-        return AgentPermissionContext(object_id_to_additional_permission_map=aid_permission_map)
-
-    @override
-    @classmethod
-    async def _permission_for_owner(
-        cls,
-    ) -> frozenset[AgentPermission]:
-        return OWNER_PERMISSIONS
-
-    @override
-    @classmethod
-    async def _permission_for_admin(
-        cls,
-    ) -> frozenset[AgentPermission]:
-        return ADMIN_PERMISSIONS
-
-    @override
-    @classmethod
-    async def _permission_for_monitor(
-        cls,
-    ) -> frozenset[AgentPermission]:
-        return MONITOR_PERMISSIONS
-
-    @override
-    @classmethod
-    async def _permission_for_privileged_member(
-        cls,
-    ) -> frozenset[AgentPermission]:
-        return PRIVILEGED_MEMBER_PERMISSIONS
-
-    @override
-    @classmethod
-    async def _permission_for_member(
-        cls,
-    ) -> frozenset[AgentPermission]:
-        return MEMBER_PERMISSIONS
-
-
-async def get_permission_ctx(
-    db_conn: SAConnection,
-    ctx: ClientContext,
-    target_scope: ScopeType,
-    requested_permission: AgentPermission,
-) -> AgentPermissionContext:
-    from ai.backend.manager.models.resource_group import ResourceGroupPermissionContextBuilder
-
-    async with ctx.db.begin_readonly_session(db_conn) as db_session:
-        sgroup_perm_ctx = await ResourceGroupPermissionContextBuilder(db_session).build(
-            ctx, target_scope, ResourceGroupPermission.AGENT_PERMISSIONS
-        )
-
-        builder = AgentPermissionContextBuilder(db_session)
-        permission_ctx = await builder.build(ctx, target_scope, requested_permission)
-        permission_ctx.apply_sgroup_permission_ctx(sgroup_perm_ctx)
-    return permission_ctx

--- a/src/ai/backend/manager/repositories/agent/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/agent/db_source/db_source.py
@@ -25,7 +25,6 @@ from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdent
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus
 from ai.backend.manager.errors.agent import AgentHasConflictingSessions
 from ai.backend.manager.errors.resource import ResourceGroupNotFound, UnresolvableResourceGroup
-from ai.backend.manager.models.agent import ADMIN_PERMISSIONS as ADMIN_AGENT_PERMISSIONS
 from ai.backend.manager.models.agent import AgentRow, agents
 from ai.backend.manager.models.image import ImageRow
 from ai.backend.manager.models.kernel import KernelRow
@@ -261,12 +260,12 @@ class AgentDBSource:
                 querier,
             )
             agent_rows: list[AgentRow] = [row.AgentRow for row in result.rows]
-            admin_permissions = list(ADMIN_AGENT_PERMISSIONS)
+            # The caller's permissions are the service's to resolve.
             agents_with_permissions = [
                 AgentDetailData(
                     agent=agent_row.to_data(),
                     resources=agent_row.resources_by_rank(),
-                    permissions=admin_permissions,
+                    permissions=[],
                 )
                 for agent_row in agent_rows
             ]

--- a/src/ai/backend/manager/repositories/agent/repository.py
+++ b/src/ai/backend/manager/repositories/agent/repository.py
@@ -27,7 +27,6 @@ from ai.backend.manager.data.agent.types import (
 )
 from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelInfo
-from ai.backend.manager.models.agent import ADMIN_PERMISSIONS as ADMIN_AGENT_PERMISSIONS
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.agent.lookups import AgentNameLookup
 from ai.backend.manager.models.agent.updaters import AgentExitStatusUpdater, AgentStatusUpdater
@@ -259,12 +258,13 @@ class AgentRepository:
         async with self._db_source._db.begin_readonly_session() as db_session:
             result = await db_session.scalars(stmt)
             agent_rows = cast(list[AgentRow], result.unique().all())
-            admin_permissions = list(ADMIN_AGENT_PERMISSIONS)
+            # Legacy GQL reads; the one caller showing permissions is superadmin-only
+            # and fills them itself.
             return [
                 AgentDetailData(
                     agent=agent_row.to_data(),
                     resources=agent_row.resources_by_rank(),
-                    permissions=admin_permissions,
+                    permissions=[],
                 )
                 for agent_row in agent_rows
             ]

--- a/src/ai/backend/manager/services/agent/actions/bulk_load_permissions.py
+++ b/src/ai/backend/manager/services/agent/actions/bulk_load_permissions.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.actions.v2.bulk.base import BasePartialBulkAction
+
+
+@dataclass
+class BulkLoadAgentPermissionsAction(BasePartialBulkAction):
+    """Read the permissions the caller holds on each agent named."""
+
+    agent_uuids: Sequence[AgentUUID]
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_load_agent_permissions"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.agent_uuids)
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, agent_uuids=[uuid for uuid in self.agent_uuids if uuid in allowed])

--- a/src/ai/backend/manager/services/agent/processors.py
+++ b/src/ai/backend/manager/services/agent/processors.py
@@ -16,10 +16,14 @@ from ai.backend.manager.actions.v2.ops.result import (
     ScopedFieldsOpsResult,
 )
 from ai.backend.manager.data.agent.types import AgentData
+from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.data.resource_slot.types import AgentResourceData
 from ai.backend.manager.services.agent.actions.bulk_get import BulkGetAgentsAction
 from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
     BulkLoadContainerCountsAction,
+)
+from ai.backend.manager.services.agent.actions.bulk_load_permissions import (
+    BulkLoadAgentPermissionsAction,
 )
 from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
@@ -80,6 +84,9 @@ class AgentProcessors:
     ]
     bulk_get: PartialBulkActionProcessor[BulkGetAgentsAction, AgentData]
     bulk_load_container_counts: PartialBulkActionProcessor[BulkLoadContainerCountsAction, int]
+    bulk_load_permissions: PartialBulkActionProcessor[
+        BulkLoadAgentPermissionsAction, list[AgentPermission]
+    ]
     scoped_search_resources: BulkActionProcessor[
         ScopedSearchAgentResourcesAction, ScopedFieldsOpsResult[AgentResourceData]
     ]
@@ -117,6 +124,9 @@ class AgentProcessors:
         self.bulk_get = group.partial_bulk_get_ops(BulkGetAgentsAction)
         self.bulk_load_container_counts = group.partial_bulk(
             BulkLoadContainerCountsAction, service.bulk_load_container_counts
+        )
+        self.bulk_load_permissions = group.partial_bulk(
+            BulkLoadAgentPermissionsAction, service.bulk_load_permissions
         )
         resources: LookupFieldGroup[AgentResourceData] = group.field_group(
             FieldGroupMeta(AGENT_RESOURCE_FIELD_TYPE),

--- a/src/ai/backend/manager/services/agent/service.py
+++ b/src/ai/backend/manager/services/agent/service.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
 from typing import Any, Literal, cast
 from uuid import UUID
 
@@ -6,6 +8,8 @@ import aiohttp
 import yarl
 from async_timeout import timeout as _timeout
 
+from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.exception import (
     AgentWatcherResponseError,
@@ -20,7 +24,9 @@ from ai.backend.common.types import (
 )
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.actions.v2.bulk.result import PartialBulkEntityResult, PartialBulkResult
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.errors.agent import ConflictingSessionRescheduleNotSupported
 from ai.backend.manager.errors.resource import AgentNotFound
 from ai.backend.manager.registry import AgentRegistry
@@ -28,6 +34,9 @@ from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository
 from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
     BulkLoadContainerCountsAction,
+)
+from ai.backend.manager.services.agent.actions.bulk_load_permissions import (
+    BulkLoadAgentPermissionsAction,
 )
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
@@ -93,6 +102,7 @@ class AgentService:
         agent_repository: AgentRepository,
         scheduler_repository: SchedulerRepository,
         scheduling_controller: SchedulingController,
+        own_check: BulkOwnCheck,
     ) -> None:
         self._etcd = etcd
         self._agent_registry = agent_registry
@@ -100,6 +110,7 @@ class AgentService:
         self._agent_repository = agent_repository
         self._scheduler_repository = scheduler_repository
         self._scheduling_controller = scheduling_controller
+        self._own_check = own_check
 
     async def _get_watcher_info(self, agent_id: AgentId) -> dict[str, Any]:
         """
@@ -258,14 +269,41 @@ class AgentService:
         total_resources = await self._scheduler_repository.get_total_resource_slots()
         return GetTotalResourcesActionResult(total_resources=total_resources)
 
+    async def _permissions_on(
+        self, agent_uuids: Sequence[AgentUUID]
+    ) -> Mapping[AgentUUID, list[AgentPermission]]:
+        """What the caller holds on each named agent, as the RBAC own check sees it,
+        mapped through :meth:`AgentPermission.from_rbac`."""
+        held = await self._own_check.held(agent_uuids)
+        return {
+            uuid: AgentPermission.from_rbac(held.get(uuid, Permission.NONE)) for uuid in agent_uuids
+        }
+
+    async def bulk_load_permissions(
+        self, action: BulkLoadAgentPermissionsAction
+    ) -> PartialBulkResult[list[AgentPermission]]:
+        permissions = await self._permissions_on(action.agent_uuids)
+        return PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[list[AgentPermission]].succeeded(
+                    uuid, permissions.get(uuid, []), description="resolved"
+                )
+                for uuid in action.agent_uuids
+            ]
+        )
+
     async def search_agents(self, action: SearchAgentsAction) -> SearchAgentsActionResult:
-        """Searches agents."""
+        """Searches agents, with what the caller holds on each."""
         result = await self._agent_repository.search_agents(
             querier=action.querier,
         )
+        permissions = await self._permissions_on([item.agent.uuid for item in result.items])
 
         return SearchAgentsActionResult(
-            agents=result.items,
+            agents=[
+                replace(item, permissions=permissions.get(item.agent.uuid, []))
+                for item in result.items
+            ],
             total_count=result.total_count,
             has_next_page=result.has_next_page,
             has_previous_page=result.has_previous_page,

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -80,6 +80,7 @@ from ai.backend.manager.actions.registry.types import (
     GroupMeta,
     ProcessorDependencies,
 )
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.clients.prometheus.preset import PromQLTemplateRenderer
 from ai.backend.manager.data.artifact.types import ArtifactRevisionData
@@ -265,6 +266,7 @@ def create_services(args: ServiceArgs) -> Services:
             repositories.agent.repository,
             repositories.scheduler.repository,
             args.scheduling_controller,
+            BulkOwnCheck(repositories.permission_controller.repository, args.config_provider),
         ),
         app_config=AppConfigService(OpsRepository(repositories.v2_ops_provider)),
         domain=DomainService(repositories.domain.repository),

--- a/tests/component/agent_api/conftest.py
+++ b/tests/component/agent_api/conftest.py
@@ -15,6 +15,7 @@ from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.types import HostPortPair
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.api.rest.agent.handler import AgentHandler
 from ai.backend.manager.api.rest.agent.registry import register_agent_routes
 from ai.backend.manager.api.rest.routing import RouteRegistry
@@ -27,6 +28,9 @@ from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository
 from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.agent.service import AgentService
@@ -87,6 +91,7 @@ def agent_processors(
         agent_repository=agent_repository,
         scheduler_repository=scheduler_repository,
         scheduling_controller=AsyncMock(),
+        own_check=BulkOwnCheck(PermissionControllerRepository(database_engine), config_provider),
     )
     return AgentProcessors(
         processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),

--- a/tests/component/infra/conftest.py
+++ b/tests/component/infra/conftest.py
@@ -23,6 +23,7 @@ from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import (
     GroupMeta,
 )
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
 from ai.backend.manager.api.rest.etcd.handler import EtcdHandler
@@ -49,6 +50,9 @@ from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.repositories.ops.v2.relation.provider import RelationOpsProvider
 from ai.backend.manager.repositories.ops.v2.share.provider import ShareOpsProvider
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
 from ai.backend.manager.repositories.project.repositories import ProjectRepositories
 from ai.backend.manager.repositories.project.repository import ProjectRepository
 from ai.backend.manager.repositories.resource_group.repository import ResourceGroupRepository
@@ -160,6 +164,7 @@ def agent_processors(
         agent_repository=agent_repo,
         scheduler_repository=scheduler_repo,
         scheduling_controller=AsyncMock(),
+        own_check=BulkOwnCheck(PermissionControllerRepository(database_engine), config_provider),
     )
     return AgentProcessors(
         processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),

--- a/tests/component/resource_preset/conftest.py
+++ b/tests/component/resource_preset/conftest.py
@@ -20,6 +20,7 @@ from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import (
     GroupMeta,
 )
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.actions.validators import ActionValidators
 from ai.backend.manager.actions.validators.rbac import RBACValidators
 from ai.backend.manager.api.rest.middleware import auth as _auth_api
@@ -41,6 +42,9 @@ from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 from ai.backend.manager.repositories.ops.v2.reconciler.provider import ReconcileOpsProvider
 from ai.backend.manager.repositories.ops.v2.relation.provider import RelationOpsProvider
 from ai.backend.manager.repositories.ops.v2.share.provider import ShareOpsProvider
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
 from ai.backend.manager.repositories.project.repositories import ProjectRepositories
 from ai.backend.manager.repositories.project.repository import ProjectRepository
 from ai.backend.manager.repositories.resource_preset.repository import ResourcePresetRepository
@@ -131,6 +135,7 @@ def agent_processors(
         agent_repository=agent_repo,
         scheduler_repository=scheduler_repo,
         scheduling_controller=AsyncMock(),
+        own_check=BulkOwnCheck(PermissionControllerRepository(database_engine), config_provider),
     )
     return AgentProcessors(
         processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -111,6 +111,9 @@ from ai.backend.manager.services.agent.actions.bulk_get import BulkGetAgentsActi
 from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
     BulkLoadContainerCountsAction,
 )
+from ai.backend.manager.services.agent.actions.bulk_load_permissions import (
+    BulkLoadAgentPermissionsAction,
+)
 from ai.backend.manager.services.agent.actions.bulk_lookup import BulkLookupAgentsAction
 from ai.backend.manager.services.agent.actions.get_total_resources import (
     GetTotalResourcesAction,
@@ -549,6 +552,11 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
         # What the DataLoaders read: checked per agent.
         BulkGetAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.BULK, ActionGate.PERMISSION),
         BulkLoadContainerCountsAction: (
+            AGENT_ENTITY_TYPE,
+            ActionKind.BULK,
+            ActionGate.PERMISSION,
+        ),
+        BulkLoadAgentPermissionsAction: (
             AGENT_ENTITY_TYPE,
             ActionKind.BULK,
             ActionGate.PERMISSION,

--- a/tests/unit/manager/actions/validators/test_bulk_own_check.py
+++ b/tests/unit/manager/actions/validators/test_bulk_own_check.py
@@ -1,0 +1,97 @@
+"""``BulkOwnCheck.held`` is the one place the caller's bits on named entities come from."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.common.contexts.user import with_user
+from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.permission.types import Permission
+from ai.backend.common.data.user.types import UserData, UserRole
+from ai.backend.common.exception import UnreachableError
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
+from ai.backend.manager.data.permission.virtual_entity import OwnCheckKey
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+
+def _user(role: UserRole) -> UserData:
+    return UserData(
+        user_id=uuid.uuid4(),
+        is_authorized=True,
+        is_admin=role is UserRole.SUPERADMIN,
+        is_superadmin=role is UserRole.SUPERADMIN,
+        role=role,
+        domain_name="default",
+        domain_id=DomainID(uuid.uuid4()),
+    )
+
+
+def _config(*, enforcement_enabled: bool) -> MagicMock:
+    config_provider = MagicMock()
+    config_provider.config.manager.rbac.enforcement_enabled = enforcement_enabled
+    return config_provider
+
+
+@pytest.fixture
+def repository() -> AsyncMock:
+    return AsyncMock(spec=PermissionControllerRepository)
+
+
+@pytest.fixture
+def entities() -> list[AgentUUID]:
+    return [AgentUUID(uuid.uuid4()), AgentUUID(uuid.uuid4())]
+
+
+async def test_superadmin_holds_everything(
+    repository: AsyncMock, entities: list[AgentUUID]
+) -> None:
+    check = BulkOwnCheck(repository, _config(enforcement_enabled=True))
+
+    with with_user(_user(UserRole.SUPERADMIN)):
+        held = await check.held(entities)
+
+    assert held == dict.fromkeys(entities, Permission.full())
+    repository.owned_permissions.assert_not_awaited()
+
+
+async def test_enforcement_off_holds_everything(
+    repository: AsyncMock, entities: list[AgentUUID]
+) -> None:
+    check = BulkOwnCheck(repository, _config(enforcement_enabled=False))
+
+    with with_user(_user(UserRole.USER)):
+        held = await check.held(entities)
+
+    assert held == dict.fromkeys(entities, Permission.full())
+    repository.owned_permissions.assert_not_awaited()
+
+
+async def test_a_user_holds_what_the_own_check_answers(
+    repository: AsyncMock, entities: list[AgentUUID]
+) -> None:
+    user = _user(UserRole.USER)
+    reached, unreached = entities
+    repository.owned_permissions.return_value = {
+        OwnCheckKey(user_id=UserID(user.user_id), entity=reached): Permission.READ,
+    }
+    check = BulkOwnCheck(repository, _config(enforcement_enabled=True))
+
+    with with_user(user):
+        held = await check.held(entities)
+
+    # An entity nothing reaches holds NONE rather than being absent.
+    assert held == {reached: Permission.READ, unreached: Permission.NONE}
+
+
+async def test_missing_user_raises(repository: AsyncMock, entities: list[AgentUUID]) -> None:
+    check = BulkOwnCheck(repository, _config(enforcement_enabled=True))
+
+    with pytest.raises(UnreachableError):
+        await check.held(entities)

--- a/tests/unit/manager/api/adapters/test_agent_adapter.py
+++ b/tests/unit/manager/api/adapters/test_agent_adapter.py
@@ -15,6 +15,7 @@ from ai.backend.manager.actions.v2.bulk.result import PartialBulkEntityResult, P
 from ai.backend.manager.actions.v2.ops.result import BulkLookupOpsResult, ScopedFieldsOpsResult
 from ai.backend.manager.api.adapters.agent.adapter import AgentAdapter
 from ai.backend.manager.data.agent.types import AgentData, AgentStatus
+from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.data.resource_slot.types import AgentResourceData
 from ai.backend.manager.errors.common import GenericForbidden
 
@@ -97,6 +98,15 @@ def processors(readable: AgentData, denied: AgentData, denial: GenericForbidden)
             items=[PartialBulkEntityResult[int].succeeded(readable.uuid, 3)]
         )
     )
+    processors.agent.bulk_load_permissions.run = AsyncMock(
+        return_value=PartialBulkResult(
+            items=[
+                PartialBulkEntityResult[list[AgentPermission]].succeeded(
+                    readable.uuid, [AgentPermission.READ_ATTRIBUTE]
+                )
+            ]
+        )
+    )
     return processors
 
 
@@ -118,13 +128,15 @@ async def test_batch_load_answers_per_name(
     assert node.id == READABLE
     assert node.resource_info.capacity == {"cpu": "4"}
     assert node.resource_info.used == {"cpu": "1"}
-    assert node.permissions == []
+    assert node.permissions == [AgentPermission.READ_ATTRIBUTE.value]
     # A denial reaches the resolver; a name matching nothing stays None.
     assert refused is denial
     assert missing is None
-    # The slot rows are read for the agents that passed, and no other.
+    # The slot rows and the permissions are read for the agents that passed, and no other.
     search_action = processors.agent.scoped_search_resources.run.await_args.args[0]
     assert list(search_action.agent_uuids) == [readable.uuid]
+    permission_action = processors.agent.bulk_load_permissions.run.await_args.args[0]
+    assert list(permission_action.agent_uuids) == [readable.uuid]
 
 
 async def test_container_counts_answer_per_name(

--- a/tests/unit/manager/services/agent/test_service.py
+++ b/tests/unit/manager/services/agent/test_service.py
@@ -10,13 +10,16 @@ import pytest
 
 from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.exception import AgentWatcherResponseError
 from ai.backend.common.types import (
     AgentId,
     SessionId,
 )
+from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.errors.agent import (
     AgentHasConflictingSessions,
     ConflictingSessionRescheduleNotSupported,
@@ -27,6 +30,9 @@ from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository
 from ai.backend.manager.services.agent.actions.bulk_load_container_counts import (
     BulkLoadContainerCountsAction,
+)
+from ai.backend.manager.services.agent.actions.bulk_load_permissions import (
+    BulkLoadAgentPermissionsAction,
 )
 from ai.backend.manager.services.agent.actions.get_watcher_status import (
     GetWatcherStatusAction,
@@ -82,6 +88,11 @@ def mock_scheduling_controller() -> AsyncMock:
 
 
 @pytest.fixture
+def mock_own_check() -> AsyncMock:
+    return AsyncMock(spec=BulkOwnCheck)
+
+
+@pytest.fixture
 def agent_service(
     mock_etcd: AsyncMock,
     mock_agent_registry: AsyncMock,
@@ -89,6 +100,7 @@ def agent_service(
     mock_agent_repository: AsyncMock,
     mock_scheduler_repository: AsyncMock,
     mock_scheduling_controller: AsyncMock,
+    mock_own_check: AsyncMock,
 ) -> AgentService:
     return AgentService(
         etcd=mock_etcd,
@@ -97,6 +109,7 @@ def agent_service(
         agent_repository=mock_agent_repository,
         scheduler_repository=mock_scheduler_repository,
         scheduling_controller=mock_scheduling_controller,
+        own_check=mock_own_check,
     )
 
 
@@ -430,3 +443,30 @@ class TestBulkLoadContainerCounts:
             known,
             unknown,
         ])
+
+
+class TestBulkLoadPermissions:
+    async def test_each_agent_holds_what_the_own_check_answers(
+        self, agent_service: AgentService, mock_own_check: AsyncMock
+    ) -> None:
+        agent_uuid = AgentUUID(uuid4())
+        unreached = AgentUUID(uuid4())
+        mock_own_check.held.return_value = {
+            agent_uuid: Permission.READ | Permission.CREATE | Permission.HARD_DELETE,
+            unreached: Permission.NONE,
+        }
+
+        result = await agent_service.bulk_load_permissions(
+            BulkLoadAgentPermissionsAction(agent_uuids=[agent_uuid, unreached])
+        )
+
+        # READ and CREATE map; HARD_DELETE has no counterpart; nothing held is empty.
+        assert result.values() == {
+            agent_uuid: [
+                AgentPermission.READ_ATTRIBUTE,
+                AgentPermission.CREATE_COMPUTE_SESSION,
+                AgentPermission.CREATE_SERVICE,
+            ],
+            unreached: [],
+        }
+        mock_own_check.held.assert_awaited_once_with([agent_uuid, unreached])


### PR DESCRIPTION
## Summary
- The agent repositories stop filling every `AgentDetailData.permissions` with the admin list. What the caller holds comes from `BulkOwnCheck.held`, the same own check the bulk RBAC validators run (enforcement off or superadmin holds everything, anyone else what the own check answers), so the shown permissions cannot disagree with what a check would allow. `AgentService` only maps the RBAC mask through `AgentPermission.from_rbac`.
- The admin search fills them in the service. The DataLoader (`KernelV2GQL.agent`, `node(agent)`) and the legacy `AgentNode` connection read them through the new per-agent `BulkLoadAgentPermissionsAction`; the legacy connection keeps its superadmin-only guard and no longer hard-codes the list.
- `ADMIN_PERMISSIONS` and its siblings, `AgentPermissionContext`, its builder and `get_permission_ctx` are removed: their only caller was a branch of the legacy connection sitting behind that superadmin early return.

Most non-superadmin callers now see fewer permissions on an agent than before. That is the intended behaviour: the list was never theirs.

| RBAC bit | `AgentPermission` |
|---|---|
| READ | READ_ATTRIBUTE |
| UPDATE | UPDATE_ATTRIBUTE |
| CREATE | CREATE_COMPUTE_SESSION, CREATE_SERVICE |
| SOFT_DELETE, HARD_DELETE | none |

## Test plan
- [x] `tests/unit/manager/actions/validators/test_bulk_own_check.py` — superadmin and enforcement-off hold everything without a read; a user holds what the own check answers, NONE where nothing reaches; no user context raises
- [x] `tests/unit/manager/services/agent/test_service.py` — the mask maps as in the table; an entity holding nothing answers an empty list
- [x] `tests/unit/manager/api/adapters/test_agent_adapter.py` — the DataLoader node carries the permissions the action answered, asked only for the agents that passed
- [x] `tests/unit/manager/actions/test_registry_catalog.py` — `BulkLoadAgentPermissionsAction` recorded as (agent, BULK, PERMISSION)
- [x] `pants fmt fix lint check test` over the changed set

Resolves BA-7716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9CzWeuzWUXTXuK3HXiouu
