### PR TITLE
doc(BA-7578): mark the legacy spec lineage deprecated

### DIFF
--- a/changes/14365.deprecation.md
+++ b/changes/14365.deprecation.md
@@ -1,0 +1,1 @@
+Mark the legacy spec lineage (CreatorSpec / UpserterSpec / PurgerSpec, the permission controller local specs, EntityRef / ScopeRef, ScopeId / ObjectId, association_scopes_entities) deprecated in favor of the v2 specs and the virtual entity graph.

--- a/src/ai/backend/common/data/entity/types.py
+++ b/src/ai/backend/common/data/entity/types.py
@@ -76,6 +76,9 @@ class NaturalKey(str):
 class EntityRef:
     """An entity identified by its (open) type and id.
 
+    Deprecated: use :class:`EntityIdentifier` — BA-7204. This pair stays only where a
+    row's type is read at run time.
+
     Both are values read at run time — the graph layer reads them off a row — so the id
     is a bare one. Where the entity is known statically, pass an
     :class:`EntityIdentifier`, which needs no separate type beside it.
@@ -88,6 +91,9 @@ class EntityRef:
 @dataclass(frozen=True, slots=True)
 class ScopeRef:
     """A scope identified by its (open) type and id.
+
+    Deprecated: use :class:`EntityIdentifier` — BA-7204. This pair stays only where a
+    row's type is read at run time.
 
     ``scope_type`` is a free-form string (NewType), not a fixed enum: the virtual
     scope layer accepts any owner type without extending a hard-coded scope enum.

--- a/src/ai/backend/manager/data/permission/id.py
+++ b/src/ai/backend/manager/data/permission/id.py
@@ -46,6 +46,8 @@ class FieldRef:
 
 @dataclass(frozen=True)
 class ScopeId:
+    """Deprecated: use ``EntityIdentifier``; this pair is keyed by the legacy scope type enum."""
+
     scope_type: ScopeType
     scope_id: str
 
@@ -60,6 +62,8 @@ class ScopeId:
 
 @dataclass(frozen=True)
 class ObjectId:
+    """Deprecated: use ``EntityIdentifier``; this pair is keyed by the legacy entity type enum."""
+
     entity_type: EntityType
     entity_id: str
 

--- a/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
+++ b/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
@@ -25,6 +25,9 @@ from ai.backend.manager.models.base import (
 
 
 class AssociationScopesEntitiesRow(Base):
+    """Deprecated: the ``association_scopes_entities`` table is replaced by the own edges
+    of the virtual entity graph and is scheduled for removal."""
+
     __tablename__ = "association_scopes_entities"
     __table_args__ = (
         sa.Index("ix_association_scopes_entities_entity", "entity_type", "entity_id"),

--- a/src/ai/backend/manager/repositories/AGENTS.md
+++ b/src/ai/backend/manager/repositories/AGENTS.md
@@ -30,8 +30,8 @@
   - write specs: `GlobalEntity*` / `Entity*` / `RoleManagedEntity*` / `FieldEntity*` (Creator/Purger/Upserter)
   - read/update: `DataQuerier`, `DataLookup`, `Searcher`, `DataUpdater`
 - No new use of the legacy specs — transition-only maintenance of existing code:
-  - `repositories/base/`: `CreatorSpec`, `DataCreator`, `UpserterSpec`, `PurgerSpec`
-  - `repositories/base/rbac/`: the scope binder and unbinder
+  - `repositories/base/`: `CreatorSpec`, `DataCreator`, `DependentCreatorSpec`, `UpserterSpec`, `PurgerSpec`
+  - `repositories/permission_controller/`: the local creator and purger specs
   - Judge by import path (`models.specs.*` is v2) — `repositories.base` re-exports some
     v2 types and bridge classes like `DataBatchPurger` share names, so never judge by
     the class name alone.
@@ -55,10 +55,11 @@
   and inject that provider only into the repositories needing the primitive
   (`ops/v2/reconciler/`, `ops/v2/user/`, `ops/rbac/`).
 - Separating into a repository is the default; internal operations may use db directly.
-- ops methods take only spec types (Querier/Creator/Updater/Upserter/Purger, `DependentCreatorSpec`).
+- ops methods take only spec types (Querier/Creator/Updater/Upserter/Purger).
   A single spec owns only a single table.
-- Do NOT do multi-table writes inside a spec. The repository creates the parent first, then composes the dependent values
-  from the result and passes them to `create_dependent` / `bulk_create_dependent` as a `DependentCreatorSpec`.
+- Do NOT do multi-table writes inside a spec. A row owned by another is a `FieldCreator` /
+  `NestedFieldCreator` built under the owner's settled id (`create_field`, or the
+  `*_with_fields` create when both rows share one transaction).
 - The read default is `batch_query_with_scopes`. `batch_query_in_global` is for superadmin/internal paths only.
 - Graph relations are written through three provider / ops pairs only. Entity write
   (`V2DBOpsProvider` / `V2WriteOps`: create and delete, own and govern written at

--- a/src/ai/backend/manager/repositories/KNOWLEDGE.md
+++ b/src/ai/backend/manager/repositories/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 ---
 name: repository-tx-and-ops
 type: design-rationale
-description: choosing between v2 ops, generic OpsRepository, and db objects, rationale for single-method transactions, single-table specs with DependentCreatorSpec, batch_query_with_scopes as the read default
+description: choosing between v2 ops, generic OpsRepository, and db objects, rationale for single-method transactions, single-table specs with field creators, batch_query_with_scopes as the read default
 scope: src/ai/backend/manager/repositories
-keywords: [DBOpsProvider, transaction, spec, DependentCreatorSpec, batch_query_with_scopes, EmptyOperationScopeError]
+keywords: [DBOpsProvider, transaction, spec, FieldCreator, batch_query_with_scopes, EmptyOperationScopeError]
 sources:
   - src/ai/backend/manager/repositories/ops
 generated:
@@ -64,8 +64,8 @@ guarantees atomicity without partial commits. Splitting a method into small piec
 
 ## Why a spec owns only a single table
 
-Hiding multi-table writes in a spec obscures ordering and dependencies. The repository reveals the parent→child order procedurally
-and makes the dependency explicit with `DependentCreatorSpec`.
+Hiding multi-table writes in a spec obscures ordering and dependencies. The owner is created first and the owned row is a
+`FieldCreator` built under the owner's settled id, so the parent→child order is explicit.
 
 ## Scope filter default
 

--- a/src/ai/backend/manager/repositories/base/creator.py
+++ b/src/ai/backend/manager/repositories/base/creator.py
@@ -1,6 +1,7 @@
 """Creator for repository insert operations.
 
-Deprecated: declare new insert specs in ``models/specs/creator.py``.
+Deprecated: declare new insert specs in ``models/specs/creator.py``. The remaining
+users move under BA-7204.
 """
 
 from __future__ import annotations
@@ -29,7 +30,7 @@ class CreatorSpec[TRow: Base](ABC):
     """Abstract base class defining a row to insert.
 
     Deprecated: use ``GlobalEntityCreator`` / ``EntityCreator`` /
-    ``RoleManagedEntityCreator`` / ``FieldCreator`` in ``models/specs/creator.py``.
+    ``RoleManagedEntityCreator`` / ``FieldCreator`` in ``models/specs/creator.py`` — BA-7204.
 
     Implementations specify what to create by providing:
     - A build_row() method that returns the ORM instance to insert
@@ -57,7 +58,7 @@ class CreatorSpec[TRow: Base](ABC):
 class DataCreator[TRow: Base, TData](CreatorSpec[TRow], ABC):
     """A creator spec that also says how the inserted row becomes data.
 
-    Deprecated with :class:`CreatorSpec`; the v2 roots already carry ``to_data``.
+    Deprecated with :class:`CreatorSpec`; the v2 roots already carry ``to_data`` — BA-7204.
 
     ``CreatorSpec`` stops at building the row, which leaves every caller converting it
     by hand. Adding ``to_data`` here lets the ops layer return the ``data/`` type

--- a/src/ai/backend/manager/repositories/base/purger.py
+++ b/src/ai/backend/manager/repositories/base/purger.py
@@ -1,6 +1,7 @@
 """Purger for delete operations.
 
-Deprecated: declare new delete specs in ``models/specs/purger.py``.
+Deprecated: declare new delete specs in ``models/specs/purger.py``. The remaining
+users move under BA-7204.
 """
 
 from __future__ import annotations
@@ -59,7 +60,7 @@ async def validate_conflict_checks(
 class PurgerSpec[TRow: Base](ABC):
     """Abstract base class defining a single-row purge target.
 
-    Deprecated: use ``EntityPurger`` / ``FieldPurger`` in ``models/specs/purger.py``.
+    Deprecated: use ``EntityPurger`` / ``FieldPurger`` in ``models/specs/purger.py`` — BA-7204.
     """
 
     @abstractmethod

--- a/src/ai/backend/manager/repositories/base/upserter.py
+++ b/src/ai/backend/manager/repositories/base/upserter.py
@@ -1,6 +1,7 @@
 """Upserter for repository upsert (INSERT ON CONFLICT UPDATE) operations.
 
-Deprecated: declare new upsert specs in ``models/specs/upserter.py``.
+Deprecated: declare new upsert specs in ``models/specs/upserter.py``. The remaining
+users move under BA-7204.
 """
 
 from __future__ import annotations
@@ -27,7 +28,7 @@ class UpserterSpec[TRow: Base](ABC):
     """Abstract base class for upsert operations.
 
     Deprecated: use ``GlobalEntityUpserter`` / ``EntityUpserter`` / ``FieldUpserter``
-    in ``models/specs/upserter.py``.
+    in ``models/specs/upserter.py`` — BA-7204.
 
     Implementations specify what to upsert by providing:
     - row_class property for target table and result reconstruction

--- a/src/ai/backend/manager/repositories/permission_controller/creators.py
+++ b/src/ai/backend/manager/repositories/permission_controller/creators.py
@@ -1,4 +1,10 @@
-"""CreatorSpec implementations for permission-related entities."""
+"""CreatorSpec implementations for permission-related entities.
+
+Deprecated: roles and their permissions use the v2 specs under
+``models/rbac_models/``; the graph rows (memberships, bindings, role grants) are
+written by the ops primitives in ``repositories/ops/v2/`` from whole declarations,
+with no spec lineage (BEP-1077). The remaining users move under BA-7204.
+"""
 
 from __future__ import annotations
 
@@ -35,6 +41,8 @@ from ai.backend.manager.repositories.base.creator import CreatorSpec, DependentC
 class RoleCreatorSpec(CreatorSpec[RoleRow]):
     """CreatorSpec for role creation.
 
+    Deprecated: use ``RoleCreator`` in ``models/rbac_models/role/creators.py`` — BA-7204.
+
     Only defines the role itself. Object permissions
     are passed separately to create_role() for better separation of concerns.
     """
@@ -58,7 +66,11 @@ class RoleCreatorSpec(CreatorSpec[RoleRow]):
 
 @dataclass
 class PermissionCreatorSpec(CreatorSpec[PermissionRow]):
-    """CreatorSpec for permissions."""
+    """CreatorSpec for permissions.
+
+    Deprecated: use ``RolePermissionCreator`` in
+    ``models/rbac_models/permission/creators.py`` — BA-7204.
+    """
 
     role_id: uuid.UUID
     scope_type: ScopeType
@@ -79,7 +91,11 @@ class PermissionCreatorSpec(CreatorSpec[PermissionRow]):
 
 @dataclass
 class UserRoleCreatorSpec(CreatorSpec[UserRoleRow]):
-    """CreatorSpec for user role mappings."""
+    """CreatorSpec for user role mappings.
+
+    Deprecated: role grants are written by ``V2EntityWriteOps`` in
+    ``repositories/ops/v2/entity_write.py`` — BA-7204.
+    """
 
     user_id: uuid.UUID
     role_id: uuid.UUID
@@ -110,7 +126,11 @@ class UserRoleCreatorSpec(CreatorSpec[UserRoleRow]):
 
 @dataclass
 class AssociationScopesEntitiesCreatorSpec(CreatorSpec[AssociationScopesEntitiesRow]):
-    """CreatorSpec for association between scopes and entities."""
+    """CreatorSpec for association between scopes and entities.
+
+    Deprecated: goes with the ``association_scopes_entities`` table; the own edge is
+    written by ``V2GraphWriteOpsBase`` in ``repositories/ops/v2/graph_write.py``.
+    """
 
     scope_id: ScopeId
     object_id: ObjectId
@@ -128,7 +148,11 @@ class AssociationScopesEntitiesCreatorSpec(CreatorSpec[AssociationScopesEntities
 @dataclass
 class EntityMembershipCreatorSpec(DependentCreatorSpec[VirtualEntityID, EntityMembershipRow]):
     """Membership of the entity behind ``member_entity_id`` in the virtual entity given
-    as the dependency."""
+    as the dependency.
+
+    Deprecated: memberships are written by ``V2GraphWriteOpsBase`` in
+    ``repositories/ops/v2/graph_write.py`` — BA-7204.
+    """
 
     member_entity_id: VirtualEntityID
     capped: bool = False
@@ -147,7 +171,11 @@ class ScopeBindingCreatorSpec(
     DependentCreatorSpec[Mapping[ScopeRef, VirtualEntityID], ScopeBindingRow]
 ):
     """Binding of ``bound_scope`` into ``anchor_scope``'s virtual entity; the dependency
-    maps both scopes to their virtual entity ids."""
+    maps both scopes to their virtual entity ids.
+
+    Deprecated: bindings are written by ``V2GraphWriteOpsBase`` in
+    ``repositories/ops/v2/graph_write.py`` — BA-7204.
+    """
 
     anchor_scope: ScopeRef
     bound_scope: ScopeRef

--- a/src/ai/backend/manager/repositories/permission_controller/purgers.py
+++ b/src/ai/backend/manager/repositories/permission_controller/purgers.py
@@ -1,3 +1,9 @@
+"""PurgerSpec implementations for permission-related entities.
+
+Deprecated: permission rows are removed through the v2 specs under
+``models/rbac_models/permission/``. The remaining users move under BA-7204.
+"""
+
 from __future__ import annotations
 
 import uuid
@@ -12,7 +18,11 @@ from ai.backend.manager.repositories.base.purger import PurgerSpec
 
 @dataclass
 class PermissionPurgerSpec(PurgerSpec[PermissionRow]):
-    """PurgerSpec for deleting a permission."""
+    """PurgerSpec for deleting a permission.
+
+    Deprecated: use ``RolePermissionPurger`` in
+    ``models/rbac_models/permission/purgers.py`` — BA-7204.
+    """
 
     permission_id: uuid.UUID
 


### PR DESCRIPTION
## Summary
- Add a deprecation note to each legacy spec declaration pointing at its replacement: the `repositories/base` CreatorSpec / UpserterSpec / PurgerSpec roots and the permission controller's local specs at the v2 specs under `models/specs` and `models/rbac_models`, `EntityRef` / `ScopeRef` and `ScopeId` / `ObjectId` at `EntityIdentifier`, and the `association_scopes_entities` row at the own edges of the virtual entity graph.
- Comments and docstrings only; no behavior changes.

## Test plan
- [x] `pants fmt` / `pants fix` / `pants lint` pass
- [x] `pants check` and `pants test` on the changed files pass locally

Resolves BA-7578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWcEuZA8AiQEyQojC7MHef