### PR TITLE
ci(BA-7735): expand test-unit and test-component shards to 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON('["0/3","1/3","2/3"]') }}
+        shard: ${{ fromJSON('["0/6","1/6","2/6","3/6","4/6","5/6"]') }}
     steps:
     - name: Verify detect-changes
       if: needs.detect-changes.result != 'success'
@@ -450,7 +450,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ${{ fromJSON('["0/2","1/2"]') }}
+        shard: ${{ fromJSON('["0/6","1/6","2/6","3/6","4/6","5/6"]') }}
     steps:
     - name: Verify detect-changes
       if: needs.detect-changes.result != 'success'

--- a/changes/14361.misc.md
+++ b/changes/14361.misc.md
@@ -1,0 +1,1 @@
+Expand the CI test-unit and test-component shard matrices to 6 shards each to shorten the critical path.


### PR DESCRIPTION
## Summary
- Expand the `test-unit` matrix from 3 shards to 6 and `test-component` from 2 to 6. `test-integration` stays at 2.
- Shards are split by file count, and the slowest shard has been running about 1.5x longer than the fastest; smaller shards shorten the critical path.
- Gate jobs read `needs.<job>.result` only, so they need no change. The `services` block is untouched.

## Test plan
- [ ] CI runs 6 `test-unit` and 6 `test-component` jobs on this PR and all pass
- [ ] After merge: confirm the added concurrent jobs stay within the organization's runner limit (확인 필요)

Resolves BA-7735

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY3vZTHRj4CSTr1AsqVKt8