### PR TITLE
ci(BA-7738): reduce pants test retry attempts from 3 to 2

### DIFF
--- a/changes/14360.misc.md
+++ b/changes/14360.misc.md
@@ -1,0 +1,1 @@
+Reduce pants test retry attempts from 3 to 2 so flaky test failures surface faster instead of being absorbed by repeated re-runs.

--- a/pants.toml
+++ b/pants.toml
@@ -56,7 +56,7 @@ env_vars.add = [
 
 [test]
 extra_env_vars = ["BACKEND_BUILD_ROOT=%(buildroot)s", "HOME"]
-attempts_default = 3
+attempts_default = 2
 timeout_default = 180
 
 [lint]


### PR DESCRIPTION
## Summary
- Set `[test] attempts_default` in `pants.toml` from 3 to 2. `timeout_default` is unchanged.
- One flaky failure re-ran a whole target twice more, so a timeout-class flake held a target for up to 9 minutes and a retried pass was absorbed instead of reported.
- No per-target retry override was added. Pants `python_test` targets have no per-target attempts field, and the known flake (BA-6817) hangs identically on every attempt, so retries never rescued it.

## Test plan
- [ ] CI is green on this PR

Resolves BA-7738

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CwhKbrvgzfEquj5oqMaPn