### PR TITLE
refactor(BA-7441): move the adapter batch loaders onto the bulk get path

### DIFF
--- a/changes/14349.enhance.md
+++ b/changes/14349.enhance.md
@@ -1,0 +1,1 @@
+Read the adapter DataLoaders for deployments, scheduling histories, resource groups, notifications, artifacts and domains per named entity through the bulk get path, answering `null` for a missing id and raising the denial for one the caller may not read.

--- a/src/ai/backend/manager/actions/AGENTS.md
+++ b/src/ai/backend/manager/actions/AGENTS.md
@@ -139,6 +139,10 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
 - A field row is denied through its owner: the check is per owner, so a denied one
   takes every row it owns out of the run. Which rows those are is known only after the
   owner lookup, so that narrowing happens in the processor.
+- A read of several named field rows is the same shape: wire it through
+  `LookupFieldGroup.partial_bulk_get_ops`. The answer is keyed by the row, the check
+  and the record by the owner. The owner lookup a partial field shape runs first is
+  wired public, for the reason the entity bulk lookup under Gates is.
 - A partial run answers with `PartialBulkResult`, one item per entity the caller named
   and in that order. Fixed rather than per domain: completing and ordering the answer
   is the processor's job, and it cannot do that for a shape only the domain knows.

--- a/src/ai/backend/manager/actions/registry/field.py
+++ b/src/ai/backend/manager/actions/registry/field.py
@@ -33,6 +33,7 @@ from ai.backend.manager.actions.v2.field.bulk_processor import (
 from ai.backend.manager.actions.v2.field.ops import (
     DeleteFieldOpsAction,
     GetFieldOpsAction,
+    PartialBulkGetFieldOpsAction,
     PartialBulkPurgeFieldOpsAction,
     PurgeFieldOpsAction,
     RestoreFieldOpsAction,
@@ -79,6 +80,7 @@ from ai.backend.manager.services.ops.service import (
     FieldAtomicCreateService,
     FieldCreateService,
     FieldGetService,
+    FieldPartialBulkGetService,
     FieldPartialBulkPurgeService,
     FieldPurgeService,
     FieldUpsertService,
@@ -269,6 +271,8 @@ class LookupFieldGroup[TFieldData: FieldData](FieldGroup[TFieldData]):
 
     _owner_lookup: OwnerLookupProcessor
     _bulk_owner_lookup: OwnerBulkLookupProcessor
+    _partial_bulk_owner_lookup: OwnerBulkLookupProcessor
+    _bulk_owner_lookup_action_cls: type[Any]
 
     def __init__(
         self,
@@ -279,10 +283,23 @@ class LookupFieldGroup[TFieldData: FieldData](FieldGroup[TFieldData]):
         owner_entity_type: EntityType,
         owner_lookup: OwnerLookupProcessor,
         bulk_owner_lookup: OwnerBulkLookupProcessor,
+        partial_bulk_owner_lookup: OwnerBulkLookupProcessor,
+        bulk_owner_lookup_action_cls: type[Any],
     ) -> None:
         super().__init__(deps, records, concern, meta, owner_entity_type)
         self._owner_lookup = owner_lookup
         self._bulk_owner_lookup = bulk_owner_lookup
+        self._partial_bulk_owner_lookup = partial_bulk_owner_lookup
+        self._bulk_owner_lookup_action_cls = bulk_owner_lookup_action_cls
+
+    def _record_partial_owner_lookup(self) -> None:
+        """The owner lookup a partial shape runs is gated by authentication alone."""
+        self._record(
+            self._bulk_owner_lookup_action_cls,
+            ActionKind.LOOKUP,
+            ActionGate.PUBLIC,
+            ActionBacking.GENERIC,
+        )
 
     def get_ops[TAction: GetFieldOpsAction[Any, Any, Any, Any]](
         self,
@@ -409,6 +426,28 @@ class LookupFieldGroup[TFieldData: FieldData](FieldGroup[TFieldData]):
             validators=(*self._deps.validators.single_entity, *validators),
         )
 
+    def partial_bulk_get_ops[TAction: PartialBulkGetFieldOpsAction[Any, Any, Any, Any]](
+        self,
+        action_cls: type[TAction],
+        *,
+        validators: Sequence[PartialBulkActionValidator] = (),
+        monitors: Sequence[BulkActionMonitor] = (),
+    ) -> PartialBulkFieldActionProcessor[TAction, TFieldData]:
+        """Read the rows the caller named, one permission check per owning entity.
+
+        The field counterpart of ``ProcessorGroup.partial_bulk_get_ops``: an owner the
+        caller may not read takes its rows out of the run and puts them back into the
+        answer as denied items, beside the rows that matched nothing.
+        """
+        self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
+        self._record_partial_owner_lookup()
+        return PartialBulkFieldActionProcessor(
+            FieldPartialBulkGetService(self._deps.repository).execute,
+            self._partial_bulk_owner_lookup,
+            monitors=(*self._deps.monitors.bulk, *monitors),
+            partial_validators=(*self._deps.validators.partial_bulk, *validators),
+        )
+
     def partial_bulk_purge_ops[TAction: PartialBulkPurgeFieldOpsAction[Any, Any, Any, Any]](
         self,
         action_cls: type[TAction],
@@ -422,9 +461,10 @@ class LookupFieldGroup[TFieldData: FieldData](FieldGroup[TFieldData]):
         back into the answer as denied items.
         """
         self._record(action_cls, ActionKind.BULK, ActionGate.PERMISSION, ActionBacking.GENERIC)
+        self._record_partial_owner_lookup()
         return PartialBulkFieldActionProcessor(
             FieldPartialBulkPurgeService(self._deps.repository).execute,
-            self._bulk_owner_lookup,
+            self._partial_bulk_owner_lookup,
             monitors=(*self._deps.monitors.bulk, *monitors),
             partial_validators=(*self._deps.validators.partial_bulk, *validators),
         )

--- a/src/ai/backend/manager/actions/registry/group.py
+++ b/src/ai/backend/manager/actions/registry/group.py
@@ -599,6 +599,12 @@ class ProcessorGroup[TData: EntityData]:
             monitors=self._deps.monitors.bulk_lookup,
             post_validators=self._deps.validators.atomic_bulk,
         )
+        # The lookup a partial shape runs first: the read that follows answers per owner,
+        # so this one refuses nothing past authentication.
+        partial_bulk_owner_lookup: OwnerBulkLookupProcessor = BulkLookupActionProcessor(
+            BulkFieldOwnerLookupService(self._deps.repository).execute,
+            monitors=self._deps.monitors.bulk_lookup,
+        )
         return LookupFieldGroup(
             self._deps,
             self._records,
@@ -607,6 +613,8 @@ class ProcessorGroup[TData: EntityData]:
             self._meta.entity_type,
             owner_lookup,
             bulk_owner_lookup,
+            partial_bulk_owner_lookup,
+            bulk_owner_lookup_action_cls,
         )
 
     def single_get_ops[TAction: GetSingleEntityOpsAction[Any, Any]](

--- a/src/ai/backend/manager/actions/registry/registry.py
+++ b/src/ai/backend/manager/actions/registry/registry.py
@@ -118,6 +118,10 @@ class ProcessorRegistry[TData: EntityData]:
             monitors=self._deps.monitors.bulk_lookup,
             post_validators=self._deps.validators.atomic_bulk,
         )
+        partial_bulk_owner_lookup: OwnerBulkLookupProcessor = BulkLookupActionProcessor(
+            BulkRuntimeFieldOwnerLookupService(self._deps.repository).execute,
+            monitors=self._deps.monitors.bulk_lookup,
+        )
         return LookupFieldGroup(
             self._deps,
             self._records,
@@ -126,6 +130,8 @@ class ProcessorRegistry[TData: EntityData]:
             GLOBAL_ENTITY_TYPE,
             owner_lookup,
             bulk_owner_lookup,
+            partial_bulk_owner_lookup,
+            bulk_owner_lookup_action_cls,
         )
 
     def _record_lookup(self, meta: FieldGroupMeta, action_cls: type[Any]) -> None:

--- a/src/ai/backend/manager/actions/v2/field/ops.py
+++ b/src/ai/backend/manager/actions/v2/field/ops.py
@@ -13,6 +13,7 @@ from ai.backend.manager.actions.v2.field.base import (
 from ai.backend.manager.actions.v2.field.bulk_base import BasePartialBulkFieldAction
 from ai.backend.manager.actions.v2.ops.base import (
     FieldGetOpsAction,
+    FieldPartialBulkGetOpsAction,
     FieldPartialBulkPurgeOpsAction,
     FieldPurgeOpsAction,
     UpdateOpsAction,
@@ -25,6 +26,7 @@ __all__ = (
     "DeleteFieldOpsAction",
     "RestoreFieldOpsAction",
     "PurgeFieldOpsAction",
+    "PartialBulkGetFieldOpsAction",
     "PartialBulkPurgeFieldOpsAction",
 )
 
@@ -126,3 +128,26 @@ class PartialBulkPurgeFieldOpsAction[
     @classmethod
     def operation_type(cls) -> ActionOperationType:
         return ActionOperationType.UPDATE
+
+
+class PartialBulkGetFieldOpsAction[
+    TFieldID: FieldIdentifier,
+    TOwnerID: EntityIdentifier,
+    TRow: Base,
+    TData: FieldData,
+](
+    BasePartialBulkFieldAction[TFieldID, TOwnerID],
+    FieldPartialBulkGetOpsAction[TRow, TData],
+    ABC,
+):
+    """A read over the field rows the caller named, each answered for on its own.
+
+    Partial rather than atomic, like :class:`PartialBulkGetEntityOpsAction`: a row
+    whose owner the caller may not read and a row matching nothing are both one failed
+    item, told apart by the error each carries.
+    """
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -29,6 +29,7 @@ from ai.backend.manager.models.specs.purger import (
 )
 from ai.backend.manager.models.specs.querier import (
     BulkEntityQuerier,
+    BulkFieldQuerier,
     DataQuerier,
     FieldQuerier,
     OwnedFieldQuerier,
@@ -451,6 +452,16 @@ class FieldPartialBulkPurgeOpsAction[TFieldID: FieldIdentifier, TRow: Base, TDat
     @abstractmethod
     def to_purgers(self) -> Mapping[TFieldID, GuardedFieldPurger[TRow, TData]]:
         """Return the delete spec for each row this action names."""
+        raise NotImplementedError
+
+
+class FieldPartialBulkGetOpsAction[TRow: Base, TData: FieldData](OpsBackendAction):
+    """A read of the field rows the caller named, each answered for separately;
+    authorized through the entities owning them."""
+
+    @abstractmethod
+    def to_querier(self) -> BulkFieldQuerier[TRow, TData]:
+        """Return the read spec this action executes."""
         raise NotImplementedError
 
 

--- a/src/ai/backend/manager/api/adapters/artifact/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact/adapter.py
@@ -83,6 +83,7 @@ from ai.backend.manager.models.artifact_revision.searchers import ArtifactRevisi
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
 from ai.backend.manager.models.specs.pagination import OffsetPagination
+from ai.backend.manager.services.artifact.actions.bulk_get import BulkGetArtifactsAction
 from ai.backend.manager.services.artifact.actions.delegate_scan import (
     DelegateScanArtifactsAction,
     DelegateScanArtifactsActionResult,
@@ -105,6 +106,9 @@ from ai.backend.manager.services.artifact.actions.search import SearchArtifactsA
 from ai.backend.manager.services.artifact.actions.update import UpdateArtifactAction
 from ai.backend.manager.services.artifact.revision.actions.approve import (
     ApproveArtifactRevisionAction,
+)
+from ai.backend.manager.services.artifact.revision.actions.bulk_get import (
+    BulkGetArtifactRevisionsAction,
 )
 from ai.backend.manager.services.artifact.revision.actions.cancel_import import CancelImportAction
 from ai.backend.manager.services.artifact.revision.actions.cleanup import (
@@ -213,47 +217,35 @@ class ArtifactAdapter(BaseAdapter):
             has_previous_page=action_result.has_previous_page,
         )
 
-    async def batch_load_by_ids(self, artifact_ids: Sequence[UUID]) -> list[ArtifactNode | None]:
-        """Batch load artifacts by their IDs for DataLoader use.
-
-        Returns ArtifactNode DTOs in the same order as the input artifact_ids list.
-        """
+    async def batch_load_by_ids(
+        self, artifact_ids: Sequence[UUID]
+    ) -> list[ArtifactNode | Exception | None]:
+        """Batch load artifacts by their IDs for DataLoader use, checked per artifact."""
         if not artifact_ids:
             return []
-
-        action_result = await self._processors.artifact.search_artifacts.run(
-            SearchArtifactsAction(
-                searcher=ArtifactSearcher(
-                    pagination=OffsetPagination(limit=len(artifact_ids)),
-                    conditions=[ArtifactConditions.by_ids(artifact_ids)],
-                )
-            )
+        result = await self._processors.artifact.bulk_get.run(
+            BulkGetArtifactsAction(ids=[ArtifactID(artifact_id) for artifact_id in artifact_ids])
         )
-
-        artifact_map = {item.id: self._data_to_dto(item) for item in action_result.data}
-        return [artifact_map.get(ArtifactID(artifact_id)) for artifact_id in artifact_ids]
+        return [
+            self._data_to_dto(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def batch_load_revisions_by_ids(
         self, revision_ids: Sequence[UUID]
-    ) -> list[ArtifactRevisionNode | None]:
-        """Batch load artifact revisions by their IDs for DataLoader use.
-
-        Returns ArtifactRevisionNode DTOs in the same order as the input revision_ids list.
-        """
+    ) -> list[ArtifactRevisionNode | Exception | None]:
+        """Batch load artifact revisions by their IDs for DataLoader use, checked per artifact."""
         if not revision_ids:
             return []
-
-        action_result = await self._processors.artifact.revision.search_revision.run(
-            SearchArtifactRevisionsAction(
-                searcher=ArtifactRevisionSearcher(
-                    pagination=OffsetPagination(limit=len(revision_ids)),
-                    conditions=[ArtifactRevisionConditions.by_ids(revision_ids)],
-                )
-            )
+        ids = [ArtifactRevisionID(revision_id) for revision_id in revision_ids]
+        return await self.batch_load_fields(
+            self._processors.artifact.revision.bulk_get,
+            BulkGetArtifactRevisionsAction(ids=ids),
+            ids,
+            self._revision_data_to_dto,
         )
-
-        revision_map = {item.id: self._revision_data_to_dto(item) for item in action_result.data}
-        return [revision_map.get(ArtifactRevisionID(revision_id)) for revision_id in revision_ids]
 
     async def get(self, artifact_id: UUID) -> ArtifactNode:
         """Retrieve a single artifact by ID."""

--- a/src/ai/backend/manager/api/adapters/base.py
+++ b/src/ai/backend/manager/api/adapters/base.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
+from ai.backend.common.data.entity.types import FieldIdentifier
+from ai.backend.manager.actions.v2.field.bulk_base import BasePartialBulkFieldAction
+from ai.backend.manager.actions.v2.field.bulk_processor import PartialBulkFieldActionProcessor
+from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
 from ai.backend.manager.api.adapter_options.pagination.pagination import (
     PaginationOptions,
     PaginationSpec,
@@ -127,6 +131,30 @@ class BaseAdapter(BaseFilterAdapter):
         if f.none is not None:
             conditions.append(nested.none(self._convert_entity_label_filter(f.none)))
         return conditions
+
+    async def batch_load_fields[TAction: BasePartialBulkFieldAction[Any, Any], TData, TNode](
+        self,
+        processor: PartialBulkFieldActionProcessor[TAction, TData],
+        action: TAction,
+        field_ids: Sequence[FieldIdentifier],
+        to_node: Callable[[TData], TNode],
+    ) -> list[TNode | Exception | None]:
+        """One answer per named field row, in the given order, for a DataLoader.
+
+        The node for a row that was read, ``None`` for an id matching no row, and the
+        denial for a row whose owner the caller may not read. A batch naming no
+        existing row at all is every id missing, not a failed run.
+        """
+        try:
+            result: BulkFieldOpsResult[TData] = await processor.run(action)
+        except EntityNotFoundError:
+            return [None for _ in field_ids]
+        return [
+            to_node(result.successes[field_id])
+            if field_id in result.successes
+            else self.batch_load_failure(result.errors.get(field_id))
+            for field_id in field_ids
+        ]
 
     def batch_load_failure(self, error: Exception | None) -> Exception | None:
         """What a DataLoader is handed for an id a bulk read returned no data for.

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -243,10 +243,13 @@ from ai.backend.manager.models.routing import RoutingRow
 from ai.backend.manager.models.routing.conditions import RouteConditions
 from ai.backend.manager.models.routing.orders import RouteOrders
 from ai.backend.manager.models.routing.searchers import ModelReplicaSearcher
-from ai.backend.manager.models.specs.pagination import NoPagination, OffsetPagination
+from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.deployment.actions.access_token.bulk_delete_access_tokens import (
     BulkDeleteAccessTokensAction,
+)
+from ai.backend.manager.services.deployment.actions.access_token.bulk_get_access_tokens import (
+    BulkGetAccessTokensAction,
 )
 from ai.backend.manager.services.deployment.actions.access_token.create_access_token import (
     CreateAccessTokenAction,
@@ -256,9 +259,6 @@ from ai.backend.manager.services.deployment.actions.access_token.delete_access_t
 )
 from ai.backend.manager.services.deployment.actions.access_token.get_access_token import (
     GetAccessTokenAction,
-)
-from ai.backend.manager.services.deployment.actions.access_token.global_search_access_tokens import (
-    GlobalSearchAccessTokensAction,
 )
 from ai.backend.manager.services.deployment.actions.access_token.search_access_tokens import (
     SearchAccessTokensAction,
@@ -282,6 +282,9 @@ from ai.backend.manager.services.deployment.actions.auto_scaling_rule.update_aut
     UpdateAutoScalingRuleAction,
 )
 from ai.backend.manager.services.deployment.actions.create_deployment import CreateDeploymentAction
+from ai.backend.manager.services.deployment.actions.deployment_policy.bulk_get_deployment_policies import (
+    BulkGetDeploymentPoliciesAction,
+)
 from ai.backend.manager.services.deployment.actions.deployment_policy.get_deployment_policy import (
     GetDeploymentPolicyAction,
 )
@@ -309,6 +312,9 @@ from ai.backend.manager.services.deployment.actions.lookup_owner import (
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
 )
+from ai.backend.manager.services.deployment.actions.model_revision.bulk_get_revisions import (
+    BulkGetRevisionsAction,
+)
 from ai.backend.manager.services.deployment.actions.model_revision.get_revision_by_id import (
     GetRevisionByIdAction,
 )
@@ -327,8 +333,14 @@ from ai.backend.manager.services.deployment.actions.refresh_deployment_revisions
 from ai.backend.manager.services.deployment.actions.replace_deployment_options import (
     ReplaceDeploymentOptionsAction,
 )
+from ai.backend.manager.services.deployment.actions.replica.bulk_get_replicas import (
+    BulkGetReplicasAction,
+)
 from ai.backend.manager.services.deployment.actions.revision_operations import (
     ActivateRevisionAction,
+)
+from ai.backend.manager.services.deployment.actions.route.bulk_get_routes import (
+    BulkGetRoutesAction,
 )
 from ai.backend.manager.services.deployment.actions.route.search_routes import SearchRoutesAction
 from ai.backend.manager.services.deployment.actions.route.update_route_traffic_status import (
@@ -1438,86 +1450,62 @@ class DeploymentAdapter(BaseAdapter):
     async def batch_load_revisions_by_ids(
         self,
         revision_ids: Sequence[uuid.UUID],
-    ) -> list[RevisionNode | None]:
-        """Batch load revisions by ID for DataLoader use.
-
-        Returns RevisionNode DTOs in the same order as the input revision_ids list.
-        """
+    ) -> list[RevisionNode | Exception | None]:
+        """Batch load revisions by ID for DataLoader use, checked per owning deployment."""
         if not revision_ids:
             return []
-        searcher = ModelRevisionSearcher(
-            pagination=OffsetPagination(limit=len(revision_ids)),
-            conditions=[RevisionConditions.by_ids(revision_ids)],
+        ids = [DeploymentRevisionID(revision_id) for revision_id in revision_ids]
+        return await self.batch_load_fields(
+            self._processors.deployment.bulk_get_revisions,
+            BulkGetRevisionsAction(ids=ids),
+            ids,
+            self._revision_data_to_dto,
         )
-        action_result = await self._processors.deployment.global_search_revisions.run(
-            GlobalSearchRevisionsAction(searcher=searcher)
-        )
-        revision_map: dict[uuid.UUID, RevisionNode] = {
-            data.id: self._revision_data_to_dto(data) for data in action_result.items
-        }
-        return [revision_map.get(revision_id) for revision_id in revision_ids]
 
     async def batch_load_replicas_by_ids(
         self,
         replica_ids: Sequence[uuid.UUID],
-    ) -> list[ReplicaNode | None]:
-        """Batch load replicas by ID for DataLoader use.
-
-        Returns ReplicaNode DTOs in the same order as the input replica_ids list.
-        """
+    ) -> list[ReplicaNode | Exception | None]:
+        """Batch load replicas by ID for DataLoader use, checked per owning deployment."""
         if not replica_ids:
             return []
-        searcher = ModelReplicaSearcher(
-            pagination=OffsetPagination(limit=len(replica_ids)),
-            conditions=[RouteConditions.by_ids(replica_ids)],
+        ids = [ReplicaID(replica_id) for replica_id in replica_ids]
+        return await self.batch_load_fields(
+            self._processors.deployment.bulk_get_replicas,
+            BulkGetReplicasAction(ids=ids),
+            ids,
+            self._replica_data_to_dto,
         )
-        action_result = await self._processors.deployment.global_search_replicas.run(
-            GlobalSearchReplicasAction(searcher=searcher)
-        )
-        replica_map = {data.id: self._replica_data_to_dto(data) for data in action_result.items}
-        return [replica_map.get(replica_id) for replica_id in replica_ids]
 
     async def batch_load_routes_by_ids(
         self,
         route_ids: Sequence[uuid.UUID],
-    ) -> list[RouteNode | None]:
-        """Batch load routes by ID for DataLoader use.
-
-        Returns RouteNode DTOs in the same order as the input route_ids list.
-        """
+    ) -> list[RouteNode | Exception | None]:
+        """Batch load routes by ID for DataLoader use, checked per owning deployment."""
         if not route_ids:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(route_ids)),
-            conditions=[RouteConditions.by_ids(route_ids)],
+        ids = [ReplicaID(route_id) for route_id in route_ids]
+        return await self.batch_load_fields(
+            self._processors.deployment.bulk_get_routes,
+            BulkGetRoutesAction(ids=ids),
+            ids,
+            self._route_info_to_dto,
         )
-        action_result = await self._processors.deployment.search_routes.run(
-            SearchRoutesAction(querier=querier)
-        )
-        route_map = {
-            route.route_id: self._route_info_to_dto(route) for route in action_result.routes
-        }
-        return [route_map.get(route_id) for route_id in route_ids]
 
     async def batch_load_access_tokens_by_ids(
         self,
         token_ids: Sequence[uuid.UUID],
-    ) -> list[AccessTokenNode | None]:
-        """Batch load access tokens by ID for DataLoader use.
-
-        Returns AccessTokenNode DTOs in the same order as the input token_ids list.
-        """
+    ) -> list[AccessTokenNode | Exception | None]:
+        """Batch load access tokens by ID for DataLoader use, checked per owning deployment."""
         if not token_ids:
             return []
-        searcher = DeploymentAccessTokenSearcher(
-            pagination=OffsetPagination(limit=len(token_ids)),
-            conditions=[AccessTokenConditions.by_ids(token_ids)],
+        ids = [DeploymentTokenID(token_id) for token_id in token_ids]
+        return await self.batch_load_fields(
+            self._processors.deployment.bulk_get_access_tokens,
+            BulkGetAccessTokensAction(ids=ids),
+            ids,
+            self._access_token_data_to_dto,
         )
-        action_result = await self._processors.deployment.global_search_access_tokens.run(
-            GlobalSearchAccessTokensAction(searcher=searcher)
-        )
-        token_map = {data.id: self._access_token_data_to_dto(data) for data in action_result.items}
-        return [token_map.get(token_id) for token_id in token_ids]
 
     async def batch_load_auto_scaling_rules_by_ids(
         self,
@@ -1545,22 +1533,22 @@ class DeploymentAdapter(BaseAdapter):
         self,
         endpoint_ids: Sequence[uuid.UUID],
     ) -> list[DeploymentPolicyNode | None]:
-        """Batch load deployment policies by endpoint ID for DataLoader use.
+        """Batch load deployment policies by deployment ID for DataLoader use.
 
-        Each endpoint has at most one deployment policy (1:1 relationship).
-        Returns DeploymentPolicyNode DTOs in the same order as the input endpoint_ids list.
+        Each deployment carries at most one policy; every named deployment is checked.
         """
         if not endpoint_ids:
             return []
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[DeploymentPolicyConditions.by_endpoint_ids(endpoint_ids)],
+        ids = [DeploymentID(endpoint_id) for endpoint_id in endpoint_ids]
+        result = await self._processors.deployment.bulk_get_deployment_policies.run(
+            BulkGetDeploymentPoliciesAction(deployment_ids=ids)
         )
-        action_result = await self._processors.deployment.search_deployment_policies.run(
-            SearchDeploymentPoliciesAction(querier=querier)
-        )
-        policy_map = {data.endpoint: self._policy_data_to_dto(data) for data in action_result.data}
-        return [policy_map.get(endpoint_id) for endpoint_id in endpoint_ids]
+        return [
+            self._policy_data_to_dto(policy)
+            if (policy := result.designated.get(deployment_id)) is not None
+            else None
+            for deployment_id in ids
+        ]
 
     # ------------------------------------------------------------------
     # Querier builders

--- a/src/ai/backend/manager/api/adapters/domain/adapter.py
+++ b/src/ai/backend/manager/api/adapters/domain/adapter.py
@@ -45,7 +45,8 @@ from ai.backend.manager.models.domain.updaters import (
     DomainSoftDeleteUpdater,
     DomainUpdater,
 )
-from ai.backend.manager.models.specs.pagination import NoPagination
+from ai.backend.manager.services.domain.actions.bulk_get import BulkGetDomainsAction
+from ai.backend.manager.services.domain.actions.bulk_lookup import BulkLookupDomainsAction
 from ai.backend.manager.services.domain.actions.create_domain_node import CreateDomainNodeAction
 from ai.backend.manager.services.domain.actions.delete_domain import DeleteDomainAction
 from ai.backend.manager.services.domain.actions.get import GetDomainAction
@@ -73,39 +74,48 @@ _DOMAIN_PAGINATION_SPEC = PaginationSpec(
 class DomainAdapter(BaseAdapter):
     """Adapter for domain operations."""
 
-    async def batch_load_by_names(self, names: Sequence[str]) -> list[DomainNode | None]:
+    async def batch_load_by_names(
+        self, names: Sequence[str]
+    ) -> list[DomainNode | Exception | None]:
         """Batch load domains by name for DataLoader use.
 
-        Returns DomainNode DTOs in the same order as the input names list.
+        One answer per name in the given order: the node, ``None`` for a name matching
+        no domain.
         """
         if not names:
             return []
-        searcher = DomainSearcher(
-            pagination=NoPagination(),
-            conditions=[DomainConditions.by_names(names)],
-        )
-        result = await self._processors.domain.global_search.run(
-            GlobalSearchDomainsAction(searcher=searcher)
-        )
-        domain_map = {data.name: self._domain_data_to_node(data) for data in result.items}
-        return [domain_map.get(name) for name in names]
+        keys = [DomainName(name) for name in names]
+        lookup = await self._processors.domain.bulk_lookup.run(BulkLookupDomainsAction(names=keys))
+        ids = [lookup.resolved[key] for key in keys if key in lookup.resolved]
+        got = await self._processors.domain.bulk_get.run(BulkGetDomainsAction(ids=ids))
+        domains = got.values()
+        errors = got.errors()
+        nodes: list[DomainNode | Exception | None] = []
+        for key in keys:
+            domain_id = lookup.resolved.get(key)
+            if domain_id is None:
+                nodes.append(None)
+                continue
+            data = domains.get(domain_id)
+            if data is None:
+                nodes.append(self.batch_load_failure(errors.get(domain_id)))
+                continue
+            nodes.append(self._domain_data_to_node(data))
+        return nodes
 
-    async def batch_load_by_ids(self, ids: Sequence[DomainID]) -> list[DomainNode | None]:
-        """Batch load domains by UUID for DataLoader use.
-
-        Returns DomainNode DTOs in the same order as the input ids list.
-        """
+    async def batch_load_by_ids(
+        self, ids: Sequence[DomainID]
+    ) -> list[DomainNode | Exception | None]:
+        """Batch load domains by UUID for DataLoader use."""
         if not ids:
             return []
-        searcher = DomainSearcher(
-            pagination=NoPagination(),
-            conditions=[DomainConditions.by_ids(ids)],
-        )
-        result = await self._processors.domain.global_search.run(
-            GlobalSearchDomainsAction(searcher=searcher)
-        )
-        domain_map = {data.id: self._domain_data_to_node(data) for data in result.items}
-        return [domain_map.get(domain_id) for domain_id in ids]
+        result = await self._processors.domain.bulk_get.run(BulkGetDomainsAction(ids=list(ids)))
+        return [
+            self._domain_data_to_node(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def get(self, domain_name: str) -> DomainNode:
         """Retrieve a single domain by name."""

--- a/src/ai/backend/manager/api/adapters/notification/adapter.py
+++ b/src/ai/backend/manager/api/adapters/notification/adapter.py
@@ -93,7 +93,6 @@ from ai.backend.manager.models.notification.updaters import (
     NotificationChannelUpdater,
     NotificationRuleUpdater,
 )
-from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.services.notification.actions import (
     CreateChannelAction,
     CreateRuleAction,
@@ -108,6 +107,10 @@ from ai.backend.manager.services.notification.actions import (
     ValidateChannelAction,
     ValidateRuleAction,
 )
+from ai.backend.manager.services.notification.actions.bulk_get_channels import (
+    BulkGetChannelsAction,
+)
+from ai.backend.manager.services.notification.actions.bulk_get_rules import BulkGetRulesAction
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -163,41 +166,35 @@ class NotificationAdapter(BaseAdapter):
 
     async def batch_load_channels_by_ids(
         self, ids: Sequence[UUID]
-    ) -> list[NotificationChannelNode | None]:
-        """Batch load notification channels by ID for DataLoader use.
-
-        Returns NotificationChannelNode DTOs in the same order as the input ids list.
-        """
+    ) -> list[NotificationChannelNode | Exception | None]:
+        """Batch load notification channels by ID for DataLoader use, checked per channel."""
         if not ids:
             return []
-        searcher = NotificationChannelSearcher(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[NotificationChannelConditions.by_ids(ids)],
+        result = await self._processors.notification.bulk_get_channels.run(
+            BulkGetChannelsAction(ids=[NotificationChannelID(channel_id) for channel_id in ids])
         )
-        action_result = await self._processors.notification.search_channels.run(
-            SearchChannelsAction(searcher=searcher)
-        )
-        channel_map = {ch.id: self._channel_data_to_dto(ch) for ch in action_result.items}
-        return [channel_map.get(NotificationChannelID(channel_id)) for channel_id in ids]
+        return [
+            self._channel_data_to_dto(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def batch_load_rules_by_ids(
         self, ids: Sequence[UUID]
-    ) -> list[NotificationRuleNode | None]:
-        """Batch load notification rules by ID for DataLoader use.
-
-        Returns NotificationRuleNode DTOs in the same order as the input ids list.
-        """
+    ) -> list[NotificationRuleNode | Exception | None]:
+        """Batch load notification rules by ID for DataLoader use, checked per rule."""
         if not ids:
             return []
-        searcher = NotificationRuleSearcher(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[NotificationRuleConditions.by_ids(ids)],
+        result = await self._processors.notification.bulk_get_rules.run(
+            BulkGetRulesAction(ids=[NotificationRuleID(rule_id) for rule_id in ids])
         )
-        action_result = await self._processors.notification.search_rules.run(
-            SearchRulesAction(searcher=searcher)
-        )
-        rule_map = {rule.id: self._rule_data_to_dto(rule) for rule in action_result.items}
-        return [rule_map.get(NotificationRuleID(rule_id)) for rule_id in ids]
+        return [
+            self._rule_data_to_dto(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     # ------------------------------------------------------------------ channels
 

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -91,9 +91,15 @@ from ai.backend.manager.models.resource_group.creators import ResourceGroupCreat
 from ai.backend.manager.models.resource_group.orders import ResourceGroupOrders
 from ai.backend.manager.models.resource_group.searchers import ResourceGroupSearcher
 from ai.backend.manager.models.resource_group.updaters import ResourceGroupUpdater
-from ai.backend.manager.models.specs.pagination import NoPagination, OffsetPagination
+from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.domain.actions.lookup import LookupDomainAction
+from ai.backend.manager.services.resource_group.actions.bulk_get import (
+    BulkGetResourceGroupsAction,
+)
+from ai.backend.manager.services.resource_group.actions.bulk_lookup import (
+    BulkLookupResourceGroupsAction,
+)
 from ai.backend.manager.services.resource_group.actions.create import CreateResourceGroupAction
 from ai.backend.manager.services.resource_group.actions.get_allowed_domains_for_rg import (
     GetAllowedDomainsForResourceGroupAction,
@@ -235,43 +241,52 @@ class ResourceGroupAdapter(BaseAdapter):
 
     async def batch_load_by_names(
         self, names: Sequence[str]
-    ) -> list[ResourceGroupDetailNode | None]:
+    ) -> list[ResourceGroupDetailNode | Exception | None]:
         """Batch load resource groups by name for DataLoader use.
 
-        Returns ResourceGroupDetailNode items in the same order as the input names list.
+        One answer per name in the given order: the node, ``None`` for a name matching
+        no resource group, and the denial for one the caller may not read.
         """
         if not names:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(names)),
-            conditions=[ResourceGroupConditions.by_names(names)],
+        keys = [ResourceGroupName(name) for name in names]
+        lookup = await self._processors.resource_group.bulk_lookup.run(
+            BulkLookupResourceGroupsAction(names=keys)
         )
-        action_result = await self._processors.resource_group.search_resource_groups.run(
-            SearchResourceGroupsAction(querier=querier)
+        ids = [lookup.resolved[key] for key in keys if key in lookup.resolved]
+        got = await self._processors.resource_group.bulk_get.run(
+            BulkGetResourceGroupsAction(ids=ids)
         )
-        rg_map = {sg.name: sg for sg in action_result.resource_groups}
-        return [
-            self._data_to_detail_node(rg_map[name]) if name in rg_map else None for name in names
-        ]
+        groups = got.values()
+        errors = got.errors()
+        nodes: list[ResourceGroupDetailNode | Exception | None] = []
+        for key in keys:
+            resource_group_id = lookup.resolved.get(key)
+            if resource_group_id is None:
+                nodes.append(None)
+                continue
+            data = groups.get(resource_group_id)
+            if data is None:
+                nodes.append(self.batch_load_failure(errors.get(resource_group_id)))
+                continue
+            nodes.append(self._data_to_detail_node(data))
+        return nodes
 
     async def batch_load_by_ids(
         self, ids: Sequence[ResourceGroupID]
-    ) -> list[ResourceGroupDetailNode | None]:
-        """Batch load resource groups by UUID for DataLoader use.
-
-        Returns ResourceGroupDetailNode items in the same order as the input ids list.
-        """
+    ) -> list[ResourceGroupDetailNode | Exception | None]:
+        """Batch load resource groups by UUID for DataLoader use, checked per resource group."""
         if not ids:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[ResourceGroupConditions.by_ids(ids)],
+        result = await self._processors.resource_group.bulk_get.run(
+            BulkGetResourceGroupsAction(ids=list(ids))
         )
-        action_result = await self._processors.resource_group.search_resource_groups.run(
-            SearchResourceGroupsAction(querier=querier)
-        )
-        rg_map = {sg.id: sg for sg in action_result.resource_groups}
-        return [self._data_to_detail_node(rg_map[id_]) if id_ in rg_map else None for id_ in ids]
+        return [
+            self._data_to_detail_node(item.value)
+            if item.value is not None
+            else self.batch_load_failure(item.error)
+            for item in result.items
+        ]
 
     async def search(self, input: AdminSearchResourceGroupsInput) -> ResourceGroupSearchPayload:
         """Search resource groups with filters, ordering, and pagination."""
@@ -364,9 +379,13 @@ class ResourceGroupAdapter(BaseAdapter):
     async def get(self, name: str) -> ResourceGroupDetailNode:
         """Retrieve a single resource group by name."""
         results = await self.batch_load_by_names([name])
-        if results[0] is None:
-            raise ResourceGroupNotFound(f"Resource group '{name}' not found.")
-        return results[0]
+        match results[0]:
+            case None:
+                raise ResourceGroupNotFound(f"Resource group '{name}' not found.")
+            case Exception() as denial:
+                raise denial
+            case node:
+                return node
 
     async def create(
         self,

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -6,10 +6,13 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_history import DeploymentHistoryID
 from ai.backend.common.data.entity.kernel import KernelID
 from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.common.data.entity.route_history import RouteHistoryID
 from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
 from ai.backend.common.data.filter_specs import UUIDEqualMatchSpec
 from ai.backend.common.dto.manager.v2.scheduling_history.request import (
     AdminSearchDeploymentHistoriesInput,
@@ -98,10 +101,21 @@ from ai.backend.manager.models.scheduling_history.scopes import (
     RouteHistoryOperationScope,
     SessionSchedulingHistoryOperationScope,
 )
-from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.resource_slot.actions.lookup_kernel_owner import (
     LookupKernelOwnerAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_deployment_histories import (
+    BulkGetDeploymentHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_kernel_histories import (
+    BulkGetKernelHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_route_histories import (
+    BulkGetRouteHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_session_histories import (
+    BulkGetSessionHistoriesAction,
 )
 from ai.backend.manager.services.scheduling_history.actions.global_search_replica_group_history import (
     GlobalSearchReplicaGroupHistoryAction,
@@ -184,79 +198,58 @@ class SchedulingHistoryAdapter(BaseAdapter):
 
     async def batch_load_session_histories_by_ids(
         self, ids: Sequence[UUID]
-    ) -> list[SessionHistoryNode | None]:
-        """Batch load session scheduling histories by their IDs for DataLoader use.
-
-        Returns SessionHistoryNode DTOs in the same order as the input ids list.
-        """
+    ) -> list[SessionHistoryNode | Exception | None]:
+        """Batch load session scheduling histories for DataLoader use, checked per session."""
         if not ids:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[SessionSchedulingHistoryConditions.by_ids(ids)],
+        history_ids = [SessionSchedulingHistoryID(history_id) for history_id in ids]
+        return await self.batch_load_fields(
+            self._processors.scheduling_history.bulk_get_session_histories,
+            BulkGetSessionHistoriesAction(ids=history_ids),
+            history_ids,
+            self._session_data_to_dto,
         )
-        action_result = await self._processors.scheduling_history.search_session_history.run(
-            SearchSessionHistoryAction(querier=querier)
-        )
-        history_map = {h.id: self._session_data_to_dto(h) for h in action_result.histories}
-        return [history_map.get(history_id) for history_id in ids]
 
     async def batch_load_kernel_histories_by_ids(
         self, ids: Sequence[KernelSchedulingHistoryID]
-    ) -> list[KernelHistoryNode | None]:
-        """Batch load kernel scheduling histories by their IDs for DataLoader use.
-
-        Returns KernelHistoryNode DTOs in the same order as the input ids list.
-        """
+    ) -> list[KernelHistoryNode | Exception | None]:
+        """Batch load kernel scheduling histories for DataLoader use, checked per session."""
         if not ids:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[KernelSchedulingHistoryConditions.by_ids(ids)],
+        return await self.batch_load_fields(
+            self._processors.scheduling_history.bulk_get_kernel_histories,
+            BulkGetKernelHistoriesAction(ids=ids),
+            ids,
+            self._kernel_data_to_dto,
         )
-        action_result = await self._processors.scheduling_history.search_kernel_history.run(
-            SearchKernelHistoryAction(querier=querier)
-        )
-        history_map = {h.id: self._kernel_data_to_dto(h) for h in action_result.items}
-        return [history_map.get(history_id) for history_id in ids]
 
     async def batch_load_deployment_histories_by_ids(
         self, ids: Sequence[UUID]
-    ) -> list[DeploymentHistoryNode | None]:
-        """Batch load deployment histories by their IDs for DataLoader use.
-
-        Returns DeploymentHistoryNode DTOs in the same order as the input ids list.
-        """
+    ) -> list[DeploymentHistoryNode | Exception | None]:
+        """Batch load deployment histories for DataLoader use, checked per deployment."""
         if not ids:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[DeploymentHistoryConditions.by_ids(ids)],
+        history_ids = [DeploymentHistoryID(history_id) for history_id in ids]
+        return await self.batch_load_fields(
+            self._processors.scheduling_history.bulk_get_deployment_histories,
+            BulkGetDeploymentHistoriesAction(ids=history_ids),
+            history_ids,
+            self._deployment_data_to_dto,
         )
-        action_result = await self._processors.scheduling_history.search_deployment_history.run(
-            SearchDeploymentHistoryAction(querier=querier)
-        )
-        history_map = {h.id: self._deployment_data_to_dto(h) for h in action_result.histories}
-        return [history_map.get(history_id) for history_id in ids]
 
     async def batch_load_route_histories_by_ids(
         self, ids: Sequence[UUID]
-    ) -> list[RouteHistoryNode | None]:
-        """Batch load route histories by their IDs for DataLoader use.
-
-        Returns RouteHistoryNode DTOs in the same order as the input ids list.
-        """
+    ) -> list[RouteHistoryNode | Exception | None]:
+        """Batch load route histories for DataLoader use, checked per deployment."""
         if not ids:
             return []
-        querier = BatchQuerier(
-            pagination=OffsetPagination(limit=len(ids)),
-            conditions=[RouteHistoryConditions.by_ids(ids)],
+        history_ids = [RouteHistoryID(history_id) for history_id in ids]
+        return await self.batch_load_fields(
+            self._processors.scheduling_history.bulk_get_route_histories,
+            BulkGetRouteHistoriesAction(ids=history_ids),
+            history_ids,
+            self._route_data_to_dto,
         )
-        action_result = await self._processors.scheduling_history.search_route_history.run(
-            SearchRouteHistoryAction(querier=querier)
-        )
-        history_map = {h.id: self._route_data_to_dto(h) for h in action_result.histories}
-        return [history_map.get(history_id) for history_id in ids]
 
     # ========== Session History ==========
 

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -241,13 +241,16 @@ class DataLoaders:
     ) -> DataLoader[str, ResourceGroupGQL | None]:
         adapter = self._adapters.resource_group
 
-        async def load_fn(names: list[str]) -> list[ResourceGroupGQL | None]:
+        async def load_fn(names: list[str]) -> list[ResourceGroupGQL | Exception | None]:
             from ai.backend.manager.api.gql.resource_group.types import (  # pants: no-infer-dep
                 ResourceGroupGQL as RG,
             )
 
             dtos = await adapter.batch_load_by_names(names)
-            return [RG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else RG.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -257,13 +260,16 @@ class DataLoaders:
     ) -> DataLoader[ResourceGroupID, ResourceGroupGQL | None]:
         adapter = self._adapters.resource_group
 
-        async def load_fn(ids: list[ResourceGroupID]) -> list[ResourceGroupGQL | None]:
+        async def load_fn(ids: list[ResourceGroupID]) -> list[ResourceGroupGQL | Exception | None]:
             from ai.backend.manager.api.gql.resource_group.types import (  # pants: no-infer-dep
                 ResourceGroupGQL as RG,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [RG.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else RG.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -289,13 +295,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, NotificationChannel | None]:
         adapter = self._adapters.notification
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[NotificationChannel | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[NotificationChannel | Exception | None]:
             from ai.backend.manager.api.gql.notification.types import (  # pants: no-infer-dep
                 NotificationChannel as NC,
             )
 
             dtos = await adapter.batch_load_channels_by_ids(ids)
-            return [NC.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else NC.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -305,13 +314,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, NotificationRule | None]:
         adapter = self._adapters.notification
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[NotificationRule | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[NotificationRule | Exception | None]:
             from ai.backend.manager.api.gql.notification.types import (  # pants: no-infer-dep
                 NotificationRule as NR,
             )
 
             dtos = await adapter.batch_load_rules_by_ids(ids)
-            return [NR.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else NR.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -451,13 +463,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, ArtifactRevision | None]:
         adapter = self._adapters.artifact
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[ArtifactRevision | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[ArtifactRevision | Exception | None]:
             from ai.backend.manager.api.gql.artifact.types import (  # pants: no-infer-dep
                 ArtifactRevision as ARev,
             )
 
             dtos = await adapter.batch_load_revisions_by_ids(ids)
-            return [ARev.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else ARev.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -696,13 +711,16 @@ class DataLoaders:
     ) -> DataLoader[str, DomainV2GQL | None]:
         adapter = self._adapters.domain
 
-        async def load_fn(names: list[str]) -> list[DomainV2GQL | None]:
+        async def load_fn(names: list[str]) -> list[DomainV2GQL | Exception | None]:
             from ai.backend.manager.api.gql.domain_v2.types.node import (  # pants: no-infer-dep
                 DomainV2GQL as D,
             )
 
             dtos = await adapter.batch_load_by_names(names)
-            return [D.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else D.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -712,13 +730,16 @@ class DataLoaders:
     ) -> DataLoader[DomainID, DomainV2GQL | None]:
         adapter = self._adapters.domain
 
-        async def load_fn(ids: list[DomainID]) -> list[DomainV2GQL | None]:
+        async def load_fn(ids: list[DomainID]) -> list[DomainV2GQL | Exception | None]:
             from ai.backend.manager.api.gql.domain_v2.types.node import (  # pants: no-infer-dep
                 DomainV2GQL as D,
             )
 
             dtos = await adapter.batch_load_by_ids(ids)
-            return [D.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else D.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
+++ b/src/ai/backend/manager/api/gql/data_loader/data_loaders.py
@@ -467,13 +467,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, Route | None]:
         adapter = self._adapters.deployment
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[Route | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[Route | Exception | None]:
             from ai.backend.manager.api.gql.deployment.types.route import (  # pants: no-infer-dep
                 Route as R,
             )
 
             dtos = await adapter.batch_load_routes_by_ids(ids)
-            return [R.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else R.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -499,13 +502,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, ModelRevision | None]:
         adapter = self._adapters.deployment
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[ModelRevision | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[ModelRevision | Exception | None]:
             from ai.backend.manager.api.gql.deployment.types.revision import (  # pants: no-infer-dep
                 ModelRevision as MRev,
             )
 
             dtos = await adapter.batch_load_revisions_by_ids(ids)
-            return [MRev.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else MRev.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -547,13 +553,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, ModelReplica | None]:
         adapter = self._adapters.deployment
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[ModelReplica | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[ModelReplica | Exception | None]:
             from ai.backend.manager.api.gql.deployment.types.replica import (  # pants: no-infer-dep
                 ModelReplica as MRep,
             )
 
             dtos = await adapter.batch_load_replicas_by_ids(ids)
-            return [MRep.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else MRep.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -770,13 +779,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, AccessToken | None]:
         adapter = self._adapters.deployment
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[AccessToken | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[AccessToken | Exception | None]:
             from ai.backend.manager.api.gql.deployment.types.access_token import (  # pants: no-infer-dep
                 AccessToken as AT,
             )
 
             dtos = await adapter.batch_load_access_tokens_by_ids(ids)
-            return [AT.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else AT.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -802,13 +814,18 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, SessionSchedulingHistory | None]:
         adapter = self._adapters.scheduling_history
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[SessionSchedulingHistory | None]:
+        async def load_fn(
+            ids: list[uuid.UUID],
+        ) -> list[SessionSchedulingHistory | Exception | None]:
             from ai.backend.manager.api.gql.scheduling_history.types import (  # pants: no-infer-dep
                 SessionSchedulingHistory as SSH,
             )
 
             dtos = await adapter.batch_load_session_histories_by_ids(ids)
-            return [SSH.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else SSH.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -820,13 +837,16 @@ class DataLoaders:
 
         async def load_fn(
             ids: list[KernelSchedulingHistoryID],
-        ) -> list[KernelSchedulingHistoryGQL | None]:
+        ) -> list[KernelSchedulingHistoryGQL | Exception | None]:
             from ai.backend.manager.api.gql.scheduling_history.types import (  # pants: no-infer-dep
                 KernelSchedulingHistoryGQL as KSH,
             )
 
             dtos = await adapter.batch_load_kernel_histories_by_ids(ids)
-            return [KSH.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else KSH.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -836,13 +856,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, DeploymentHistory | None]:
         adapter = self._adapters.scheduling_history
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[DeploymentHistory | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[DeploymentHistory | Exception | None]:
             from ai.backend.manager.api.gql.scheduling_history.types import (  # pants: no-infer-dep
                 DeploymentHistory as DH,
             )
 
             dtos = await adapter.batch_load_deployment_histories_by_ids(ids)
-            return [DH.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else DH.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 
@@ -852,13 +875,16 @@ class DataLoaders:
     ) -> DataLoader[uuid.UUID, RouteHistory | None]:
         adapter = self._adapters.scheduling_history
 
-        async def load_fn(ids: list[uuid.UUID]) -> list[RouteHistory | None]:
+        async def load_fn(ids: list[uuid.UUID]) -> list[RouteHistory | Exception | None]:
             from ai.backend.manager.api.gql.scheduling_history.types import (  # pants: no-infer-dep
                 RouteHistory as RH,
             )
 
             dtos = await adapter.batch_load_route_histories_by_ids(ids)
-            return [RH.from_pydantic(dto) if dto is not None else None for dto in dtos]
+            return [
+                dto if dto is None or isinstance(dto, Exception) else RH.from_pydantic(dto)
+                for dto in dtos
+            ]
 
         return DataLoader(load_fn=load_fn)
 

--- a/src/ai/backend/manager/api/rest/v2/resource_group/handler.py
+++ b/src/ai/backend/manager/api/rest/v2/resource_group/handler.py
@@ -30,7 +30,6 @@ from ai.backend.manager.api.rest.v2.path_params import (
     ProjectIdPathParam,
     ResourceGroupNamePathParam,
 )
-from ai.backend.manager.errors.resource import ResourceGroupNotFound
 
 if TYPE_CHECKING:
     from ai.backend.manager.api.adapters.resource_group.adapter import ResourceGroupAdapter
@@ -71,10 +70,7 @@ class V2ResourceGroupHandler:
         path: PathParam[ResourceGroupNamePathParam],
     ) -> APIResponse:
         """Retrieve a single resource group by name."""
-        results = await self._adapter.batch_load_by_names([path.parsed.name])
-        result = results[0]
-        if result is None:
-            raise ResourceGroupNotFound(path.parsed.name)
+        result = await self._adapter.get(path.parsed.name)
         return APIResponse.build(status_code=HTTPStatus.OK, response_model=result)
 
     async def update(

--- a/src/ai/backend/manager/data/deployment/types.py
+++ b/src/ai/backend/manager/data/deployment/types.py
@@ -937,7 +937,7 @@ class ScaleOutDecision:
 
 
 @dataclass
-class RouteInfo:
+class RouteInfo(FieldData):
     """Route information for deployment."""
 
     route_id: UUID

--- a/src/ai/backend/manager/models/artifact/queriers.py
+++ b/src/ai/backend/manager/models/artifact/queriers.py
@@ -1,0 +1,27 @@
+"""BulkEntityQuerier implementation for the artifacts table."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.manager.data.artifact.types import ArtifactData
+from ai.backend.manager.models.artifact.row import ArtifactRow
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier
+
+
+class BulkArtifactQuerier(BulkEntityQuerier[ArtifactRow, ArtifactData]):
+    """The artifacts the caller named."""
+
+    @override
+    def row_class(self) -> type[ArtifactRow]:
+        return ArtifactRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return ArtifactRow.id
+
+    @override
+    def to_data(self, row: ArtifactRow) -> ArtifactData:
+        return row.to_dataclass()

--- a/src/ai/backend/manager/models/artifact_revision/queriers.py
+++ b/src/ai/backend/manager/models/artifact_revision/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionID
 from ai.backend.manager.data.artifact.types import ArtifactRevisionData
 from ai.backend.manager.models.artifact_revision.row import ArtifactRevisionRow
-from ai.backend.manager.models.specs.querier import FieldQuerier
+from ai.backend.manager.models.specs.querier import BulkFieldQuerier, FieldQuerier
 
 
 @dataclass
@@ -28,6 +28,22 @@ class ArtifactRevisionQuerier(FieldQuerier[ArtifactRevisionRow, ArtifactRevision
     @override
     def target_id_value(self) -> ArtifactRevisionID:
         return self.revision_id
+
+    @override
+    def to_data(self, row: ArtifactRevisionRow) -> ArtifactRevisionData:
+        return row.to_dataclass()
+
+
+class BulkArtifactRevisionQuerier(BulkFieldQuerier[ArtifactRevisionRow, ArtifactRevisionData]):
+    """The artifact revisions the caller named."""
+
+    @override
+    def row_class(self) -> type[ArtifactRevisionRow]:
+        return ArtifactRevisionRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return ArtifactRevisionRow.id
 
     @override
     def to_data(self, row: ArtifactRevisionRow) -> ArtifactRevisionData:

--- a/src/ai/backend/manager/models/deployment_policy/lookups.py
+++ b/src/ai/backend/manager/models/deployment_policy/lookups.py
@@ -1,0 +1,32 @@
+"""Lookup specs for the deployment_policies table."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyID
+from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
+from ai.backend.manager.models.specs.lookup import FieldOwnerLookup
+
+
+@dataclass
+class DeploymentPolicyOwnerLookup(FieldOwnerLookup[DeploymentPolicyID, DeploymentID]):
+    """The deployment a policy belongs to."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[DeploymentPolicyID]
+    ) -> sa.sql.Select[tuple[DeploymentPolicyID, DeploymentID]]:
+        return sa.select(DeploymentPolicyRow.id, DeploymentPolicyRow.endpoint).where(
+            DeploymentPolicyRow.id.in_(field_ids)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> DeploymentID:
+        return DeploymentID(value)

--- a/src/ai/backend/manager/models/deployment_policy/queriers.py
+++ b/src/ai/backend/manager/models/deployment_policy/queriers.py
@@ -1,0 +1,31 @@
+"""Querier specs for the deployment_policies table."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+import sqlalchemy as sa
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.manager.data.deployment.types import DeploymentPolicyData
+from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
+from ai.backend.manager.models.specs.querier import OwnedFieldQuerier
+
+
+class DeploymentPolicyByDeploymentQuerier(
+    OwnedFieldQuerier[DeploymentID, DeploymentPolicyRow, DeploymentPolicyData]
+):
+    """The policy a deployment carries; ``uq_deployment_policies_endpoint`` caps it at one."""
+
+    @override
+    def build_select(self) -> sa.sql.Select[Any]:
+        return sa.select(DeploymentPolicyRow)
+
+    @override
+    def owner_id_column(self) -> InstrumentedAttribute[Any]:
+        return DeploymentPolicyRow.endpoint
+
+    @override
+    def to_data(self, row: DeploymentPolicyRow) -> DeploymentPolicyData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/deployment_policy/row.py
+++ b/src/ai/backend/manager/models/deployment_policy/row.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-import uuid
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyID
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.schema.deployment import BlueGreenSpec, RollingUpdateSpec
 from ai.backend.logging import BraceStyleAdapter
@@ -41,8 +41,11 @@ class DeploymentPolicyRow(LifecycleTimestampsMixin, Base):
         sa.Index("ix_deployment_policies_endpoint", "endpoint"),
     )
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v7()")
+    id: Mapped[DeploymentPolicyID] = mapped_column(
+        "id",
+        GUID(DeploymentPolicyID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v7()"),
     )
     endpoint: Mapped[DeploymentID] = mapped_column(
         "endpoint",

--- a/src/ai/backend/manager/models/deployment_revision/queriers.py
+++ b/src/ai/backend/manager/models/deployment_revision/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
 from ai.backend.manager.data.deployment.types import ModelRevisionData
 from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
-from ai.backend.manager.models.specs.querier import FieldQuerier
+from ai.backend.manager.models.specs.querier import BulkFieldQuerier, FieldQuerier
 
 
 @dataclass
@@ -28,6 +28,22 @@ class ModelRevisionQuerier(FieldQuerier[DeploymentRevisionRow, ModelRevisionData
     @override
     def target_id_value(self) -> DeploymentRevisionID:
         return self.revision_id
+
+    @override
+    def to_data(self, row: DeploymentRevisionRow) -> ModelRevisionData:
+        return row.to_data()
+
+
+class BulkModelRevisionQuerier(BulkFieldQuerier[DeploymentRevisionRow, ModelRevisionData]):
+    """The revisions the caller named."""
+
+    @override
+    def row_class(self) -> type[DeploymentRevisionRow]:
+        return DeploymentRevisionRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return DeploymentRevisionRow.id
 
     @override
     def to_data(self, row: DeploymentRevisionRow) -> ModelRevisionData:

--- a/src/ai/backend/manager/models/domain/lookups.py
+++ b/src/ai/backend/manager/models/domain/lookups.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import Any, override
+from uuid import UUID
+
+import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.domain.row import DomainRow
-from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 
 
 @dataclass
@@ -29,3 +32,16 @@ class DomainNameLookup(DataLookup[DomainRow, DomainID]):
     @override
     def to_entity_id(self, row: DomainRow) -> DomainID:
         return row.id
+
+
+@dataclass
+class DomainNamesLookup(BulkDataLookup[DomainName, DomainID]):
+    """Resolves several names into the domains they name."""
+
+    @override
+    def build_query(self, keys: Sequence[DomainName]) -> sa.sql.Select[Any]:
+        return sa.select(DomainRow.name, DomainRow.id).where(DomainRow.name.in_(keys))
+
+    @override
+    def to_entity_id(self, value: UUID) -> DomainID:
+        return DomainID(value)

--- a/src/ai/backend/manager/models/domain/queriers.py
+++ b/src/ai/backend/manager/models/domain/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.manager.data.domain.types import DomainData
 from ai.backend.manager.models.domain.row import DomainRow
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -33,6 +33,22 @@ class DomainQuerier(DataQuerier[DomainRow, DomainData]):
     @override
     def entity_id_value(self) -> DomainID:
         return self.domain_id
+
+    @override
+    def to_data(self, row: DomainRow) -> DomainData:
+        return row.to_data()
+
+
+class BulkDomainQuerier(BulkEntityQuerier[DomainRow, DomainData]):
+    """The domains the caller named, keyed by the uuid column."""
+
+    @override
+    def row_class(self) -> type[DomainRow]:
+        return DomainRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return DomainRow.id
 
     @override
     def to_data(self, row: DomainRow) -> DomainData:

--- a/src/ai/backend/manager/models/endpoint/queriers.py
+++ b/src/ai/backend/manager/models/endpoint/queriers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
 from ai.backend.manager.models.endpoint.row import EndpointTokenRow
-from ai.backend.manager.models.specs.querier import FieldQuerier
+from ai.backend.manager.models.specs.querier import BulkFieldQuerier, FieldQuerier
 
 
 @dataclass
@@ -28,6 +28,24 @@ class DeploymentAccessTokenQuerier(FieldQuerier[EndpointTokenRow, ModelDeploymen
     @override
     def target_id_value(self) -> DeploymentTokenID:
         return self.access_token_id
+
+    @override
+    def to_data(self, row: EndpointTokenRow) -> ModelDeploymentAccessTokenData:
+        return row.to_access_token_data()
+
+
+class BulkDeploymentAccessTokenQuerier(
+    BulkFieldQuerier[EndpointTokenRow, ModelDeploymentAccessTokenData]
+):
+    """The access tokens the caller named."""
+
+    @override
+    def row_class(self) -> type[EndpointTokenRow]:
+        return EndpointTokenRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return EndpointTokenRow.id
 
     @override
     def to_data(self, row: EndpointTokenRow) -> ModelDeploymentAccessTokenData:

--- a/src/ai/backend/manager/models/notification/queriers.py
+++ b/src/ai/backend/manager/models/notification/queriers.py
@@ -19,7 +19,7 @@ from ai.backend.manager.models.notification.row import (
     NotificationChannelRow,
     NotificationRuleRow,
 )
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
 
 
 @dataclass
@@ -60,6 +60,40 @@ class NotificationRuleQuerier(DataQuerier[NotificationRuleRow, NotificationRuleD
     @override
     def entity_id_value(self) -> NotificationRuleID:
         return self.rule_id
+
+    @override
+    def to_data(self, row: NotificationRuleRow) -> NotificationRuleData:
+        return row.to_data()
+
+
+class BulkNotificationChannelQuerier(
+    BulkEntityQuerier[NotificationChannelRow, NotificationChannelData]
+):
+    """The notification channels the caller named."""
+
+    @override
+    def row_class(self) -> type[NotificationChannelRow]:
+        return NotificationChannelRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return NotificationChannelRow.id
+
+    @override
+    def to_data(self, row: NotificationChannelRow) -> NotificationChannelData:
+        return row.to_data()
+
+
+class BulkNotificationRuleQuerier(BulkEntityQuerier[NotificationRuleRow, NotificationRuleData]):
+    """The notification rules the caller named."""
+
+    @override
+    def row_class(self) -> type[NotificationRuleRow]:
+        return NotificationRuleRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return NotificationRuleRow.id
 
     @override
     def to_data(self, row: NotificationRuleRow) -> NotificationRuleData:

--- a/src/ai/backend/manager/models/resource_group/lookups.py
+++ b/src/ai/backend/manager/models/resource_group/lookups.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import override
+from typing import Any, override
+from uuid import UUID
+
+import sqlalchemy as sa
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.resource_group.row import ResourceGroupRow
-from ai.backend.manager.models.specs.lookup import DataLookup
+from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 
 
 @dataclass
@@ -29,3 +32,18 @@ class ResourceGroupNameLookup(DataLookup[ResourceGroupRow, ResourceGroupID]):
     @override
     def to_entity_id(self, row: ResourceGroupRow) -> ResourceGroupID:
         return row.id
+
+
+@dataclass
+class ResourceGroupNamesLookup(BulkDataLookup[ResourceGroupName, ResourceGroupID]):
+    """Resolves several names into the resource groups they refer to."""
+
+    @override
+    def build_query(self, keys: Sequence[ResourceGroupName]) -> sa.sql.Select[Any]:
+        return sa.select(ResourceGroupRow.name, ResourceGroupRow.id).where(
+            ResourceGroupRow.name.in_(keys)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> ResourceGroupID:
+        return ResourceGroupID(value)

--- a/src/ai/backend/manager/models/resource_group/queriers.py
+++ b/src/ai/backend/manager/models/resource_group/queriers.py
@@ -1,0 +1,27 @@
+"""BulkEntityQuerier implementation for the scaling groups table."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.manager.data.resource_group.types import ResourceGroupData
+from ai.backend.manager.models.resource_group.row import ResourceGroupRow
+from ai.backend.manager.models.specs.querier import BulkEntityQuerier
+
+
+class BulkResourceGroupQuerier(BulkEntityQuerier[ResourceGroupRow, ResourceGroupData]):
+    """The resource groups the caller named."""
+
+    @override
+    def row_class(self) -> type[ResourceGroupRow]:
+        return ResourceGroupRow
+
+    @override
+    def entity_id_column(self) -> InstrumentedAttribute[Any]:
+        return ResourceGroupRow.id
+
+    @override
+    def to_data(self, row: ResourceGroupRow) -> ResourceGroupData:
+        return row.to_dataclass()

--- a/src/ai/backend/manager/models/routing/queriers.py
+++ b/src/ai/backend/manager/models/routing/queriers.py
@@ -8,9 +8,9 @@ from typing import Any, override
 from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.replica import ReplicaID
-from ai.backend.manager.data.deployment.types import ModelReplicaData
+from ai.backend.manager.data.deployment.types import ModelReplicaData, RouteInfo
 from ai.backend.manager.models.routing.row import RoutingRow
-from ai.backend.manager.models.specs.querier import FieldQuerier
+from ai.backend.manager.models.specs.querier import BulkFieldQuerier, FieldQuerier
 
 
 @dataclass
@@ -32,3 +32,35 @@ class ModelReplicaQuerier(FieldQuerier[RoutingRow, ModelReplicaData]):
     @override
     def to_data(self, row: RoutingRow) -> ModelReplicaData:
         return row.to_replica_data()
+
+
+class BulkModelReplicaQuerier(BulkFieldQuerier[RoutingRow, ModelReplicaData]):
+    """The replicas the caller named."""
+
+    @override
+    def row_class(self) -> type[RoutingRow]:
+        return RoutingRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return RoutingRow.id
+
+    @override
+    def to_data(self, row: RoutingRow) -> ModelReplicaData:
+        return row.to_replica_data()
+
+
+class BulkRouteQuerier(BulkFieldQuerier[RoutingRow, RouteInfo]):
+    """The same rows read as routes."""
+
+    @override
+    def row_class(self) -> type[RoutingRow]:
+        return RoutingRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return RoutingRow.id
+
+    @override
+    def to_data(self, row: RoutingRow) -> RouteInfo:
+        return row.to_route_info()

--- a/src/ai/backend/manager/models/scheduling_history/lookups.py
+++ b/src/ai/backend/manager/models/scheduling_history/lookups.py
@@ -1,0 +1,92 @@
+"""Lookup specs reaching the session or deployment a history row was recorded for."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_history import DeploymentHistoryID
+from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
+from ai.backend.common.data.entity.route_history import RouteHistoryID
+from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
+from ai.backend.manager.models.scheduling_history.row import (
+    DeploymentHistoryRow,
+    KernelSchedulingHistoryRow,
+    RouteHistoryRow,
+    SessionSchedulingHistoryRow,
+)
+from ai.backend.manager.models.specs.lookup import FieldOwnerLookup
+
+
+@dataclass
+class SessionSchedulingHistoryOwnerLookup(FieldOwnerLookup[SessionSchedulingHistoryID, SessionID]):
+    """The session a scheduling history row was recorded for."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[SessionSchedulingHistoryID]
+    ) -> sa.sql.Select[tuple[SessionSchedulingHistoryID, SessionID]]:
+        return sa.select(
+            SessionSchedulingHistoryRow.id, SessionSchedulingHistoryRow.session_id
+        ).where(SessionSchedulingHistoryRow.id.in_(field_ids))
+
+    @override
+    def to_entity_id(self, value: UUID) -> SessionID:
+        return SessionID(value)
+
+
+@dataclass
+class KernelSchedulingHistoryOwnerLookup(FieldOwnerLookup[KernelSchedulingHistoryID, SessionID]):
+    """The session a kernel scheduling history row was recorded under."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[KernelSchedulingHistoryID]
+    ) -> sa.sql.Select[tuple[KernelSchedulingHistoryID, SessionID]]:
+        return sa.select(
+            KernelSchedulingHistoryRow.id, KernelSchedulingHistoryRow.session_id
+        ).where(KernelSchedulingHistoryRow.id.in_(field_ids))
+
+    @override
+    def to_entity_id(self, value: UUID) -> SessionID:
+        return SessionID(value)
+
+
+@dataclass
+class DeploymentHistoryOwnerLookup(FieldOwnerLookup[DeploymentHistoryID, DeploymentID]):
+    """The deployment a history row was recorded for."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[DeploymentHistoryID]
+    ) -> sa.sql.Select[tuple[DeploymentHistoryID, DeploymentID]]:
+        return sa.select(DeploymentHistoryRow.id, DeploymentHistoryRow.deployment_id).where(
+            DeploymentHistoryRow.id.in_(field_ids)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> DeploymentID:
+        return DeploymentID(value)
+
+
+@dataclass
+class RouteHistoryOwnerLookup(FieldOwnerLookup[RouteHistoryID, DeploymentID]):
+    """The deployment a route history row was recorded under."""
+
+    @override
+    def build_query(
+        self, field_ids: Sequence[RouteHistoryID]
+    ) -> sa.sql.Select[tuple[RouteHistoryID, DeploymentID]]:
+        return sa.select(RouteHistoryRow.id, RouteHistoryRow.deployment_id).where(
+            RouteHistoryRow.id.in_(field_ids)
+        )
+
+    @override
+    def to_entity_id(self, value: UUID) -> DeploymentID:
+        return DeploymentID(value)

--- a/src/ai/backend/manager/models/scheduling_history/queriers.py
+++ b/src/ai/backend/manager/models/scheduling_history/queriers.py
@@ -1,0 +1,86 @@
+"""BulkFieldQuerier implementations for the scheduling history tables."""
+
+from __future__ import annotations
+
+from typing import Any, override
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from ai.backend.manager.data.deployment.types import DeploymentHistoryData, RouteHistoryData
+from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
+from ai.backend.manager.data.session.types import SessionSchedulingHistoryData
+from ai.backend.manager.models.scheduling_history.row import (
+    DeploymentHistoryRow,
+    KernelSchedulingHistoryRow,
+    RouteHistoryRow,
+    SessionSchedulingHistoryRow,
+)
+from ai.backend.manager.models.specs.querier import BulkFieldQuerier
+
+
+class BulkSessionSchedulingHistoryQuerier(
+    BulkFieldQuerier[SessionSchedulingHistoryRow, SessionSchedulingHistoryData]
+):
+    """The session scheduling history rows the caller named."""
+
+    @override
+    def row_class(self) -> type[SessionSchedulingHistoryRow]:
+        return SessionSchedulingHistoryRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return SessionSchedulingHistoryRow.id
+
+    @override
+    def to_data(self, row: SessionSchedulingHistoryRow) -> SessionSchedulingHistoryData:
+        return row.to_data()
+
+
+class BulkKernelSchedulingHistoryQuerier(
+    BulkFieldQuerier[KernelSchedulingHistoryRow, KernelSchedulingHistoryData]
+):
+    """The kernel scheduling history rows the caller named."""
+
+    @override
+    def row_class(self) -> type[KernelSchedulingHistoryRow]:
+        return KernelSchedulingHistoryRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return KernelSchedulingHistoryRow.id
+
+    @override
+    def to_data(self, row: KernelSchedulingHistoryRow) -> KernelSchedulingHistoryData:
+        return row.to_data()
+
+
+class BulkDeploymentHistoryQuerier(BulkFieldQuerier[DeploymentHistoryRow, DeploymentHistoryData]):
+    """The deployment history rows the caller named."""
+
+    @override
+    def row_class(self) -> type[DeploymentHistoryRow]:
+        return DeploymentHistoryRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return DeploymentHistoryRow.id
+
+    @override
+    def to_data(self, row: DeploymentHistoryRow) -> DeploymentHistoryData:
+        return row.to_data()
+
+
+class BulkRouteHistoryQuerier(BulkFieldQuerier[RouteHistoryRow, RouteHistoryData]):
+    """The route history rows the caller named."""
+
+    @override
+    def row_class(self) -> type[RouteHistoryRow]:
+        return RouteHistoryRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return RouteHistoryRow.id
+
+    @override
+    def to_data(self, row: RouteHistoryRow) -> RouteHistoryData:
+        return row.to_data()

--- a/src/ai/backend/manager/models/scheduling_history/row.py
+++ b/src/ai/backend/manager/models/scheduling_history/row.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from datetime import datetime
 from typing import override
 
@@ -8,10 +7,13 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_history import DeploymentHistoryID
 from ai.backend.common.data.entity.kernel import KernelID
 from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.common.data.entity.route_history import RouteHistoryID
 from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
 from ai.backend.common.data.model_deployment.types import ModelDeploymentStatus
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.data.deployment.types import (
@@ -44,9 +46,15 @@ __all__ = (
 class SessionSchedulingHistoryRow(ReconcileHistoryMixin, Base):
     __tablename__ = "session_scheduling_history"
 
-    # Common columns (id, phase, from/to_status, result, error_code, message,
-    # sub_steps, attempts, created_at, updated_at) come from the mixin; the merge
-    # rule below replaces the mixin's.
+    # Common columns (phase, from/to_status, result, error_code, message,
+    # sub_steps, attempts, created_at, updated_at) come from the mixin; the id is
+    # typed here and the merge rule below replaces the mixin's.
+    id: Mapped[SessionSchedulingHistoryID] = mapped_column(
+        "id",
+        GUID(SessionSchedulingHistoryID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v7()"),
+    )
     session_id: Mapped[SessionID] = mapped_column(
         "session_id", GUID(SessionID), nullable=False, index=True
     )
@@ -169,8 +177,11 @@ class KernelSchedulingHistoryRow(Base):
 class DeploymentHistoryRow(Base):
     __tablename__ = "deployment_history"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v7()")
+    id: Mapped[DeploymentHistoryID] = mapped_column(
+        "id",
+        GUID(DeploymentHistoryID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v7()"),
     )
     deployment_id: Mapped[DeploymentID] = mapped_column(
         "deployment_id", GUID(DeploymentID), nullable=False, index=True
@@ -239,8 +250,11 @@ class DeploymentHistoryRow(Base):
 class RouteHistoryRow(Base):
     __tablename__ = "route_history"
 
-    id: Mapped[uuid.UUID] = mapped_column(
-        "id", GUID, primary_key=True, server_default=sa.text("uuid_generate_v7()")
+    id: Mapped[RouteHistoryID] = mapped_column(
+        "id",
+        GUID(RouteHistoryID),
+        primary_key=True,
+        server_default=sa.text("uuid_generate_v7()"),
     )
     route_id: Mapped[ReplicaID] = mapped_column(
         "route_id", GUID(ReplicaID), nullable=False, index=True

--- a/src/ai/backend/manager/models/specs/querier.py
+++ b/src/ai/backend/manager/models/specs/querier.py
@@ -148,3 +148,27 @@ class FieldQuerier[TRow: Base, TData: FieldData](ABC):
     def to_data(self, row: TRow) -> TData:
         """Convert the fetched row into its ``data/`` type."""
         raise NotImplementedError
+
+
+class BulkFieldQuerier[TRow: Base, TData: FieldData](ABC):
+    """Reads the field rows the caller named, keyed by their own ids.
+
+    Plural :class:`FieldQuerier`. The ids are the whole query, so the spec owns it and
+    ops adds no clause of its own; each row is authorized through the owner the
+    lookup reads, the way the single read is.
+    """
+
+    @abstractmethod
+    def row_class(self) -> type[TRow]:
+        """Return the ORM class the rows are read from."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        """Return the column carrying the field id, which the read keys on."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def to_data(self, row: TRow) -> TData:
+        """Convert one fetched row into its ``data/`` type."""
+        raise NotImplementedError

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -44,6 +44,7 @@ from ai.backend.manager.models.specs.purger import (
 )
 from ai.backend.manager.models.specs.querier import (
     BulkEntityQuerier,
+    BulkFieldQuerier,
     DataQuerier,
     FieldQuerier,
     OwnedFieldQuerier,
@@ -125,6 +126,13 @@ class OpsRepository[TData]:
         """Resolve several keys into the ids they name; a key naming nothing is absent."""
         async with self._ops.read_ops() as r:
             return await r.lookup_entity_ids(lookup, keys)
+
+    async def bulk_get_fields[TFieldData: FieldData](
+        self, querier: BulkFieldQuerier[Any, TFieldData], field_ids: Sequence[FieldIdentifier]
+    ) -> Mapping[FieldIdentifier, TFieldData]:
+        """Read the named field rows; one that is gone is absent instead of raising."""
+        async with self._ops.read_ops() as r:
+            return await r.query_bulk_field_data(querier, field_ids)
 
     async def owned_fields[TOwnerID: EntityIdentifier, TFieldData: FieldData](
         self,

--- a/src/ai/backend/manager/repositories/ops/v2/read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/read.py
@@ -31,6 +31,7 @@ from ai.backend.manager.models.specs.lookup import (
 )
 from ai.backend.manager.models.specs.querier import (
     BulkEntityQuerier,
+    BulkFieldQuerier,
     DataQuerier,
     FieldQuerier,
     OwnedFieldQuerier,
@@ -213,6 +214,25 @@ class V2ReadOps(V2GraphReadOpsBase):
         if row is None:
             return None
         return querier.to_data(row)
+
+    async def query_bulk_field_data[TRow: Base, TData: FieldData](
+        self,
+        querier: BulkFieldQuerier[TRow, TData],
+        field_ids: Sequence[FieldIdentifier],
+    ) -> Mapping[FieldIdentifier, TData]:
+        """Read the named field rows, keyed by the ids the caller passed.
+
+        An id matching no row is absent rather than an error, as in
+        :meth:`query_bulk_data`.
+        """
+        if not field_ids:
+            return {}
+        id_column = querier.target_id_column()
+        rows = (
+            await self._sess.scalars(sa.select(querier.row_class()).where(id_column.in_(field_ids)))
+        ).all()
+        found = {getattr(row, id_column.key): querier.to_data(row) for row in rows}
+        return {field_id: found[field_id] for field_id in field_ids if field_id in found}
 
     async def search_with_scopes[TRow: Base, TData](
         self,

--- a/src/ai/backend/manager/services/artifact/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/artifact/actions/bulk_get.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.artifact import ArtifactID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.artifact.types import ArtifactData
+from ai.backend.manager.models.artifact.queriers import BulkArtifactQuerier
+from ai.backend.manager.models.artifact.row import ArtifactRow
+
+
+@dataclass
+class BulkGetArtifactsAction(PartialBulkGetEntityOpsAction[ArtifactRow, ArtifactData]):
+    """Read the artifacts the caller named, answering for each id."""
+
+    ids: Sequence[ArtifactID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_artifacts"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkArtifactQuerier:
+        return BulkArtifactQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/artifact/processors.py
+++ b/src/ai/backend/manager/services/artifact/processors.py
@@ -1,10 +1,12 @@
 from ai.backend.manager.actions.registry.field import FieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import ScopedFieldsOpsResult
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.artifact.types import ArtifactData, ArtifactRevisionData
+from ai.backend.manager.services.artifact.actions.bulk_get import BulkGetArtifactsAction
 from ai.backend.manager.services.artifact.actions.delegate_scan import (
     DelegateScanArtifactsAction,
     DelegateScanArtifactsActionResult,
@@ -62,6 +64,8 @@ from .service import ArtifactService
 class ArtifactProcessors:
     scan: GlobalActionProcessor[ScanArtifactsAction, ScanArtifactsActionResult]
     get: SingleEntityActionProcessor[GetArtifactAction, GetArtifactActionResult]
+    # What the DataLoader reads: checked per artifact.
+    bulk_get: PartialBulkActionProcessor[BulkGetArtifactsAction, ArtifactData]
     search_artifacts: GlobalActionProcessor[SearchArtifactsAction, SearchArtifactsActionResult]
     search_artifacts_with_revisions: GlobalActionProcessor[
         SearchArtifactsWithRevisionsAction, SearchArtifactsWithRevisionsActionResult
@@ -95,6 +99,7 @@ class ArtifactProcessors:
         # TODO: Move scan action to ArtifactRegistryService
         self.scan = group.global_scope(ScanArtifactsAction, service.scan)
         self.get = group.single_entity(GetArtifactAction, service.get)
+        self.bulk_get = group.partial_bulk_get_ops(BulkGetArtifactsAction)
         self.search_artifacts = group.global_scope(SearchArtifactsAction, service.search)
         self.search_artifacts_with_revisions = group.global_scope(
             SearchArtifactsWithRevisionsAction, service.search_with_revisions

--- a/src/ai/backend/manager/services/artifact/revision/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/artifact/revision/actions/bulk_get.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.artifact import ArtifactID
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.artifact.types import ArtifactRevisionData
+from ai.backend.manager.models.artifact_revision.queriers import BulkArtifactRevisionQuerier
+from ai.backend.manager.models.artifact_revision.row import ArtifactRevisionRow
+from ai.backend.manager.services.artifact.revision.actions.lookup_owner import (
+    LookupBulkArtifactRevisionOwnerAction,
+)
+
+
+@dataclass
+class BulkGetArtifactRevisionsAction(
+    PartialBulkGetFieldOpsAction[
+        ArtifactRevisionID, ArtifactID, ArtifactRevisionRow, ArtifactRevisionData
+    ]
+):
+    """Read the artifact revisions the caller named, answering for each one."""
+
+    ids: Sequence[ArtifactRevisionID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_artifact_revisions"
+
+    @override
+    def field_ids(self) -> Sequence[ArtifactRevisionID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkArtifactRevisionOwnerAction:
+        return LookupBulkArtifactRevisionOwnerAction(revision_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkArtifactRevisionQuerier:
+        return BulkArtifactRevisionQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[ArtifactRevisionID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/artifact/revision/processors.py
+++ b/src/ai/backend/manager/services/artifact/revision/processors.py
@@ -1,5 +1,6 @@
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.field.bulk_processor import PartialBulkFieldActionProcessor
 from ai.backend.manager.actions.v2.field.processor import SingleFieldActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import EntityOpsResult
@@ -11,6 +12,9 @@ from ai.backend.manager.services.artifact.revision.actions.approve import (
 from ai.backend.manager.services.artifact.revision.actions.associate_with_storage import (
     AssociateWithStorageAction,
     AssociateWithStorageActionResult,
+)
+from ai.backend.manager.services.artifact.revision.actions.bulk_get import (
+    BulkGetArtifactRevisionsAction,
 )
 from ai.backend.manager.services.artifact.revision.actions.cancel_import import (
     CancelImportAction,
@@ -59,6 +63,8 @@ from ai.backend.manager.services.artifact.revision.service import ArtifactRevisi
 
 
 class ArtifactRevisionProcessors:
+    # What the DataLoader reads: checked per owning artifact.
+    bulk_get: PartialBulkFieldActionProcessor[BulkGetArtifactRevisionsAction, ArtifactRevisionData]
     get: SingleFieldActionProcessor[
         GetArtifactRevisionAction, EntityOpsResult[ArtifactRevisionData]
     ]
@@ -105,6 +111,7 @@ class ArtifactRevisionProcessors:
         service: ArtifactRevisionService,
     ) -> None:
         self.get = revisions.get_ops(GetArtifactRevisionAction)
+        self.bulk_get = revisions.partial_bulk_get_ops(BulkGetArtifactRevisionsAction)
         self.get_readme = revisions.single_field(
             GetArtifactRevisionReadmeAction, service.get_readme
         )

--- a/src/ai/backend/manager/services/deployment/actions/access_token/bulk_get_access_tokens.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/bulk_get_access_tokens.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
+from ai.backend.manager.models.endpoint.queriers import BulkDeploymentAccessTokenQuerier
+from ai.backend.manager.models.endpoint.row import EndpointTokenRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupBulkDeploymentAccessTokenOwnerAction,
+)
+
+
+@dataclass
+class BulkGetAccessTokensAction(
+    PartialBulkGetFieldOpsAction[
+        DeploymentTokenID, DeploymentID, EndpointTokenRow, ModelDeploymentAccessTokenData
+    ]
+):
+    """Read the access tokens the caller named, answering for each one."""
+
+    ids: Sequence[DeploymentTokenID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_access_tokens"
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentTokenID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkDeploymentAccessTokenOwnerAction:
+        return LookupBulkDeploymentAccessTokenOwnerAction(access_token_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkDeploymentAccessTokenQuerier:
+        return BulkDeploymentAccessTokenQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[DeploymentTokenID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/deployment/actions/deployment_policy/bulk_get_deployment_policies.py
+++ b/src/ai/backend/manager/services/deployment/actions/deployment_policy/bulk_get_deployment_policies.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import BulkGetOwnedFieldOpsAction
+from ai.backend.manager.data.deployment.types import DeploymentPolicyData
+from ai.backend.manager.models.deployment_policy.queriers import (
+    DeploymentPolicyByDeploymentQuerier,
+)
+from ai.backend.manager.models.deployment_policy.row import DeploymentPolicyRow
+
+
+@dataclass
+class BulkGetDeploymentPoliciesAction(
+    BulkGetOwnedFieldOpsAction[DeploymentID, DeploymentPolicyRow, DeploymentPolicyData]
+):
+    """Read the policy each named deployment carries."""
+
+    deployment_ids: Sequence[DeploymentID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_deployment_policies"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.deployment_ids)
+
+    @override
+    def owner_ids(self) -> Sequence[DeploymentID]:
+        return tuple(self.deployment_ids)
+
+    @override
+    def to_querier(self) -> DeploymentPolicyByDeploymentQuerier:
+        return DeploymentPolicyByDeploymentQuerier()

--- a/src/ai/backend/manager/services/deployment/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/deployment/actions/lookup_owner.py
@@ -8,6 +8,7 @@ from typing import Any, override
 from uuid import UUID
 
 from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.common.data.entity.replica import ReplicaID
@@ -18,6 +19,7 @@ from ai.backend.manager.actions.v2.field.lookup import (
     LookupFieldOwnerOpsAction,
 )
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
+from ai.backend.manager.models.deployment_policy.lookups import DeploymentPolicyOwnerLookup
 from ai.backend.manager.models.deployment_revision.lookups import DeploymentRevisionOwnerLookup
 from ai.backend.manager.models.endpoint.lookups import (
     AutoScalingRuleDeploymentLookup,
@@ -291,3 +293,80 @@ class LookupBulkDeploymentAccessTokenOwnerAction(
     @override
     def to_owner_lookup(self) -> DeploymentAccessTokenOwnerLookup:
         return DeploymentAccessTokenOwnerLookup()
+
+
+@dataclass(frozen=True)
+class DeploymentPolicyIDLookupKey(LookupKey):
+    """A policy's id, resolved into the deployment it belongs to."""
+
+    policy_id: DeploymentPolicyID
+
+    @override
+    def kind(self) -> str:
+        return "deployment_policy_id"
+
+    @override
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": str(self.policy_id)}
+
+
+@dataclass
+class LookupDeploymentPolicyOwnerAction(
+    LookupFieldOwnerOpsAction[DeploymentPolicyID, DeploymentID]
+):
+    """The deployment a policy belongs to."""
+
+    policy_id: DeploymentPolicyID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_deployment_policy_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return DeploymentPolicyIDLookupKey(self.policy_id)
+
+    @override
+    def field_id(self) -> DeploymentPolicyID:
+        return self.policy_id
+
+    @override
+    def to_owner_lookup(self) -> DeploymentPolicyOwnerLookup:
+        return DeploymentPolicyOwnerLookup()
+
+
+@dataclass
+class LookupBulkDeploymentPolicyOwnerAction(
+    LookupBulkFieldOwnerOpsAction[DeploymentPolicyID, DeploymentID]
+):
+    """The deployments several policies belong to."""
+
+    policy_ids: Sequence[DeploymentPolicyID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_deployment_policy_owner"
+
+    @override
+    def to_lookup_key(self, field_id: DeploymentPolicyID) -> LookupKey:
+        return DeploymentPolicyIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentPolicyID]:
+        return tuple(self.policy_ids)
+
+    @override
+    def to_owner_lookup(self) -> DeploymentPolicyOwnerLookup:
+        return DeploymentPolicyOwnerLookup()

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/bulk_get_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/bulk_get_revisions.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.deployment.types import ModelRevisionData
+from ai.backend.manager.models.deployment_revision.queriers import BulkModelRevisionQuerier
+from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupBulkDeploymentRevisionOwnerAction,
+)
+
+
+@dataclass
+class BulkGetRevisionsAction(
+    PartialBulkGetFieldOpsAction[
+        DeploymentRevisionID, DeploymentID, DeploymentRevisionRow, ModelRevisionData
+    ]
+):
+    """Read the revisions the caller named, answering for each one."""
+
+    ids: Sequence[DeploymentRevisionID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_revisions"
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentRevisionID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkDeploymentRevisionOwnerAction:
+        return LookupBulkDeploymentRevisionOwnerAction(revision_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkModelRevisionQuerier:
+        return BulkModelRevisionQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[DeploymentRevisionID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/deployment/actions/replica/bulk_get_replicas.py
+++ b/src/ai/backend/manager/services/deployment/actions/replica/bulk_get_replicas.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.deployment.types import ModelReplicaData
+from ai.backend.manager.models.routing.queriers import BulkModelReplicaQuerier
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupBulkReplicaOwnerAction,
+)
+
+
+@dataclass
+class BulkGetReplicasAction(
+    PartialBulkGetFieldOpsAction[ReplicaID, DeploymentID, RoutingRow, ModelReplicaData]
+):
+    """Read the replicas the caller named, answering for each one."""
+
+    ids: Sequence[ReplicaID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_replicas"
+
+    @override
+    def field_ids(self) -> Sequence[ReplicaID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkReplicaOwnerAction:
+        return LookupBulkReplicaOwnerAction(replica_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkModelReplicaQuerier:
+        return BulkModelReplicaQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[ReplicaID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/deployment/actions/route/bulk_get_routes.py
+++ b/src/ai/backend/manager/services/deployment/actions/route/bulk_get_routes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.replica import ReplicaID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.deployment.types import RouteInfo
+from ai.backend.manager.models.routing.queriers import BulkRouteQuerier
+from ai.backend.manager.models.routing.row import RoutingRow
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupBulkReplicaOwnerAction,
+)
+
+
+@dataclass
+class BulkGetRoutesAction(
+    PartialBulkGetFieldOpsAction[ReplicaID, DeploymentID, RoutingRow, RouteInfo]
+):
+    """Read the routes the caller named, answering for each one."""
+
+    ids: Sequence[ReplicaID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_routes"
+
+    @override
+    def field_ids(self) -> Sequence[ReplicaID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkReplicaOwnerAction:
+        return LookupBulkReplicaOwnerAction(replica_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkRouteQuerier:
+        return BulkRouteQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[ReplicaID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_policy import DEPLOYMENT_POLICY_FIELD_TYPE
 from ai.backend.common.data.entity.deployment_revision import DEPLOYMENT_REVISION_FIELD_TYPE
 from ai.backend.common.data.entity.deployment_token import DEPLOYMENT_TOKEN_FIELD_TYPE
 from ai.backend.common.data.entity.replica import REPLICA_FIELD_TYPE
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.registry.types import FieldGroupMeta
+from ai.backend.manager.actions.v2.bulk.processor import BulkActionProcessor
+from ai.backend.manager.actions.v2.field.bulk_processor import PartialBulkFieldActionProcessor
 from ai.backend.manager.actions.v2.field.processor import SingleFieldActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
@@ -17,19 +21,25 @@ from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
     EntityOpsResult,
     FieldOwnerLookupOpsResult,
+    OwnedFieldsOpsResult,
     ScopedFieldsOpsResult,
 )
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.deployment.types import (
+    DeploymentPolicyData,
     ModelDeploymentAccessTokenData,
     ModelDeploymentData,
     ModelReplicaData,
     ModelRevisionData,
+    RouteInfo,
 )
 from ai.backend.manager.services.deployment.actions.access_token.bulk_delete_access_tokens import (
     BulkDeleteAccessTokensAction,
     BulkDeleteAccessTokensActionResult,
+)
+from ai.backend.manager.services.deployment.actions.access_token.bulk_get_access_tokens import (
+    BulkGetAccessTokensAction,
 )
 from ai.backend.manager.services.deployment.actions.access_token.create_access_token import (
     CreateAccessTokenAction,
@@ -88,6 +98,9 @@ from ai.backend.manager.services.deployment.actions.deployment_policy import (
     UpsertDeploymentPolicyAction,
     UpsertDeploymentPolicyActionResult,
 )
+from ai.backend.manager.services.deployment.actions.deployment_policy.bulk_get_deployment_policies import (
+    BulkGetDeploymentPoliciesAction,
+)
 from ai.backend.manager.services.deployment.actions.destroy_deployment import (
     DestroyDeploymentAction,
     DestroyDeploymentActionResult,
@@ -109,15 +122,20 @@ from ai.backend.manager.services.deployment.actions.global_search_replicas impor
 from ai.backend.manager.services.deployment.actions.lookup_owner import (
     LookupAutoScalingRuleDeploymentAction,
     LookupBulkDeploymentAccessTokenOwnerAction,
+    LookupBulkDeploymentPolicyOwnerAction,
     LookupBulkDeploymentRevisionOwnerAction,
     LookupBulkReplicaOwnerAction,
     LookupDeploymentAccessTokenOwnerAction,
+    LookupDeploymentPolicyOwnerAction,
     LookupDeploymentRevisionOwnerAction,
     LookupReplicaOwnerAction,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.add_model_revision import (
     AddModelRevisionAction,
     AddModelRevisionActionResult,
+)
+from ai.backend.manager.services.deployment.actions.model_revision.bulk_get_revisions import (
+    BulkGetRevisionsAction,
 )
 from ai.backend.manager.services.deployment.actions.model_revision.get_revision_by_id import (
     GetRevisionByIdAction,
@@ -140,6 +158,9 @@ from ai.backend.manager.services.deployment.actions.replace_deployment_options i
     ReplaceDeploymentOptionsAction,
     ReplaceDeploymentOptionsActionResult,
 )
+from ai.backend.manager.services.deployment.actions.replica.bulk_get_replicas import (
+    BulkGetReplicasAction,
+)
 from ai.backend.manager.services.deployment.actions.revision_operations import (
     ActivateRevisionAction,
     ActivateRevisionActionResult,
@@ -149,6 +170,9 @@ from ai.backend.manager.services.deployment.actions.route import (
     SearchRoutesActionResult,
     UpdateRouteTrafficStatusAction,
     UpdateRouteTrafficStatusActionResult,
+)
+from ai.backend.manager.services.deployment.actions.route.bulk_get_routes import (
+    BulkGetRoutesAction,
 )
 from ai.backend.manager.services.deployment.actions.scoped_search import (
     ScopedSearchDeploymentsAction,
@@ -297,6 +321,17 @@ class DeploymentProcessors:
         SearchAccessTokensAction, ScopedFieldsOpsResult[ModelDeploymentAccessTokenData]
     ]
 
+    # What the DataLoaders read: checked per owning deployment.
+    bulk_get_revisions: PartialBulkFieldActionProcessor[BulkGetRevisionsAction, ModelRevisionData]
+    bulk_get_replicas: PartialBulkFieldActionProcessor[BulkGetReplicasAction, ModelReplicaData]
+    bulk_get_routes: PartialBulkFieldActionProcessor[BulkGetRoutesAction, RouteInfo]
+    bulk_get_access_tokens: PartialBulkFieldActionProcessor[
+        BulkGetAccessTokensAction, ModelDeploymentAccessTokenData
+    ]
+    bulk_get_deployment_policies: BulkActionProcessor[
+        BulkGetDeploymentPoliciesAction, OwnedFieldsOpsResult[DeploymentID, DeploymentPolicyData]
+    ]
+
     global_search_replicas: GlobalActionProcessor[
         GlobalSearchReplicasAction, BatchOpsResult[ModelReplicaData]
     ]
@@ -327,6 +362,25 @@ class DeploymentProcessors:
             ModelDeploymentAccessTokenData,
             LookupDeploymentAccessTokenOwnerAction,
             LookupBulkDeploymentAccessTokenOwnerAction,
+        )
+        policies: LookupFieldGroup[DeploymentPolicyData] = group.field_group(
+            FieldGroupMeta(DEPLOYMENT_POLICY_FIELD_TYPE),
+            DeploymentPolicyData,
+            LookupDeploymentPolicyOwnerAction,
+            LookupBulkDeploymentPolicyOwnerAction,
+        )
+        self.bulk_get_revisions = revisions.partial_bulk_get_ops(BulkGetRevisionsAction)
+        self.bulk_get_replicas = replicas.partial_bulk_get_ops(BulkGetReplicasAction)
+        routes: LookupFieldGroup[RouteInfo] = group.field_group(
+            FieldGroupMeta(REPLICA_FIELD_TYPE),
+            RouteInfo,
+            LookupReplicaOwnerAction,
+            LookupBulkReplicaOwnerAction,
+        )
+        self.bulk_get_routes = routes.partial_bulk_get_ops(BulkGetRoutesAction)
+        self.bulk_get_access_tokens = access_tokens.partial_bulk_get_ops(BulkGetAccessTokensAction)
+        self.bulk_get_deployment_policies = policies.atomic_bulk_get_ops(
+            BulkGetDeploymentPoliciesAction
         )
         self.lookup_auto_scaling_rule_deployment = group.key_owner_lookup_ops(
             LookupAutoScalingRuleDeploymentAction

--- a/src/ai/backend/manager/services/domain/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/domain/actions/bulk_get.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.domain.types import DomainData
+from ai.backend.manager.models.domain.queriers import BulkDomainQuerier
+from ai.backend.manager.models.domain.row import DomainRow
+
+
+@dataclass
+class BulkGetDomainsAction(PartialBulkGetEntityOpsAction[DomainRow, DomainData]):
+    """Read the domains the caller named, answering for each id.
+
+    Wired public: a regular user holds no read on the domain entity, and the domains
+    a DataLoader names are the ones the caller's own rows already point at.
+    """
+
+    ids: Sequence[DomainID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_domains"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkDomainQuerier:
+        return BulkDomainQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/domain/actions/bulk_lookup.py
+++ b/src/ai/backend/manager/services/domain/actions/bulk_lookup.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID, DomainName
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import BulkLookupEntityOpsAction
+from ai.backend.manager.models.domain.lookups import DomainNamesLookup
+from ai.backend.manager.services.domain.actions.lookup import DomainNameKey
+
+
+@dataclass
+class BulkLookupDomainsAction(BulkLookupEntityOpsAction[DomainName, DomainID]):
+    """Resolve several names into the domains they name."""
+
+    names: Sequence[DomainName]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DOMAIN_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_lookup_domains"
+
+    @override
+    def keys(self) -> Sequence[DomainName]:
+        return tuple(self.names)
+
+    @override
+    def to_lookup_key(self, key: DomainName) -> DomainNameKey:
+        return DomainNameKey(name=key)
+
+    @override
+    def to_lookup(self) -> DomainNamesLookup:
+        return DomainNamesLookup()

--- a/src/ai/backend/manager/services/domain/processors.py
+++ b/src/ai/backend/manager/services/domain/processors.py
@@ -1,10 +1,13 @@
-from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.domain import DomainID, DomainName
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
+from ai.backend.manager.actions.v2.lookup.bulk_processor import BulkLookupActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
+    BulkLookupOpsResult,
     CreatedEntityOpsResult,
     EntityOpsResult,
     LookupOpsResult,
@@ -15,6 +18,8 @@ from ai.backend.manager.actions.v2.single_entity.processor import (
     SingleEntityActionProcessor,
 )
 from ai.backend.manager.data.domain.types import DomainData
+from ai.backend.manager.services.domain.actions.bulk_get import BulkGetDomainsAction
+from ai.backend.manager.services.domain.actions.bulk_lookup import BulkLookupDomainsAction
 from ai.backend.manager.services.domain.actions.create_domain import CreateDomainAction
 from ai.backend.manager.services.domain.actions.create_domain_dotfile import (
     CreateDomainDotfileAction,
@@ -53,6 +58,11 @@ from ai.backend.manager.services.domain.service import DomainService
 class DomainProcessors:
     get: SingleEntityActionProcessor[GetDomainAction, EntityOpsResult[DomainData]]
     lookup: LookupActionProcessor[LookupDomainAction, LookupOpsResult[DomainID]]
+    bulk_lookup: BulkLookupActionProcessor[
+        BulkLookupDomainsAction, BulkLookupOpsResult[DomainName, DomainID]
+    ]
+    # What the DataLoaders read: open to every authenticated caller.
+    bulk_get: PartialBulkActionProcessor[BulkGetDomainsAction, DomainData]
     global_search: GlobalActionProcessor[GlobalSearchDomainsAction, BatchOpsResult[DomainData]]
     scoped_search: ScopeActionProcessor[ScopedSearchDomainsAction, ScopedBatchOpsResult[DomainData]]
     update_domain: SingleEntityActionProcessor[UpdateDomainAction, EntityOpsResult[DomainData]]
@@ -82,6 +92,8 @@ class DomainProcessors:
     ) -> None:
         self.get = group.single_get_ops(GetDomainAction)
         self.lookup = group.public_lookup_ops(LookupDomainAction)
+        self.bulk_lookup = group.public_bulk_lookup_ops(BulkLookupDomainsAction)
+        self.bulk_get = group.public_partial_bulk_get_ops(BulkGetDomainsAction)
         self.global_search = group.global_search_ops(GlobalSearchDomainsAction)
         self.scoped_search = group.scope_search_ops(ScopedSearchDomainsAction)
         self.update_domain = group.single_guarded_update_ops(UpdateDomainAction)

--- a/src/ai/backend/manager/services/notification/actions/bulk_get_channels.py
+++ b/src/ai/backend/manager/services/notification/actions/bulk_get_channels.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.notification import NotificationChannelID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.notification.types import NotificationChannelData
+from ai.backend.manager.models.notification.queriers import BulkNotificationChannelQuerier
+from ai.backend.manager.models.notification.row import NotificationChannelRow
+
+
+@dataclass
+class BulkGetChannelsAction(
+    PartialBulkGetEntityOpsAction[NotificationChannelRow, NotificationChannelData]
+):
+    """Read the notification channels the caller named, answering for each id."""
+
+    ids: Sequence[NotificationChannelID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_notification_channels"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkNotificationChannelQuerier:
+        return BulkNotificationChannelQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/notification/actions/bulk_get_rules.py
+++ b/src/ai/backend/manager/services/notification/actions/bulk_get_rules.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.notification import NotificationRuleID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.notification.types import NotificationRuleData
+from ai.backend.manager.models.notification.queriers import BulkNotificationRuleQuerier
+from ai.backend.manager.models.notification.row import NotificationRuleRow
+
+
+@dataclass
+class BulkGetRulesAction(PartialBulkGetEntityOpsAction[NotificationRuleRow, NotificationRuleData]):
+    """Read the notification rules the caller named, answering for each id."""
+
+    ids: Sequence[NotificationRuleID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_notification_rules"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkNotificationRuleQuerier:
+        return BulkNotificationRuleQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/notification/processors.py
+++ b/src/ai/backend/manager/services/notification/processors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.ops.result import (
     BatchOpsResult,
@@ -14,6 +15,10 @@ from ai.backend.manager.data.notification.types import (
     NotificationChannelData,
     NotificationRuleData,
 )
+from ai.backend.manager.services.notification.actions.bulk_get_channels import (
+    BulkGetChannelsAction,
+)
+from ai.backend.manager.services.notification.actions.bulk_get_rules import BulkGetRulesAction
 from ai.backend.manager.services.notification.actions.create_channel import CreateChannelAction
 from ai.backend.manager.services.notification.actions.create_rule import CreateRuleAction
 from ai.backend.manager.services.notification.actions.get_channel import GetChannelAction
@@ -41,6 +46,10 @@ from ai.backend.manager.services.notification.service import NotificationService
 
 class NotificationProcessors:
     """Both catalogs run against ops; only dispatch and the two validations keep a service."""
+
+    # What the DataLoaders read: checked per channel or rule.
+    bulk_get_channels: PartialBulkActionProcessor[BulkGetChannelsAction, NotificationChannelData]
+    bulk_get_rules: PartialBulkActionProcessor[BulkGetRulesAction, NotificationRuleData]
 
     create_channel: GlobalActionProcessor[
         CreateChannelAction, CreatedEntityOpsResult[NotificationChannelData]
@@ -80,6 +89,8 @@ class NotificationProcessors:
         rule_group: ProcessorGroup[NotificationRuleData],
         service: NotificationService,
     ) -> None:
+        self.bulk_get_channels = channel_group.partial_bulk_get_ops(BulkGetChannelsAction)
+        self.bulk_get_rules = rule_group.partial_bulk_get_ops(BulkGetRulesAction)
         self.create_channel = channel_group.global_create_ops(CreateChannelAction)
         self.update_channel = channel_group.single_update_ops(UpdateChannelAction)
         self.purge_channel = channel_group.entity_purge_ops(PurgeChannelAction)

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -32,6 +32,7 @@ from ai.backend.manager.actions.v2.field.lookup import (
     FieldOwnerLookupOpsAction,
     RuntimeFieldOwnerLookupOpsAction,
 )
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
 from ai.backend.manager.actions.v2.lookup.bulk_base import BulkLookupKeyResult
 from ai.backend.manager.actions.v2.ops.base import (
     BatchPurgeOpsAction,
@@ -117,6 +118,7 @@ __all__ = (
     "FieldPurgeService",
     "GlobalPartialBulkPurgeService",
     "EntityPartialBulkPurgeService",
+    "FieldPartialBulkGetService",
     "FieldPartialBulkPurgeService",
     "GlobalUpsertService",
     "EntityUpsertService",
@@ -706,6 +708,36 @@ class EntityPartialBulkPurgeService[TData]:
     ) -> PartialBulkResult[TData]:
         result = await self._repository.partial_bulk_purge_entities(action.to_purgers())
         return PartialBulkResult(items=_partial_bulk_items(result))
+
+
+class FieldPartialBulkGetService[TData: FieldData]:
+    """Reads the field rows the action names, answering for each one.
+
+    The rows whose owner the caller may not read are gone from the action by the time
+    this runs; a row matching nothing is one failed item.
+    """
+
+    _repository: OpsRepository[Any]
+
+    def __init__(self, repository: OpsRepository[Any]) -> None:
+        self._repository = repository
+
+    async def execute(
+        self, action: PartialBulkGetFieldOpsAction[Any, Any, Any, TData]
+    ) -> BulkFieldOpsResult[TData]:
+        field_ids = action.field_ids()
+        querier = action.to_querier()
+        found = await self._repository.bulk_get_fields(querier, field_ids)
+        return BulkFieldOpsResult(
+            successes={field_id: found[field_id] for field_id in field_ids if field_id in found},
+            errors={
+                field_id: EntityNotFoundError(
+                    f"{querier.row_class().__name__} {field_id} not found"
+                )
+                for field_id in field_ids
+                if field_id not in found
+            },
+        )
 
 
 class FieldPartialBulkPurgeService[TData: FieldData]:

--- a/src/ai/backend/manager/services/resource_group/actions/bulk_get.py
+++ b/src/ai/backend/manager/services/resource_group/actions/bulk_get.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.manager.actions.v2.ops.base import PartialBulkGetEntityOpsAction
+from ai.backend.manager.data.resource_group.types import ResourceGroupData
+from ai.backend.manager.models.resource_group.queriers import BulkResourceGroupQuerier
+from ai.backend.manager.models.resource_group.row import ResourceGroupRow
+
+
+@dataclass
+class BulkGetResourceGroupsAction(
+    PartialBulkGetEntityOpsAction[ResourceGroupRow, ResourceGroupData]
+):
+    """Read the resource groups the caller named, answering for each id."""
+
+    ids: Sequence[ResourceGroupID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_resource_groups"
+
+    @override
+    def entity_ids(self) -> Sequence[EntityIdentifier]:
+        return tuple(self.ids)
+
+    @override
+    def to_querier(self) -> BulkResourceGroupQuerier:
+        return BulkResourceGroupQuerier()
+
+    @override
+    def narrowed_to(self, entity_ids: Sequence[EntityIdentifier]) -> Self:
+        allowed = frozenset(entity_ids)
+        return replace(self, ids=[entity_id for entity_id in self.ids if entity_id in allowed])

--- a/src/ai/backend/manager/services/resource_group/actions/bulk_lookup.py
+++ b/src/ai/backend/manager/services/resource_group/actions/bulk_lookup.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.data.entity.resource_group import (
+    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupID,
+    ResourceGroupName,
+)
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.manager.actions.v2.ops.base import BulkLookupEntityOpsAction
+from ai.backend.manager.models.resource_group.lookups import ResourceGroupNamesLookup
+from ai.backend.manager.services.resource_group.actions.lookup import ResourceGroupNameKey
+
+
+@dataclass
+class BulkLookupResourceGroupsAction(BulkLookupEntityOpsAction[ResourceGroupName, ResourceGroupID]):
+    """Resolve several names into the resource groups they refer to.
+
+    Every authenticated caller may resolve the names, as with the single lookup: the
+    read that follows is checked against each resource group on its own.
+    """
+
+    names: Sequence[ResourceGroupName]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return RESOURCE_GROUP_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_lookup_resource_groups"
+
+    @override
+    def keys(self) -> Sequence[ResourceGroupName]:
+        return tuple(self.names)
+
+    @override
+    def to_lookup_key(self, key: ResourceGroupName) -> ResourceGroupNameKey:
+        return ResourceGroupNameKey(name=key)
+
+    @override
+    def to_lookup(self) -> ResourceGroupNamesLookup:
+        return ResourceGroupNamesLookup()

--- a/src/ai/backend/manager/services/resource_group/processors.py
+++ b/src/ai/backend/manager/services/resource_group/processors.py
@@ -1,11 +1,17 @@
-from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.v2.bulk.partial_processor import PartialBulkActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import (
     GlobalActionProcessor,
     PublicActionProcessor,
 )
+from ai.backend.manager.actions.v2.lookup.bulk_processor import BulkLookupActionProcessor
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
-from ai.backend.manager.actions.v2.ops.result import LookupOpsResult, ScopedBatchOpsResult
+from ai.backend.manager.actions.v2.ops.result import (
+    BulkLookupOpsResult,
+    LookupOpsResult,
+    ScopedBatchOpsResult,
+)
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.resource_group.types import ResourceGroupData
@@ -20,6 +26,12 @@ from ai.backend.manager.services.resource_group.actions.associate_with_keypair i
 from ai.backend.manager.services.resource_group.actions.associate_with_user_group import (
     AssociateResourceGroupWithUserGroupsAction,
     AssociateResourceGroupWithUserGroupsActionResult,
+)
+from ai.backend.manager.services.resource_group.actions.bulk_get import (
+    BulkGetResourceGroupsAction,
+)
+from ai.backend.manager.services.resource_group.actions.bulk_lookup import (
+    BulkLookupResourceGroupsAction,
 )
 from ai.backend.manager.services.resource_group.actions.create import (
     CreateResourceGroupAction,
@@ -106,6 +118,11 @@ from ai.backend.manager.services.resource_group.service import ResourceGroupServ
 
 class ResourceGroupProcessors:
     lookup: LookupActionProcessor[LookupResourceGroupAction, LookupOpsResult[ResourceGroupID]]
+    bulk_lookup: BulkLookupActionProcessor[
+        BulkLookupResourceGroupsAction, BulkLookupOpsResult[ResourceGroupName, ResourceGroupID]
+    ]
+    # What the DataLoaders read: checked per resource group.
+    bulk_get: PartialBulkActionProcessor[BulkGetResourceGroupsAction, ResourceGroupData]
     create_resource_group: GlobalActionProcessor[
         CreateResourceGroupAction, CreateResourceGroupActionResult
     ]
@@ -191,6 +208,8 @@ class ResourceGroupProcessors:
         self, group: ProcessorGroup[ResourceGroupData], service: ResourceGroupService
     ) -> None:
         self.lookup = group.public_lookup_ops(LookupResourceGroupAction)
+        self.bulk_lookup = group.public_bulk_lookup_ops(BulkLookupResourceGroupsAction)
+        self.bulk_get = group.partial_bulk_get_ops(BulkGetResourceGroupsAction)
         self.create_resource_group = group.global_scope(
             CreateResourceGroupAction, service.create_resource_group
         )

--- a/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_deployment_histories.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_deployment_histories.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.deployment_history import DeploymentHistoryID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.deployment.types import DeploymentHistoryData
+from ai.backend.manager.models.scheduling_history.queriers import BulkDeploymentHistoryQuerier
+from ai.backend.manager.models.scheduling_history.row import DeploymentHistoryRow
+from ai.backend.manager.services.scheduling_history.actions.lookup_owner import (
+    LookupBulkDeploymentHistoryOwnerAction,
+)
+
+
+@dataclass
+class BulkGetDeploymentHistoriesAction(
+    PartialBulkGetFieldOpsAction[
+        DeploymentHistoryID, DeploymentID, DeploymentHistoryRow, DeploymentHistoryData
+    ]
+):
+    """Read the deployment history rows the caller named."""
+
+    ids: Sequence[DeploymentHistoryID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_deployment_histories"
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentHistoryID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkDeploymentHistoryOwnerAction:
+        return LookupBulkDeploymentHistoryOwnerAction(history_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkDeploymentHistoryQuerier:
+        return BulkDeploymentHistoryQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[DeploymentHistoryID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_kernel_histories.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_kernel_histories.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
+from ai.backend.common.data.entity.session import SessionID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
+from ai.backend.manager.models.scheduling_history.queriers import (
+    BulkKernelSchedulingHistoryQuerier,
+)
+from ai.backend.manager.models.scheduling_history.row import KernelSchedulingHistoryRow
+from ai.backend.manager.services.scheduling_history.actions.lookup_owner import (
+    LookupBulkKernelSchedulingHistoryOwnerAction,
+)
+
+
+@dataclass
+class BulkGetKernelHistoriesAction(
+    PartialBulkGetFieldOpsAction[
+        KernelSchedulingHistoryID,
+        SessionID,
+        KernelSchedulingHistoryRow,
+        KernelSchedulingHistoryData,
+    ]
+):
+    """Read the kernel scheduling history rows the caller named."""
+
+    ids: Sequence[KernelSchedulingHistoryID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_kernel_histories"
+
+    @override
+    def field_ids(self) -> Sequence[KernelSchedulingHistoryID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkKernelSchedulingHistoryOwnerAction:
+        return LookupBulkKernelSchedulingHistoryOwnerAction(history_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkKernelSchedulingHistoryQuerier:
+        return BulkKernelSchedulingHistoryQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[KernelSchedulingHistoryID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_route_histories.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_route_histories.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.route_history import RouteHistoryID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.deployment.types import RouteHistoryData
+from ai.backend.manager.models.scheduling_history.queriers import BulkRouteHistoryQuerier
+from ai.backend.manager.models.scheduling_history.row import RouteHistoryRow
+from ai.backend.manager.services.scheduling_history.actions.lookup_owner import (
+    LookupBulkRouteHistoryOwnerAction,
+)
+
+
+@dataclass
+class BulkGetRouteHistoriesAction(
+    PartialBulkGetFieldOpsAction[RouteHistoryID, DeploymentID, RouteHistoryRow, RouteHistoryData]
+):
+    """Read the route history rows the caller named."""
+
+    ids: Sequence[RouteHistoryID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_route_histories"
+
+    @override
+    def field_ids(self) -> Sequence[RouteHistoryID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkRouteHistoryOwnerAction:
+        return LookupBulkRouteHistoryOwnerAction(history_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkRouteHistoryQuerier:
+        return BulkRouteHistoryQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[RouteHistoryID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_session_histories.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/bulk_get_session_histories.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Self, override
+
+from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
+from ai.backend.manager.data.session.types import SessionSchedulingHistoryData
+from ai.backend.manager.models.scheduling_history.queriers import (
+    BulkSessionSchedulingHistoryQuerier,
+)
+from ai.backend.manager.models.scheduling_history.row import SessionSchedulingHistoryRow
+from ai.backend.manager.services.scheduling_history.actions.lookup_owner import (
+    LookupBulkSessionSchedulingHistoryOwnerAction,
+)
+
+
+@dataclass
+class BulkGetSessionHistoriesAction(
+    PartialBulkGetFieldOpsAction[
+        SessionSchedulingHistoryID,
+        SessionID,
+        SessionSchedulingHistoryRow,
+        SessionSchedulingHistoryData,
+    ]
+):
+    """Read the session scheduling history rows the caller named."""
+
+    ids: Sequence[SessionSchedulingHistoryID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "bulk_get_session_histories"
+
+    @override
+    def field_ids(self) -> Sequence[SessionSchedulingHistoryID]:
+        return tuple(self.ids)
+
+    @override
+    def to_owner_lookup_action(self) -> LookupBulkSessionSchedulingHistoryOwnerAction:
+        return LookupBulkSessionSchedulingHistoryOwnerAction(history_ids=self.ids)
+
+    @override
+    def to_querier(self) -> BulkSessionSchedulingHistoryQuerier:
+        return BulkSessionSchedulingHistoryQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[SessionSchedulingHistoryID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])

--- a/src/ai/backend/manager/services/scheduling_history/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/lookup_owner.py
@@ -1,0 +1,285 @@
+"""Owner resolutions reaching the session or deployment a history row was recorded for."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, override
+
+from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment_history import DeploymentHistoryID
+from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
+from ai.backend.common.data.entity.route_history import RouteHistoryID
+from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
+from ai.backend.common.data.entity.types import EntityType, FieldIdentifier
+from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
+from ai.backend.manager.actions.v2.lookup.base import LookupKey
+from ai.backend.manager.models.scheduling_history.lookups import (
+    DeploymentHistoryOwnerLookup,
+    KernelSchedulingHistoryOwnerLookup,
+    RouteHistoryOwnerLookup,
+    SessionSchedulingHistoryOwnerLookup,
+)
+
+
+@dataclass(frozen=True)
+class HistoryIDLookupKey(LookupKey):
+    """A history row's id, resolved into the entity it was recorded for."""
+
+    history_id: FieldIdentifier
+
+    @override
+    def kind(self) -> str:
+        return f"{self.history_id.field_type()}_id"
+
+    @override
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": str(self.history_id)}
+
+
+@dataclass
+class LookupSessionSchedulingHistoryOwnerAction(
+    LookupFieldOwnerOpsAction[SessionSchedulingHistoryID, SessionID]
+):
+    """The session a scheduling history row was recorded for."""
+
+    history_id: SessionSchedulingHistoryID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return SESSION_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_session_scheduling_history_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return HistoryIDLookupKey(self.history_id)
+
+    @override
+    def field_id(self) -> SessionSchedulingHistoryID:
+        return self.history_id
+
+    @override
+    def to_owner_lookup(self) -> SessionSchedulingHistoryOwnerLookup:
+        return SessionSchedulingHistoryOwnerLookup()
+
+
+@dataclass
+class LookupBulkSessionSchedulingHistoryOwnerAction(
+    LookupBulkFieldOwnerOpsAction[SessionSchedulingHistoryID, SessionID]
+):
+    """The sessions several scheduling history rows were recorded for."""
+
+    history_ids: Sequence[SessionSchedulingHistoryID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return SESSION_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_session_scheduling_history_owner"
+
+    @override
+    def to_lookup_key(self, field_id: SessionSchedulingHistoryID) -> LookupKey:
+        return HistoryIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[SessionSchedulingHistoryID]:
+        return tuple(self.history_ids)
+
+    @override
+    def to_owner_lookup(self) -> SessionSchedulingHistoryOwnerLookup:
+        return SessionSchedulingHistoryOwnerLookup()
+
+
+@dataclass
+class LookupKernelSchedulingHistoryOwnerAction(
+    LookupFieldOwnerOpsAction[KernelSchedulingHistoryID, SessionID]
+):
+    """The session a kernel scheduling history row was recorded under."""
+
+    history_id: KernelSchedulingHistoryID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return SESSION_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_kernel_scheduling_history_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return HistoryIDLookupKey(self.history_id)
+
+    @override
+    def field_id(self) -> KernelSchedulingHistoryID:
+        return self.history_id
+
+    @override
+    def to_owner_lookup(self) -> KernelSchedulingHistoryOwnerLookup:
+        return KernelSchedulingHistoryOwnerLookup()
+
+
+@dataclass
+class LookupBulkKernelSchedulingHistoryOwnerAction(
+    LookupBulkFieldOwnerOpsAction[KernelSchedulingHistoryID, SessionID]
+):
+    """The sessions several kernel scheduling history rows were recorded under."""
+
+    history_ids: Sequence[KernelSchedulingHistoryID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return SESSION_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_kernel_scheduling_history_owner"
+
+    @override
+    def to_lookup_key(self, field_id: KernelSchedulingHistoryID) -> LookupKey:
+        return HistoryIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[KernelSchedulingHistoryID]:
+        return tuple(self.history_ids)
+
+    @override
+    def to_owner_lookup(self) -> KernelSchedulingHistoryOwnerLookup:
+        return KernelSchedulingHistoryOwnerLookup()
+
+
+@dataclass
+class LookupDeploymentHistoryOwnerAction(
+    LookupFieldOwnerOpsAction[DeploymentHistoryID, DeploymentID]
+):
+    """The deployment a history row was recorded for."""
+
+    history_id: DeploymentHistoryID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_deployment_history_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return HistoryIDLookupKey(self.history_id)
+
+    @override
+    def field_id(self) -> DeploymentHistoryID:
+        return self.history_id
+
+    @override
+    def to_owner_lookup(self) -> DeploymentHistoryOwnerLookup:
+        return DeploymentHistoryOwnerLookup()
+
+
+@dataclass
+class LookupBulkDeploymentHistoryOwnerAction(
+    LookupBulkFieldOwnerOpsAction[DeploymentHistoryID, DeploymentID]
+):
+    """The deployments several history rows were recorded for."""
+
+    history_ids: Sequence[DeploymentHistoryID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_deployment_history_owner"
+
+    @override
+    def to_lookup_key(self, field_id: DeploymentHistoryID) -> LookupKey:
+        return HistoryIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[DeploymentHistoryID]:
+        return tuple(self.history_ids)
+
+    @override
+    def to_owner_lookup(self) -> DeploymentHistoryOwnerLookup:
+        return DeploymentHistoryOwnerLookup()
+
+
+@dataclass
+class LookupRouteHistoryOwnerAction(LookupFieldOwnerOpsAction[RouteHistoryID, DeploymentID]):
+    """The deployment a route history row was recorded under."""
+
+    history_id: RouteHistoryID
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_route_history_owner"
+
+    @override
+    def lookup_key(self) -> LookupKey:
+        return HistoryIDLookupKey(self.history_id)
+
+    @override
+    def field_id(self) -> RouteHistoryID:
+        return self.history_id
+
+    @override
+    def to_owner_lookup(self) -> RouteHistoryOwnerLookup:
+        return RouteHistoryOwnerLookup()
+
+
+@dataclass
+class LookupBulkRouteHistoryOwnerAction(
+    LookupBulkFieldOwnerOpsAction[RouteHistoryID, DeploymentID]
+):
+    """The deployments several route history rows were recorded under."""
+
+    history_ids: Sequence[RouteHistoryID]
+
+    @override
+    @classmethod
+    def entity_type(cls) -> EntityType:
+        return DEPLOYMENT_ENTITY_TYPE
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "lookup_bulk_route_history_owner"
+
+    @override
+    def to_lookup_key(self, field_id: RouteHistoryID) -> LookupKey:
+        return HistoryIDLookupKey(field_id)
+
+    @override
+    def field_ids(self) -> Sequence[RouteHistoryID]:
+        return tuple(self.history_ids)
+
+    @override
+    def to_owner_lookup(self) -> RouteHistoryOwnerLookup:
+        return RouteHistoryOwnerLookup()

--- a/src/ai/backend/manager/services/scheduling_history/processors.py
+++ b/src/ai/backend/manager/services/scheduling_history/processors.py
@@ -1,10 +1,48 @@
 from __future__ import annotations
 
+from ai.backend.common.data.entity.deployment_history import DEPLOYMENT_HISTORY_FIELD_TYPE
+from ai.backend.common.data.entity.kernel_scheduling_history import (
+    KERNEL_SCHEDULING_HISTORY_FIELD_TYPE,
+)
+from ai.backend.common.data.entity.route_history import ROUTE_HISTORY_FIELD_TYPE
+from ai.backend.common.data.entity.session_scheduling_history import (
+    SESSION_SCHEDULING_HISTORY_FIELD_TYPE,
+)
+from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
+from ai.backend.manager.actions.registry.types import FieldGroupMeta
+from ai.backend.manager.actions.v2.field.bulk_processor import PartialBulkFieldActionProcessor
 from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
-from ai.backend.manager.data.deployment.types import ModelDeploymentData
-from ai.backend.manager.data.session.types import SessionData
+from ai.backend.manager.data.deployment.types import (
+    DeploymentHistoryData,
+    ModelDeploymentData,
+    RouteHistoryData,
+)
+from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
+from ai.backend.manager.data.session.types import SessionData, SessionSchedulingHistoryData
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_deployment_histories import (
+    BulkGetDeploymentHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_kernel_histories import (
+    BulkGetKernelHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_route_histories import (
+    BulkGetRouteHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_session_histories import (
+    BulkGetSessionHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.lookup_owner import (
+    LookupBulkDeploymentHistoryOwnerAction,
+    LookupBulkKernelSchedulingHistoryOwnerAction,
+    LookupBulkRouteHistoryOwnerAction,
+    LookupBulkSessionSchedulingHistoryOwnerAction,
+    LookupDeploymentHistoryOwnerAction,
+    LookupKernelSchedulingHistoryOwnerAction,
+    LookupRouteHistoryOwnerAction,
+    LookupSessionSchedulingHistoryOwnerAction,
+)
 
 from .actions import (
     GlobalSearchReplicaGroupHistoryAction,
@@ -33,6 +71,20 @@ from .service import SchedulingHistoryService
 
 class SchedulingHistoryProcessors:
     """Processor package for scheduling history operations."""
+
+    # What the DataLoaders read: checked per session or deployment the row belongs to.
+    bulk_get_session_histories: PartialBulkFieldActionProcessor[
+        BulkGetSessionHistoriesAction, SessionSchedulingHistoryData
+    ]
+    bulk_get_kernel_histories: PartialBulkFieldActionProcessor[
+        BulkGetKernelHistoriesAction, KernelSchedulingHistoryData
+    ]
+    bulk_get_deployment_histories: PartialBulkFieldActionProcessor[
+        BulkGetDeploymentHistoriesAction, DeploymentHistoryData
+    ]
+    bulk_get_route_histories: PartialBulkFieldActionProcessor[
+        BulkGetRouteHistoriesAction, RouteHistoryData
+    ]
 
     # Admin processors
     search_session_history: GlobalActionProcessor[
@@ -75,6 +127,43 @@ class SchedulingHistoryProcessors:
         replica_group: ProcessorGroup[ModelDeploymentData],
         service: SchedulingHistoryService,
     ) -> None:
+        session_histories: LookupFieldGroup[SessionSchedulingHistoryData] = session.field_group(
+            FieldGroupMeta(SESSION_SCHEDULING_HISTORY_FIELD_TYPE),
+            SessionSchedulingHistoryData,
+            LookupSessionSchedulingHistoryOwnerAction,
+            LookupBulkSessionSchedulingHistoryOwnerAction,
+        )
+        kernel_histories: LookupFieldGroup[KernelSchedulingHistoryData] = session.field_group(
+            FieldGroupMeta(KERNEL_SCHEDULING_HISTORY_FIELD_TYPE),
+            KernelSchedulingHistoryData,
+            LookupKernelSchedulingHistoryOwnerAction,
+            LookupBulkKernelSchedulingHistoryOwnerAction,
+        )
+        deployment_histories: LookupFieldGroup[DeploymentHistoryData] = deployment.field_group(
+            FieldGroupMeta(DEPLOYMENT_HISTORY_FIELD_TYPE),
+            DeploymentHistoryData,
+            LookupDeploymentHistoryOwnerAction,
+            LookupBulkDeploymentHistoryOwnerAction,
+        )
+        route_histories: LookupFieldGroup[RouteHistoryData] = deployment.field_group(
+            FieldGroupMeta(ROUTE_HISTORY_FIELD_TYPE),
+            RouteHistoryData,
+            LookupRouteHistoryOwnerAction,
+            LookupBulkRouteHistoryOwnerAction,
+        )
+        self.bulk_get_session_histories = session_histories.partial_bulk_get_ops(
+            BulkGetSessionHistoriesAction
+        )
+        self.bulk_get_kernel_histories = kernel_histories.partial_bulk_get_ops(
+            BulkGetKernelHistoriesAction
+        )
+        self.bulk_get_deployment_histories = deployment_histories.partial_bulk_get_ops(
+            BulkGetDeploymentHistoriesAction
+        )
+        self.bulk_get_route_histories = route_histories.partial_bulk_get_ops(
+            BulkGetRouteHistoriesAction
+        )
+
         # Admin processors
         self.search_session_history = session.global_scope(
             SearchSessionHistoryAction, service.search_session_history

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -145,6 +145,25 @@ from ai.backend.manager.services.artifact_registry.processors import ArtifactReg
 from ai.backend.manager.services.audit_log.processors import AuditLogProcessors
 from ai.backend.manager.services.auth.processors import AuthProcessors
 from ai.backend.manager.services.container_registry.processors import ContainerRegistryProcessors
+from ai.backend.manager.services.deployment.actions.access_token.bulk_get_access_tokens import (
+    BulkGetAccessTokensAction,
+)
+from ai.backend.manager.services.deployment.actions.deployment_policy.bulk_get_deployment_policies import (
+    BulkGetDeploymentPoliciesAction,
+)
+from ai.backend.manager.services.deployment.actions.lookup_owner import (
+    LookupBulkDeploymentAccessTokenOwnerAction,
+    LookupBulkReplicaOwnerAction,
+)
+from ai.backend.manager.services.deployment.actions.model_revision.bulk_get_revisions import (
+    BulkGetRevisionsAction,
+)
+from ai.backend.manager.services.deployment.actions.replica.bulk_get_replicas import (
+    BulkGetReplicasAction,
+)
+from ai.backend.manager.services.deployment.actions.route.bulk_get_routes import (
+    BulkGetRoutesAction,
+)
 from ai.backend.manager.services.deployment.actions.scoped_search import (
     ScopedSearchDeploymentsAction,
 )
@@ -213,6 +232,22 @@ from ai.backend.manager.services.role_preset.processors import RolePresetProcess
 from ai.backend.manager.services.runtime_variant.processors import RuntimeVariantProcessors
 from ai.backend.manager.services.runtime_variant_preset.processors import (
     RuntimeVariantPresetProcessors,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_deployment_histories import (
+    BulkGetDeploymentHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_kernel_histories import (
+    BulkGetKernelHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_route_histories import (
+    BulkGetRouteHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.bulk_get_session_histories import (
+    BulkGetSessionHistoriesAction,
+)
+from ai.backend.manager.services.scheduling_history.actions.lookup_owner import (
+    LookupBulkKernelSchedulingHistoryOwnerAction,
+    LookupBulkSessionSchedulingHistoryOwnerAction,
 )
 from ai.backend.manager.services.scheduling_history.processors import (
     SchedulingHistoryProcessors,
@@ -641,3 +676,57 @@ def test_scoped_deployment_read_is_a_scoped_permission_read() -> None:
         ActionKind.SCOPE,
         ActionGate.PERMISSION,
     )
+
+
+def test_field_data_loader_reads_are_partial_permission_reads() -> None:
+    """The DataLoaders over field rows read per named row, checked per owning entity.
+
+    The owner lookup a partial field read runs first is recorded public beside its
+    permission-gated record: it refuses nothing, the read that follows answers per owner.
+    """
+    registry = _ops_registry()
+    DeploymentProcessors(registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), MagicMock())
+    SchedulingHistoryProcessors(
+        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+        registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+        MagicMock(),
+    )
+
+    recorded = {
+        record.action_cls: (record.entity_type, record.kind, record.gate)
+        for record in registry.wired_processors()
+        if record.kind == ActionKind.BULK
+    }
+    partial = (DEPLOYMENT_ENTITY_TYPE, ActionKind.BULK, ActionGate.PERMISSION)
+    assert recorded[BulkGetRevisionsAction] == partial
+    assert recorded[BulkGetReplicasAction] == partial
+    assert recorded[BulkGetRoutesAction] == partial
+    assert recorded[BulkGetAccessTokensAction] == partial
+    assert recorded[BulkGetDeploymentPoliciesAction] == partial
+    assert recorded[BulkGetDeploymentHistoriesAction] == partial
+    assert recorded[BulkGetRouteHistoriesAction] == partial
+    assert recorded[BulkGetSessionHistoriesAction] == (
+        SESSION_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+    assert recorded[BulkGetKernelHistoriesAction] == (
+        SESSION_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+
+    lookup_gates = {
+        (record.action_cls, record.gate)
+        for record in registry.wired_processors()
+        if record.kind == ActionKind.LOOKUP
+    }
+    for owner_lookup in (
+        LookupBulkReplicaOwnerAction,
+        LookupBulkDeploymentAccessTokenOwnerAction,
+        LookupBulkSessionSchedulingHistoryOwnerAction,
+        LookupBulkKernelSchedulingHistoryOwnerAction,
+    ):
+        assert (owner_lookup, ActionGate.PUBLIC) in lookup_gates
+        assert (owner_lookup, ActionGate.PERMISSION) in lookup_gates

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -132,7 +132,11 @@ from ai.backend.manager.services.agent.actions.scoped_search_resources import (
 from ai.backend.manager.services.agent.actions.search_agents import SearchAgentsAction
 from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.app_config.processors import AppConfigProcessors
+from ai.backend.manager.services.artifact.actions.bulk_get import BulkGetArtifactsAction
 from ai.backend.manager.services.artifact.processors import ArtifactProcessors
+from ai.backend.manager.services.artifact.revision.actions.bulk_get import (
+    BulkGetArtifactRevisionsAction,
+)
 from ai.backend.manager.services.artifact.revision.actions.lookup_owner import (
     LookupArtifactRevisionOwnerAction,
     LookupBulkArtifactRevisionOwnerAction,
@@ -171,6 +175,8 @@ from ai.backend.manager.services.deployment.processors import DeploymentProcesso
 from ai.backend.manager.services.deployment_revision_preset.processors import (
     DeploymentPresetProcessors,
 )
+from ai.backend.manager.services.domain.actions.bulk_get import BulkGetDomainsAction
+from ai.backend.manager.services.domain.actions.bulk_lookup import BulkLookupDomainsAction
 from ai.backend.manager.services.domain.actions.get import GetDomainAction
 from ai.backend.manager.services.domain.actions.scoped_search import ScopedSearchDomainsAction
 from ai.backend.manager.services.domain.processors import DomainProcessors
@@ -200,6 +206,10 @@ from ai.backend.manager.services.model_serving.processors.auto_scaling import (
 from ai.backend.manager.services.model_serving.processors.model_serving import (
     ModelServingProcessors,
 )
+from ai.backend.manager.services.notification.actions.bulk_get_channels import (
+    BulkGetChannelsAction,
+)
+from ai.backend.manager.services.notification.actions.bulk_get_rules import BulkGetRulesAction
 from ai.backend.manager.services.notification.processors import NotificationProcessors
 from ai.backend.manager.services.object_storage.processors import ObjectStorageProcessors
 from ai.backend.manager.services.permission_contoller.processors import (
@@ -214,6 +224,12 @@ from ai.backend.manager.services.prometheus_query_preset.processors import (
 )
 from ai.backend.manager.services.prometheus_query_preset_category.processors import (
     PrometheusQueryPresetCategoryProcessors,
+)
+from ai.backend.manager.services.resource_group.actions.bulk_get import (
+    BulkGetResourceGroupsAction,
+)
+from ai.backend.manager.services.resource_group.actions.bulk_lookup import (
+    BulkLookupResourceGroupsAction,
 )
 from ai.backend.manager.services.resource_group.processors import ResourceGroupProcessors
 from ai.backend.manager.services.resource_preset.actions.check_presets import (
@@ -730,3 +746,78 @@ def test_field_data_loader_reads_are_partial_permission_reads() -> None:
     ):
         assert (owner_lookup, ActionGate.PUBLIC) in lookup_gates
         assert (owner_lookup, ActionGate.PERMISSION) in lookup_gates
+
+
+def test_entity_data_loader_reads_are_checked_per_entity_except_domains() -> None:
+    """The resource group, notification and artifact DataLoaders read per named
+    entity; the domain one is public, since a regular user holds no read on domains.
+    """
+    registry = _ops_registry()
+    ResourceGroupProcessors(registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), MagicMock())
+    DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    NotificationProcessors(
+        registry.group(GroupMeta(NOTIFICATION_CHANNEL_ENTITY_TYPE)),
+        registry.group(GroupMeta(NOTIFICATION_RULE_ENTITY_TYPE)),
+        MagicMock(),
+    )
+    artifact_revisions = registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
+        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        ArtifactRevisionData,
+        LookupArtifactRevisionOwnerAction,
+        LookupBulkArtifactRevisionOwnerAction,
+    )
+    ArtifactProcessors(
+        registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        artifact_revisions,
+        ArtifactRevisionProcessors(
+            registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            artifact_revisions,
+            MagicMock(),
+        ),
+        MagicMock(),
+    )
+
+    recorded = {
+        record.action_cls: (record.entity_type, record.kind, record.gate)
+        for record in registry.wired_processors()
+    }
+    assert recorded[BulkGetResourceGroupsAction] == (
+        RESOURCE_GROUP_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+    assert recorded[BulkLookupResourceGroupsAction] == (
+        RESOURCE_GROUP_ENTITY_TYPE,
+        ActionKind.LOOKUP,
+        ActionGate.PUBLIC,
+    )
+    assert recorded[BulkGetChannelsAction] == (
+        NOTIFICATION_CHANNEL_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+    assert recorded[BulkGetRulesAction] == (
+        NOTIFICATION_RULE_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+    assert recorded[BulkGetArtifactsAction] == (
+        ARTIFACT_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+    assert recorded[BulkGetArtifactRevisionsAction] == (
+        ARTIFACT_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PERMISSION,
+    )
+    assert recorded[BulkGetDomainsAction] == (
+        DOMAIN_ENTITY_TYPE,
+        ActionKind.BULK,
+        ActionGate.PUBLIC,
+    )
+    assert recorded[BulkLookupDomainsAction] == (
+        DOMAIN_ENTITY_TYPE,
+        ActionKind.LOOKUP,
+        ActionGate.PUBLIC,
+    )

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -16,6 +16,7 @@ from ai.backend.common.config import ModelConfig, ModelDefinition, ModelServiceC
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.image import ImageID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
@@ -23,8 +24,10 @@ from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.data.entity.types import ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
 from ai.backend.common.data.entity.vfolder import VFolderUUID
+from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.dto.manager.v2.deployment.request import AdminSearchDeploymentsInput
+from ai.backend.common.schema.deployment import RollingUpdateSpec
 from ai.backend.common.types import ClusterMode, MountPermission, ResourceSlot
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.monitors import ActionMonitors
@@ -33,6 +36,7 @@ from ai.backend.manager.actions.registry.types import GroupMeta, ProcessorDepend
 from ai.backend.manager.actions.v2.global_scope.validator.superadmin import (
     SuperAdminActionValidator,
 )
+from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult, OwnedFieldsOpsResult
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.validator.base import ScopeActionValidator
 from ai.backend.manager.actions.v2.validators import ActionValidators
@@ -42,7 +46,9 @@ from ai.backend.manager.api.adapters.deployment.adapter import (
 )
 from ai.backend.manager.data.deployment.types import (
     ClusterConfigData,
+    DeploymentPolicyData,
     ExecutionData,
+    ModelDeploymentAccessTokenData,
     ModelMountConfigData,
     ModelRevisionData,
     ModelRuntimeConfigData,
@@ -50,12 +56,16 @@ from ai.backend.manager.data.deployment.types import (
     ResourceConfigData,
 )
 from ai.backend.manager.errors.auth import InsufficientPrivilege
+from ai.backend.manager.errors.common import GenericForbidden
+from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 from ai.backend.manager.services.deployment.actions.scoped_search import (
     ScopedSearchDeploymentsActionResult,
 )
 from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.types import TriState
+
+DENIED_TOKEN = DeploymentTokenID(uuid4())
 
 
 class TestRevisionDataToDTO:
@@ -240,3 +250,107 @@ class TestDeploymentSearchGates:
     ) -> None:
         with with_user(regular_user), pytest.raises(InsufficientPrivilege):
             await adapter.admin_search(AdminSearchDeploymentsInput(limit=10, offset=0))
+
+
+class TestFieldBatchLoads:
+    """The field DataLoaders answer per named row, each checked through its deployment."""
+
+    @pytest.fixture
+    def token(self) -> ModelDeploymentAccessTokenData:
+        return ModelDeploymentAccessTokenData(
+            id=uuid4(),
+            token="tok",
+            expires_at=None,
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+    @pytest.fixture
+    def denial(self) -> GenericForbidden:
+        return GenericForbidden("no read on this deployment")
+
+    @pytest.fixture
+    def adapter(
+        self, token: ModelDeploymentAccessTokenData, denial: GenericForbidden
+    ) -> tuple[DeploymentAdapter, MagicMock]:
+        processors = MagicMock()
+        processors.deployment.bulk_get_access_tokens.run = AsyncMock(
+            return_value=BulkFieldOpsResult(
+                successes={DeploymentTokenID(token.id): token},
+                errors={DENIED_TOKEN: denial},
+            )
+        )
+        return DeploymentAdapter(processors, MagicMock()), processors
+
+    async def test_access_tokens_answer_per_id(
+        self,
+        adapter: tuple[DeploymentAdapter, MagicMock],
+        token: ModelDeploymentAccessTokenData,
+        denial: GenericForbidden,
+    ) -> None:
+        deployment_adapter, processors = adapter
+        absent = uuid4()
+
+        nodes = await deployment_adapter.batch_load_access_tokens_by_ids([
+            token.id,
+            DENIED_TOKEN,
+            absent,
+        ])
+
+        node, refused, missing = nodes
+        assert node is not None and not isinstance(node, Exception)
+        assert node.id == token.id
+        # A denial reaches the resolver; an id matching nothing stays None.
+        assert refused is denial
+        assert missing is None
+        action = processors.deployment.bulk_get_access_tokens.run.await_args.args[0]
+        assert list(action.field_ids()) == [
+            DeploymentTokenID(token.id),
+            DENIED_TOKEN,
+            DeploymentTokenID(absent),
+        ]
+
+    async def test_a_batch_naming_no_row_is_every_id_missing(
+        self, adapter: tuple[DeploymentAdapter, MagicMock]
+    ) -> None:
+        deployment_adapter, processors = adapter
+        processors.deployment.bulk_get_access_tokens.run = AsyncMock(
+            side_effect=EntityNotFoundError("No field row matches the given ids")
+        )
+
+        assert await deployment_adapter.batch_load_access_tokens_by_ids([uuid4(), uuid4()]) == [
+            None,
+            None,
+        ]
+
+    async def test_no_ids_read_nothing(self, adapter: tuple[DeploymentAdapter, MagicMock]) -> None:
+        deployment_adapter, processors = adapter
+        assert await deployment_adapter.batch_load_access_tokens_by_ids([]) == []
+        processors.deployment.bulk_get_access_tokens.run.assert_not_awaited()
+
+    async def test_policies_answer_per_deployment(self) -> None:
+        deployment_id = DeploymentID(uuid4())
+        policy = DeploymentPolicyData(
+            id=uuid4(),
+            endpoint=deployment_id,
+            strategy=DeploymentStrategy.ROLLING,
+            strategy_spec=RollingUpdateSpec(),
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        processors = MagicMock()
+        processors.deployment.bulk_get_deployment_policies.run = AsyncMock(
+            return_value=OwnedFieldsOpsResult(designated={deployment_id: policy})
+        )
+        deployment_adapter = DeploymentAdapter(processors, MagicMock())
+        without_policy = uuid4()
+
+        nodes = await deployment_adapter.batch_load_policies_by_endpoint_ids([
+            deployment_id,
+            without_policy,
+        ])
+
+        node, none = nodes
+        assert node is not None and node.id == policy.id
+        assert none is None
+        action = processors.deployment.bulk_get_deployment_policies.run.await_args.args[0]
+        assert list(action.owner_ids()) == [deployment_id, DeploymentID(without_policy)]

--- a/tests/unit/manager/api/adapters/test_scheduling_history_adapter.py
+++ b/tests/unit/manager/api/adapters/test_scheduling_history_adapter.py
@@ -1,0 +1,132 @@
+"""The history DataLoader paths: each row is answered for through its session or
+deployment."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
+from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
+from ai.backend.common.types import KernelId, SessionId
+from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
+from ai.backend.manager.api.adapters.scheduling_history.adapter import SchedulingHistoryAdapter
+from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
+from ai.backend.manager.data.session.types import SchedulingResult, SessionSchedulingHistoryData
+from ai.backend.manager.errors.common import GenericForbidden
+from ai.backend.manager.errors.repository import EntityNotFoundError
+
+READABLE = SessionSchedulingHistoryID(uuid.uuid4())
+DENIED = SessionSchedulingHistoryID(uuid.uuid4())
+ABSENT = SessionSchedulingHistoryID(uuid.uuid4())
+
+
+@pytest.fixture
+def readable() -> SessionSchedulingHistoryData:
+    return SessionSchedulingHistoryData(
+        id=READABLE,
+        session_id=SessionId(uuid.uuid4()),
+        phase="schedule",
+        from_status=None,
+        to_status=None,
+        result=SchedulingResult.SUCCESS,
+        error_code=None,
+        message="",
+        sub_steps=[],
+        attempts=1,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def denial() -> GenericForbidden:
+    return GenericForbidden("no read on this session")
+
+
+@pytest.fixture
+def processors(readable: SessionSchedulingHistoryData, denial: GenericForbidden) -> MagicMock:
+    processors = MagicMock()
+    processors.scheduling_history.bulk_get_session_histories.run = AsyncMock(
+        return_value=BulkFieldOpsResult(successes={READABLE: readable}, errors={DENIED: denial})
+    )
+    processors.scheduling_history.bulk_get_kernel_histories.run = AsyncMock(
+        side_effect=EntityNotFoundError("No field row matches the given ids")
+    )
+    return processors
+
+
+@pytest.fixture
+def adapter(processors: MagicMock) -> SchedulingHistoryAdapter:
+    return SchedulingHistoryAdapter(processors)
+
+
+async def test_session_histories_answer_per_id(
+    adapter: SchedulingHistoryAdapter,
+    processors: MagicMock,
+    readable: SessionSchedulingHistoryData,
+    denial: GenericForbidden,
+) -> None:
+    nodes = await adapter.batch_load_session_histories_by_ids([READABLE, DENIED, ABSENT])
+
+    node, refused, missing = nodes
+    assert node is not None and not isinstance(node, Exception)
+    assert node.id == readable.id
+    # A denial reaches the resolver; an id matching nothing stays None.
+    assert refused is denial
+    assert missing is None
+    action = processors.scheduling_history.bulk_get_session_histories.run.await_args.args[0]
+    assert list(action.field_ids()) == [READABLE, DENIED, ABSENT]
+
+
+async def test_a_batch_naming_no_row_is_every_id_missing(
+    adapter: SchedulingHistoryAdapter,
+) -> None:
+    ids = [KernelSchedulingHistoryID(uuid.uuid4()), KernelSchedulingHistoryID(uuid.uuid4())]
+    assert await adapter.batch_load_kernel_histories_by_ids(ids) == [None, None]
+
+
+async def test_no_ids_read_nothing(
+    adapter: SchedulingHistoryAdapter, processors: MagicMock
+) -> None:
+    assert await adapter.batch_load_session_histories_by_ids([]) == []
+    assert await adapter.batch_load_kernel_histories_by_ids([]) == []
+    assert await adapter.batch_load_deployment_histories_by_ids([]) == []
+    assert await adapter.batch_load_route_histories_by_ids([]) == []
+    processors.scheduling_history.bulk_get_session_histories.run.assert_not_awaited()
+    processors.scheduling_history.bulk_get_kernel_histories.run.assert_not_awaited()
+
+
+def _kernel_history() -> KernelSchedulingHistoryData:
+    return KernelSchedulingHistoryData(
+        id=KernelSchedulingHistoryID(uuid.uuid4()),
+        kernel_id=KernelId(uuid.uuid4()),
+        session_id=SessionId(uuid.uuid4()),
+        phase="schedule",
+        from_status=None,
+        to_status=None,
+        result=SchedulingResult.SUCCESS,
+        error_code=None,
+        message="",
+        attempts=1,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+async def test_kernel_histories_keep_the_given_order(processors: MagicMock) -> None:
+    first, second = _kernel_history(), _kernel_history()
+    processors.scheduling_history.bulk_get_kernel_histories.run = AsyncMock(
+        return_value=BulkFieldOpsResult(successes={second.id: second, first.id: first}, errors={})
+    )
+    adapter = SchedulingHistoryAdapter(processors)
+
+    nodes = await adapter.batch_load_kernel_histories_by_ids([first.id, second.id])
+
+    assert [node.id for node in nodes if node is not None and not isinstance(node, Exception)] == [
+        first.id,
+        second.id,
+    ]

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -28,6 +28,9 @@ from ai.backend.common.data.entity.types import (
     EntityData,
     EntityIdentifier,
     EntityType,
+    FieldData,
+    FieldIdentifier,
+    FieldType,
     ScopeRef,
     ScopeType,
 )
@@ -57,7 +60,11 @@ from ai.backend.manager.models.specs.creator import GlobalEntityCreator
 from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.models.specs.purger import EntityBatchPurger
-from ai.backend.manager.models.specs.querier import BulkEntityQuerier, DataQuerier
+from ai.backend.manager.models.specs.querier import (
+    BulkEntityQuerier,
+    BulkFieldQuerier,
+    DataQuerier,
+)
 from ai.backend.manager.models.specs.searcher import Searcher
 from ai.backend.manager.models.specs.types import ConflictCheck, IntegrityErrorCheck
 from ai.backend.manager.models.specs.updater import DataBatchUpdater
@@ -182,6 +189,35 @@ class _PresetBulkQuerier(BulkEntityQuerier[RolePresetRow, RolePresetData]):
     @override
     def to_data(self, row: RolePresetRow) -> RolePresetData:
         return row.to_data()
+
+
+class _PresetFieldID(FieldIdentifier):
+    @override
+    @classmethod
+    def field_type(cls) -> FieldType:
+        return FieldType("test_preset_field")
+
+
+@dataclass(frozen=True)
+class _PresetFieldData(FieldData):
+    id: _PresetFieldID
+    name: str
+
+
+class _PresetBulkFieldQuerier(BulkFieldQuerier[RolePresetRow, _PresetFieldData]):
+    """The preset rows read as field rows, keyed by their own id."""
+
+    @override
+    def row_class(self) -> type[RolePresetRow]:
+        return RolePresetRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return RolePresetRow.id
+
+    @override
+    def to_data(self, row: RolePresetRow) -> _PresetFieldData:
+        return _PresetFieldData(id=_PresetFieldID(row.id), name=row.name)
 
 
 class _PresetsByName(BulkDataLookup[str, EntityIdentifier]):
@@ -396,6 +432,39 @@ class TestBulkGet:
         self, repository: OpsRepository[RolePresetData], preset: RolePresetData
     ) -> None:
         assert await repository.bulk_get(_PresetBulkQuerier(), []) == {}
+
+
+class TestBulkGetFields:
+    async def test_every_named_row_comes_back_keyed_by_its_id(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        other = await repository.create_global_entity(
+            _PresetCreator(name="analysts", scope_type=RBACScopeType.PROJECT)
+        )
+        first, second = _PresetFieldID(preset.id), _PresetFieldID(other.id)
+
+        found = await repository.bulk_get_fields(_PresetBulkFieldQuerier(), [second, first])
+
+        assert [(key, value.name) for key, value in found.items()] == [
+            (second, "analysts"),
+            (first, "default"),
+        ]
+
+    async def test_a_missing_id_is_absent_rather_than_raising(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        absent = _PresetFieldID(uuid.uuid4())
+
+        found = await repository.bulk_get_fields(
+            _PresetBulkFieldQuerier(), [_PresetFieldID(preset.id), absent]
+        )
+
+        assert list(found) == [_PresetFieldID(preset.id)]
+
+    async def test_no_ids_reads_nothing(
+        self, repository: OpsRepository[RolePresetData], preset: RolePresetData
+    ) -> None:
+        assert await repository.bulk_get_fields(_PresetBulkFieldQuerier(), []) == {}
 
 
 class TestLookup:

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Collection, Mapping, Sequence
-from dataclasses import dataclass, field
-from typing import Any, override
+from dataclasses import dataclass, field, replace
+from typing import Any, Self, override
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -39,6 +39,7 @@ from ai.backend.common.data.entity.types import (
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
+from ai.backend.manager.actions.v2.field.ops import PartialBulkGetFieldOpsAction
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.lookup.base import BaseLookupAction, LookupKey
 from ai.backend.manager.actions.v2.lookup.processor import LookupActionProcessor
@@ -79,6 +80,7 @@ from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
+from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
 from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
@@ -97,7 +99,7 @@ from ai.backend.manager.models.specs.purger import (
     GuardedEntityPurger,
     GuardedFieldPurger,
 )
-from ai.backend.manager.models.specs.querier import DataQuerier
+from ai.backend.manager.models.specs.querier import BulkFieldQuerier, DataQuerier
 from ai.backend.manager.models.specs.searcher import Searcher, SearcherResult
 from ai.backend.manager.models.specs.types import (
     BulkResultWithFailures,
@@ -126,6 +128,7 @@ from ai.backend.manager.services.ops.service import (
     EntityPurgeService,
     EntityUpsertService,
     FieldAtomicCreateService,
+    FieldPartialBulkGetService,
     FieldPartialBulkPurgeService,
     FieldUpsertService,
     GetService,
@@ -1032,6 +1035,49 @@ class _BulkPurgeFieldAction(
         return self.purgers
 
 
+class _PresetBulkFieldQuerier(BulkFieldQuerier[RolePresetRow, _PresetFieldData]):
+    @override
+    def row_class(self) -> type[RolePresetRow]:
+        return RolePresetRow
+
+    @override
+    def target_id_column(self) -> InstrumentedAttribute[Any]:
+        return RolePresetRow.id
+
+    @override
+    def to_data(self, row: RolePresetRow) -> _PresetFieldData:
+        return _PresetFieldData(id=_FieldID(row.id), owner=_EntityID(row.id))
+
+
+@dataclass
+class _BulkGetFieldAction(
+    PartialBulkGetFieldOpsAction[_FieldID, _EntityID, RolePresetRow, _PresetFieldData]
+):
+    ids: list[_FieldID]
+
+    @classmethod
+    @override
+    def action_name(cls) -> str:
+        return "bulk_get_field_role_presets"
+
+    @override
+    def field_ids(self) -> Sequence[_FieldID]:
+        return self.ids
+
+    @override
+    def to_owner_lookup_action(self) -> Any:
+        raise NotImplementedError
+
+    @override
+    def to_querier(self) -> _PresetBulkFieldQuerier:
+        return _PresetBulkFieldQuerier()
+
+    @override
+    def narrowed_to(self, field_ids: Sequence[_FieldID]) -> Self:
+        allowed = frozenset(field_ids)
+        return replace(self, ids=[field_id for field_id in self.ids if field_id in allowed])
+
+
 @dataclass
 class _FieldUpsertAction(
     BaseSingleEntityAction, FieldUpsertOpsAction[_EntityID, RolePresetRow, _PresetFieldData]
@@ -1617,6 +1663,20 @@ async def test_field_partial_bulk_purge_answers_for_every_named_entity(
 
     assert list(result.successes) == [field_id]
     repository.partial_bulk_purge_field_entities.assert_awaited_once_with(purgers)
+
+
+async def test_field_partial_bulk_get_answers_for_every_named_row(
+    repository: MagicMock, field_stored: _PresetFieldData
+) -> None:
+    service: FieldPartialBulkGetService[_PresetFieldData] = FieldPartialBulkGetService(repository)
+    absent = _FieldID(uuid.uuid4())
+    repository.bulk_get_fields.return_value = {field_stored.id: field_stored}
+
+    result = await service.execute(_BulkGetFieldAction(ids=[field_stored.id, absent]))
+
+    assert result.successes == {field_stored.id: field_stored}
+    assert list(result.errors) == [absent]
+    assert isinstance(result.errors[absent], EntityNotFoundError)
 
 
 async def test_field_upsert_forwards_owner_and_upserter(


### PR DESCRIPTION
## Summary
- Add the field counterpart of the partial bulk get (`BulkFieldQuerier`, `PartialBulkGetFieldOpsAction`, `FieldPartialBulkGetService`, `LookupFieldGroup.partial_bulk_get_ops`). The owner lookup a partial field shape runs first is wired public, as the entity bulk lookup already is; this also applies to `partial_bulk_purge_ops`, so a denied owner there now becomes per-row denied items instead of refusing the whole batch.
- Move 17 adapter batch loaders off the search path: deployment revisions, replicas, routes, access tokens and policies; the four scheduling history loaders; resource group, notification channel and rule, artifact and artifact revision loaders (checked per named entity); domain loaders (public bulk get, since a regular user holds no read on domains).
- A DataLoader now answers `null` for an id matching no row and raises the denial at the resolver for a row the caller may not read. The deployment `batch_load_by_ids` and auto-scaling rule loaders stay on the search path: the first reads replica group and policy rows beside the endpoint, the second has no field type yet.

## Test plan
- [x] `pants fmt fix lint check test --changed-since=HEAD~1` (direct dependents) pass locally
- [x] Adapter tests: per-id answers (node / null / denial), all-miss batches, empty batches
- [x] Registry catalog: gates of the new bulk get actions and the public owner lookups
- [x] Ops repository and generic service tests for the field bulk read

Resolves BA-7441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vFfpY64CePsCgPZ5zcEtZ
