### PR TITLE
feat(BA-7733): add delete_shared_vfolders to the user purge APIs

### DIFF
--- a/changes/14367.feature.md
+++ b/changes/14367.feature.md
@@ -1,0 +1,1 @@
+Add `delete_shared_vfolders` to the user purge APIs. When set, the purged user's virtual folders that are shared with other users are deleted along with the rest; otherwise their ownership is transferred to the requesting admin.

--- a/docs/manager/graphql-reference/schema.graphql
+++ b/docs/manager/graphql-reference/schema.graphql
@@ -2872,7 +2872,12 @@ type PurgeUser {
 }
 
 input PurgeUserInput {
-  purge_shared_vfolders: Boolean
+  purge_shared_vfolders: Boolean @deprecated(reason: "Deprecated since 26.9.0 and ignored: it did the opposite of its name. Use `delete_shared_vfolders`.")
+
+  """
+  Added in 26.9.0. The default value is `false`. If true, the user's virtual folders shared with other users are deleted along with the rest; otherwise their ownership goes to the requester.
+  """
+  delete_shared_vfolders: Boolean
 
   """
   Added in 25.4.0. The default value is `false`. Indicates whether the user's existing endpoints are delegated to the requester.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -2627,9 +2627,14 @@ input BulkPurgeUsersV2Options
   @join__type(graph: STRAWBERRY)
 {
   """
-  If true, migrate shared virtual folders to the admin user before purging.
+  Added in 26.3.0. Whether to purge the user's shared virtual folders. Deprecated since 26.9.0.
   """
-  purgeSharedVfolders: Boolean! = false
+  purgeSharedVfolders: Boolean! = false @deprecated(reason: "Ignored: it did the opposite of its name. Use deleteSharedVfolders.")
+
+  """
+  Added in 26.9.0. If true, delete the purged user's virtual folders that are shared with other users. If false, their ownership is transferred to the requesting admin. Virtual folders that are not shared are deleted either way.
+  """
+  deleteSharedVfolders: Boolean! = false
 
   """If true, delegate endpoint ownership to the admin user before purging."""
   delegateEndpointOwnership: Boolean! = false
@@ -15962,7 +15967,12 @@ type PurgeUser
 input PurgeUserInput
   @join__type(graph: GRAPHENE)
 {
-  purge_shared_vfolders: Boolean
+  purge_shared_vfolders: Boolean @deprecated(reason: "Deprecated since 26.9.0 and ignored: it did the opposite of its name. Use `delete_shared_vfolders`.")
+
+  """
+  Added in 26.9.0. The default value is `false`. If true, the user's virtual folders shared with other users are deleted along with the rest; otherwise their ownership goes to the requester.
+  """
+  delete_shared_vfolders: Boolean
 
   """
   Added in 25.4.0. The default value is `false`. Indicates whether the user's existing endpoints are delegated to the requester.
@@ -15988,9 +15998,14 @@ input PurgeUserV2Options
   @join__type(graph: STRAWBERRY)
 {
   """
-  If true, migrate shared virtual folders to the admin user before purging.
+  Added in 26.4.2. Whether to purge the user's shared virtual folders. Deprecated since 26.9.0.
   """
-  purgeSharedVfolders: Boolean! = false
+  purgeSharedVfolders: Boolean! = false @deprecated(reason: "Ignored: it did the opposite of its name. Use deleteSharedVfolders.")
+
+  """
+  Added in 26.9.0. If true, delete the purged user's virtual folders that are shared with other users. If false, their ownership is transferred to the requesting admin. Virtual folders that are not shared are deleted either way.
+  """
+  deleteSharedVfolders: Boolean! = false
 
   """If true, delegate endpoint ownership to the admin user before purging."""
   delegateEndpointOwnership: Boolean! = false

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -1944,9 +1944,14 @@ input BulkPurgeUsersV2Input {
 """Added in 26.3.0. Options for bulk user purge operation."""
 input BulkPurgeUsersV2Options {
   """
-  If true, migrate shared virtual folders to the admin user before purging.
+  Added in 26.3.0. Whether to purge the user's shared virtual folders. Deprecated since 26.9.0.
   """
-  purgeSharedVfolders: Boolean! = false
+  purgeSharedVfolders: Boolean! = false @deprecated(reason: "Ignored: it did the opposite of its name. Use deleteSharedVfolders.")
+
+  """
+  Added in 26.9.0. If true, delete the purged user's virtual folders that are shared with other users. If false, their ownership is transferred to the requesting admin. Virtual folders that are not shared are deleted either way.
+  """
+  deleteSharedVfolders: Boolean! = false
 
   """If true, delegate endpoint ownership to the admin user before purging."""
   delegateEndpointOwnership: Boolean! = false
@@ -11189,9 +11194,14 @@ input PurgeUserV2Input {
 """Added in 26.4.2. Options for single user purge operation."""
 input PurgeUserV2Options {
   """
-  If true, migrate shared virtual folders to the admin user before purging.
+  Added in 26.4.2. Whether to purge the user's shared virtual folders. Deprecated since 26.9.0.
   """
-  purgeSharedVfolders: Boolean! = false
+  purgeSharedVfolders: Boolean! = false @deprecated(reason: "Ignored: it did the opposite of its name. Use deleteSharedVfolders.")
+
+  """
+  Added in 26.9.0. If true, delete the purged user's virtual folders that are shared with other users. If false, their ownership is transferred to the requesting admin. Virtual folders that are not shared are deleted either way.
+  """
+  deleteSharedVfolders: Boolean! = false
 
   """If true, delegate endpoint ownership to the admin user before purging."""
   delegateEndpointOwnership: Boolean! = false

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -34379,8 +34379,15 @@
           },
           "purge_shared_vfolders": {
             "default": false,
-            "description": "Whether to purge shared virtual folders",
+            "deprecated": true,
+            "description": "Whether to purge shared virtual folders. Deprecated since 26.9.0 and ignored: it did the opposite of its name. Use delete_shared_vfolders.",
             "title": "Purge Shared Vfolders",
+            "type": "boolean"
+          },
+          "delete_shared_vfolders": {
+            "default": false,
+            "description": "If true, delete the purged user's virtual folders that are shared with other users. If false, their ownership is transferred to the requesting admin.",
+            "title": "Delete Shared Vfolders",
             "type": "boolean"
           },
           "delegate_endpoint_ownership": {

--- a/src/ai/backend/client/cli/admin/user.py
+++ b/src/ai/backend/client/cli/admin/user.py
@@ -633,13 +633,12 @@ def delete(ctx: CLIContext, email: str) -> None:
 @pass_ctx_obj
 @click.argument("email", type=str, metavar="EMAIL")
 @click.option(
-    "--purge-shared-vfolders",
+    "--delete-shared-vfolders",
     is_flag=True,
     default=False,
     help=(
-        "Delete user's all virtual folders. "
-        "If False, shared folders will not be deleted "
-        "and migrated the ownership to the requested admin."
+        "Delete the user's virtual folders that are shared with other users. "
+        "If False, their ownership is migrated to the requested admin instead."
     ),
 )
 @click.option(
@@ -653,7 +652,7 @@ def delete(ctx: CLIContext, email: str) -> None:
     ),
 )
 def purge(
-    ctx: CLIContext, email: str, purge_shared_vfolders: bool, delegate_endpoint_ownership: bool
+    ctx: CLIContext, email: str, delete_shared_vfolders: bool, delegate_endpoint_ownership: bool
 ) -> None:
     """
     Delete an existing user. This action cannot be undone.
@@ -666,7 +665,7 @@ def purge(
             if not ask_yn():
                 print_info("Cancelled")
                 sys.exit(ExitCode.FAILURE)
-            data = session.User.purge(email, purge_shared_vfolders, delegate_endpoint_ownership)
+            data = session.User.purge(email, delete_shared_vfolders, delegate_endpoint_ownership)
         except Exception as e:
             ctx.output.print_mutation_error(
                 e,

--- a/src/ai/backend/client/func/user.py
+++ b/src/ai/backend/client/func/user.py
@@ -394,7 +394,7 @@ class User(BaseFunction):
     async def purge(
         cls,
         email: str,
-        purge_shared_vfolders: bool = False,
+        delete_shared_vfolders: bool = False,
         delegate_endpoint_ownership: bool = False,
     ) -> dict[str, Any]:
         """
@@ -402,7 +402,7 @@ class User(BaseFunction):
 
         User's virtual folders are also deleted, except the ones shared with other users.
         Shared virtual folder's ownership will be transferred to the requested admin.
-        To delete shared folders as well, set ``purge_shared_vfolders`` to ``True``.
+        To delete shared folders as well, set ``delete_shared_vfolders`` to ``True``.
         """
         query = _d("""
             mutation($email: String!, $input: PurgeUserInput!) {
@@ -414,7 +414,7 @@ class User(BaseFunction):
         variables = {
             "email": email,
             "input": {
-                "purge_shared_vfolders": purge_shared_vfolders,
+                "delete_shared_vfolders": delete_shared_vfolders,
                 "delegate_endpoint_ownership": delegate_endpoint_ownership,
             },
         }

--- a/src/ai/backend/common/dto/manager/user/request.py
+++ b/src/ai/backend/common/dto/manager/user/request.py
@@ -11,6 +11,7 @@ from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 from .types import OrderDirection, UserOrderField, UserRole, UserStatus
 
@@ -124,7 +125,20 @@ class PurgeUserRequest(BaseRequestModel):
 
     user_id: UUID = Field(description="UUID of the user to purge")
     purge_shared_vfolders: bool = Field(
-        default=False, description="Whether to purge shared virtual folders"
+        default=False,
+        description=(
+            "Whether to purge shared virtual folders. "
+            f"Deprecated since {NEXT_RELEASE_VERSION} and ignored: it did the opposite of "
+            "its name. Use delete_shared_vfolders."
+        ),
+        deprecated=True,
+    )
+    delete_shared_vfolders: bool = Field(
+        default=False,
+        description=(
+            "If true, delete the purged user's virtual folders that are shared with other "
+            "users. If false, their ownership is transferred to the requesting admin."
+        ),
     )
     delegate_endpoint_ownership: bool = Field(
         default=False, description="Whether to delegate endpoint ownership"

--- a/src/ai/backend/common/dto/manager/v2/user/request.py
+++ b/src/ai/backend/common/dto/manager/v2/user/request.py
@@ -28,6 +28,7 @@ from ai.backend.common.dto.manager.v2.user.types import (
     UserStatus,
     UserStatusFilter,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 
 __all__ = (
     "AdminSearchUsersInput",
@@ -211,7 +212,20 @@ class PurgeUserInput(BaseRequestModel):
     user_id: UUID = Field(description="UUID of the user to purge.")
     purge_shared_vfolders: bool = Field(
         default=False,
-        description="If true, migrate shared virtual folders to the admin user before purging.",
+        description=(
+            "Whether to purge the user's shared virtual folders. "
+            f"Deprecated since {NEXT_RELEASE_VERSION} and ignored: it did the opposite of "
+            "its name. Use delete_shared_vfolders."
+        ),
+        deprecated=True,
+    )
+    delete_shared_vfolders: bool = Field(
+        default=False,
+        description=(
+            "If true, delete the purged user's virtual folders that are shared with other "
+            "users. If false, their ownership is transferred to the requesting admin. "
+            "Virtual folders that are not shared are deleted either way."
+        ),
     )
     delegate_endpoint_ownership: bool = Field(
         default=False,
@@ -249,7 +263,20 @@ class PurgeUserV2Options(BaseRequestModel):
 
     purge_shared_vfolders: bool = Field(
         default=False,
-        description="If true, migrate shared virtual folders to the admin user before purging.",
+        description=(
+            "Whether to purge the user's shared virtual folders. "
+            f"Deprecated since {NEXT_RELEASE_VERSION} and ignored: it did the opposite of "
+            "its name. Use delete_shared_vfolders."
+        ),
+        deprecated=True,
+    )
+    delete_shared_vfolders: bool = Field(
+        default=False,
+        description=(
+            "If true, delete the purged user's virtual folders that are shared with other "
+            "users. If false, their ownership is transferred to the requesting admin. "
+            "Virtual folders that are not shared are deleted either way."
+        ),
     )
     delegate_endpoint_ownership: bool = Field(
         default=False,
@@ -271,7 +298,20 @@ class BulkPurgeUsersOptions(BaseRequestModel):
 
     purge_shared_vfolders: bool = Field(
         default=False,
-        description="If true, migrate shared virtual folders to the admin user before purging.",
+        description=(
+            "Whether to purge the user's shared virtual folders. "
+            f"Deprecated since {NEXT_RELEASE_VERSION} and ignored: it did the opposite of "
+            "its name. Use delete_shared_vfolders."
+        ),
+        deprecated=True,
+    )
+    delete_shared_vfolders: bool = Field(
+        default=False,
+        description=(
+            "If true, delete the purged user's virtual folders that are shared with other "
+            "users. If false, their ownership is transferred to the requesting admin. "
+            "Virtual folders that are not shared are deleted either way."
+        ),
     )
     delegate_endpoint_ownership: bool = Field(
         default=False,

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -582,11 +582,7 @@ class UserAdapter(BaseAdapter):
             PurgeUserAction(
                 user_id=UserID(input.user_id),
                 admin_user_id=admin_user_id,
-                purge_shared_vfolders=(
-                    OptionalState.update(input.purge_shared_vfolders)
-                    if input.purge_shared_vfolders
-                    else OptionalState.nop()
-                ),
+                delete_shared_vfolders=input.delete_shared_vfolders,
                 delegate_endpoint_ownership=(
                     OptionalState.update(input.delegate_endpoint_ownership)
                     if input.delegate_endpoint_ownership

--- a/src/ai/backend/manager/api/gql/user/resolver/mutation.py
+++ b/src/ai/backend/manager/api/gql/user/resolver/mutation.py
@@ -509,7 +509,7 @@ async def admin_purge_user_v2(
     await ctx.adapters.user.purge_user_by_id(
         PurgeUserInput(
             user_id=dto.user_id,
-            purge_shared_vfolders=options.purge_shared_vfolders if options else False,
+            delete_shared_vfolders=options.delete_shared_vfolders if options else False,
             delegate_endpoint_ownership=options.delegate_endpoint_ownership if options else False,
         ),
         me.user_id,
@@ -547,11 +547,7 @@ async def admin_bulk_purge_users_v2(
     action = BulkPurgeUserAction(
         user_ids=input.user_ids,
         admin_user_id=me.user_id,
-        purge_shared_vfolders=(
-            OptionalState.update(options.purge_shared_vfolders)
-            if options and options.purge_shared_vfolders
-            else OptionalState.nop()
-        ),
+        delete_shared_vfolders=bool(options and options.delete_shared_vfolders),
         delegate_endpoint_ownership=(
             OptionalState.update(options.delegate_endpoint_ownership)
             if options and options.delegate_endpoint_ownership

--- a/src/ai/backend/manager/api/gql/user/types/inputs.py
+++ b/src/ai/backend/manager/api/gql/user/types/inputs.py
@@ -39,6 +39,7 @@ from ai.backend.common.dto.manager.v2.user.request import (
 from ai.backend.common.dto.manager.v2.user.request import (
     UpdateUserInput as UpdateUserInputDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     gql_added_field,
@@ -217,8 +218,24 @@ class DeleteUsersInputGQL(PydanticInputMixin[DeleteUsersInputDTO]):
 class PurgeUserV2OptionsGQL(PydanticInputMixin[PurgeUserV2OptionsDTO]):
     """Options for single user purge operation."""
 
-    purge_shared_vfolders: bool = gql_field(
-        description="If true, migrate shared virtual folders to the admin user before purging.",
+    purge_shared_vfolders: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.4.2",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="Whether to purge the user's shared virtual folders.",
+        ),
+        deprecation_reason=("Ignored: it did the opposite of its name. Use deleteSharedVfolders."),
+        default=False,
+    )
+    delete_shared_vfolders: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "If true, delete the purged user's virtual folders that are shared with "
+                "other users. If false, their ownership is transferred to the requesting "
+                "admin. Virtual folders that are not shared are deleted either way."
+            ),
+        ),
         default=False,
     )
     delegate_endpoint_ownership: bool = gql_field(
@@ -254,8 +271,24 @@ class PurgeUserInputGQL(PydanticInputMixin[PurgeUserV2InputDTO]):
 class BulkPurgeUsersV2OptionsGQL(PydanticInputMixin[BulkPurgeUsersOptionsDTO]):
     """Options for bulk user purge operation."""
 
-    purge_shared_vfolders: bool = gql_field(
-        description="If true, migrate shared virtual folders to the admin user before purging.",
+    purge_shared_vfolders: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version="26.3.0",
+            deprecated_version=NEXT_RELEASE_VERSION,
+            description="Whether to purge the user's shared virtual folders.",
+        ),
+        deprecation_reason=("Ignored: it did the opposite of its name. Use deleteSharedVfolders."),
+        default=False,
+    )
+    delete_shared_vfolders: bool = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description=(
+                "If true, delete the purged user's virtual folders that are shared with "
+                "other users. If false, their ownership is transferred to the requesting "
+                "admin. Virtual folders that are not shared are deleted either way."
+            ),
+        ),
         default=False,
     )
     delegate_endpoint_ownership: bool = gql_field(

--- a/src/ai/backend/manager/api/gql_legacy/user.py
+++ b/src/ai/backend/manager/api/gql_legacy/user.py
@@ -1052,7 +1052,23 @@ class ModifyUserInput(graphene.InputObjectType):  # type: ignore[misc]
 
 
 class PurgeUserInput(graphene.InputObjectType):  # type: ignore[misc]
-    purge_shared_vfolders = graphene.Boolean(required=False, default=False)
+    purge_shared_vfolders = graphene.Boolean(
+        required=False,
+        default=False,
+        deprecation_reason=(
+            f"Deprecated since {NEXT_RELEASE_VERSION} and ignored: it did the opposite of "
+            "its name. Use `delete_shared_vfolders`."
+        ),
+    )
+    delete_shared_vfolders = graphene.Boolean(
+        required=False,
+        default=False,
+        description=(
+            f"Added in {NEXT_RELEASE_VERSION}. The default value is `false`. "
+            "If true, the user's virtual folders shared with other users are deleted "
+            "along with the rest; otherwise their ownership goes to the requester."
+        ),
+    )
     delegate_endpoint_ownership = graphene.Boolean(
         required=False,
         default=False,
@@ -1066,9 +1082,7 @@ class PurgeUserInput(graphene.InputObjectType):  # type: ignore[misc]
         return PurgeUserAction(
             user_id=user_id,
             admin_user_id=admin_user_id,
-            purge_shared_vfolders=OptionalState[bool].from_graphql(
-                self.purge_shared_vfolders,
-            ),
+            delete_shared_vfolders=bool(self.delete_shared_vfolders),
             delegate_endpoint_ownership=OptionalState[bool].from_graphql(
                 self.delegate_endpoint_ownership,
             ),

--- a/src/ai/backend/manager/api/rest/user/handler.py
+++ b/src/ai/backend/manager/api/rest/user/handler.py
@@ -244,10 +244,7 @@ class UserHandler:
         body: BodyParam[PurgeUserRequest],
         ctx: UserContext,
     ) -> APIResponse:
-        purge_shared = OptionalState[bool].nop()
         delegate_endpoint = OptionalState[bool].nop()
-        if body.parsed.purge_shared_vfolders:
-            purge_shared = OptionalState.update(body.parsed.purge_shared_vfolders)
         if body.parsed.delegate_endpoint_ownership:
             delegate_endpoint = OptionalState.update(body.parsed.delegate_endpoint_ownership)
 
@@ -255,7 +252,7 @@ class UserHandler:
             PurgeUserAction(
                 user_id=UserID(body.parsed.user_id),
                 admin_user_id=ctx.user_uuid,
-                purge_shared_vfolders=purge_shared,
+                delete_shared_vfolders=body.parsed.delete_shared_vfolders,
                 delegate_endpoint_ownership=delegate_endpoint,
             )
         )

--- a/src/ai/backend/manager/services/user/actions/purge_user.py
+++ b/src/ai/backend/manager/services/user/actions/purge_user.py
@@ -26,7 +26,7 @@ class PurgeUserAction(BaseSingleEntityAction):
 
     user_id: UserID
     admin_user_id: UUID
-    purge_shared_vfolders: OptionalState[bool] = field(default_factory=OptionalState[bool].nop)
+    delete_shared_vfolders: bool = False
     delegate_endpoint_ownership: OptionalState[bool] = field(
         default_factory=OptionalState[bool].nop
     )
@@ -57,7 +57,7 @@ class BulkPurgeUserAction(BaseGlobalAction):
 
     user_ids: list[UUID]
     admin_user_id: UUID
-    purge_shared_vfolders: OptionalState[bool] = field(default_factory=OptionalState[bool].nop)
+    delete_shared_vfolders: bool = False
     delegate_endpoint_ownership: OptionalState[bool] = field(
         default_factory=OptionalState[bool].nop
     )

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -188,7 +188,7 @@ class UserService:
         bulk_action = BulkPurgeUserAction(
             user_ids=[action.user_id],
             admin_user_id=action.admin_user_id,
-            purge_shared_vfolders=action.purge_shared_vfolders,
+            delete_shared_vfolders=action.delete_shared_vfolders,
             delegate_endpoint_ownership=action.delegate_endpoint_ownership,
         )
         await self._purge_single_user(action.user_id, bulk_action, user_info_ctx)
@@ -217,8 +217,10 @@ class UserService:
                 "Terminate those kernels first.",
             )
 
-        # Handle shared vfolders migration
-        if action.purge_shared_vfolders.optional_value():
+        # Folders shared with other users are handed to the requesting admin unless the
+        # caller asked for them to go too; the delete pass below only sweeps rows still
+        # owned by the purged user.
+        if not action.delete_shared_vfolders:
             await self._user_repository.migrate_shared_vfolders(
                 deleted_user_uuid=user_uuid,
                 target_user_uuid=user_info_ctx.uuid,

--- a/tests/unit/client_v2/test_user.py
+++ b/tests/unit/client_v2/test_user.py
@@ -220,7 +220,7 @@ class TestUserCRUD:
 
         request = PurgeUserRequest(
             user_id=_SAMPLE_USER_ID,
-            purge_shared_vfolders=True,
+            delete_shared_vfolders=True,
             delegate_endpoint_ownership=True,
         )
         result = await uc.purge(request)
@@ -232,5 +232,5 @@ class TestUserCRUD:
         assert url.endswith("/admin/users/purge")
         assert body is not None
         assert body["user_id"] == str(_SAMPLE_USER_ID)
-        assert body["purge_shared_vfolders"] is True
+        assert body["delete_shared_vfolders"] is True
         assert body["delegate_endpoint_ownership"] is True

--- a/tests/unit/common/dto/manager/v2/user/test_request.py
+++ b/tests/unit/common/dto/manager/v2/user/test_request.py
@@ -310,26 +310,26 @@ class TestPurgeUserInput:
     def test_default_flags_are_false(self) -> None:
         user_id = uuid.uuid4()
         req = PurgeUserInput(user_id=user_id)
-        assert req.purge_shared_vfolders is False
+        assert req.delete_shared_vfolders is False
         assert req.delegate_endpoint_ownership is False
 
     def test_all_fields(self) -> None:
         user_id = uuid.uuid4()
         req = PurgeUserInput(
             user_id=user_id,
-            purge_shared_vfolders=True,
+            delete_shared_vfolders=True,
             delegate_endpoint_ownership=True,
         )
-        assert req.purge_shared_vfolders is True
+        assert req.delete_shared_vfolders is True
         assert req.delegate_endpoint_ownership is True
 
     def test_round_trip(self) -> None:
         user_id = uuid.uuid4()
-        req = PurgeUserInput(user_id=user_id, purge_shared_vfolders=True)
+        req = PurgeUserInput(user_id=user_id, delete_shared_vfolders=True)
         json_data = req.model_dump_json()
         restored = PurgeUserInput.model_validate_json(json_data)
         assert restored.user_id == user_id
-        assert restored.purge_shared_vfolders is True
+        assert restored.delete_shared_vfolders is True
 
 
 class TestPurgeUserV2Options:
@@ -337,38 +337,43 @@ class TestPurgeUserV2Options:
 
     def test_default_values_are_false(self) -> None:
         opts = PurgeUserV2Options()
-        assert opts.purge_shared_vfolders is False
+        assert opts.delete_shared_vfolders is False
         assert opts.delegate_endpoint_ownership is False
 
-    def test_purge_shared_vfolders_true(self) -> None:
-        opts = PurgeUserV2Options(purge_shared_vfolders=True)
-        assert opts.purge_shared_vfolders is True
+    def test_delete_shared_vfolders_true(self) -> None:
+        opts = PurgeUserV2Options(delete_shared_vfolders=True)
+        assert opts.delete_shared_vfolders is True
         assert opts.delegate_endpoint_ownership is False
 
     def test_delegate_endpoint_ownership_true(self) -> None:
         opts = PurgeUserV2Options(delegate_endpoint_ownership=True)
-        assert opts.purge_shared_vfolders is False
+        assert opts.delete_shared_vfolders is False
         assert opts.delegate_endpoint_ownership is True
 
     def test_both_flags_true(self) -> None:
-        opts = PurgeUserV2Options(purge_shared_vfolders=True, delegate_endpoint_ownership=True)
-        assert opts.purge_shared_vfolders is True
+        opts = PurgeUserV2Options(delete_shared_vfolders=True, delegate_endpoint_ownership=True)
+        assert opts.delete_shared_vfolders is True
         assert opts.delegate_endpoint_ownership is True
 
     def test_round_trip(self) -> None:
-        opts = PurgeUserV2Options(purge_shared_vfolders=True, delegate_endpoint_ownership=False)
+        opts = PurgeUserV2Options(delete_shared_vfolders=True, delegate_endpoint_ownership=False)
         json_data = opts.model_dump_json()
         restored = PurgeUserV2Options.model_validate_json(json_data)
-        assert restored.purge_shared_vfolders is True
+        assert restored.delete_shared_vfolders is True
         assert restored.delegate_endpoint_ownership is False
 
     def test_from_dict(self) -> None:
         opts = PurgeUserV2Options.model_validate({
-            "purge_shared_vfolders": True,
+            "delete_shared_vfolders": True,
             "delegate_endpoint_ownership": True,
         })
-        assert opts.purge_shared_vfolders is True
+        assert opts.delete_shared_vfolders is True
         assert opts.delegate_endpoint_ownership is True
+
+    def test_deprecated_flag_is_accepted_but_does_not_set_the_new_one(self) -> None:
+        opts = PurgeUserV2Options.model_validate({"purge_shared_vfolders": True})
+        assert opts.purge_shared_vfolders is True
+        assert opts.delete_shared_vfolders is False
 
 
 class TestPurgeUserV2Input:
@@ -385,12 +390,12 @@ class TestPurgeUserV2Input:
         req = PurgeUserV2Input(user_id=user_id)
         assert req.options is None
 
-    def test_with_options_purge_shared_vfolders(self) -> None:
+    def test_with_options_delete_shared_vfolders(self) -> None:
         user_id = uuid.uuid4()
-        opts = PurgeUserV2Options(purge_shared_vfolders=True)
+        opts = PurgeUserV2Options(delete_shared_vfolders=True)
         req = PurgeUserV2Input(user_id=user_id, options=opts)
         assert req.options is not None
-        assert req.options.purge_shared_vfolders is True
+        assert req.options.delete_shared_vfolders is True
         assert req.options.delegate_endpoint_ownership is False
 
     def test_with_options_delegate_endpoint_ownership(self) -> None:
@@ -398,7 +403,7 @@ class TestPurgeUserV2Input:
         opts = PurgeUserV2Options(delegate_endpoint_ownership=True)
         req = PurgeUserV2Input(user_id=user_id, options=opts)
         assert req.options is not None
-        assert req.options.purge_shared_vfolders is False
+        assert req.options.delete_shared_vfolders is False
         assert req.options.delegate_endpoint_ownership is True
 
     def test_with_explicit_null_options(self) -> None:
@@ -424,13 +429,13 @@ class TestPurgeUserV2Input:
 
     def test_round_trip_with_options(self) -> None:
         user_id = uuid.uuid4()
-        opts = PurgeUserV2Options(purge_shared_vfolders=True, delegate_endpoint_ownership=True)
+        opts = PurgeUserV2Options(delete_shared_vfolders=True, delegate_endpoint_ownership=True)
         req = PurgeUserV2Input(user_id=user_id, options=opts)
         json_data = req.model_dump_json()
         restored = PurgeUserV2Input.model_validate_json(json_data)
         assert restored.user_id == user_id
         assert restored.options is not None
-        assert restored.options.purge_shared_vfolders is True
+        assert restored.options.delete_shared_vfolders is True
         assert restored.options.delegate_endpoint_ownership is True
 
     def test_from_dict_with_options(self) -> None:
@@ -438,13 +443,13 @@ class TestPurgeUserV2Input:
         req = PurgeUserV2Input.model_validate({
             "user_id": str(user_id),
             "options": {
-                "purge_shared_vfolders": True,
+                "delete_shared_vfolders": True,
                 "delegate_endpoint_ownership": False,
             },
         })
         assert req.user_id == user_id
         assert req.options is not None
-        assert req.options.purge_shared_vfolders is True
+        assert req.options.delete_shared_vfolders is True
         assert req.options.delegate_endpoint_ownership is False
 
     def test_from_dict_without_options(self) -> None:

--- a/tests/unit/manager/services/test_users.py
+++ b/tests/unit/manager/services/test_users.py
@@ -501,7 +501,12 @@ class TestPurgeUser:
         with pytest.raises(UserPurgeFailure):
             await service.purge_user(action)
 
-    async def test_purge_user_with_shared_vfolders_migration(
+    @pytest.mark.parametrize(
+        ("delete_shared_vfolders", "should_migrate"),
+        [(True, False), (False, True)],
+        ids=["delete-shared", "keep-shared"],
+    )
+    async def test_purge_user_shared_vfolders_disposition(
         self,
         admin_user_row: MagicMock,
         service: UserService,
@@ -509,8 +514,10 @@ class TestPurgeUser:
         purge_user_uuid: uuid.UUID,
         purge_user_data: UserData,
         admin_user_info_ctx: UserInfoContext,
+        delete_shared_vfolders: bool,
+        should_migrate: bool,
     ) -> None:
-        """Purge user with shared vfolders migration enabled should migrate vfolders."""
+        """The flag deletes the shared vfolders when set and migrates them when not."""
         mock_user_repository.get_user_by_uuid = AsyncMock(return_value=admin_user_row)
         mock_user_repository.check_user_vfolder_mounted_to_active_kernels = AsyncMock(
             return_value=False
@@ -524,17 +531,50 @@ class TestPurgeUser:
         action = PurgeUserAction(
             user_id=UserID(purge_user_uuid),
             admin_user_id=admin_user_info_ctx.uuid,
-            purge_shared_vfolders=OptionalState.update(True),
+            delete_shared_vfolders=delete_shared_vfolders,
         )
 
         result = await service.purge_user(action)
 
         assert result is not None
-        mock_user_repository.migrate_shared_vfolders.assert_called_once_with(
-            deleted_user_uuid=purge_user_uuid,
-            target_user_uuid=admin_user_info_ctx.uuid,
-            target_user_email=admin_user_info_ctx.email,
+        if should_migrate:
+            mock_user_repository.migrate_shared_vfolders.assert_called_once_with(
+                deleted_user_uuid=purge_user_uuid,
+                target_user_uuid=admin_user_info_ctx.uuid,
+                target_user_email=admin_user_info_ctx.email,
+            )
+        else:
+            mock_user_repository.migrate_shared_vfolders.assert_not_called()
+        mock_user_repository.delete_user_vfolders.assert_called_once()
+
+    async def test_purge_user_keeps_shared_vfolders_by_default(
+        self,
+        admin_user_row: MagicMock,
+        service: UserService,
+        mock_user_repository: MagicMock,
+        purge_user_uuid: uuid.UUID,
+        purge_user_data: UserData,
+        admin_user_info_ctx: UserInfoContext,
+    ) -> None:
+        """Leaving the flag unset must not destroy the shared vfolders."""
+        mock_user_repository.get_user_by_uuid = AsyncMock(return_value=admin_user_row)
+        mock_user_repository.check_user_vfolder_mounted_to_active_kernels = AsyncMock(
+            return_value=False
         )
+        mock_user_repository.migrate_shared_vfolders = AsyncMock(return_value=None)
+        mock_user_repository.retrieve_active_sessions = AsyncMock(return_value=[])
+        mock_user_repository.delete_endpoints = AsyncMock(return_value=None)
+        mock_user_repository.delete_user_vfolders = AsyncMock(return_value=None)
+        mock_user_repository.purge_user_by_uuid = AsyncMock(return_value=None)
+
+        action = PurgeUserAction(
+            user_id=UserID(purge_user_uuid),
+            admin_user_id=admin_user_info_ctx.uuid,
+        )
+
+        await service.purge_user(action)
+
+        mock_user_repository.migrate_shared_vfolders.assert_called_once()
 
     async def test_purge_user_with_endpoint_delegation(
         self,


### PR DESCRIPTION
## Summary

- `purge_shared_vfolders` on the user purge APIs does the opposite of its name: since 25.6.0, `true` keeps the purged user's shared virtual folders (migrating them to the requesting admin) and `false` deletes them. The inversion came from `3c97066da2` (BA-1099, #4103), which dropped a `not` while realigning the action architecture; no changelog acknowledged a behavior change.
- Rather than flipping the polarity under existing callers, this deprecates `purge_shared_vfolders`, **ignores its value**, and adds `delete_shared_vfolders`, whose name matches what it does: `true` deletes the shared folders, `false`/unset transfers their ownership to the requesting admin.
- Callers that sent `purge_shared_vfolders=true` keep the behavior they had. Callers that sent `false` now preserve the folders instead of destroying them, so the only behavior change moves away from irreversible deletion.
- The action field is a plain `bool` instead of `OptionalState[bool]`. The `if x else OptionalState.nop()` gates in the adapter, REST handler and GraphQL resolver collapsed `False` into "unset", which is what made the inverted flag hard to read; a flag with a default has no third state to carry.

Applied across the whole surface: v2 DTO + Strawberry GQL inputs, v1 REST DTO + handler, `gql_legacy` input, adapter, service, action, and the client SDK/CLI (`--purge-shared-vfolders` → `--delete-shared-vfolders`).

## Points for review

- **`gql_legacy` gained a new field.** `AGENTS.md` says not to add to `gql_legacy`, but the client SDK's `User.purge()` calls the legacy `purge_user` mutation, so without it the CLI could no longer express "delete the shared folders" at all. Happy to drop it if the capability loss is acceptable.
- **The CLI flag was renamed, not aliased.** Scripts passing `--purge-shared-vfolders` will now fail rather than silently do the wrong thing. Say the word if a hidden alias is preferred.
- **WebUI is a separate repo.** `PurgeUsersModal.tsx` still sends `purge_shared_vfolders`; its "Delete shared virtual folders as well?" checkbox only becomes truthful once lablup/backend.ai-webui switches to `delete_shared_vfolders`. Until then that checkbox is inert, which is the safe failure mode. Blocks lablup/backend.ai-webui#9508.

## Not addressed here

Two defects found while tracing `_migrate_shared_vfolders`, both independent of the flag and unchanged by this PR:

- The `vfolder_permissions` join has no `DISTINCT`, so a folder shared with N users produces N `UPDATE`s; the collision suffix is regenerated per iteration, so the folder keeps the last random name and the returned rowcount over-counts.
- Only folders with a per-user `vfolder_permissions` row migrate. A user-owned folder shared through a project/group grant may fall outside that join and be deleted even when preservation was requested. Not traced to a conclusion — worth its own issue.

## Test plan

- [x] `pants fmt ::`, `pants fix ::`, `pants lint --changed-since=origin/main`
- [x] `pants check --changed-since=origin/main` (14 files, mypy clean)
- [x] `pants test` in CI
- [x] GraphQL schema regeneration

Resolves BA-7733

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14367.org.readthedocs.build/en/14367/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14367.org.readthedocs.build/ko/14367/

<!-- readthedocs-preview sorna-ko end -->