### PR TITLE
feat(BA-7682): record the preset a role was instantiated from

### DIFF
--- a/changes/14350.feature.md
+++ b/changes/14350.feature.md
@@ -1,0 +1,1 @@
+Record the role preset a role was instantiated from in `roles.role_preset_id` and backfill it for existing preset-derived roles.

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import override
 
 from ai.backend.common.data.entity.role import RoleID
+from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import (
     EntityData,
     EntityIdentifier,
@@ -47,6 +48,7 @@ class RoleData(EntityData):
     deleted_at: datetime | None
     auto_assign: bool = False
     description: str | None = None
+    role_preset_id: RolePresetID | None = None
 
     @override
     def entity_id(self) -> EntityIdentifier:
@@ -83,6 +85,7 @@ class RoleDetailData:
     deleted_at: datetime | None
     auto_assign: bool = False
     description: str | None = None
+    role_preset_id: RolePresetID | None = None
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/models/alembic/versions/b8c828d3636e_link_roles_to_their_preset.py
+++ b/src/ai/backend/manager/models/alembic/versions/b8c828d3636e_link_roles_to_their_preset.py
@@ -1,0 +1,254 @@
+"""Link roles to the preset they were instantiated from
+
+Adds ``roles.role_preset_id`` and backfills it for existing rows whose name is exactly
+what one active preset's naming rule yields for the scope the role is bound to.
+A name two presets both yield is left unlinked.
+
+Create Date: 2026-09-08
+
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import jinja2
+import jinja2.sandbox
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+from ai.backend.manager.models.base import GUID
+
+# revision identifiers, used by Alembic.
+revision = "b8c828d3636e"
+down_revision = "c1a7f3e0d94b"
+# Part of: NEXT_RELEASE_VERSION
+branch_labels = None
+depends_on = None
+
+# Metadata local to this revision so that the table snapshots below cannot be
+# altered by definitions living in other revisions.
+_local_metadata = sa.MetaData()
+
+# Rendered names are stored in ``roles.name`` (sa.String(64)).
+_MAX_ROLE_NAME_LENGTH = 64
+
+
+def _roles_table() -> sa.Table:
+    return sa.Table(
+        "roles",
+        _local_metadata,
+        sa.Column("id", GUID, primary_key=True),
+        sa.Column("name", sa.String(64), nullable=False),
+        sa.Column("source", sa.VARCHAR(16), nullable=False),
+        sa.Column("role_preset_id", GUID, nullable=True),
+        extend_existing=True,
+    )
+
+
+def _role_presets_table() -> sa.Table:
+    return sa.Table(
+        "role_presets",
+        _local_metadata,
+        sa.Column("id", GUID, primary_key=True),
+        sa.Column("name", sa.String(64), nullable=False),
+        sa.Column("role_name_template", sa.Text, nullable=True),
+        sa.Column("scope_type", sa.VARCHAR(32), nullable=False),
+        sa.Column("deleted", sa.Boolean, nullable=False),
+        extend_existing=True,
+    )
+
+
+def _association_scopes_entities_table() -> sa.Table:
+    return sa.Table(
+        "association_scopes_entities",
+        _local_metadata,
+        sa.Column("scope_type", sa.String(32), nullable=False),
+        sa.Column("scope_id", sa.String(64), nullable=False),
+        sa.Column("entity_type", sa.String(32), nullable=False),
+        sa.Column("entity_id", sa.String(64), nullable=False),
+        extend_existing=True,
+    )
+
+
+def _virtual_entities_table() -> sa.Table:
+    return sa.Table(
+        "virtual_entities",
+        _local_metadata,
+        sa.Column("id", GUID, primary_key=True),
+        sa.Column("entity_type", sa.String(32), nullable=False),
+        sa.Column("entity_id", GUID, nullable=False),
+        extend_existing=True,
+    )
+
+
+def _entity_memberships_table() -> sa.Table:
+    return sa.Table(
+        "entity_memberships",
+        _local_metadata,
+        sa.Column("virtual_entity_id", GUID, nullable=False),
+        sa.Column("member_entity_id", GUID, nullable=False),
+        extend_existing=True,
+    )
+
+
+def _scope_table(name: str, id_column: str, name_column: str) -> sa.Table:
+    return sa.Table(
+        name,
+        _local_metadata,
+        sa.Column(id_column, GUID, primary_key=True),
+        sa.Column(name_column, sa.String(64), nullable=False),
+        extend_existing=True,
+    )
+
+
+# Scope type -> (table, id column, name column) of the rows presets instantiate roles on.
+_SCOPE_SOURCES: Mapping[str, tuple[str, str, str]] = {
+    "domain": ("domains", "id", "name"),
+    "project": ("groups", "id", "name"),
+    "user": ("users", "uuid", "username"),
+}
+
+_template_env = jinja2.sandbox.ImmutableSandboxedEnvironment(undefined=jinja2.StrictUndefined)
+
+
+def _render_role_name(template: str, scope: Mapping[str, Any]) -> str | None:
+    """Minimal copy of V2EntityWriteOps._render_role_name: a migration cannot import
+    the repository ops, and the rule must stay frozen at the time of writing."""
+    try:
+        rendered = _template_env.from_string(template).render(scope=scope).strip()
+    except jinja2.TemplateError:
+        return None
+    if not rendered:
+        return None
+    return rendered[:_MAX_ROLE_NAME_LENGTH]
+
+
+def _candidate_names(
+    preset_name: str,
+    template: str | None,
+    scope_type: str,
+    scope_id: uuid.UUID,
+    scope_name: str,
+) -> set[str]:
+    """Every name a preset may have given a role on the scope: the legacy rule (the
+    preset name as is), the v2 template-less rule (preset name + scope id), and the
+    rendered template. The ``{type}-{id}-role`` fallback is not a candidate."""
+    suffix = f"-{str(scope_id)[:8]}"
+    names = {preset_name, f"{preset_name[: _MAX_ROLE_NAME_LENGTH - len(suffix)]}{suffix}"}
+    if template is not None:
+        rendered = _render_role_name(
+            template, {"id": str(scope_id), "name": scope_name, "type": scope_type}
+        )
+        if rendered is not None:
+            names.add(rendered)
+    return names
+
+
+def _unlinked_system_roles_by_scope(
+    conn: Connection, scope_type: str
+) -> dict[str, list[tuple[uuid.UUID, str]]]:
+    """(role id, name) of every SYSTEM role not yet linked, keyed by the id of the
+    scope it is bound to — through the legacy association or the virtual entity graph."""
+    roles = _roles_table()
+    assoc = _association_scopes_entities_table()
+    scope_node = _virtual_entities_table().alias("scope_node")
+    role_node = _virtual_entities_table().alias("role_node")
+    memberships = _entity_memberships_table()
+    unlinked = sa.and_(roles.c.source == "system", roles.c.role_preset_id.is_(None))
+    via_association = (
+        sa.select(assoc.c.scope_id, roles.c.id, roles.c.name)
+        .select_from(assoc.join(roles, assoc.c.entity_id == sa.cast(roles.c.id, sa.String)))
+        .where(assoc.c.scope_type == scope_type, assoc.c.entity_type == "role", unlinked)
+    )
+    via_graph = (
+        sa.select(sa.cast(scope_node.c.entity_id, sa.String), roles.c.id, roles.c.name)
+        .select_from(
+            memberships.join(scope_node, scope_node.c.id == memberships.c.virtual_entity_id)
+            .join(role_node, role_node.c.id == memberships.c.member_entity_id)
+            .join(roles, roles.c.id == role_node.c.entity_id)
+        )
+        .where(scope_node.c.entity_type == scope_type, role_node.c.entity_type == "role", unlinked)
+    )
+    by_scope: dict[str, list[tuple[uuid.UUID, str]]] = defaultdict(list)
+    for scope_id, role_id, name in conn.execute(sa.union(via_association, via_graph)).all():
+        by_scope[scope_id].append((role_id, name))
+    return by_scope
+
+
+def backfill(conn: Connection) -> None:
+    presets_table = _role_presets_table()
+    presets = conn.execute(
+        sa.select(
+            presets_table.c.id,
+            presets_table.c.name,
+            presets_table.c.role_name_template,
+            presets_table.c.scope_type,
+        ).where(presets_table.c.deleted.is_(False))
+    ).all()
+    presets_by_scope_type: dict[str, list[Any]] = defaultdict(list)
+    for preset in presets:
+        presets_by_scope_type[preset.scope_type].append(preset)
+
+    matches: dict[uuid.UUID, set[uuid.UUID]] = defaultdict(set)
+    for scope_type, (table, id_column, name_column) in _SCOPE_SOURCES.items():
+        scoped_presets = presets_by_scope_type.get(scope_type)
+        if not scoped_presets:
+            continue
+        roles_by_scope = _unlinked_system_roles_by_scope(conn, scope_type)
+        if not roles_by_scope:
+            continue
+        scope_table = _scope_table(table, id_column, name_column)
+        scope_rows = conn.execute(
+            sa.select(scope_table.c[id_column], scope_table.c[name_column])
+        ).all()
+        for scope_id, scope_name in scope_rows:
+            scope_roles = roles_by_scope.get(str(scope_id))
+            if not scope_roles:
+                continue
+            for preset in scoped_presets:
+                candidates = _candidate_names(
+                    preset.name, preset.role_name_template, scope_type, scope_id, scope_name
+                )
+                for role_id, role_name in scope_roles:
+                    if role_name in candidates:
+                        matches[role_id].add(preset.id)
+
+    updates: Sequence[dict[str, Any]] = [
+        {"b_role_id": role_id, "b_preset_id": next(iter(preset_ids))}
+        for role_id, preset_ids in matches.items()
+        if len(preset_ids) == 1
+    ]
+    if not updates:
+        return
+    roles = _roles_table()
+    conn.execute(
+        sa.update(roles)
+        .where(roles.c.id == sa.bindparam("b_role_id"))
+        .values(role_preset_id=sa.bindparam("b_preset_id")),
+        updates,
+    )
+
+
+def upgrade() -> None:
+    op.add_column("roles", sa.Column("role_preset_id", GUID(), nullable=True))
+    op.create_index(op.f("ix_roles_role_preset_id"), "roles", ["role_preset_id"], unique=False)
+    op.create_foreign_key(
+        "fk_roles_role_preset_id_role_presets",
+        "roles",
+        "role_presets",
+        ["role_preset_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    backfill(op.get_bind())
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_roles_role_preset_id_role_presets", "roles", type_="foreignkey")
+    op.drop_index(op.f("ix_roles_role_preset_id"), table_name="roles")
+    op.drop_column("roles", "role_preset_id")

--- a/src/ai/backend/manager/models/rbac_models/role/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role/row.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import (
 )
 
 from ai.backend.common.data.entity.role import RoleID
+from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.manager.data.permission.role import (
     RoleData,
     RoleDetailData,
@@ -76,6 +77,21 @@ class RoleRow(LifecycleTimestampsMixin, Base):
     deleted_at: Mapped[datetime | None] = mapped_column(
         "deleted_at", sa.DateTime(timezone=True), nullable=True
     )
+    # The preset this role was instantiated from; NULL for roles made by hand or
+    # before presets were recorded. `use_alter` keeps the FK out of the CREATE TABLE
+    # so table subsets that omit ``role_presets`` still build.
+    role_preset_id: Mapped[RolePresetID | None] = mapped_column(
+        "role_preset_id",
+        GUID(RolePresetID),
+        sa.ForeignKey(
+            "role_presets.id",
+            ondelete="SET NULL",
+            use_alter=True,
+            name="fk_roles_role_preset_id_role_presets",
+        ),
+        index=True,
+        nullable=True,
+    )
 
     object_permission_rows: Mapped[list[ObjectPermissionRow]] = relationship(
         "ObjectPermissionRow",
@@ -94,6 +110,7 @@ class RoleRow(LifecycleTimestampsMixin, Base):
             deleted_at=self.deleted_at,
             auto_assign=self.auto_assign,
             description=self.description,
+            role_preset_id=self.role_preset_id,
         )
 
     def to_detail_data_without_users(self) -> RoleDetailData:
@@ -108,5 +125,6 @@ class RoleRow(LifecycleTimestampsMixin, Base):
             deleted_at=self.deleted_at,
             auto_assign=self.auto_assign,
             description=self.description,
+            role_preset_id=self.role_preset_id,
             object_permissions=[op_row.to_data() for op_row in self.object_permission_rows],
         )

--- a/src/ai/backend/manager/repositories/ops/v2/entity_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/entity_write.py
@@ -77,6 +77,7 @@ class _PresetRoleSpec:
     """One role a preset calls for on one scope, as plain values ready to write."""
 
     entity: EntityIdentifier
+    role_preset_id: RolePresetID
     name: str
     auto_assign: bool
     entity_operations: Mapping[RBACElementType, Sequence[OperationType]]
@@ -338,6 +339,7 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
                 source=RoleSource.SYSTEM,
                 status=RoleStatus.ACTIVE,
                 auto_assign=spec.auto_assign,
+                role_preset_id=spec.role_preset_id,
             )
             for spec in specs
         ]
@@ -407,6 +409,7 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
         return [
             _PresetRoleSpec(
                 entity=entity,
+                role_preset_id=preset.id,
                 name=self._preset_role_name(preset, entity, entity_values[entity]),
                 auto_assign=preset.auto_assign,
                 entity_operations={

--- a/tests/unit/manager/models/alembic/test_link_roles_to_their_preset.py
+++ b/tests/unit/manager/models/alembic/test_link_roles_to_their_preset.py
@@ -1,0 +1,271 @@
+"""Verifies the role -> preset backfill migration against a real database.
+
+Static analysis does not reach the migration's SQL, so the backfill is exercised here:
+presets and scope-bound roles go in, the backfill runs, and the links are read back.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Table
+
+from ai.backend.common.data.entity.domain import DomainID, DomainName
+from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
+from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.data.permission.types import EntityType as LegacyEntityType
+from ai.backend.manager.data.permission.types import RoleSource
+from ai.backend.manager.data.permission.types import ScopeType as LegacyScopeType
+from ai.backend.manager.models.alembic.versions.b8c828d3636e_link_roles_to_their_preset import (
+    backfill,
+)
+from ai.backend.manager.models.domain import DomainRow
+from ai.backend.manager.models.keypair import KeyPairRow
+from ai.backend.manager.models.project import ProjectRow, ProjectType
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    AssociationScopesEntitiesRow,
+)
+from ai.backend.manager.models.rbac_models.role import RoleRow
+from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
+from ai.backend.manager.models.resource_policy import (
+    KeyPairResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    UserResourcePolicyRow,
+)
+from ai.backend.manager.models.user import UserRow
+from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
+from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
+from ai.backend.testutils.db import HasTable, with_tables
+
+_TABLES: list[Table | type[HasTable]] = [
+    DomainRow,
+    UserResourcePolicyRow,
+    ProjectResourcePolicyRow,
+    KeyPairResourcePolicyRow,
+    UserRow,
+    KeyPairRow,
+    ProjectRow,
+    RolePresetRow,
+    RoleRow,
+    AssociationScopesEntitiesRow,
+    VirtualEntityRow,
+    EntityMembershipRow,
+]
+
+
+@dataclass
+class DomainFixture:
+    name: DomainName
+    id: DomainID
+
+
+@pytest.fixture
+async def db(
+    database_connection: ExtendedAsyncSAEngine,
+) -> AsyncGenerator[ExtendedAsyncSAEngine, None]:
+    async with with_tables(database_connection, _TABLES):
+        yield database_connection
+
+
+@pytest.fixture
+async def domain(db: ExtendedAsyncSAEngine) -> DomainFixture:
+    domain_id = DomainID(uuid.uuid4())
+    domain_name = DomainName(f"test-domain-{uuid.uuid4().hex[:8]}")
+    async with db.begin_session() as session:
+        session.add(
+            DomainRow(
+                id=domain_id,
+                name=domain_name,
+                description="Test domain",
+                is_active=True,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                allowed_docker_registries=[],
+                dotfiles=b"",
+                integration_id=None,
+            )
+        )
+        session.add(
+            ProjectResourcePolicyRow(
+                name="default",
+                max_vfolder_count=0,
+                max_quota_scope_size=-1,
+                max_network_count=3,
+            )
+        )
+    return DomainFixture(name=domain_name, id=domain_id)
+
+
+async def _add_preset(
+    db: ExtendedAsyncSAEngine,
+    name: str,
+    *,
+    template: str | None = None,
+    scope_type: LegacyScopeType = LegacyScopeType.PROJECT,
+    deleted: bool = False,
+) -> uuid.UUID:
+    async with db.begin_session() as session:
+        preset = RolePresetRow(
+            name=name, role_name_template=template, scope_type=scope_type, deleted=deleted
+        )
+        session.add(preset)
+        await session.flush()
+        return preset.id
+
+
+async def _add_project(db: ExtendedAsyncSAEngine, domain: DomainFixture, name: str) -> uuid.UUID:
+    project_id = uuid.uuid4()
+    async with db.begin_session() as session:
+        session.add(
+            ProjectRow(
+                id=project_id,
+                name=name,
+                domain_name=domain.name,
+                total_resource_slots=ResourceSlot(),
+                allowed_vfolder_hosts=VFolderHostPermissionMap(),
+                resource_policy="default",
+                type=ProjectType.GENERAL,
+            )
+        )
+    return project_id
+
+
+async def _add_role(
+    db: ExtendedAsyncSAEngine,
+    name: str,
+    project_id: uuid.UUID,
+    *,
+    source: RoleSource = RoleSource.SYSTEM,
+    via_graph: bool = False,
+) -> uuid.UUID:
+    """A role bound to the project as the legacy association writes it, or through the
+    virtual entity graph when ``via_graph``."""
+    role_id = uuid.uuid4()
+    async with db.begin_session() as session:
+        session.add(RoleRow(id=role_id, name=name, source=source, status=RoleStatus.ACTIVE))
+        if via_graph:
+            scope_node = VirtualEntityRow(entity_type="project", entity_id=project_id)
+            role_node = VirtualEntityRow(entity_type="role", entity_id=role_id)
+            session.add_all([scope_node, role_node])
+            await session.flush()
+            session.add(
+                EntityMembershipRow(
+                    virtual_entity_id=scope_node.id, member_entity_id=role_node.id, capped=False
+                )
+            )
+        else:
+            session.add(
+                AssociationScopesEntitiesRow(
+                    scope_type=LegacyScopeType.PROJECT,
+                    scope_id=str(project_id),
+                    entity_type=LegacyEntityType.ROLE,
+                    entity_id=str(role_id),
+                )
+            )
+    return role_id
+
+
+async def _run_backfill(db: ExtendedAsyncSAEngine) -> None:
+    async with db.begin() as conn:
+        await conn.run_sync(backfill)
+
+
+async def _links(db: ExtendedAsyncSAEngine) -> dict[uuid.UUID, uuid.UUID | None]:
+    async with db.begin_readonly_session() as session:
+        rows = (await session.execute(sa.select(RoleRow.id, RoleRow.role_preset_id))).all()
+        return {row.id: row.role_preset_id for row in rows}
+
+
+class TestRolePresetLinkBackfill:
+    async def test_legacy_name_links_through_the_association(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        preset_id = await _add_preset(db, "member")
+        project_id = await _add_project(db, domain, "alpha")
+        role_id = await _add_role(db, "member", project_id)
+
+        await _run_backfill(db)
+
+        assert (await _links(db))[role_id] == preset_id
+
+    async def test_generated_name_links_through_the_graph(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        preset_id = await _add_preset(db, "member")
+        project_id = await _add_project(db, domain, "alpha")
+        role_id = await _add_role(db, f"member-{str(project_id)[:8]}", project_id, via_graph=True)
+
+        await _run_backfill(db)
+
+        assert (await _links(db))[role_id] == preset_id
+
+    async def test_templated_name_is_rendered_from_the_scope(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        preset_id = await _add_preset(db, "member", template="{{ scope.name }}-member")
+        project_id = await _add_project(db, domain, "alpha")
+        role_id = await _add_role(db, "alpha-member", project_id)
+
+        await _run_backfill(db)
+
+        assert (await _links(db))[role_id] == preset_id
+
+    async def test_other_names_stay_unlinked(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_preset(db, "member", template="{{ scope.name }}-member")
+        project_id = await _add_project(db, domain, "alpha")
+        mismatch = await _add_role(db, "beta-member", project_id)
+        fallback = await _add_role(db, f"project-{str(project_id)[:8]}-role", project_id)
+        custom = await _add_role(db, "member", project_id, source=RoleSource.CUSTOM)
+
+        await _run_backfill(db)
+
+        links = await _links(db)
+        assert links[mismatch] is None
+        assert links[fallback] is None
+        assert links[custom] is None
+
+    async def test_a_name_two_presets_yield_is_left_alone(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_preset(db, "member")
+        await _add_preset(db, "other", template="member")
+        project_id = await _add_project(db, domain, "alpha")
+        role_id = await _add_role(db, "member", project_id)
+
+        await _run_backfill(db)
+
+        assert (await _links(db))[role_id] is None
+
+    async def test_a_deleted_preset_and_another_scope_type_do_not_link(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        await _add_preset(db, "member", deleted=True)
+        await _add_preset(db, "viewer", scope_type=LegacyScopeType.DOMAIN)
+        project_id = await _add_project(db, domain, "alpha")
+        deleted = await _add_role(db, "member", project_id)
+        other_type = await _add_role(db, "viewer", project_id)
+
+        await _run_backfill(db)
+
+        links = await _links(db)
+        assert links[deleted] is None
+        assert links[other_type] is None
+
+    async def test_running_it_again_keeps_the_links(
+        self, db: ExtendedAsyncSAEngine, domain: DomainFixture
+    ) -> None:
+        preset_id = await _add_preset(db, "member")
+        project_id = await _add_project(db, domain, "alpha")
+        role_id = await _add_role(db, "member", project_id)
+
+        await _run_backfill(db)
+        await _run_backfill(db)
+
+        assert (await _links(db))[role_id] == preset_id

--- a/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
+++ b/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
@@ -407,6 +407,13 @@ def _expected_preset_role_name(scope_id: UUID) -> str:
     return f"{_PRESET_NAME}-{str(scope_id)[:8]}"
 
 
+async def _preset_id(database: ExtendedAsyncSAEngine, name: str) -> UUID:
+    async with database.begin_readonly_session() as sess:
+        return (
+            await sess.execute(sa.select(RolePresetRow.id).where(RolePresetRow.name == name))
+        ).scalar_one()
+
+
 async def _virtual_entity_id(
     database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: ScopeType = _SCOPE_TYPE
 ) -> UUID | None:
@@ -507,6 +514,7 @@ class _RoleProbe:
     source: RoleSource
     status: RoleStatus
     auto_assign: bool
+    role_preset_id: UUID | None
 
 
 async def _scope_roles(database: ExtendedAsyncSAEngine, scope_id: UUID) -> dict[str, _RoleProbe]:
@@ -516,7 +524,12 @@ async def _scope_roles(database: ExtendedAsyncSAEngine, scope_id: UUID) -> dict[
         rows = (
             await sess.execute(
                 sa.select(
-                    RoleRow.name, RoleRow.id, RoleRow.source, RoleRow.status, RoleRow.auto_assign
+                    RoleRow.name,
+                    RoleRow.id,
+                    RoleRow.source,
+                    RoleRow.status,
+                    RoleRow.auto_assign,
+                    RoleRow.role_preset_id,
                 )
                 .join(role_node, role_node.entity_id == RoleRow.id)
                 .join(EntityMembershipRow, EntityMembershipRow.member_entity_id == role_node.id)
@@ -528,7 +541,11 @@ async def _scope_roles(database: ExtendedAsyncSAEngine, scope_id: UUID) -> dict[
         ).all()
         return {
             row.name: _RoleProbe(
-                id=row.id, source=row.source, status=row.status, auto_assign=row.auto_assign
+                id=row.id,
+                source=row.source,
+                status=row.status,
+                auto_assign=row.auto_assign,
+                role_preset_id=row.role_preset_id,
             )
             for row in rows
         }
@@ -698,6 +715,24 @@ class TestRoleManagedGlobalEntityCreate:
         role = (await _scope_roles(database, data.id))[_expected_preset_role_name(data.id)]
         assert await _scope_governs_role(database, data.id, role.id)
 
+    async def test_a_preset_role_points_at_the_preset_it_came_from(
+        self,
+        database: ExtendedAsyncSAEngine,
+        repository: OpsRepository[_EntityData],
+        presets: None,
+    ) -> None:
+        data = await repository.create_role_managed_global_entity(
+            _RoleManagedGlobalCreator(name="alpha")
+        )
+
+        roles = await _scope_roles(database, data.id)
+        assert roles[_expected_preset_role_name(data.id)].role_preset_id == await _preset_id(
+            database, _PRESET_NAME
+        )
+        assert roles["alpha-member"].role_preset_id == await _preset_id(
+            database, "preset-templated"
+        )
+
     async def test_create_renders_templated_preset_role_names(
         self,
         database: ExtendedAsyncSAEngine,
@@ -780,7 +815,9 @@ class TestRoleManagedEntityCreate:
             _RoleManagedCreator(name="a", parents=(parent_id,))
         )
 
-        assert _expected_preset_role_name(data.id) in await _scope_roles(database, data.id)
+        roles = await _scope_roles(database, data.id)
+        role = roles[_expected_preset_role_name(data.id)]
+        assert role.role_preset_id == await _preset_id(database, _PRESET_NAME)
 
     async def test_missing_created_in_target_fails_without_inserting(
         self, database: ExtendedAsyncSAEngine, repository: OpsRepository[_EntityData]


### PR DESCRIPTION
## Summary
- Add `roles.role_preset_id`, a nullable FK to `role_presets` (`ON DELETE SET NULL`, indexed), and fill it when the v2 entity write provisions a scope's preset roles. Roles made by hand keep it empty.
- Backfill existing SYSTEM roles: a role is linked when its name is exactly what one active preset's naming rule yields for the scope the role is bound to (template render, v2 default name, or the preset name itself). A name two presets yield stays unlinked.
- `RoleData`/`RoleDetailData` carry the new field; existing fields are unchanged.

## Test plan
- [x] `test_entity_lifecycle.py`: preset roles point at their preset
- [x] `test_link_roles_to_their_preset.py`: backfill links exact matches only, skips ambiguous, fallback, deleted-preset and custom roles, and is re-runnable
- [x] Migration `upgrade`/`downgrade` run against a local DB with seeded roles

Resolves BA-7682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019k2ASDc1uaaseusbuswPXN