### PR TITLE
refactor(BA-7728): carry the guard checks on the updater and purger roots

### DIFF
--- a/changes/14344.enhance.md
+++ b/changes/14344.enhance.md
@@ -1,0 +1,1 @@
+Carry the guard checks on the v2 updater and purger spec roots, so a refused write raises the error the spec declares instead of a generic `EntityWriteRefusedError`.

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -24,8 +24,8 @@ from ai.backend.manager.models.specs.creator import (
 from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 from ai.backend.manager.models.specs.purger import (
     EntityBatchPurger,
-    EntityPurger,
-    FieldPurger,
+    GuardedEntityPurger,
+    GuardedFieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
     BulkEntityQuerier,
@@ -34,11 +34,7 @@ from ai.backend.manager.models.specs.querier import (
     OwnedFieldQuerier,
 )
 from ai.backend.manager.models.specs.searcher import Searcher
-from ai.backend.manager.models.specs.updater import (
-    DataBatchUpdater,
-    DataUpdater,
-    GuardedDataUpdater,
-)
+from ai.backend.manager.models.specs.updater import DataBatchUpdater, GuardedDataUpdater
 from ai.backend.manager.models.specs.upserter import (
     EntityUpserter,
     FieldUpserter,
@@ -411,7 +407,7 @@ class EntityPurgeOpsAction[TRow: Base, TData](OpsBackendAction):
     """Carries the delete spec of one entity named by id."""
 
     @abstractmethod
-    def to_purger(self) -> EntityPurger[TRow, TData]:
+    def to_purger(self) -> GuardedEntityPurger[TRow, TData]:
         """Return the hard-delete spec this action executes."""
         raise NotImplementedError
 
@@ -421,7 +417,7 @@ class FieldPurgeOpsAction[TRow: Base, TData: FieldData](OpsBackendAction):
     shape names, like an update to the owning entity."""
 
     @abstractmethod
-    def to_purger(self) -> FieldPurger[TRow, TData]:
+    def to_purger(self) -> GuardedFieldPurger[TRow, TData]:
         """Return the hard-delete spec this action executes."""
         raise NotImplementedError
 
@@ -431,7 +427,7 @@ class GlobalEntityPartialBulkPurgeOpsAction[TRow: Base, TData](OpsBackendAction)
     separately; no membership involved."""
 
     @abstractmethod
-    def to_purgers(self) -> Mapping[EntityIdentifier, EntityPurger[TRow, TData]]:
+    def to_purgers(self) -> Mapping[EntityIdentifier, GuardedEntityPurger[TRow, TData]]:
         """Return the delete spec for each entity this action names."""
         raise NotImplementedError
 
@@ -441,7 +437,7 @@ class EntityPartialBulkPurgeOpsAction[TRow: Base, TData](OpsBackendAction):
     every row's scope is torn down with it."""
 
     @abstractmethod
-    def to_purgers(self) -> Mapping[EntityIdentifier, EntityPurger[TRow, TData]]:
+    def to_purgers(self) -> Mapping[EntityIdentifier, GuardedEntityPurger[TRow, TData]]:
         """Return the delete spec for each entity this action names."""
         raise NotImplementedError
 
@@ -453,7 +449,7 @@ class FieldPartialBulkPurgeOpsAction[TFieldID: FieldIdentifier, TRow: Base, TDat
     authorized through the entities owning them."""
 
     @abstractmethod
-    def to_purgers(self) -> Mapping[TFieldID, FieldPurger[TRow, TData]]:
+    def to_purgers(self) -> Mapping[TFieldID, GuardedFieldPurger[TRow, TData]]:
         """Return the delete spec for each row this action names."""
         raise NotImplementedError
 
@@ -512,7 +508,7 @@ class FieldUpsertOpsAction[TOwnerID: OwnerEntityID, TRow: Base, TData: FieldData
 
 class UpdateOpsAction[TRow: Base, TData](OpsBackendAction):
     @abstractmethod
-    def to_updater(self) -> DataUpdater[TRow, TData]:
+    def to_updater(self) -> GuardedDataUpdater[TRow, TData]:
         """Return the update spec this action executes.
 
         A soft delete uses this too: which column marks a row deleted is domain
@@ -525,14 +521,13 @@ class UpdateOpsAction[TRow: Base, TData](OpsBackendAction):
 class GuardedUpdateOpsAction[TRow: Base, TData](OpsBackendAction):
     """An update that declines to write unless the named row's guard holds.
 
-    Kept apart from :class:`UpdateOpsAction` because the two answer differently: a
-    guarded write that touched nothing reports the refusal, while a plain one has only
-    "no such row" to report.
+    Every updater carries its guard now, so this answers as :class:`UpdateOpsAction`
+    does; kept until the guarded action surfaces are retired.
     """
 
     @abstractmethod
     def to_updater(self) -> GuardedDataUpdater[TRow, TData]:
-        """Return the guarded update spec this action executes."""
+        """Return the update spec this action executes."""
         raise NotImplementedError
 
 
@@ -548,7 +543,7 @@ class PartialBulkUpdateOpsAction[TRow: Base, TData](OpsBackendAction):
     """
 
     @abstractmethod
-    def to_updaters(self) -> Mapping[EntityIdentifier, DataUpdater[TRow, TData]]:
+    def to_updaters(self) -> Mapping[EntityIdentifier, GuardedDataUpdater[TRow, TData]]:
         """Return the update spec for each entity this action names."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/errors/agent.py
+++ b/src/ai/backend/manager/errors/agent.py
@@ -8,6 +8,7 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -35,6 +36,25 @@ class AgentConnectionUnavailable(BackendAIError, web.HTTPServiceUnavailable):
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.ACCESS,
             error_detail=ErrorDetail.UNAVAILABLE,
+        )
+
+
+class AgentAlreadyExited(BackendAIError, web.HTTPConflict):
+    """Raised when an exit is recorded for an agent already in a terminal status."""
+
+    error_type = "https://api.backend.ai/probs/agent-already-exited"
+    error_title = "Agent has already exited."
+
+    def __init__(self, agent_uuid: AgentUUID) -> None:
+        self.agent_uuid = agent_uuid
+        super().__init__(f"Agent {agent_uuid} is already in a terminal status.")
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.UPDATE,
+            error_detail=ErrorDetail.CONFLICT,
         )
 
 

--- a/src/ai/backend/manager/errors/repository.py
+++ b/src/ai/backend/manager/errors/repository.py
@@ -247,22 +247,3 @@ class ExclusionViolationError(RepositoryIntegrityError):
             operation=ErrorOperation.GENERIC,
             error_detail=ErrorDetail.CONFLICT,
         )
-
-
-class EntityWriteRefusedError(RepositoryError, web.HTTPConflict):
-    """Raised when a guarded write names an existing row whose guard declined it.
-
-    Kept apart from :class:`EntityNotFoundError` so a caller can tell a row that is
-    gone from a row that is there and refusing.
-    """
-
-    error_type = "https://api.backend.ai/probs/entity-write-refused"
-    error_title = "Entity refused the write."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DATABASE,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
-        )

--- a/src/ai/backend/manager/event_dispatcher/handlers/agent.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/agent.py
@@ -18,6 +18,7 @@ from ai.backend.common.plugin.event import EventDispatcherPluginContext
 from ai.backend.common.types import AgentId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import AgentHeartbeatUpsert
+from ai.backend.manager.errors.agent import AgentAlreadyExited
 from ai.backend.manager.errors.resource import InstanceNotFound
 from ai.backend.manager.models.agent import AgentStatus, agents
 from ai.backend.manager.models.agent.updaters import AgentExitStatusUpdater, AgentStatusUpdater
@@ -76,14 +77,17 @@ class AgentEventHandler:
         agent_uuid = await self._agent_repository.lookup_uuid(agent_id)
         if agent_uuid is not None:
             now = datetime.now(tzutc())
-            written = await self._agent_repository.mark_agent_exit(
-                AgentExitStatusUpdater(
-                    agent_uuid=agent_uuid,
-                    status=status,
-                    status_changed=now,
-                    lost_at=OptionalState.update(now),
+            try:
+                written = await self._agent_repository.mark_agent_exit(
+                    AgentExitStatusUpdater(
+                        agent_uuid=agent_uuid,
+                        status=status,
+                        status_changed=now,
+                        lost_at=OptionalState.update(now),
+                    )
                 )
-            )
+            except AgentAlreadyExited:
+                written = None
             if written is not None:
                 match status:
                     case AgentStatus.LOST:

--- a/src/ai/backend/manager/models/agent/updaters.py
+++ b/src/ai/backend/manager/models/agent/updaters.py
@@ -12,10 +12,10 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.types import AgentId
 from ai.backend.manager.data.agent.types import AgentStatus
+from ai.backend.manager.errors.agent import AgentAlreadyExited
 from ai.backend.manager.models.agent.conditions import AgentConditions
 from ai.backend.manager.models.agent.row import AgentRow
-from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.types import OptionalState
 
@@ -95,8 +95,13 @@ class AgentExitStatusUpdater(GuardedDataUpdater[AgentRow, AgentId]):
         return self.agent_uuid
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [AgentConditions.by_status_not_in(TERMINAL_AGENT_STATUSES)]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=AgentConditions.by_status_not_in(TERMINAL_AGENT_STATUSES),
+                error=AgentAlreadyExited(self.agent_uuid),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/artifact/updaters.py
+++ b/src/ai/backend/manager/models/artifact/updaters.py
@@ -12,10 +12,11 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.artifact import ArtifactID
 from ai.backend.manager.data.artifact.types import ArtifactAvailability, ArtifactData
+from ai.backend.manager.errors.artifact import ArtifactNotFoundError
 from ai.backend.manager.models.artifact.conditions import ArtifactConditions
 from ai.backend.manager.models.artifact.row import ArtifactRow
 from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import (
     DataBatchUpdater,
     DataUpdater,
@@ -28,8 +29,7 @@ from ai.backend.manager.types import TriState
 class ArtifactUpdater(GuardedDataUpdater[ArtifactRow, ArtifactData]):
     """Edit one artifact's readonly flag and description.
 
-    Guarded on availability: a deleted artifact is left alone and the caller is told
-    nothing was written.
+    Guarded on availability: a deleted artifact is left alone and answers as not found.
     """
 
     artifact_id: ArtifactID
@@ -55,8 +55,13 @@ class ArtifactUpdater(GuardedDataUpdater[ArtifactRow, ArtifactData]):
         return ()
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [lambda: ArtifactRow.availability != ArtifactAvailability.DELETED]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=lambda: ArtifactRow.availability != ArtifactAvailability.DELETED,
+                error=ArtifactNotFoundError(f"Artifact with ID {self.artifact_id} is deleted"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/domain/updaters.py
+++ b/src/ai/backend/manager/models/domain/updaters.py
@@ -12,10 +12,10 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.domain.types import DomainData, DomainStatus
-from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.errors.resource import DomainPurgeInProgress
 from ai.backend.manager.models.domain.conditions import DomainConditions
 from ai.backend.manager.models.domain.row import DomainRow
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -52,8 +52,13 @@ class DomainUpdater(GuardedDataUpdater[DomainRow, DomainData]):
         return self.domain_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [DomainConditions.not_being_purged()]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=DomainConditions.not_being_purged(),
+                error=DomainPurgeInProgress(f"Domain is being purged: {self.domain_id}"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -133,8 +138,13 @@ class DomainSoftDeleteUpdater(GuardedDataUpdater[DomainRow, DomainData]):
         return self.domain_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [DomainConditions.not_being_purged()]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=DomainConditions.not_being_purged(),
+                error=DomainPurgeInProgress(f"Domain is being purged: {self.domain_id}"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -171,8 +181,13 @@ class DomainRestoreUpdater(GuardedDataUpdater[DomainRow, DomainData]):
         return self.domain_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [DomainConditions.not_being_purged()]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=DomainConditions.not_being_purged(),
+                error=DomainPurgeInProgress(f"Domain is being purged: {self.domain_id}"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/entity_share/updaters.py
+++ b/src/ai/backend/manager/models/entity_share/updaters.py
@@ -23,9 +23,10 @@ from ai.backend.manager.data.entity_share.types import (
     EntityShareData,
     EntityShareStatus,
 )
+from ai.backend.manager.errors.entity_share import EntityShareNotFound
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.entity_share.row import EntityShareRow
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.models.user.row import UserRow
 
@@ -91,7 +92,7 @@ class _RecipientInvitationUpdater(GuardedDataUpdater[EntityShareRow, EntityShare
         return inner
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         def pending() -> sa.sql.expression.ColumnElement[bool]:
             return EntityShareRow.status == EntityShareStatus.PENDING
 
@@ -101,7 +102,22 @@ class _RecipientInvitationUpdater(GuardedDataUpdater[EntityShareRow, EntityShare
                 EntityShareRow.expires_at > sa.func.now(),
             )
 
-        return [pending, in_time, self.addressed_to_scope()]
+        return (
+            GuardCheck(
+                condition=pending,
+                error=EntityShareNotFound(f"No open offer {self.share_id} to answer"),
+            ),
+            GuardCheck(
+                condition=in_time,
+                error=EntityShareNotFound(f"Offer {self.share_id} has expired"),
+            ),
+            GuardCheck(
+                condition=self.addressed_to_scope(),
+                error=EntityShareNotFound(
+                    f"Offer {self.share_id} is not addressed to {self.answering_scope}"
+                ),
+            ),
+        )
 
     @property
     @override
@@ -154,11 +170,22 @@ class EntityShareLeaveUpdater(_RecipientInvitationUpdater):
     """
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         def taken() -> sa.sql.expression.ColumnElement[bool]:
             return EntityShareRow.status == EntityShareStatus.ACCEPTED
 
-        return [taken, self.addressed_to_scope()]
+        return (
+            GuardCheck(
+                condition=taken,
+                error=EntityShareNotFound(f"No held share {self.share_id} to give back"),
+            ),
+            GuardCheck(
+                condition=self.addressed_to_scope(),
+                error=EntityShareNotFound(
+                    f"Share {self.share_id} is not held by {self.answering_scope}"
+                ),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -191,11 +218,16 @@ class EntityShareRevokeUpdater(GuardedDataUpdater[EntityShareRow, EntityShareDat
         return self.share_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         def taken() -> sa.sql.expression.ColumnElement[bool]:
             return EntityShareRow.status == EntityShareStatus.ACCEPTED
 
-        return [taken]
+        return (
+            GuardCheck(
+                condition=taken,
+                error=EntityShareNotFound(f"No held share {self.share_id} to take back"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -235,11 +267,16 @@ class EntityShareCancelUpdater(GuardedDataUpdater[EntityShareRow, EntityShareDat
         return self.share_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         def pending() -> sa.sql.expression.ColumnElement[bool]:
             return EntityShareRow.status == EntityShareStatus.PENDING
 
-        return [pending]
+        return (
+            GuardCheck(
+                condition=pending,
+                error=EntityShareNotFound(f"No open offer {self.share_id} to cancel"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/keypair/purgers.py
+++ b/src/ai/backend/manager/models/keypair/purgers.py
@@ -11,11 +11,11 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.manager.data.keypair.types import KeyPairData
-from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.errors.user import KeyPairForbidden
 from ai.backend.manager.models.keypair.conditions import KeypairConditions
 from ai.backend.manager.models.keypair.row import KeyPairRow
 from ai.backend.manager.models.specs.purger import GuardedFieldPurger
-from ai.backend.manager.models.specs.types import ConflictCheck
+from ai.backend.manager.models.specs.types import ConflictCheck, GuardCheck
 
 
 @dataclass
@@ -41,8 +41,15 @@ class NonDefaultKeypairPurger(GuardedFieldPurger[KeyPairRow, KeyPairData]):
         return self.keypair_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [KeypairConditions.by_is_default(False)]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=KeypairConditions.by_is_default(False),
+                error=KeyPairForbidden(
+                    "Cannot delete the default access key. Switch the default access key first."
+                ),
+            ),
+        )
 
     @override
     def conflict_checks(self) -> Sequence[ConflictCheck]:

--- a/src/ai/backend/manager/models/keypair/updaters.py
+++ b/src/ai/backend/manager/models/keypair/updaters.py
@@ -13,10 +13,10 @@ from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.manager.data.keypair.types import KeyPairData
 from ai.backend.manager.errors.keypair import KeypairResourcePolicyNotFound
 from ai.backend.manager.errors.repository import ForeignKeyViolationError
-from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.errors.user import KeyPairForbidden
 from ai.backend.manager.models.keypair.conditions import KeypairConditions
 from ai.backend.manager.models.keypair.row import KeyPairRow
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.types import OptionalState
 
@@ -119,10 +119,17 @@ class KeypairUpdater(GuardedDataUpdater[KeyPairRow, KeyPairData]):
         return self.keypair_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         if self.is_active.optional_value() is not False:
-            return []
-        return [KeypairConditions.by_is_default(False)]
+            return ()
+        return (
+            GuardCheck(
+                condition=KeypairConditions.by_is_default(False),
+                error=KeyPairForbidden(
+                    "Cannot deactivate the default access key. Switch the default access key first."
+                ),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/project/updaters.py
+++ b/src/ai/backend/manager/models/project/updaters.py
@@ -12,11 +12,14 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.project.types import ProjectData, ProjectStatus, ProjectType
-from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.errors.resource import (
+    PersonalProjectDeletionError,
+    ProjectPurgeInProgress,
+)
 from ai.backend.manager.models.condition_utils import negate_conditions
 from ai.backend.manager.models.project.conditions import ProjectConditions
 from ai.backend.manager.models.project.row import ProjectRow
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -57,8 +60,13 @@ class ProjectUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
         return self.project_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [ProjectConditions.not_being_purged()]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=ProjectConditions.not_being_purged(),
+                error=ProjectPurgeInProgress(f"Project is being purged: {self.project_id}"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -141,11 +149,21 @@ class ProjectSoftDeleteUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
         return self.project_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [
-            ProjectConditions.not_being_purged(),
-            negate_conditions([ProjectConditions.by_type_equals(ProjectType.PERSONAL)]),
-        ]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=ProjectConditions.not_being_purged(),
+                error=ProjectPurgeInProgress(f"Project is being purged: {self.project_id}"),
+            ),
+            GuardCheck(
+                condition=negate_conditions([
+                    ProjectConditions.by_type_equals(ProjectType.PERSONAL)
+                ]),
+                error=PersonalProjectDeletionError(
+                    f"Project {self.project_id} is a personal project."
+                ),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -182,8 +200,13 @@ class ProjectRestoreUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
         return self.project_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [ProjectConditions.not_being_purged()]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=ProjectConditions.not_being_purged(),
+                error=ProjectPurgeInProgress(f"Project is being purged: {self.project_id}"),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/rbac_models/role/purgers.py
+++ b/src/ai/backend/manager/models/rbac_models/role/purgers.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.role import RoleID
@@ -12,13 +11,14 @@ from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.data.permission.role import RoleData
 from ai.backend.manager.data.permission.types import RoleSource
 from ai.backend.manager.errors.role_preset import SystemRoleNotEditable
+from ai.backend.manager.models.rbac_models.role.conditions import RoleConditions
 from ai.backend.manager.models.rbac_models.role.row import RoleRow
-from ai.backend.manager.models.specs.purger import EntityPurger
-from ai.backend.manager.models.specs.types import ConflictCheck
+from ai.backend.manager.models.specs.purger import GuardedEntityPurger
+from ai.backend.manager.models.specs.types import ConflictCheck, GuardCheck
 
 
 @dataclass
-class RolePurger(EntityPurger[RoleRow, RoleData]):
+class RolePurger(GuardedEntityPurger[RoleRow, RoleData]):
     """Purger for a role. Its permission rows and assignments follow by FK cascade.
 
     Declines a SYSTEM role: its declaration belongs to the role preset.
@@ -39,15 +39,17 @@ class RolePurger(EntityPurger[RoleRow, RoleData]):
         return self.role_id
 
     @override
-    def conflict_checks(self) -> Sequence[ConflictCheck]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         return (
-            ConflictCheck(
-                condition=lambda: sa.and_(
-                    RoleRow.id == self.role_id, RoleRow.source == RoleSource.SYSTEM
-                ),
+            GuardCheck(
+                condition=RoleConditions.by_source_equals(RoleSource.CUSTOM),
                 error=SystemRoleNotEditable(f"Role {self.role_id} is a SYSTEM role."),
             ),
         )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
+        return ()
 
     @override
     def to_data(self, row: RoleRow) -> RoleData:

--- a/src/ai/backend/manager/models/rbac_models/role/updaters.py
+++ b/src/ai/backend/manager/models/rbac_models/role/updaters.py
@@ -18,10 +18,10 @@ from ai.backend.common.data.entity.role import RoleID
 from ai.backend.manager.data.permission.role import RoleData
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import RoleSource
-from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.errors.role_preset import SystemRoleNotEditable
 from ai.backend.manager.models.rbac_models.role.conditions import RoleConditions
 from ai.backend.manager.models.rbac_models.role.row import RoleRow
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.types import OptionalState, TriState
 
@@ -52,8 +52,13 @@ class RoleUpdater(GuardedDataUpdater[RoleRow, RoleData]):
         return self.role_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [RoleConditions.by_source_equals(RoleSource.CUSTOM)]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=RoleConditions.by_source_equals(RoleSource.CUSTOM),
+                error=SystemRoleNotEditable(f"Role {self.role_id} is a SYSTEM role."),
+            ),
+        )
 
     @property
     @override
@@ -96,8 +101,13 @@ class RoleSoftDeleteUpdater(GuardedDataUpdater[RoleRow, RoleData]):
         return self.role_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [RoleConditions.by_source_equals(RoleSource.CUSTOM)]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=RoleConditions.by_source_equals(RoleSource.CUSTOM),
+                error=SystemRoleNotEditable(f"Role {self.role_id} is a SYSTEM role."),
+            ),
+        )
 
     @property
     @override

--- a/src/ai/backend/manager/models/specs/AGENTS.md
+++ b/src/ai/backend/manager/models/specs/AGENTS.md
@@ -42,14 +42,30 @@ and is read through an entity's permission like a field, while belonging to neit
 
 | Operation | Roots | Why |
 |---|---|---|
-| creator | `GlobalEntityCreator` / `EntityCreator` / `RoleManagedGlobalEntityCreator` / `RoleManagedEntityCreator` / `FieldCreator` / `SidecarCreator` | only a create settles what a row belongs to |
-| purger | `EntityPurger` / `EntityBatchPurger` / `FieldPurger` / `GuardedFieldPurger` / `FieldBatchPurger` | removing an entity removes what it left in the graph; a field row splits further on how it is picked: by id, or by id behind a precondition; the batch roots pick by subquery instead of by id |
-| updater | `DataUpdater` / `GuardedDataUpdater` | an update never changes what a row belongs to, so the roots split on how the row is picked: by id, or by id behind a precondition |
+| creator | `GlobalEntityCreator` / `GuardedEntityCreator` / `RoleManagedGlobalEntityCreator` / `RoleManagedEntityCreator` / `FieldCreator` / `SidecarCreator` | only a create settles what a row belongs to |
+| purger | `GuardedEntityPurger` / `EntityBatchPurger` / `GuardedFieldPurger` / `FieldBatchPurger` | removing an entity removes what it left in the graph; the batch roots pick by subquery instead of by id |
+| updater | `GuardedDataUpdater` / `DataBatchUpdater` | an update never changes what a row belongs to, so the roots split on how the row is picked: by id, or by conditions |
 
 The roots are deliberately unrelated. Do NOT extract a common base across them
 or type any function against "any creator/purger" — the absence of a common supertype
 is the enforcement. Reuse execution logic through ops-layer helpers that take plain
 values (`row_class`, `pk_value`, ...).
+
+## A single-row write carries its guard on the root
+
+- `GuardedEntityCreator.precondition_checks()`, `GuardedDataUpdater.guard_checks()`,
+  `GuardedEntityPurger.guard_checks()` and `GuardedFieldPurger.guard_checks()` are
+  abstract on the root. `EntityCreator`, `DataUpdater`, `EntityPurger` and `FieldPurger`
+  answer an empty list under `@final`; a spec that refuses inherits the guarded root
+  directly.
+- A `GuardCheck` is a condition on the row already named, paired with the error to
+  raise when it fails. It rides on the UPDATE / DELETE statement; ops tells a missing
+  row (`EntityNotFoundError`) from a refusing one (the first failing check's error)
+  with one read of that row after the statement touched nothing.
+- A `PreconditionCheck` names rows elsewhere whose presence turns a create away; a
+  `ConflictCheck` names rows a purge must not leave behind. Neither is a guard.
+- Do NOT translate a refusal in the caller. The error a guard answers is declared on
+  the spec, and the repository has no `None` to branch on for it.
 
 ## An entity answers its own id
 

--- a/src/ai/backend/manager/models/specs/KNOWLEDGE.md
+++ b/src/ai/backend/manager/models/specs/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 ---
 name: write-spec-design
 type: design-rationale
-description: write-spec selection criteria (Entity/Global/Field/Sidecar/Relation), why a row two entities own belongs to neither position, why switching a relation off keeps both reads, why the roots share no common ABC, what a sidecar row is and why it belongs to neither position, why the role-managed root is not an EntityCreator subtype, why a global entity is provisioned in the graph, how a field row's owner is read, the two graph relations (own, govern), how created_in combines them, relation and cap-based sharing, open entity-type strings
+description: write-spec selection criteria (Entity/Global/Field/Sidecar/Relation), why a row two entities own belongs to neither position, why switching a relation off keeps both reads, why the roots share no common ABC, why a guard lives on the root and how ops diagnoses a refusal, what a sidecar row is and why it belongs to neither position, why the role-managed root is not an EntityCreator subtype, why a global entity is provisioned in the graph, how a field row's owner is read, the two graph relations (own, govern), how created_in combines them, relation and cap-based sharing, open entity-type strings
 scope: src/ai/backend/manager/models/specs
-keywords: [RelationCreator, RelationPurger, RelationLifecycleUpdater, EntityCreator, GlobalEntityCreator, FieldCreator, RoleManagedEntityCreator, SidecarCreator, FieldOwnerLookup, RoleTemplateSource, created_in, create_relation, entity_id, virtual-entity, preset-role, DataUpdater, soft-delete]
+keywords: [RelationCreator, RelationPurger, RelationLifecycleUpdater, EntityCreator, GlobalEntityCreator, FieldCreator, RoleManagedEntityCreator, SidecarCreator, FieldOwnerLookup, RoleTemplateSource, created_in, create_relation, entity_id, virtual-entity, preset-role, DataUpdater, GuardCheck, guard_checks, soft-delete]
 sources:
   - src/ai/backend/manager/models/specs/creator.py
   - src/ai/backend/manager/models/specs/lookup.py
@@ -78,6 +78,28 @@ execution path.
 - Duplicating method declarations across roots is the price of making that path
   inexpressible.
 - Execution-logic reuse happens via ops helpers that take plain values.
+
+## The guard lives on the root so no path can skip it
+
+- A creator, an updater and a single-row purger each have a root that declares its
+  guard as abstract and one subtype that answers an empty list under `@final`. One ops
+  path serves both, so a spec with a guard cannot be handed to a path that would write
+  without it — the shape enforces it, as the absent common ABC does elsewhere.
+- Two unrelated roots instead (`DataUpdater` beside `GuardedDataUpdater`, as it once
+  was) doubled the ops, service, action and group surfaces and left the refusal
+  generic: the write answered `None`, the caller re-read the row
+  to tell a missing one from a refusing one, and each caller invented its own error.
+- With the error on the check, the diagnosis moves into ops: after a statement
+  touched nothing, one SELECT of the named row evaluates every guard condition beside
+  it. No row means gone; the first `false` names the error. A row every guard now
+  passes changed between the two statements, and the first guard answers for it — the
+  write did refuse, and re-running it would be a second write the caller did not ask
+  for.
+- Failure stays at one round trip, which is what `row_exists` cost before. A spec whose
+  `guard_checks()` is empty pays nothing: the diagnosis runs only when there is a
+  guard to blame.
+- `RolePurger` states its SYSTEM refusal as a guard rather than a conflict check: the
+  condition is on the row being removed, not on rows it would leave behind.
 
 ## The role-managed root not being a subtype is the same mechanism
 

--- a/src/ai/backend/manager/models/specs/purger.py
+++ b/src/ai/backend/manager/models/specs/purger.py
@@ -1,14 +1,16 @@
 """Delete specs of the v2 lineage.
 
-The roots below are deliberately unrelated — no common ABC. See AGENTS.md
-in this package before typing anything against more than one of them.
+The roots below are deliberately unrelated — no common ABC — with one exception per
+single-row root: it carries its guard, and the spec that has none says so once rather
+than every spec repeating it. See AGENTS.md in this package before typing anything
+against more than one of them.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, final, override
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -16,15 +18,19 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.types import EntityIdentifier, FieldData
 from ai.backend.manager.models.base import Base
-from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.specs.types import ConflictCheck
+from ai.backend.manager.models.specs.types import ConflictCheck, GuardCheck
 
 
-class EntityPurger[TRow: Base, TData](ABC):
+class GuardedEntityPurger[TRow: Base, TData](ABC):
     """Delete spec of one entity named by id.
 
     Removing the row removes what it left in the RBAC graph. Declared separately from
     ``pk_value()`` because a primary key is not always the entity id.
+
+    The id names exactly one row. A guard is a precondition on that row's current
+    values, carried in the statement so the read and the delete cannot part ways. The
+    root every entity purger shares, so one ops path serves both; a spec with no guard
+    answers an empty list once via :class:`EntityPurger`.
     """
 
     @abstractmethod
@@ -42,30 +48,12 @@ class EntityPurger[TRow: Base, TData](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def conflict_checks(self) -> Sequence[ConflictCheck]:
-        raise NotImplementedError
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        """The conditions the named row must satisfy, each with the error it answers.
 
-    @abstractmethod
-    def to_data(self, row: TRow) -> TData:
-        raise NotImplementedError
-
-
-class FieldPurger[TRow: Base, TData: FieldData](ABC):
-    """Delete spec of a field row — authorized through its owner, like an update
-    to the owning entity; no scope to tear down."""
-
-    @abstractmethod
-    def row_class(self) -> type[TRow]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def target_id_column(self) -> InstrumentedAttribute[Any]:
-        """Return the column carrying the field id, which the delete keys on."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def target_id_value(self) -> UUID:
-        """Return the id of the field row to delete."""
+        They narrow nothing: the row is already named. A row failing one is left alone
+        and the first failing check's error is raised.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -75,14 +63,27 @@ class FieldPurger[TRow: Base, TData: FieldData](ABC):
     @abstractmethod
     def to_data(self, row: TRow) -> TData:
         raise NotImplementedError
+
+
+class EntityPurger[TRow: Base, TData](GuardedEntityPurger[TRow, TData], ABC):
+    """Delete spec of an entity nothing about its own state can refuse.
+
+    Everything :class:`GuardedEntityPurger` describes, with no guards. A spec that
+    needs one inherits the guarded root directly rather than answering here.
+    """
+
+    @final
+    @override
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return ()
 
 
 class GuardedFieldPurger[TRow: Base, TData: FieldData](ABC):
-    """Delete spec of a field row that declines to delete unless its guard holds.
+    """Delete spec of a field row — authorized through its owner, like an update
+    to the owning entity; no scope to tear down.
 
-    The id still names exactly one row. The guard is a precondition on that row's
-    current values, carried in the statement so the read and the delete cannot part
-    ways.
+    Carries its guard as :class:`GuardedEntityPurger` does; a spec with none answers
+    an empty list once via :class:`FieldPurger`.
     """
 
     @abstractmethod
@@ -100,12 +101,8 @@ class GuardedFieldPurger[TRow: Base, TData: FieldData](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def guard_conditions(self) -> list[QueryCondition]:
-        """Return the preconditions the row must satisfy (AND combined).
-
-        They narrow nothing: the row is already named. A row failing them is left
-        alone and the operation reports that it removed nothing.
-        """
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        """The conditions the named row must satisfy, each with the error it answers."""
         raise NotImplementedError
 
     @abstractmethod
@@ -115,6 +112,15 @@ class GuardedFieldPurger[TRow: Base, TData: FieldData](ABC):
     @abstractmethod
     def to_data(self, row: TRow) -> TData:
         raise NotImplementedError
+
+
+class FieldPurger[TRow: Base, TData: FieldData](GuardedFieldPurger[TRow, TData], ABC):
+    """Delete spec of a field row nothing about its own state can refuse."""
+
+    @final
+    @override
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return ()
 
 
 class FieldBatchPurger[TOwnerID: EntityIdentifier, TRow: Base, TData](ABC):
@@ -144,7 +150,7 @@ class FieldBatchPurger[TOwnerID: EntityIdentifier, TRow: Base, TData](ABC):
 
 class EntityBatchPurger[TRow: Base, TData](ABC):
     """Delete spec for every entity row a subquery selects; each row's RBAC graph goes
-    with it, as :class:`EntityPurger` does for one.
+    with it, as :class:`GuardedEntityPurger` does for one.
 
     Deliberately NOT a :class:`FieldBatchPurger` subtype — the hooks are duplicated
     instead — so an entity spec cannot flow through the field path and leave its virtual

--- a/src/ai/backend/manager/models/specs/types.py
+++ b/src/ai/backend/manager/models/specs/types.py
@@ -33,6 +33,22 @@ class ConflictCheck:
 
 
 @dataclass(frozen=True)
+class GuardCheck:
+    """A condition the named row must satisfy for an updater or a purger to write it.
+
+    Rides on the statement, so no read stands between the check and the write. A row
+    failing it is left alone and the write answers with the error declared here.
+    Unlike :class:`ConflictCheck`, this names the row already picked, not other rows.
+    """
+
+    condition: QueryCondition
+    """Condition on the named row (e.g., lambda: RoleRow.source == RoleSource.CUSTOM)."""
+
+    error: BackendAIError
+    """The error to raise when the row does not satisfy the condition."""
+
+
+@dataclass(frozen=True)
 class PreconditionCheck:
     """A state elsewhere that forbids the write, declared beside the spec that makes it.
 
@@ -42,9 +58,9 @@ class PreconditionCheck:
     impossible. What to look for is declared here and run by the ops that writes, so
     the spec stays a value.
 
-    Unlike the guard conditions an updater or a purger carries, this is not a condition
-    the named row must satisfy: it names rows whose presence turns the write away, and
-    failing it raises rather than writing nothing.
+    Unlike the :class:`GuardCheck` an updater or a purger carries, this is not a
+    condition the named row must satisfy: it names rows whose presence turns the write
+    away.
     """
 
     finder: sa.Select[Any]

--- a/src/ai/backend/manager/models/specs/updater.py
+++ b/src/ai/backend/manager/models/specs/updater.py
@@ -1,26 +1,34 @@
 """Update specs of the v2 lineage.
 
 Updates carry no membership work, so the roots differ only in how they pick what to
-write: by id, by id behind a guard, or by conditions.
+write: by id, or by conditions. The single-row root carries its guard, and the one
+that has none says so once rather than every spec repeating it.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, final, override
 from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 
 
-class DataUpdater[TRow: Base, TData](ABC):
-    """Update spec for one row: the target row, the values to set, and how the
-    updated row becomes data."""
+class GuardedDataUpdater[TRow: Base, TData](ABC):
+    """Update spec for one row: the target row, the values to set, the guards the row
+    must satisfy, and how the updated row becomes data.
+
+    The id names exactly one row — this is not a condition-selected write. A guard is a
+    precondition on that row's current values, carried in the statement so the read and
+    the write cannot part ways. The root every single-row updater shares, so one ops
+    path serves both and a spec carrying guards cannot reach a path that would skip
+    them; a spec with none answers an empty list once via :class:`DataUpdater`.
+    """
 
     @property
     @abstractmethod
@@ -45,52 +53,11 @@ class DataUpdater[TRow: Base, TData](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def build_values(self) -> dict[str, Any]:
-        """Build the column-to-value mapping to set."""
-        raise NotImplementedError
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        """The conditions the named row must satisfy, each with the error it answers.
 
-    @property
-    @abstractmethod
-    def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
-        """Return integrity error checks for declarative error matching."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def to_data(self, row: TRow) -> TData:
-        """Convert the updated row into its ``data/`` type."""
-        raise NotImplementedError
-
-
-class GuardedDataUpdater[TRow: Base, TData](ABC):
-    """Update spec for one row that declines to write unless its guard holds.
-
-    The id still names exactly one row — this is not a condition-selected write. The
-    guard is a precondition on that row's current values, carried in the statement so
-    the read and the write cannot part ways.
-    """
-
-    @property
-    @abstractmethod
-    def row_class(self) -> type[TRow]:
-        """Return the ORM class for table access and PK detection."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def target_id_column(self) -> InstrumentedAttribute[Any]:
-        """Return the column that carries the id the row is written by."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def target_id_value(self) -> UUID:
-        """Return the id of the row to write."""
-        raise NotImplementedError
-
-    @abstractmethod
-    def guard_conditions(self) -> list[QueryCondition]:
-        """Return the preconditions the row must satisfy (AND combined).
-
-        They narrow nothing: the row is already named. A row failing them is left
-        alone and the operation reports that it wrote nothing.
+        They narrow nothing: the row is already named. A row failing one is left alone
+        and the first failing check's error is raised.
         """
         raise NotImplementedError
 
@@ -109,6 +76,20 @@ class GuardedDataUpdater[TRow: Base, TData](ABC):
     def to_data(self, row: TRow) -> TData:
         """Convert the updated row into its ``data/`` type."""
         raise NotImplementedError
+
+
+class DataUpdater[TRow: Base, TData](GuardedDataUpdater[TRow, TData], ABC):
+    """Update spec of a row nothing about its own state can refuse.
+
+    Everything :class:`GuardedDataUpdater` describes, with no guards: a row that is
+    there is written. A spec that needs a guard inherits the guarded root directly
+    rather than answering here.
+    """
+
+    @final
+    @override
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return ()
 
 
 class DataBatchUpdater[TRow: Base, TData](ABC):

--- a/src/ai/backend/manager/models/vfolder/updaters.py
+++ b/src/ai/backend/manager/models/vfolder/updaters.py
@@ -17,9 +17,9 @@ from ai.backend.manager.data.vfolder.types import (
     VFolderOperationStatus,
     VFolderPermissionData,
 )
-from ai.backend.manager.models.clauses import QueryCondition
+from ai.backend.manager.errors.storage import VFolderDeletionNotAllowed, VFolderFilterStatusFailed
 from ai.backend.manager.models.session import DEAD_SESSION_STATUSES, SessionRow
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
 from ai.backend.manager.models.vfolder.conditions import VFolderConditions
 from ai.backend.manager.models.vfolder.row import VFolderPermissionRow, VFolderRow
@@ -52,8 +52,13 @@ class VFolderAttributeUpdater(GuardedDataUpdater[VFolderRow, VFolderData]):
         return self.vfolder_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [VFolderConditions.not_being_purged()]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=VFolderConditions.not_being_purged(),
+                error=VFolderFilterStatusFailed(f"VFolder is being purged: {self.vfolder_id}"),
+            ),
+        )
 
     @property
     @override
@@ -169,7 +174,7 @@ class VFolderTrashUpdater(GuardedDataUpdater[VFolderRow, VFolderData]):
         return self.vfolder_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
+    def guard_checks(self) -> Sequence[GuardCheck]:
         def not_mounted() -> sa.sql.expression.ColumnElement[bool]:
             return sa.not_(
                 sa.exists(
@@ -182,7 +187,19 @@ class VFolderTrashUpdater(GuardedDataUpdater[VFolderRow, VFolderData]):
                 )
             )
 
-        return [VFolderConditions.not_being_purged(), not_mounted]
+        return (
+            GuardCheck(
+                condition=VFolderConditions.not_being_purged(),
+                error=VFolderFilterStatusFailed(f"VFolder is being purged: {self.vfolder_id}"),
+            ),
+            GuardCheck(
+                condition=not_mounted,
+                error=VFolderDeletionNotAllowed(
+                    "Cannot delete the vfolder. "
+                    f"The vfolder(id: {self.vfolder_id}) is mounted on a running session."
+                ),
+            ),
+        )
 
     @property
     @override

--- a/src/ai/backend/manager/repositories/agent/repository.py
+++ b/src/ai/backend/manager/repositories/agent/repository.py
@@ -183,10 +183,10 @@ class AgentRepository:
 
     @agent_repository_resilience.apply()
     async def mark_agent_exit(self, updater: AgentExitStatusUpdater) -> AgentId | None:
-        """Record the agent's exit, returning it when the write landed and ``None``
-        when the agent was already terminal."""
+        """Record the agent's exit; ``None`` when the agent is gone, and the spec's
+        error when it was already terminal."""
         async with self._v2_ops.write_ops() as w:
-            return await w.update_guarded_data(updater)
+            return await w.update_data(updater)
 
     @agent_repository_resilience.apply()
     async def update_agent_status(self, updater: AgentStatusUpdater) -> None:

--- a/src/ai/backend/manager/repositories/artifact/repository.py
+++ b/src/ai/backend/manager/repositories/artifact/repository.py
@@ -90,7 +90,7 @@ class ArtifactRepository:
         Raises ArtifactNotFoundError if the artifact is gone or already deleted.
         """
         async with self._v2_ops.write_ops() as w:
-            data = await w.update_guarded_data(updater)
+            data = await w.update_data(updater)
             if data is None:
                 raise ArtifactNotFoundError(f"Artifact with ID {updater.artifact_id} not found")
             return data

--- a/src/ai/backend/manager/repositories/base/updater.py
+++ b/src/ai/backend/manager/repositories/base/updater.py
@@ -31,7 +31,7 @@ TRow = TypeVar("TRow", bound=Base)
 class UpdaterSpec[TRow: Base](ABC):
     """Abstract base class defining values to update for single-row updates.
 
-    Deprecated: use ``DataUpdater`` / ``GuardedDataUpdater`` in
+    Deprecated: use ``DataUpdater`` in
     ``models/specs/updater.py``.
 
     Implementations specify what to update by providing:

--- a/src/ai/backend/manager/repositories/domain/repository.py
+++ b/src/ai/backend/manager/repositories/domain/repository.py
@@ -12,7 +12,7 @@ from ai.backend.common.resilience.policies.metrics import MetricArgs, MetricPoli
 from ai.backend.common.resilience.policies.retry import BackoffStrategy, RetryArgs, RetryPolicy
 from ai.backend.common.resilience.resilience import Resilience
 from ai.backend.manager.data.domain.types import DomainData
-from ai.backend.manager.errors.resource import DomainDeletionFailed, DomainPurgeInProgress
+from ai.backend.manager.errors.resource import DomainDeletionFailed
 from ai.backend.manager.models.domain.creators import DomainCreator
 from ai.backend.manager.models.domain.purgers import DomainKernelPurger, DomainPurger
 from ai.backend.manager.models.domain.updaters import DomainDotfilesUpdater, DomainUpdater
@@ -109,14 +109,10 @@ class DomainRepository:
                         ),
                     )
         async with self._v2_ops.write_ops() as w:
-            data = await w.update_guarded_data(updater)
-            if data is not None:
-                return data
-            if await w.row_exists(
-                updater.row_class, updater.target_id_column(), updater.target_id_value()
-            ):
-                raise DomainPurgeInProgress(f"Domain is being purged: {updater.target_id_value()}")
-            raise DomainNotFound(f"Domain not found: {updater.target_id_value()}")
+            data = await w.update_data(updater)
+            if data is None:
+                raise DomainNotFound(f"Domain not found: {updater.target_id_value()}")
+            return data
 
     @domain_repository_resilience.apply()
     async def update_dotfiles(self, updater: DomainDotfilesUpdater) -> DomainData:

--- a/src/ai/backend/manager/repositories/entity_share/repository.py
+++ b/src/ai/backend/manager/repositories/entity_share/repository.py
@@ -65,7 +65,7 @@ class EntityShareRepository:
     ) -> EntityShareData:
         """Turn down what was offered, lending nothing."""
         async with self._ops.write_ops() as w:
-            data = await w.update_guarded_data(
+            data = await w.update_data(
                 EntityShareRejectUpdater(share_id=share_id, answering_scope=answering_scope)
             )
             if data is None:
@@ -95,7 +95,7 @@ class EntityShareRepository:
     async def cancel(self, share_id: EntityShareID) -> EntityShareData:
         """Withdraw the offer before it was answered."""
         async with self._ops.write_ops() as w:
-            data = await w.update_guarded_data(EntityShareCancelUpdater(share_id=share_id))
+            data = await w.update_data(EntityShareCancelUpdater(share_id=share_id))
             if data is None:
                 raise EntityShareNotFound(f"No open offer {share_id} to cancel")
             return data

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -17,7 +17,7 @@ from ai.backend.common.data.entity.types import (
     RuntimeEntityID,
 )
 from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
-from ai.backend.manager.errors.repository import EntityNotFoundError, EntityWriteRefusedError
+from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.models.specs.creator import (
     DanglingFieldCreator,
@@ -39,8 +39,8 @@ from ai.backend.manager.models.specs.lookup import (
 )
 from ai.backend.manager.models.specs.purger import (
     EntityBatchPurger,
-    EntityPurger,
-    FieldPurger,
+    GuardedEntityPurger,
+    GuardedFieldPurger,
 )
 from ai.backend.manager.models.specs.querier import (
     BulkEntityQuerier,
@@ -50,11 +50,7 @@ from ai.backend.manager.models.specs.querier import (
 )
 from ai.backend.manager.models.specs.searcher import Searcher, SearcherResult
 from ai.backend.manager.models.specs.types import BulkResultWithFailures, EntityWithFieldsResult
-from ai.backend.manager.models.specs.updater import (
-    DataBatchUpdater,
-    DataUpdater,
-    GuardedDataUpdater,
-)
+from ai.backend.manager.models.specs.updater import DataBatchUpdater, GuardedDataUpdater
 from ai.backend.manager.models.specs.upserter import (
     EntityUpserter,
     FieldUpserter,
@@ -372,8 +368,12 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             return await w.atomic_create_dangling_fields_with_nested(creators, field_creators)
 
-    async def purge_entity(self, purger: EntityPurger[Any, TData]) -> TData:
-        """Hard-delete one entity row, tearing its scope down with it."""
+    async def purge_entity(self, purger: GuardedEntityPurger[Any, TData]) -> TData:
+        """Hard-delete one entity row, tearing its scope down with it.
+
+        A row the spec's guard refuses raises the guard's own error; a missing row
+        raises :class:`EntityNotFoundError`.
+        """
         async with self._ops.write_ops() as w:
             data = await w.purge_entity(purger)
             if data is None:
@@ -383,9 +383,10 @@ class OpsRepository[TData]:
             return data
 
     async def purge_field_entity[TFieldData: FieldData](
-        self, purger: FieldPurger[Any, TFieldData]
+        self, purger: GuardedFieldPurger[Any, TFieldData]
     ) -> TFieldData:
-        """Hard-delete one field row; authorized through the owner, no membership work."""
+        """Hard-delete one field row; authorized through the owner, no membership work.
+        Refused and missing rows answer as :meth:`purge_entity` does."""
         async with self._ops.write_ops() as w:
             data = await w.purge_field_entity(purger)
             if data is None:
@@ -395,14 +396,14 @@ class OpsRepository[TData]:
             return data
 
     async def partial_bulk_purge_entities(
-        self, purgers: Mapping[EntityIdentifier, EntityPurger[Any, TData]]
+        self, purgers: Mapping[EntityIdentifier, GuardedEntityPurger[Any, TData]]
     ) -> BulkResultWithFailures[TData]:
         """Hard-delete each named entity independently, answering for every one."""
         async with self._ops.write_ops() as w:
             return await w.partial_bulk_purge_entities(purgers)
 
     async def partial_bulk_purge_field_entities[TFieldData: FieldData](
-        self, purgers: Mapping[FieldIdentifier, FieldPurger[Any, TFieldData]]
+        self, purgers: Mapping[FieldIdentifier, GuardedFieldPurger[Any, TFieldData]]
     ) -> BulkFieldOpsResult[TFieldData]:
         """Hard-delete each named field row independently; authorized through the owner."""
         async with self._ops.write_ops() as w:
@@ -438,7 +439,12 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             return await w.upsert_field_entity(owner_id, upserter)
 
-    async def update(self, updater: DataUpdater[Any, TData]) -> TData:
+    async def update(self, updater: GuardedDataUpdater[Any, TData]) -> TData:
+        """Apply the update, telling a missing row from a refused one.
+
+        The guards ride on the UPDATE; a row that refused answers with the error its
+        spec declared, and a row that is gone with :class:`EntityNotFoundError`.
+        """
         async with self._ops.write_ops() as w:
             data = await w.update_data(updater)
             if data is None:
@@ -447,25 +453,8 @@ class OpsRepository[TData]:
                 )
             return data
 
-    async def update_guarded(self, updater: GuardedDataUpdater[Any, TData]) -> TData:
-        """Apply a guarded update, telling a missing row from a refused one.
-
-        The guard rides on the UPDATE, so the row it declined is read back in the same
-        session rather than re-checked against a later state.
-        """
-        async with self._ops.write_ops() as w:
-            data = await w.update_guarded_data(updater)
-            if data is not None:
-                return data
-            row_name = f"{updater.row_class.__name__} {updater.target_id_value()}"
-            if await w.row_exists(
-                updater.row_class, updater.target_id_column(), updater.target_id_value()
-            ):
-                raise EntityWriteRefusedError(f"{row_name} refused the write")
-            raise EntityNotFoundError(f"{row_name} not found")
-
     async def partial_bulk_update(
-        self, updaters: Mapping[EntityIdentifier, DataUpdater[Any, TData]]
+        self, updaters: Mapping[EntityIdentifier, GuardedDataUpdater[Any, TData]]
     ) -> BulkResultWithFailures[TData]:
         """Update each named entity independently, answering for every one of them.
 

--- a/src/ai/backend/manager/repositories/ops/v2/artifact_registry/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/artifact_registry/write.py
@@ -17,8 +17,8 @@ from ai.backend.manager.models.artifact_registries.row import ArtifactRegistryRo
 from ai.backend.manager.models.artifact_registries.updaters import ArtifactRegistryMetaUpdater
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.creator import GlobalEntityCreator
-from ai.backend.manager.models.specs.purger import EntityPurger
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.purger import GuardedEntityPurger
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
 
 
@@ -41,7 +41,7 @@ class ArtifactRegistryWriteOps(V2WriteOps):
 
     async def update_registry[TRow: Base, TData](
         self,
-        updater: DataUpdater[TRow, TData],
+        updater: GuardedDataUpdater[TRow, TData],
         meta_updater: ArtifactRegistryMetaUpdater,
     ) -> TData | None:
         """Edit a registry and its name; ``None`` if the registry is gone."""
@@ -49,6 +49,7 @@ class ArtifactRegistryWriteOps(V2WriteOps):
             updater.row_class,
             updater.target_id_column(),
             updater.target_id_value(),
+            updater.guard_checks(),
             updater.build_values(),
             updater.integrity_error_checks,
         )
@@ -58,6 +59,7 @@ class ArtifactRegistryWriteOps(V2WriteOps):
             meta_updater.row_class,
             meta_updater.target_id_column(),
             meta_updater.target_id_value(),
+            meta_updater.guard_checks(),
             meta_updater.build_values(),
             meta_updater.integrity_error_checks,
         )
@@ -65,7 +67,7 @@ class ArtifactRegistryWriteOps(V2WriteOps):
         return updater.to_data(row)
 
     async def purge_registry[TRow: Base, TData](
-        self, purger: EntityPurger[TRow, TData]
+        self, purger: GuardedEntityPurger[TRow, TData]
     ) -> TData | None:
         """Delete a registry, the row naming it, and the graph node it was."""
         await self._sess.execute(

--- a/src/ai/backend/manager/repositories/ops/v2/entity_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/entity_write.py
@@ -59,7 +59,7 @@ from ai.backend.manager.models.specs.creator import (
     RoleManagedEntityCreator,
     RoleManagedGlobalEntityCreator,
 )
-from ai.backend.manager.models.specs.purger import EntityPurger
+from ai.backend.manager.models.specs.purger import GuardedEntityPurger
 from ai.backend.manager.models.specs.types import BulkResultWithFailures
 from ai.backend.manager.models.specs.upserter import EntityUpserter
 from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
@@ -199,12 +199,14 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
         return [creator.to_data(row) for creator, row in zip(creators, rows, strict=True)]
 
     async def purge_entity[TRow: Base, TData](
-        self, purger: EntityPurger[TRow, TData]
+        self, purger: GuardedEntityPurger[TRow, TData]
     ) -> TData | None:
-        """Delete one entity row and the RBAC graph it left; ``None`` if already gone."""
+        """Delete the entity row the id names while its guards hold, and the RBAC
+        graph it left; ``None`` if already gone, the failing guard's error if it
+        refused."""
         await self._validate_conflict_checks(purger.conflict_checks())
         row = await self._delete_row_returning(
-            purger.row_class(), purger.target_id_column(), purger.entity_id()
+            purger.row_class(), purger.target_id_column(), purger.entity_id(), purger.guard_checks()
         )
         if row is None:
             return None
@@ -212,7 +214,7 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
         return purger.to_data(row)
 
     async def partial_bulk_purge_entities[TRow: Base, TData](
-        self, purgers: Mapping[EntityIdentifier, EntityPurger[TRow, TData]]
+        self, purgers: Mapping[EntityIdentifier, GuardedEntityPurger[TRow, TData]]
     ) -> BulkResultWithFailures[TData]:
         """Delete each named entity independently, a row and its teardown sharing one
         savepoint; a missing row raises :class:`EntityNotFoundError`."""

--- a/src/ai/backend/manager/repositories/ops/v2/field_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/field_write.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-import sqlalchemy as sa
-
 from ai.backend.common.data.entity.types import EntityIdentifier, FieldData, FieldIdentifier
 from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
 from ai.backend.manager.errors.repository import EntityNotFoundError
@@ -19,11 +17,7 @@ from ai.backend.manager.models.specs.creator import (
     NestedFieldCreator,
     NestedFieldToCreate,
 )
-from ai.backend.manager.models.specs.purger import (
-    FieldBatchPurger,
-    FieldPurger,
-    GuardedFieldPurger,
-)
+from ai.backend.manager.models.specs.purger import FieldBatchPurger, GuardedFieldPurger
 from ai.backend.manager.models.specs.upserter import FieldUpserter
 from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
 
@@ -126,46 +120,24 @@ class V2FieldWriteOps(V2WriteOpsBase):
         )
 
     async def purge_field_entity[TRow: Base, TData: FieldData](
-        self, purger: FieldPurger[TRow, TData]
+        self, purger: GuardedFieldPurger[TRow, TData]
     ) -> TData | None:
-        """Delete one field row; ``None`` if already gone. The delete is
+        """Delete the field row the id names while its guards hold; ``None`` if
+        already gone, the failing guard's error if it refused. The delete is
         authorized through the owner."""
         await self._validate_conflict_checks(purger.conflict_checks())
         row = await self._delete_row_returning(
-            purger.row_class(), purger.target_id_column(), purger.target_id_value()
+            purger.row_class(),
+            purger.target_id_column(),
+            purger.target_id_value(),
+            purger.guard_checks(),
         )
         if row is None:
             return None
         return purger.to_data(row)
 
-    async def purge_guarded_field_entity[TRow: Base, TData: FieldData](
-        self, purger: GuardedFieldPurger[TRow, TData]
-    ) -> TData | None:
-        """Delete the field row the id names when its guard holds, returning what was
-        removed; ``None`` when nothing was — the row is gone or the guard refused.
-
-        The guard rides on the statement, so no separate read and no row lock stand
-        between the check and the delete. Callers that must tell the two misses apart
-        read the row themselves.
-        """
-        await self._validate_conflict_checks(purger.conflict_checks())
-        row_class = purger.row_class()
-        table = row_class.__table__
-        stmt = sa.delete(table).where(purger.target_id_column() == purger.target_id_value())
-        for condition in purger.guard_conditions():
-            stmt = stmt.where(condition())
-        returning_stmt = stmt.returning(*table.columns)
-        try:
-            result = await self._sess.execute(sa.select(row_class).from_statement(returning_stmt))
-        except sa.exc.IntegrityError as e:
-            raise self._parse_integrity_error(e) from e
-        row = result.scalar_one_or_none()
-        if row is None:
-            return None
-        return purger.to_data(row)
-
     async def partial_bulk_purge_field_entities[TRow: Base, TData: FieldData](
-        self, purgers: Mapping[FieldIdentifier, FieldPurger[TRow, TData]]
+        self, purgers: Mapping[FieldIdentifier, GuardedFieldPurger[TRow, TData]]
     ) -> BulkFieldOpsResult[TData]:
         """Delete each named field row independently in its own savepoint; a
         missing row is answered with :class:`EntityNotFoundError` rather than

--- a/src/ai/backend/manager/repositories/ops/v2/reconciler/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/reconciler/write.py
@@ -29,7 +29,7 @@ from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.mixins.history import ReconcileHistoryMixin
 from ai.backend.manager.models.specs.creator import FieldCreator, FieldToCreate
-from ai.backend.manager.models.specs.updater import DataBatchUpdater, DataUpdater
+from ai.backend.manager.models.specs.updater import DataBatchUpdater, GuardedDataUpdater
 from ai.backend.manager.repositories.ops.v2.write import V2WriteOps
 
 
@@ -50,7 +50,7 @@ class ReconcileTransition[
     owner_id: TOwnerID
     history_creator: FieldCreator[TOwnerID, THistoryRow, THistoryData]
     match_conditions: Sequence[QueryCondition]
-    status_updater: DataUpdater[TStatusRow, TStatusData] | None = None
+    status_updater: GuardedDataUpdater[TStatusRow, TStatusData] | None = None
 
 
 @dataclass
@@ -85,6 +85,7 @@ class ReconcileWriteOps(V2WriteOps):
                     transition.status_updater.row_class,
                     transition.status_updater.target_id_column(),
                     transition.status_updater.target_id_value(),
+                    transition.status_updater.guard_checks(),
                     transition.status_updater.build_values(),
                     transition.status_updater.integrity_error_checks,
                 )

--- a/src/ai/backend/manager/repositories/ops/v2/share/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/share/write.py
@@ -135,11 +135,11 @@ class V2ShareWriteOps(V2WriteOps, V2CapOps):
         one must not cost the invitee access they already had. An invitation without a
         cap hands over every operation on every field.
         """
-        row = await self._update_guarded_row_returning(
+        row = await self._update_row_returning(
             updater.row_class,
             updater.target_id_column(),
             updater.target_id_value(),
-            updater.guard_conditions(),
+            updater.guard_checks(),
             updater.build_values(),
             updater.integrity_error_checks,
         )
@@ -228,11 +228,11 @@ class V2ShareWriteOps(V2WriteOps, V2CapOps):
         Where it landed is derived from the recipient the row names, the same way
         acceptance derived it.
         """
-        row = await self._update_guarded_row_returning(
+        row = await self._update_row_returning(
             updater.row_class,
             updater.target_id_column(),
             updater.target_id_value(),
-            updater.guard_conditions(),
+            updater.guard_checks(),
             updater.build_values(),
             updater.integrity_error_checks,
         )

--- a/src/ai/backend/manager/repositories/ops/v2/update_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/update_write.py
@@ -1,4 +1,4 @@
-"""Update writes of the v2 ops: single-row, guarded single-row, and bulk updates.
+"""Update writes of the v2 ops: single-row and bulk updates.
 
 Updates never touch scope provisioning; the specs differ only in how the row to
 write is picked.
@@ -7,16 +7,12 @@ write is picked.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
-
-import sqlalchemy as sa
-from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.types import BulkResultWithFailures
-from ai.backend.manager.models.specs.updater import DataUpdater, GuardedDataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.ops.v2.write_base import V2WriteOpsBase
 
 
@@ -24,60 +20,30 @@ class V2UpdateWriteOps(V2WriteOpsBase):
     """Family-neutral update writes, bound to a single session."""
 
     async def update_data[TRow: Base, TData](
-        self, updater: DataUpdater[TRow, TData]
+        self, updater: GuardedDataUpdater[TRow, TData]
     ) -> TData | None:
-        """Update a single row by primary key and return it as its ``data/`` type.
+        """Update the row the id names while its guards hold, returning what was
+        written; ``None`` when the row is gone, the failing guard's error when it
+        refused.
 
-        Updates carry no scope work, so one update spec serves every row.
+        The guards ride on the statement, so no separate read and no row lock stand
+        between the check and the write. Updates carry no scope work, so one update
+        spec serves every row.
         """
         row = await self._update_row_returning(
             updater.row_class,
             updater.target_id_column(),
             updater.target_id_value(),
+            updater.guard_checks(),
             updater.build_values(),
             updater.integrity_error_checks,
         )
         if row is None:
             return None
         return updater.to_data(row)
-
-    async def update_guarded_data[TRow: Base, TData](
-        self, updater: GuardedDataUpdater[TRow, TData]
-    ) -> TData | None:
-        """Update the row the id names when its guard holds, returning what was
-        written; ``None`` when nothing was — the row is gone or the guard refused.
-
-        The guard rides on the statement, so no separate read and no row lock stand
-        between the check and the write. Callers that must tell the two misses apart
-        read the row themselves.
-        """
-        row = await self._update_guarded_row_returning(
-            updater.row_class,
-            updater.target_id_column(),
-            updater.target_id_value(),
-            updater.guard_conditions(),
-            updater.build_values(),
-            updater.integrity_error_checks,
-        )
-        if row is None:
-            return None
-        return updater.to_data(row)
-
-    async def row_exists[TRow: Base](
-        self, row_class: type[TRow], id_column: InstrumentedAttribute[Any], id_value: Any
-    ) -> bool:
-        """Report whether the row the id names is there.
-
-        Reads in the session the write ran in, so a guarded write that touched nothing
-        can tell a missing row from a refusing one without a second transaction.
-        """
-        stmt = (
-            sa.select(sa.literal(1)).select_from(row_class.__table__).where(id_column == id_value)
-        )
-        return (await self._sess.execute(stmt)).first() is not None
 
     async def partial_bulk_update_data[TRow: Base, TData](
-        self, updaters: Mapping[EntityIdentifier, DataUpdater[TRow, TData]]
+        self, updaters: Mapping[EntityIdentifier, GuardedDataUpdater[TRow, TData]]
     ) -> BulkResultWithFailures[TData]:
         """Update each named entity independently in its own savepoint, reporting
         per entity — a missing row is an answer, not a gap."""
@@ -90,6 +56,7 @@ class V2UpdateWriteOps(V2WriteOpsBase):
                         updater.row_class,
                         updater.target_id_column(),
                         updater.target_id_value(),
+                        updater.guard_checks(),
                         updater.build_values(),
                         updater.integrity_error_checks,
                     )

--- a/src/ai/backend/manager/repositories/ops/v2/write_base.py
+++ b/src/ai/backend/manager/repositories/ops/v2/write_base.py
@@ -27,7 +27,7 @@ from ai.backend.manager.errors.repository import (
     UpsertEmptyResultError,
 )
 from ai.backend.manager.models.base import Base
-from ai.backend.manager.models.specs.types import ConflictCheck, IntegrityErrorCheck
+from ai.backend.manager.models.specs.types import ConflictCheck, GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.repositories.ops.v2.base import V2OpsBase
 
 
@@ -177,39 +177,12 @@ class V2WriteOpsBase(V2OpsBase):
         row_class: type[TRow],
         id_column: InstrumentedAttribute[Any],
         id_value: Any,
+        guards: Sequence[GuardCheck],
         values: dict[str, Any],
         checks: Sequence[IntegrityErrorCheck],
     ) -> TRow | None:
-        """Update the row the id names and return it; ``None`` if no row matched.
-
-        With nothing to set, reads the current row instead, so callers can tell
-        "nothing to change" apart from "row not found".
-        """
-        table = row_class.__table__
-        if not values:
-            existing = await self._sess.execute(sa.select(row_class).where(id_column == id_value))
-            return existing.scalar_one_or_none()
-        stmt = (
-            sa.update(table).values(values).where(id_column == id_value).returning(*table.columns)
-        )
-        # from_statement lets SQLAlchemy map the RETURNING columns onto the ORM class.
-        select_stmt = sa.select(row_class).from_statement(stmt)
-        try:
-            result = await self._sess.execute(select_stmt)
-        except sa.exc.IntegrityError as e:
-            self._match_integrity_error(self._parse_integrity_error(e), checks)
-        return result.scalar_one_or_none()
-
-    async def _update_guarded_row_returning[TRow: Base](
-        self,
-        row_class: type[TRow],
-        id_column: InstrumentedAttribute[Any],
-        id_value: Any,
-        guards: Sequence[Callable[[], sa.sql.expression.ColumnElement[bool]]],
-        values: dict[str, Any],
-        checks: Sequence[IntegrityErrorCheck],
-    ) -> TRow | None:
-        """Update the row the id names while its guards hold; ``None`` if none matched.
+        """Update the row the id names while its guards hold and return it; ``None``
+        if the row is gone, the first failing guard's error if it refused.
 
         The guards ride on the statement, so no separate read and no row lock stand
         between the check and the write. With nothing to set, reads the current row
@@ -221,30 +194,72 @@ class V2WriteOpsBase(V2OpsBase):
             return existing.scalar_one_or_none()
         stmt = sa.update(table).values(values).where(id_column == id_value)
         for guard in guards:
-            stmt = stmt.where(guard())
+            stmt = stmt.where(guard.condition())
         # from_statement lets SQLAlchemy map the RETURNING columns onto the ORM class.
         select_stmt = sa.select(row_class).from_statement(stmt.returning(*table.columns))
         try:
             result = await self._sess.execute(select_stmt)
         except sa.exc.IntegrityError as e:
             self._match_integrity_error(self._parse_integrity_error(e), checks)
-        return result.scalar_one_or_none()
+        row = result.scalar_one_or_none()
+        if row is None:
+            await self._raise_failing_guard(row_class, id_column, id_value, guards)
+        return row
+
+    async def _raise_failing_guard(
+        self,
+        row_class: type[Base],
+        id_column: InstrumentedAttribute[Any],
+        id_value: Any,
+        guards: Sequence[GuardCheck],
+    ) -> None:
+        """Tell a missing row from a refusing one after a write touched nothing.
+
+        One read of the named row, evaluating every guard beside it. Returns when the
+        row is gone; raises the first failing guard's error otherwise. A row every guard
+        now passes changed under the write, so the first guard answers for it.
+        """
+        if not guards:
+            return
+        stmt = (
+            sa.select(*[guard.condition().label(f"guard_{i}") for i, guard in enumerate(guards)])
+            .select_from(row_class.__table__)
+            .where(id_column == id_value)
+        )
+        row = (await self._sess.execute(stmt)).mappings().first()
+        if row is None:
+            return
+        for i, guard in enumerate(guards):
+            if not row[f"guard_{i}"]:
+                raise guard.error
+        raise guards[0].error
 
     async def _delete_row_returning[TRow: Base](
-        self, row_class: type[TRow], id_column: InstrumentedAttribute[Any], id_value: Any
+        self,
+        row_class: type[TRow],
+        id_column: InstrumentedAttribute[Any],
+        id_value: Any,
+        guards: Sequence[GuardCheck],
     ) -> TRow | None:
+        """Delete the row the id names while its guards hold and return it; ``None``
+        if the row is gone, the first failing guard's error if it refused."""
         table = row_class.__table__
-        stmt = sa.delete(table).where(id_column == id_value).returning(*table.columns)
+        stmt = sa.delete(table).where(id_column == id_value)
+        for guard in guards:
+            stmt = stmt.where(guard.condition())
         # from_statement lets SQLAlchemy map the RETURNING columns onto the ORM class.
         # Calling the row class instead would go through its __init__, which many rows
         # narrow to the caller-supplied columns — a server-generated one then arrives as
         # an unexpected keyword and the purge fails on rows it can read back perfectly.
-        select_stmt = sa.select(row_class).from_statement(stmt)
+        select_stmt = sa.select(row_class).from_statement(stmt.returning(*table.columns))
         try:
             result = await self._sess.execute(select_stmt)
         except sa.exc.IntegrityError as e:
             raise self._parse_integrity_error(e) from e
-        return result.scalar_one_or_none()
+        row = result.scalar_one_or_none()
+        if row is None:
+            await self._raise_failing_guard(row_class, id_column, id_value, guards)
+        return row
 
     async def _upsert_row_returning[TRow: Base](
         self,

--- a/src/ai/backend/manager/repositories/project/repository.py
+++ b/src/ai/backend/manager/repositories/project/repository.py
@@ -24,7 +24,6 @@ from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.errors.resource import (
     InvalidUserUpdateMode,
     ProjectNotFound,
-    ProjectPurgeInProgress,
 )
 from ai.backend.manager.models.kernel import KernelRow
 from ai.backend.manager.models.project.updaters import ProjectDotfilesUpdater, ProjectUpdater
@@ -87,14 +86,7 @@ class ProjectRepository:
                 project_id, user_update_mode, [UserID(uid) for uid in user_uuids]
             )
         async with self._v2_ops.write_ops() as w:
-            data = await w.update_guarded_data(updater)
-            if data is None and await w.row_exists(
-                updater.row_class, updater.target_id_column(), updater.target_id_value()
-            ):
-                raise ProjectPurgeInProgress(
-                    f"Project is being purged: {updater.target_id_value()}"
-                )
-            return data
+            return await w.update_data(updater)
 
     @project_repository_resilience.apply()
     async def update_dotfiles(self, updater: ProjectDotfilesUpdater) -> ProjectData:

--- a/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/replica_group/db_source/db_source.py
@@ -43,7 +43,7 @@ from ai.backend.manager.models.routing.updaters import ReplicaBatchUpdater
 from ai.backend.manager.models.session_group.creators import SessionGroupCreator
 from ai.backend.manager.models.specs.creator import FieldToCreate
 from ai.backend.manager.models.specs.pagination import NoPagination
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.ops.v2.reconciler.write import ReconcileTransition
 from ai.backend.manager.repositories.ops.v2.replica_group.provider import ReplicaGroupOpsProvider
 from ai.backend.manager.repositories.ops.v2.replica_group.query import ReplicaGroupQueryOps
@@ -253,8 +253,8 @@ class ReplicaGroupDBSource:
     async def apply_writes(
         self,
         *,
-        group_updaters: Sequence[DataUpdater[ReplicaGroupRow, ReplicaGroupData]],
-        endpoint_updaters: Sequence[DataUpdater[EndpointRow, DeploymentInfo]],
+        group_updaters: Sequence[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]],
+        endpoint_updaters: Sequence[GuardedDataUpdater[EndpointRow, DeploymentInfo]],
     ) -> ApplyWritesResult:
         """Apply the given replica-group and endpoint updates in one transaction and return which
         rows were actually updated. Each update names one row, so a row that is gone is simply

--- a/src/ai/backend/manager/repositories/replica_group/repository.py
+++ b/src/ai/backend/manager/repositories/replica_group/repository.py
@@ -21,7 +21,7 @@ from ai.backend.manager.data.deployment.types import (
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.replica_group import ReplicaGroupRow
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.ops.v2.replica_group.provider import ReplicaGroupOpsProvider
 from ai.backend.manager.repositories.replica_group.types import (
     ApplyWritesResult,
@@ -117,8 +117,8 @@ class ReplicaGroupRepository:
     async def apply_writes(
         self,
         *,
-        group_updaters: Sequence[DataUpdater[ReplicaGroupRow, ReplicaGroupData]],
-        endpoint_updaters: Sequence[DataUpdater[EndpointRow, DeploymentInfo]],
+        group_updaters: Sequence[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]],
+        endpoint_updaters: Sequence[GuardedDataUpdater[EndpointRow, DeploymentInfo]],
     ) -> ApplyWritesResult:
         return await self._db_source.apply_writes(
             group_updaters=group_updaters,

--- a/src/ai/backend/manager/repositories/replica_group/types.py
+++ b/src/ai/backend/manager/repositories/replica_group/types.py
@@ -15,7 +15,7 @@ from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.replica_group_history.creators import (
     ReplicaGroupHistoryCreator,
 )
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.views.replica_group import (
     ReplicaGroupAutoscaleReconcileView,
     ReplicaGroupLifecycleReconcileView,
@@ -58,7 +58,7 @@ class ReplicaGroupReconcileTransition:
 
     deployment_id: DeploymentID
     history_creator: ReplicaGroupHistoryCreator
-    status_updater: DataUpdater[ReplicaGroupRow, ReplicaGroupData] | None = None
+    status_updater: GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData] | None = None
 
 
 @dataclass

--- a/src/ai/backend/manager/repositories/user/repository.py
+++ b/src/ai/backend/manager/repositories/user/repository.py
@@ -39,7 +39,7 @@ from ai.backend.manager.models.keypair.row import generate_keypair_data
 from ai.backend.manager.models.keypair.scopes import UserKeypairOperationScope
 from ai.backend.manager.models.keypair.updaters import KeypairUpdater
 from ai.backend.manager.models.session import SessionRow
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.models.user.creators import UserCreator
 from ai.backend.manager.models.user.scopes import (
     DomainUserOperationScope,
@@ -326,25 +326,23 @@ class UserRepository:
         return await self._db_source.keypair(keypair_id)
 
     @user_repository_resilience.apply()
-    async def purge_keypair(self, keypair_id: KeyPairID) -> KeyPairData | None:
-        """Remove one keypair unless it is the key its user authorizes with.
-
-        ``None`` when nothing was removed — the row is gone, or the guard refused.
-        """
+    async def purge_keypair(self, keypair_id: KeyPairID) -> KeyPairData:
+        """Remove one keypair unless it is the key its user authorizes with."""
         async with self._v2_ops.write_ops() as w:
-            return await w.purge_guarded_field_entity(
-                NonDefaultKeypairPurger(keypair_id=keypair_id)
-            )
+            data = await w.purge_field_entity(NonDefaultKeypairPurger(keypair_id=keypair_id))
+            if data is None:
+                raise KeyPairNotFound(f"Keypair not found: {keypair_id}")
+            return data
 
     @user_repository_resilience.apply()
-    async def update_keypair(self, updater: KeypairUpdater) -> KeyPairData | None:
+    async def update_keypair(self, updater: KeypairUpdater) -> KeyPairData:
         """Write one keypair's settings unless the write would deactivate the key its
-        user authorizes with.
-
-        ``None`` when nothing was written — the row is gone, or the guard refused.
-        """
+        user authorizes with."""
         async with self._v2_ops.write_ops() as w:
-            return await w.update_guarded_data(updater)
+            data = await w.update_data(updater)
+            if data is None:
+                raise KeyPairNotFound(f"Keypair not found: {updater.target_id_value()}")
+            return data
 
     @user_repository_resilience.apply()
     async def switch_default_access_key(self, user_id: UserID, access_key: AccessKey) -> None:
@@ -377,7 +375,9 @@ class UserRepository:
         return await self._db_source.admin_search_keypairs(querier)
 
     @user_repository_resilience.apply()
-    async def update_keypair_column(self, updater: DataUpdater[Any, KeyPairData]) -> KeyPairData:
+    async def update_keypair_column(
+        self, updater: GuardedDataUpdater[Any, KeyPairData]
+    ) -> KeyPairData:
         """Write one column of a keypair row."""
         async with self._v2_ops.write_ops() as w:
             data = await w.update_data(updater)

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -581,26 +581,12 @@ class VfolderRepository:
             mount_key = str(VFolderID.from_row(vfolder_row))
 
         async with self._v2_ops.write_ops() as w:
-            data = await w.update_guarded_data(
+            data = await w.update_data(
                 VFolderTrashUpdater(vfolder_id=updater.vfolder_id, mount_key=mount_key)
             )
-        if data is not None:
-            return data
-
-        async with self._db.begin_readonly_session_read_committed() as session:
-            refused = await self._get_vfolder_by_id(session, updater.vfolder_id)
-            if refused is None:
+            if data is None:
                 raise VFolderNotFound()
-            if refused.status in VFolderOperationStatus.purge_in_progress():
-                raise VFolderFilterStatusFailed(f"VFolder is being purged: {updater.vfolder_id}")
-            mount_sessions = await get_sessions_by_mounted_folder(
-                session, VFolderID.from_str(mount_key)
-            )
-        session_ids = [str(sid) for sid in mount_sessions]
-        raise VFolderDeletionNotAllowed(
-            "Cannot delete the vfolder. "
-            f"The vfolder(id: {updater.vfolder_id}) is mounted on sessions(ids: {session_ids})."
-        )
+            return data
 
     @vfolder_repository_resilience.apply()
     async def update_vfolder_attribute(self, updater: VFolderAttributeUpdater) -> VFolderData:
@@ -609,10 +595,10 @@ class VfolderRepository:
         Returns updated VFolderData.
         """
         async with self._v2_ops.write_ops() as w:
-            data = await w.update_guarded_data(updater)
-            if data is not None:
-                return data
-        raise await self._refusal_error(updater.vfolder_id)
+            data = await w.update_data(updater)
+            if data is None:
+                raise VFolderNotFound()
+            return data
 
     @vfolder_repository_resilience.apply()
     async def move_vfolders_to_trash(self, vfolder_ids: list[uuid.UUID]) -> list[VFolderData]:
@@ -683,14 +669,6 @@ class VfolderRepository:
             for row in vfolder_rows:
                 await session.refresh(row, attribute_names=["updated_at"])
             return [self._vfolder_row_to_data(row) for row in vfolder_rows]
-
-    async def _refusal_error(self, vfolder_id: uuid.UUID) -> BackendAIError:
-        """Name why a guarded write touched nothing: the row is gone, or a purge holds it."""
-        async with self._db.begin_readonly_session_read_committed() as session:
-            row = await self._get_vfolder_by_id(session, vfolder_id)
-        if row is None:
-            return VFolderNotFound()
-        return VFolderFilterStatusFailed(f"VFolder is being purged: {vfolder_id}")
 
     async def _fetch_vfolders_with_linked_model_cards(
         self,

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -860,7 +860,7 @@ class GuardedUpdateService[TData]:
         self._repository = repository
 
     async def execute(self, action: GuardedUpdateOpsAction[Any, TData]) -> EntityOpsResult[TData]:
-        return EntityOpsResult(data=await self._repository.update_guarded(action.to_updater()))
+        return EntityOpsResult(data=await self._repository.update(action.to_updater()))
 
 
 class PartialBulkUpdateService[TData]:

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -18,7 +18,7 @@ from ai.backend.manager.data.user.types import (
     UserInfoContext,
 )
 from ai.backend.manager.errors.storage import DotfileCreationFailed
-from ai.backend.manager.errors.user import KeyPairForbidden, UserPurgeFailure
+from ai.backend.manager.errors.user import UserPurgeFailure
 from ai.backend.manager.models.domain.row import verify_dotfile_name
 from ai.backend.manager.models.keypair.updaters import (
     KeypairBootstrapScriptUpdater,
@@ -310,26 +310,12 @@ class UserService:
         return GetKeypairActionResult(keypair=keypair)
 
     async def update_keypair(self, action: UpdateKeypairAction) -> UpdateKeypairActionResult:
-        """Write the keypair's settings. Nothing written means the row is gone or the
-        guard refused; one more read tells the two apart."""
         written = await self._user_repository.update_keypair(action.to_updater())
-        if written is not None:
-            return UpdateKeypairActionResult(keypair=written)
-        await self._user_repository.keypair(action.keypair_id)
-        raise KeyPairForbidden(
-            "Cannot deactivate the default access key. Switch the default access key first."
-        )
+        return UpdateKeypairActionResult(keypair=written)
 
     async def purge_keypair(self, action: PurgeKeypairAction) -> PurgeKeypairActionResult:
-        """Remove the keypair. Nothing removed is told apart the same way a refused
-        edit is."""
         removed = await self._user_repository.purge_keypair(action.keypair_id)
-        if removed is not None:
-            return PurgeKeypairActionResult(keypair=removed)
-        await self._user_repository.keypair(action.keypair_id)
-        raise KeyPairForbidden(
-            "Cannot delete the default access key. Switch the default access key first."
-        )
+        return PurgeKeypairActionResult(keypair=removed)
 
     async def switch_default_access_key(
         self, action: SwitchDefaultAccessKeyAction

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_draining.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_draining.py
@@ -18,7 +18,7 @@ from ai.backend.manager.defs import LockID
 from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.replica_group.conditions import ReplicaGroupConditions
 from ai.backend.manager.models.replica_group.updaters import ReplicaGroupDeployUpdater
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
 from ai.backend.manager.repositories.replica_group.repository import ReplicaGroupRepository
 from ai.backend.manager.sokovan.deployment.types import (
@@ -97,7 +97,7 @@ class DeployingDrainingHandler(DeploymentHandler):
 
         successes: list[DeploymentWithHistory] = []
         skipped: list[DeploymentWithHistory] = []
-        group_updaters: list[DataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
+        group_updaters: list[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
         drained_deployment_ids: set[DeploymentID] = set()
         for deployment in deployments:
             info = deployment.deployment_info

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_finalizing.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_finalizing.py
@@ -18,7 +18,7 @@ from ai.backend.manager.models.endpoint import EndpointRow
 from ai.backend.manager.models.endpoint.updaters import EndpointReplicaGroupUpdater
 from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.replica_group.updaters import ReplicaGroupDeployUpdater
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.replica_group.repository import ReplicaGroupRepository
 from ai.backend.manager.sokovan.deployment.deployment_controller import DeploymentController
 from ai.backend.manager.sokovan.deployment.types import (
@@ -98,8 +98,8 @@ class DeployingFinalizingHandler(DeploymentHandler):
     ) -> DeploymentExecutionResult:
         successes: list[DeploymentWithHistory] = []
         failures: list[DeploymentExecutionError] = []
-        group_updaters: list[DataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
-        endpoint_updaters: list[DataUpdater[EndpointRow, DeploymentInfo]] = []
+        group_updaters: list[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
+        endpoint_updaters: list[GuardedDataUpdater[EndpointRow, DeploymentInfo]] = []
         to_finalize: list[DeploymentWithHistory] = []
 
         for deployment in deployments:

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_promoting.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_promoting.py
@@ -18,7 +18,7 @@ from ai.backend.manager.defs import LockID
 from ai.backend.manager.models.replica_group import ReplicaGroupRow
 from ai.backend.manager.models.replica_group.conditions import ReplicaGroupConditions
 from ai.backend.manager.models.replica_group.updaters import ReplicaGroupDeployUpdater
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.replica_group.repository import ReplicaGroupRepository
 from ai.backend.manager.sokovan.deployment.deployment_controller import DeploymentController
 from ai.backend.manager.sokovan.deployment.types import (
@@ -105,7 +105,7 @@ class DeployingPromotingHandler(DeploymentHandler):
 
         completed: list[DeploymentWithHistory] = []
         failures: list[DeploymentExecutionError] = []
-        group_updaters: list[DataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
+        group_updaters: list[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
 
         for deployment in deployments:
             info = deployment.deployment_info

--- a/src/ai/backend/manager/sokovan/deployment/handlers/deploying_rolling_back.py
+++ b/src/ai/backend/manager/sokovan/deployment/handlers/deploying_rolling_back.py
@@ -25,7 +25,7 @@ from ai.backend.manager.models.replica_group.updaters import (
     ReplicaGroupDeployUpdater,
     ReplicaGroupLifecycleUpdater,
 )
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.repositories.deployment.repository import DeploymentRepository
 from ai.backend.manager.repositories.replica_group.repository import ReplicaGroupRepository
 from ai.backend.manager.sokovan.deployment.route.route_controller import RouteController
@@ -106,8 +106,8 @@ class DeployingRollingBackHandler(DeploymentHandler):
     ) -> DeploymentExecutionResult:
         rollback_targets: list[DeploymentWithHistory] = []
         failures: list[DeploymentExecutionError] = []
-        group_updaters: list[DataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
-        endpoint_updaters: list[DataUpdater[EndpointRow, DeploymentInfo]] = []
+        group_updaters: list[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]] = []
+        endpoint_updaters: list[GuardedDataUpdater[EndpointRow, DeploymentInfo]] = []
 
         for deployment in deployments:
             info = deployment.deployment_info

--- a/tests/unit/manager/models/rbac_models/test_role_specs.py
+++ b/tests/unit/manager/models/rbac_models/test_role_specs.py
@@ -69,8 +69,9 @@ class TestRoleUpdater:
     def test_edit_and_soft_delete_guard_on_a_custom_source(self) -> None:
         role_id = RoleID(uuid.uuid4())
         for updater in (RoleUpdater(role_id=role_id), RoleSoftDeleteUpdater(role_id=role_id)):
-            (guard,) = updater.guard_conditions()
-            assert str(guard()) == str(RoleRow.source == RoleSource.CUSTOM)
+            (guard,) = updater.guard_checks()
+            assert str(guard.condition()) == str(RoleRow.source == RoleSource.CUSTOM)
+            assert isinstance(guard.error, SystemRoleNotEditable)
 
     def test_soft_delete_and_restore_write_constants(self) -> None:
         role_id = RoleID(uuid.uuid4())
@@ -103,5 +104,7 @@ class TestRoleReadAndPurgeSpecs:
     def test_the_purger_declines_a_system_role(self) -> None:
         purger = RolePurger(role_id=RoleID(uuid.uuid4()))
 
-        (check,) = purger.conflict_checks()
-        assert isinstance(check.error, SystemRoleNotEditable)
+        (guard,) = purger.guard_checks()
+        assert str(guard.condition()) == str(RoleRow.source == RoleSource.CUSTOM)
+        assert isinstance(guard.error, SystemRoleNotEditable)
+        assert purger.conflict_checks() == ()

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -43,7 +43,7 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.agent.types import AgentHeartbeatUpsert, AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.errors.agent import AgentHasConflictingSessions
+from ai.backend.manager.errors.agent import AgentAlreadyExited, AgentHasConflictingSessions
 from ai.backend.manager.errors.resource import ResourceGroupNotFound, UnresolvableResourceGroup
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.agent.updaters import AgentExitStatusUpdater
@@ -372,16 +372,16 @@ class TestAgentRepositoryDB:
         assert agent_uuid is not None
         before = await agent_repository.get_by_id(lost_agent.agent_id)
 
-        written = await agent_repository.mark_agent_exit(
-            AgentExitStatusUpdater(
-                agent_uuid=agent_uuid,
-                status=AgentStatus.TERMINATED,
-                status_changed=datetime.now(tzutc()),
-                lost_at=OptionalState.update(datetime.now(tzutc())),
+        with pytest.raises(AgentAlreadyExited):
+            await agent_repository.mark_agent_exit(
+                AgentExitStatusUpdater(
+                    agent_uuid=agent_uuid,
+                    status=AgentStatus.TERMINATED,
+                    status_changed=datetime.now(tzutc()),
+                    lost_at=OptionalState.update(datetime.now(tzutc())),
+                )
             )
-        )
 
-        assert written is None
         after = await agent_repository.get_by_id(lost_agent.agent_id)
         assert after.status == AgentStatus.LOST
         assert after.lost_at == before.lost_at

--- a/tests/unit/manager/repositories/ops/v2/test_guarded_update.py
+++ b/tests/unit/manager/repositories/ops/v2/test_guarded_update.py
@@ -1,15 +1,16 @@
-"""The guarded update of the v2 write specs runs against a real database.
+"""The guard an update or a purge spec carries runs against a real database.
 
 What these tests pin down:
 
-- The id names exactly one row: a guarded update never reaches a second row, even
+- The id names exactly one row: a guarded write never reaches a second row, even
   when the guard alone would match several.
 - The guard is a precondition, not a selection. A row failing it is left untouched
-  and the operation reports that it wrote nothing.
+  and the write answers with the error the failing check declared.
 - Guard and write travel in one statement, so nothing can change the row between
   the check and the write.
-- Both misses answer ``None`` — a row that is gone and a row the guard refused are
-  the same answer, which is what the single return value means.
+- A row that is gone answers ``None``; a row that refused raises. The two misses are
+  told apart by one read of the named row after the write touched nothing.
+- With several guards, the first failing one answers.
 """
 
 from __future__ import annotations
@@ -22,11 +23,20 @@ from uuid import UUID, uuid4
 
 import pytest
 import sqlalchemy as sa
+from aiohttp import web
 from sqlalchemy.orm import InstrumentedAttribute, Mapped, mapped_column
 
+from ai.backend.common.data.entity.types import FieldData
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+)
 from ai.backend.manager.models.base import GUID, Base
-from ai.backend.manager.models.clauses import QueryCondition
-from ai.backend.manager.models.specs.types import IntegrityErrorCheck
+from ai.backend.manager.models.specs.purger import GuardedFieldPurger
+from ai.backend.manager.models.specs.types import ConflictCheck, GuardCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
@@ -45,18 +55,39 @@ class GuardedUpdateTestRow(Base):
 
 
 @dataclass(frozen=True)
-class _RowData:
+class _RowData(FieldData):
     id: UUID
     status: str
     note: str | None
 
 
+class _Refusal(BackendAIError, web.HTTPConflict):
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.BACKENDAI,
+            operation=ErrorOperation.GENERIC,
+            error_detail=ErrorDetail.CONFLICT,
+        )
+
+
+class _Terminal(_Refusal):
+    error_type = "https://api.backend.ai/probs/test-terminal"
+    error_title = "Row is terminal."
+
+
+class _Pinned(_Refusal):
+    error_type = "https://api.backend.ai/probs/test-pinned"
+    error_title = "Row is pinned."
+
+
 _TERMINAL = "terminal"
+_PINNED_NOTE = "pinned"
 
 
 @dataclass
 class _StatusUpdater(GuardedDataUpdater[GuardedUpdateTestRow, _RowData]):
-    """Writes a row's status unless it already reached the terminal one."""
+    """Writes a row's status unless it already reached the terminal one, or is pinned."""
 
     row_id: UUID
     status: str
@@ -76,8 +107,20 @@ class _StatusUpdater(GuardedDataUpdater[GuardedUpdateTestRow, _RowData]):
         return self.row_id
 
     @override
-    def guard_conditions(self) -> list[QueryCondition]:
-        return [lambda: GuardedUpdateTestRow.status != _TERMINAL]
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=lambda: GuardedUpdateTestRow.status != _TERMINAL,
+                error=_Terminal(),
+            ),
+            GuardCheck(
+                condition=lambda: sa.or_(
+                    GuardedUpdateTestRow.note.is_(None),
+                    GuardedUpdateTestRow.note != _PINNED_NOTE,
+                ),
+                error=_Pinned(),
+            ),
+        )
 
     @override
     def build_values(self) -> dict[str, Any]:
@@ -86,6 +129,42 @@ class _StatusUpdater(GuardedDataUpdater[GuardedUpdateTestRow, _RowData]):
     @property
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:
+        return ()
+
+    @override
+    def to_data(self, row: GuardedUpdateTestRow) -> _RowData:
+        return _RowData(id=row.id, status=row.status, note=row.note)
+
+
+@dataclass
+class _NonTerminalPurger(GuardedFieldPurger[GuardedUpdateTestRow, _RowData]):
+    """Removes a row unless it reached the terminal status."""
+
+    row_id: UUID
+
+    @override
+    def row_class(self) -> type[GuardedUpdateTestRow]:
+        return GuardedUpdateTestRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return GuardedUpdateTestRow.id
+
+    @override
+    def target_id_value(self) -> UUID:
+        return self.row_id
+
+    @override
+    def guard_checks(self) -> Sequence[GuardCheck]:
+        return (
+            GuardCheck(
+                condition=lambda: GuardedUpdateTestRow.status != _TERMINAL,
+                error=_Terminal(),
+            ),
+        )
+
+    @override
+    def conflict_checks(self) -> Sequence[ConflictCheck]:
         return ()
 
     @override
@@ -106,17 +185,18 @@ def ops(database: ExtendedAsyncSAEngine) -> V2DBOpsProvider:
     return V2DBOpsProvider(database)
 
 
-async def _insert(database: ExtendedAsyncSAEngine, status: str) -> UUID:
+async def _insert(database: ExtendedAsyncSAEngine, status: str, note: str | None = None) -> UUID:
     row_id = uuid4()
     async with database.begin_session() as sess:
-        sess.add(GuardedUpdateTestRow(id=row_id, status=status, note=None))
+        sess.add(GuardedUpdateTestRow(id=row_id, status=status, note=note))
     return row_id
 
 
-async def _read(database: ExtendedAsyncSAEngine, row_id: UUID) -> _RowData:
+async def _read(database: ExtendedAsyncSAEngine, row_id: UUID) -> _RowData | None:
     async with database.begin_readonly_session() as sess:
         row = await sess.get(GuardedUpdateTestRow, row_id)
-        assert row is not None
+        if row is None:
+            return None
         return _RowData(id=row.id, status=row.status, note=row.note)
 
 
@@ -127,29 +207,40 @@ class TestGuardedUpdate:
         row_id = await _insert(database, "alive")
 
         async with ops.write_ops() as w:
-            written = await w.update_guarded_data(
+            written = await w.update_data(
                 _StatusUpdater(row_id=row_id, status=_TERMINAL, note="gone")
             )
 
         assert written == _RowData(id=row_id, status=_TERMINAL, note="gone")
         assert await _read(database, row_id) == written
 
-    async def test_refuses_and_leaves_the_row_untouched_when_the_guard_fails(
+    async def test_raises_the_declared_error_and_leaves_the_row_untouched(
         self, database: ExtendedAsyncSAEngine, ops: V2DBOpsProvider
     ) -> None:
         row_id = await _insert(database, _TERMINAL)
 
-        async with ops.write_ops() as w:
-            written = await w.update_guarded_data(
-                _StatusUpdater(row_id=row_id, status="alive", note="revived")
-            )
+        with pytest.raises(_Terminal):
+            async with ops.write_ops() as w:
+                await w.update_data(_StatusUpdater(row_id=row_id, status="alive", note="revived"))
 
-        assert written is None
         assert await _read(database, row_id) == _RowData(id=row_id, status=_TERMINAL, note=None)
+
+    async def test_the_first_failing_guard_answers(
+        self, database: ExtendedAsyncSAEngine, ops: V2DBOpsProvider
+    ) -> None:
+        pinned = await _insert(database, "alive", note=_PINNED_NOTE)
+        both = await _insert(database, _TERMINAL, note=_PINNED_NOTE)
+
+        with pytest.raises(_Pinned):
+            async with ops.write_ops() as w:
+                await w.update_data(_StatusUpdater(row_id=pinned, status=_TERMINAL))
+        with pytest.raises(_Terminal):
+            async with ops.write_ops() as w:
+                await w.update_data(_StatusUpdater(row_id=both, status="alive"))
 
     async def test_answers_none_for_an_id_that_names_no_row(self, ops: V2DBOpsProvider) -> None:
         async with ops.write_ops() as w:
-            written = await w.update_guarded_data(_StatusUpdater(row_id=uuid4(), status="alive"))
+            written = await w.update_data(_StatusUpdater(row_id=uuid4(), status="alive"))
 
         assert written is None
 
@@ -161,10 +252,12 @@ class TestGuardedUpdate:
         bystander = await _insert(database, "alive")
 
         async with ops.write_ops() as w:
-            await w.update_guarded_data(_StatusUpdater(row_id=target, status=_TERMINAL))
+            await w.update_data(_StatusUpdater(row_id=target, status=_TERMINAL))
 
-        assert (await _read(database, target)).status == _TERMINAL
-        assert (await _read(database, bystander)).status == "alive"
+        target_row = await _read(database, target)
+        bystander_row = await _read(database, bystander)
+        assert target_row is not None and target_row.status == _TERMINAL
+        assert bystander_row is not None and bystander_row.status == "alive"
 
     async def test_only_one_of_two_racing_writes_lands(
         self, database: ExtendedAsyncSAEngine, ops: V2DBOpsProvider
@@ -174,12 +267,45 @@ class TestGuardedUpdate:
 
         async def write(note: str) -> _RowData | None:
             async with ops.write_ops() as w:
-                return await w.update_guarded_data(
+                return await w.update_data(
                     _StatusUpdater(row_id=row_id, status=_TERMINAL, note=note)
                 )
 
-        results = await asyncio.gather(write("first"), write("second"))
+        results = await asyncio.gather(write("first"), write("second"), return_exceptions=True)
 
-        written = [r for r in results if r is not None]
+        written = [r for r in results if isinstance(r, _RowData)]
+        refused = [r for r in results if isinstance(r, _Terminal)]
         assert len(written) == 1
-        assert (await _read(database, row_id)).note == written[0].note
+        assert len(refused) == 1
+        row = await _read(database, row_id)
+        assert row is not None and row.note == written[0].note
+
+
+class TestGuardedPurge:
+    async def test_removes_and_returns_the_row_when_the_guard_holds(
+        self, database: ExtendedAsyncSAEngine, ops: V2DBOpsProvider
+    ) -> None:
+        row_id = await _insert(database, "alive")
+
+        async with ops.write_ops() as w:
+            removed = await w.purge_field_entity(_NonTerminalPurger(row_id=row_id))
+
+        assert removed == _RowData(id=row_id, status="alive", note=None)
+        assert await _read(database, row_id) is None
+
+    async def test_raises_the_declared_error_and_keeps_the_row(
+        self, database: ExtendedAsyncSAEngine, ops: V2DBOpsProvider
+    ) -> None:
+        row_id = await _insert(database, _TERMINAL)
+
+        with pytest.raises(_Terminal):
+            async with ops.write_ops() as w:
+                await w.purge_field_entity(_NonTerminalPurger(row_id=row_id))
+
+        assert await _read(database, row_id) == _RowData(id=row_id, status=_TERMINAL, note=None)
+
+    async def test_answers_none_for_an_id_that_names_no_row(self, ops: V2DBOpsProvider) -> None:
+        async with ops.write_ops() as w:
+            removed = await w.purge_field_entity(_NonTerminalPurger(row_id=uuid4()))
+
+        assert removed is None

--- a/tests/unit/manager/repositories/permission_controller/test_role_write.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_write.py
@@ -15,7 +15,7 @@ from ai.backend.common.data.permission.types import RoleSource
 from ai.backend.manager.data.permission.role import RoleData
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.errors.permission import VirtualEntityNotFound
-from ai.backend.manager.errors.repository import EntityNotFoundError, EntityWriteRefusedError
+from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.errors.role_preset import SystemRoleNotEditable
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.entity_label.row import EntityLabelRow
@@ -99,9 +99,9 @@ class TestRoleWrite:
         self, repository: OpsRepository[RoleData], db_with_tables: ExtendedAsyncSAEngine
     ) -> None:
         role_id = await self._insert_role(db_with_tables, RoleSource.CUSTOM)
-        updated = await repository.update_guarded(self._rename(role_id))
+        updated = await repository.update(self._rename(role_id))
         assert updated.name == "renamed"
-        deleted = await repository.update_guarded(RoleSoftDeleteUpdater(role_id=role_id))
+        deleted = await repository.update(RoleSoftDeleteUpdater(role_id=role_id))
         assert deleted.status == RoleStatus.DELETED
         assert deleted.deleted_at is not None
         purged = await repository.purge_entity(RolePurger(role_id=role_id))
@@ -112,15 +112,15 @@ class TestRoleWrite:
         self, repository: OpsRepository[RoleData], db_with_tables: ExtendedAsyncSAEngine
     ) -> None:
         role_id = await self._insert_role(db_with_tables, RoleSource.SYSTEM)
-        with pytest.raises(EntityWriteRefusedError):
-            await repository.update_guarded(self._rename(role_id))
+        with pytest.raises(SystemRoleNotEditable):
+            await repository.update(self._rename(role_id))
 
     async def test_system_role_delete_is_refused(
         self, repository: OpsRepository[RoleData], db_with_tables: ExtendedAsyncSAEngine
     ) -> None:
         role_id = await self._insert_role(db_with_tables, RoleSource.SYSTEM)
-        with pytest.raises(EntityWriteRefusedError):
-            await repository.update_guarded(RoleSoftDeleteUpdater(role_id=role_id))
+        with pytest.raises(SystemRoleNotEditable):
+            await repository.update(RoleSoftDeleteUpdater(role_id=role_id))
 
     async def test_system_role_purge_is_refused(
         self, repository: OpsRepository[RoleData], db_with_tables: ExtendedAsyncSAEngine
@@ -133,9 +133,9 @@ class TestRoleWrite:
     async def test_missing_role_raises_not_found(self, repository: OpsRepository[RoleData]) -> None:
         role_id = RoleID(uuid.uuid4())
         with pytest.raises(EntityNotFoundError):
-            await repository.update_guarded(self._rename(role_id))
+            await repository.update(self._rename(role_id))
         with pytest.raises(EntityNotFoundError):
-            await repository.update_guarded(RoleSoftDeleteUpdater(role_id=role_id))
+            await repository.update(RoleSoftDeleteUpdater(role_id=role_id))
         with pytest.raises(EntityNotFoundError):
             await repository.purge_entity(RolePurger(role_id=role_id))
 

--- a/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
+++ b/tests/unit/manager/repositories/replica_group/test_replica_group_repository.py
@@ -63,7 +63,7 @@ from ai.backend.manager.models.resource_preset import ResourcePresetRow
 from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.session import SessionRow
 from ai.backend.manager.models.session_group.row import SessionGroupRow
-from ai.backend.manager.models.specs.updater import DataUpdater
+from ai.backend.manager.models.specs.updater import GuardedDataUpdater
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
@@ -421,7 +421,7 @@ class TestReplicaGroupRepository:
         two_group_ids: tuple[ReplicaGroupID, ReplicaGroupID],
     ) -> None:
         first_id, second_id = two_group_ids
-        updaters: list[DataUpdater[ReplicaGroupRow, ReplicaGroupData]] = [
+        updaters: list[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]] = [
             ReplicaGroupDeployUpdater(
                 replica_group_id=first_id,
                 lifecycle=OptionalState.update(ReplicaGroupLifecycle.DRAINING),
@@ -518,7 +518,7 @@ class TestReplicaGroupRepository:
         two_group_ids: tuple[ReplicaGroupID, ReplicaGroupID],
     ) -> None:
         first_id, second_id = two_group_ids
-        updaters: list[DataUpdater[ReplicaGroupRow, ReplicaGroupData]] = [
+        updaters: list[GuardedDataUpdater[ReplicaGroupRow, ReplicaGroupData]] = [
             ReplicaGroupScalingUpdater(
                 replica_group_id=first_id,
                 desired_current_replica_count=OptionalState.update(5),

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -94,6 +94,8 @@ from ai.backend.manager.models.specs.purger import (
     EntityBatchPurger,
     EntityPurger,
     FieldPurger,
+    GuardedEntityPurger,
+    GuardedFieldPurger,
 )
 from ai.backend.manager.models.specs.querier import DataQuerier
 from ai.backend.manager.models.specs.searcher import Searcher, SearcherResult
@@ -102,7 +104,11 @@ from ai.backend.manager.models.specs.types import (
     ConflictCheck,
     IntegrityErrorCheck,
 )
-from ai.backend.manager.models.specs.updater import DataBatchUpdater, DataUpdater
+from ai.backend.manager.models.specs.updater import (
+    DataBatchUpdater,
+    DataUpdater,
+    GuardedDataUpdater,
+)
 from ai.backend.manager.models.specs.upserter import (
     EntityUpserter,
     FieldUpserter,
@@ -640,7 +646,7 @@ class _DeleteAction(BaseSingleEntityAction, UpdateOpsAction[RolePresetRow, _Pres
     updater: _PresetUpdater
 
     @override
-    def to_updater(self) -> DataUpdater[RolePresetRow, _PresetData]:
+    def to_updater(self) -> GuardedDataUpdater[RolePresetRow, _PresetData]:
         return self.updater
 
     @override
@@ -693,7 +699,7 @@ class _UpdateAction(BaseSingleEntityAction, UpdateOpsAction[RolePresetRow, _Pres
     updater: _PresetUpdater
 
     @override
-    def to_updater(self) -> DataUpdater[RolePresetRow, _PresetData]:
+    def to_updater(self) -> GuardedDataUpdater[RolePresetRow, _PresetData]:
         return self.updater
 
     @override
@@ -717,7 +723,7 @@ class _PurgeAction(BaseSingleEntityAction, EntityPurgeOpsAction[RolePresetRow, _
     purger: _PresetPurger
 
     @override
-    def to_purger(self) -> EntityPurger[RolePresetRow, _PresetData]:
+    def to_purger(self) -> GuardedEntityPurger[RolePresetRow, _PresetData]:
         return self.purger
 
     @override
@@ -831,7 +837,9 @@ class _BulkUpdateAction(BaseBulkAction, PartialBulkUpdateOpsAction[RolePresetRow
     updaters: dict[EntityIdentifier, _PresetUpdater]
 
     @override
-    def to_updaters(self) -> Mapping[EntityIdentifier, DataUpdater[RolePresetRow, _PresetData]]:
+    def to_updaters(
+        self,
+    ) -> Mapping[EntityIdentifier, GuardedDataUpdater[RolePresetRow, _PresetData]]:
         return self.updaters
 
     @override
@@ -855,7 +863,9 @@ class _BulkPurgeAction(BaseBulkAction, EntityPartialBulkPurgeOpsAction[RolePrese
     purgers: dict[EntityIdentifier, _PresetPurger]
 
     @override
-    def to_purgers(self) -> Mapping[EntityIdentifier, EntityPurger[RolePresetRow, _PresetData]]:
+    def to_purgers(
+        self,
+    ) -> Mapping[EntityIdentifier, GuardedEntityPurger[RolePresetRow, _PresetData]]:
         return self.purgers
 
     @override
@@ -961,7 +971,9 @@ class _BulkPurgeGlobalAction(
     purgers: dict[EntityIdentifier, _PresetGlobalPurger]
 
     @override
-    def to_purgers(self) -> Mapping[EntityIdentifier, EntityPurger[RolePresetRow, _PresetData]]:
+    def to_purgers(
+        self,
+    ) -> Mapping[EntityIdentifier, GuardedEntityPurger[RolePresetRow, _PresetData]]:
         return self.purgers
 
     @override
@@ -1016,7 +1028,7 @@ class _BulkPurgeFieldAction(
     purgers: dict[_FieldID, _PresetFieldPurger]
 
     @override
-    def to_purgers(self) -> Mapping[_FieldID, FieldPurger[RolePresetRow, _PresetFieldData]]:
+    def to_purgers(self) -> Mapping[_FieldID, GuardedFieldPurger[RolePresetRow, _PresetFieldData]]:
         return self.purgers
 
 


### PR DESCRIPTION
## Summary
- `GuardedDataUpdater`, `GuardedEntityPurger` and `GuardedFieldPurger` become the roots and declare `guard_checks()`; `DataUpdater`, `EntityPurger` and `FieldPurger` answer an empty list under `@final`, as the creator lineage does. A `GuardCheck` pairs the condition on the named row with the error to raise.
- ops carries every check on the UPDATE / DELETE statement. When no row matched, one read of the named row tells a missing row (`EntityNotFoundError`) from the first failing check (its declared error). `OpsRepository.update_guarded`, `update_guarded_data`, `purge_guarded_field_entity`, `row_exists` and `EntityWriteRefusedError` are removed.
- The 17 guarded specs attach an error to each condition, and the callers that re-read the row to name a refusal (domain, project, vfolder, user repositories; user service; agent exit handler) drop that branch. `RolePurger` states its SYSTEM refusal as a guard.

## Test plan
- [x] `tests/unit/manager/repositories/ops/v2/test_guarded_update.py`: guard holds, declared error on refusal, first failing guard answers, `None` for a missing row, racing writes, guarded purge
- [x] `tests/unit/manager/repositories/permission_controller/test_role_write.py`: SYSTEM role update, delete and purge raise `SystemRoleNotEditable`; missing role raises `EntityNotFoundError`
- [x] Existing domain, project, keypair, vfolder, entity share and agent repository tests pass with `pants test --changed-since --changed-dependents=direct`
- [x] `pants fmt fix lint check` pass

Resolves BA-7728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6yBsLtRAxUmgx9tHnK5Bs