### PR TITLE
fix(BA-7772): open the image reads that a wiring swap can fix

### DIFF
--- a/changes/14399.fix.md
+++ b/changes/14399.fix.md
@@ -1,0 +1,1 @@
+Restore the `images` GraphQL query for non-superadmin users, so the session launcher can list environments again.

--- a/src/ai/backend/manager/api/gql_legacy/image.py
+++ b/src/ai/backend/manager/api/gql_legacy/image.py
@@ -75,7 +75,7 @@ from ai.backend.manager.services.image.actions.forget_image import (
     ForgetImageAction,
     ForgetImageByIdAction,
 )
-from ai.backend.manager.services.image.actions.get_all_images import GetAllImagesAction
+from ai.backend.manager.services.image.actions.get_all_images import PublicGetAllImagesAction
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
     GetImageInstalledAgentsAction,
 )
@@ -307,8 +307,8 @@ class Image(graphene.ObjectType):  # type: ignore[misc]
             filter_by_statuses = [ImageStatus.ALIVE]
         if types is None:
             types = set()
-        result = await ctx.processors.image.get_all_images.run(
-            GetAllImagesAction(status_filter=filter_by_statuses)
+        result = await ctx.processors.image.public_get_all_images.run(
+            PublicGetAllImagesAction(status_filter=filter_by_statuses)
         )
         all_items = [cls.from_image_with_agent_install_status(img) for img in result.data.values()]
         return [item for item in all_items if item.matches_filter(ctx, types)]

--- a/src/ai/backend/manager/api/gql_legacy/image.py
+++ b/src/ai/backend/manager/api/gql_legacy/image.py
@@ -80,9 +80,9 @@ from ai.backend.manager.services.image.actions.get_image_installed_agents import
     GetImageInstalledAgentsAction,
 )
 from ai.backend.manager.services.image.actions.get_images import (
-    GetImageByIdAction,
-    GetImageByIdentifierAction,
-    GetImagesByCanonicalsAction,
+    PublicGetImageByIdAction,
+    PublicGetImageByIdentifierAction,
+    PublicGetImagesByCanonicalsAction,
 )
 from ai.backend.manager.services.image.actions.purge_images import PurgeImageByIdAction
 from ai.backend.manager.services.image.actions.untag_image_from_registry import (
@@ -237,8 +237,8 @@ class Image(graphene.ObjectType):  # type: ignore[misc]
     ) -> list[Self]:
         if filter_by_statuses is None:
             filter_by_statuses = [ImageStatus.ALIVE]
-        result = await graph_ctx.processors.image.get_images_by_canonicals.run(
-            GetImagesByCanonicalsAction(
+        result = await graph_ctx.processors.image.public_get_images_by_canonicals.run(
+            PublicGetImagesByCanonicalsAction(
                 image_canonicals=list(image_names),
                 image_status=filter_by_statuses,
             )
@@ -269,8 +269,8 @@ class Image(graphene.ObjectType):  # type: ignore[misc]
     ) -> Image:
         if filter_by_statuses is None:
             filter_by_statuses = [ImageStatus.ALIVE]
-        result = await ctx.processors.image.get_image_by_id.run(
-            GetImageByIdAction(
+        result = await ctx.processors.image.public_get_image_by_id.run(
+            PublicGetImageByIdAction(
                 image_id=ImageID(id),
                 image_status=filter_by_statuses,
             )
@@ -287,8 +287,8 @@ class Image(graphene.ObjectType):  # type: ignore[misc]
     ) -> Image:
         if filter_by_statuses is None:
             filter_by_statuses = [ImageStatus.ALIVE]
-        result = await ctx.processors.image.get_image_by_identifier.run(
-            GetImageByIdentifierAction(
+        result = await ctx.processors.image.public_get_image_by_identifier.run(
+            PublicGetImageByIdentifierAction(
                 image_identifier=ImageIdentifier(reference, architecture),
                 image_status=filter_by_statuses,
             )
@@ -731,8 +731,8 @@ class ImageNode(graphene.ObjectType):  # type: ignore[misc]
     async def __resolve_reference(self, info: graphene.ResolveInfo, **kwargs: Any) -> Image:
         ctx: GraphQueryContext = info.context
         _, image_id = AsyncNode.resolve_global_id(info, self.id)
-        action_result = await ctx.processors.image.get_image_by_id.run(
-            GetImageByIdAction(
+        action_result = await ctx.processors.image.public_get_image_by_id.run(
+            PublicGetImageByIdAction(
                 image_id=ImageID(UUID(image_id)),
                 image_status=None,
             )

--- a/src/ai/backend/manager/api/rest/image/handler.py
+++ b/src/ai/backend/manager/api/rest/image/handler.py
@@ -29,7 +29,7 @@ from ai.backend.manager.dto.image_request import GetImagePathParam
 from ai.backend.manager.services.image.actions.alias_image import AliasImageByIdAction
 from ai.backend.manager.services.image.actions.dealias_image import DealiasImageAction
 from ai.backend.manager.services.image.actions.forget_image import ForgetImageByIdAction
-from ai.backend.manager.services.image.actions.get_images import GetImageByIdAction
+from ai.backend.manager.services.image.actions.get_images import PublicGetImageByIdAction
 from ai.backend.manager.services.image.actions.purge_images import PurgeImageByIdAction
 from ai.backend.manager.services.image.actions.scan_image import ScanImageAction
 from ai.backend.manager.services.image.actions.search_images import SearchImagesAction
@@ -71,8 +71,8 @@ class ImageHandler:
         ctx: UserContext,
     ) -> APIResponse:
         """Get a single image by ID."""
-        action_result = await self._image.get_image_by_id.run(
-            GetImageByIdAction(image_id=ImageID(path.parsed.image_id), image_status=None)
+        action_result = await self._image.public_get_image_by_id.run(
+            PublicGetImageByIdAction(image_id=ImageID(path.parsed.image_id), image_status=None)
         )
         resp = GetImageResponse(
             item=self._adapter.convert_detailed_to_dto(

--- a/src/ai/backend/manager/services/image/actions/get_all_images.py
+++ b/src/ai/backend/manager/services/image/actions/get_all_images.py
@@ -12,7 +12,7 @@ from ai.backend.manager.services.image.actions.base import ImageAction
 
 
 @dataclass
-class GetAllImagesAction(ImageAction):
+class PublicGetAllImagesAction(ImageAction):
     """
     Action to retrieve all images, optionally filtered by their status.
     Args:
@@ -25,7 +25,7 @@ class GetAllImagesAction(ImageAction):
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "get_all_images"
+        return "public_get_all_images"
 
     @override
     @classmethod
@@ -34,5 +34,5 @@ class GetAllImagesAction(ImageAction):
 
 
 @dataclass
-class GetAllImagesActionResult:
+class PublicGetAllImagesActionResult:
     data: Mapping[ImageID, ImageWithAgentInstallStatus]

--- a/src/ai/backend/manager/services/image/actions/get_images.py
+++ b/src/ai/backend/manager/services/image/actions/get_images.py
@@ -12,14 +12,14 @@ from ai.backend.manager.services.image.actions.base import ImageAction
 
 
 @dataclass
-class GetImageByIdAction(ImageAction):
+class PublicGetImageByIdAction(ImageAction):
     image_id: ImageID
     image_status: list[ImageStatus] | None
 
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "get_image_by_id"
+        return "public_get_image_by_id"
 
     @override
     @classmethod
@@ -28,19 +28,19 @@ class GetImageByIdAction(ImageAction):
 
 
 @dataclass
-class GetImageByIdActionResult:
+class PublicGetImageByIdActionResult:
     image_with_agent_install_status: ImageWithAgentInstallStatus
 
 
 @dataclass
-class GetImageByIdentifierAction(ImageAction):
+class PublicGetImageByIdentifierAction(ImageAction):
     image_identifier: ImageIdentifier
     image_status: list[ImageStatus] | None
 
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "get_image_by_identifier"
+        return "public_get_image_by_identifier"
 
     @override
     @classmethod
@@ -49,12 +49,12 @@ class GetImageByIdentifierAction(ImageAction):
 
 
 @dataclass
-class GetImageByIdentifierActionResult:
+class PublicGetImageByIdentifierActionResult:
     image_with_agent_install_status: ImageWithAgentInstallStatus
 
 
 @dataclass
-class GetImagesByCanonicalsAction(ImageAction):
+class PublicGetImagesByCanonicalsAction(ImageAction):
     """
     Deprecated. Use SearchImagesAction instead.
     """
@@ -65,7 +65,7 @@ class GetImagesByCanonicalsAction(ImageAction):
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "get_images_by_canonicals"
+        return "public_get_images_by_canonicals"
 
     @override
     @classmethod
@@ -75,5 +75,5 @@ class GetImagesByCanonicalsAction(ImageAction):
 
 @dataclass
 # TODO: Refactor dataclass with BatchActionResult
-class GetImagesByCanonicalsActionResult:
+class PublicGetImagesByCanonicalsActionResult:
     images_with_agent_install_status: list[ImageWithAgentInstallStatus]

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -1,5 +1,8 @@
 from ai.backend.manager.actions.registry.group import ProcessorGroup
-from ai.backend.manager.actions.v2.global_scope.processor import GlobalActionProcessor
+from ai.backend.manager.actions.v2.global_scope.processor import (
+    GlobalActionProcessor,
+    PublicActionProcessor,
+)
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.image.types import ImageData
 from ai.backend.manager.services.image.actions.alias_image import (
@@ -25,8 +28,8 @@ from ai.backend.manager.services.image.actions.forget_image import (
     ForgetImageByIdActionResult,
 )
 from ai.backend.manager.services.image.actions.get_all_images import (
-    GetAllImagesAction,
-    GetAllImagesActionResult,
+    PublicGetAllImagesAction,
+    PublicGetAllImagesActionResult,
 )
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
     GetImageInstalledAgentsAction,
@@ -135,7 +138,9 @@ class ImageProcessors:
     get_image_installed_agents: GlobalActionProcessor[
         GetImageInstalledAgentsAction, GetImageInstalledAgentsActionResult
     ]
-    get_all_images: GlobalActionProcessor[GetAllImagesAction, GetAllImagesActionResult]
+    public_get_all_images: PublicActionProcessor[
+        PublicGetAllImagesAction, PublicGetAllImagesActionResult
+    ]
     search_images: GlobalActionProcessor[SearchImagesAction, SearchImagesActionResult]
     search_aliases: GlobalActionProcessor[SearchAliasesAction, SearchAliasesActionResult]
 
@@ -153,7 +158,7 @@ class ImageProcessors:
         self.get_image_by_id = group.global_scope(GetImageByIdAction, service.get_image_by_id)
         self.forget_image = group.global_scope(ForgetImageAction, service.forget_image)
 
-        self.get_all_images = group.global_scope(GetAllImagesAction, service.get_all_images)
+        self.public_get_all_images = group.public(PublicGetAllImagesAction, service.get_all_images)
         self.search_images = group.global_scope(SearchImagesAction, service.search_images)
 
         self.forget_image_by_id = group.single_entity(

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -36,12 +36,12 @@ from ai.backend.manager.services.image.actions.get_image_installed_agents import
     GetImageInstalledAgentsActionResult,
 )
 from ai.backend.manager.services.image.actions.get_images import (
-    GetImageByIdAction,
-    GetImageByIdActionResult,
-    GetImageByIdentifierAction,
-    GetImageByIdentifierActionResult,
-    GetImagesByCanonicalsAction,
-    GetImagesByCanonicalsActionResult,
+    PublicGetImageByIdAction,
+    PublicGetImageByIdActionResult,
+    PublicGetImageByIdentifierAction,
+    PublicGetImageByIdentifierActionResult,
+    PublicGetImagesByCanonicalsAction,
+    PublicGetImagesByCanonicalsActionResult,
 )
 from ai.backend.manager.services.image.actions.preload_image import (
     PreloadImageAction,
@@ -128,12 +128,14 @@ class ImageProcessors:
     set_image_resource_limit_by_id: GlobalActionProcessor[
         SetImageResourceLimitByIdAction, SetImageResourceLimitByIdActionResult
     ]
-    get_image_by_id: GlobalActionProcessor[GetImageByIdAction, GetImageByIdActionResult]
-    get_image_by_identifier: GlobalActionProcessor[
-        GetImageByIdentifierAction, GetImageByIdentifierActionResult
+    public_get_image_by_id: PublicActionProcessor[
+        PublicGetImageByIdAction, PublicGetImageByIdActionResult
     ]
-    get_images_by_canonicals: GlobalActionProcessor[
-        GetImagesByCanonicalsAction, GetImagesByCanonicalsActionResult
+    public_get_image_by_identifier: PublicActionProcessor[
+        PublicGetImageByIdentifierAction, PublicGetImageByIdentifierActionResult
+    ]
+    public_get_images_by_canonicals: PublicActionProcessor[
+        PublicGetImagesByCanonicalsAction, PublicGetImagesByCanonicalsActionResult
     ]
     get_image_installed_agents: GlobalActionProcessor[
         GetImageInstalledAgentsAction, GetImageInstalledAgentsActionResult
@@ -145,20 +147,21 @@ class ImageProcessors:
     search_aliases: GlobalActionProcessor[SearchAliasesAction, SearchAliasesActionResult]
 
     def __init__(self, group: ProcessorGroup[ImageData], service: ImageService) -> None:
-        # Actions without RBAC validation (internal/system or special entity types)
+        self.public_get_all_images = group.public(PublicGetAllImagesAction, service.get_all_images)
+        self.public_get_image_by_id = group.public(
+            PublicGetImageByIdAction, service.get_image_by_id
+        )
+        self.public_get_image_by_identifier = group.public(
+            PublicGetImageByIdentifierAction, service.get_image_by_identifier
+        )
+        self.public_get_images_by_canonicals = group.public(
+            PublicGetImagesByCanonicalsAction, service.get_images_by_canonicals
+        )
+
         self.get_image_installed_agents = group.global_scope(
             GetImageInstalledAgentsAction, service.get_image_installed_agents
         )
-        self.get_images_by_canonicals = group.global_scope(
-            GetImagesByCanonicalsAction, service.get_images_by_canonicals
-        )
-        self.get_image_by_identifier = group.global_scope(
-            GetImageByIdentifierAction, service.get_image_by_identifier
-        )
-        self.get_image_by_id = group.global_scope(GetImageByIdAction, service.get_image_by_id)
         self.forget_image = group.global_scope(ForgetImageAction, service.forget_image)
-
-        self.public_get_all_images = group.public(PublicGetAllImagesAction, service.get_all_images)
         self.search_images = group.global_scope(SearchImagesAction, service.search_images)
 
         self.forget_image_by_id = group.single_entity(

--- a/src/ai/backend/manager/services/image/service.py
+++ b/src/ai/backend/manager/services/image/service.py
@@ -41,8 +41,8 @@ from ai.backend.manager.services.image.actions.forget_image import (
     ForgetImageByIdActionResult,
 )
 from ai.backend.manager.services.image.actions.get_all_images import (
-    GetAllImagesAction,
-    GetAllImagesActionResult,
+    PublicGetAllImagesAction,
+    PublicGetAllImagesActionResult,
 )
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
     GetImageInstalledAgentsAction,
@@ -183,9 +183,11 @@ class ImageService:
         agent_counts_per_image = await self._image_repository.get_image_installed_agents(image_ids)
         return GetImageInstalledAgentsActionResult(data=agent_counts_per_image)
 
-    async def get_all_images(self, action: GetAllImagesAction) -> GetAllImagesActionResult:
+    async def get_all_images(
+        self, action: PublicGetAllImagesAction
+    ) -> PublicGetAllImagesActionResult:
         images = await self._image_repository.get_all_images(status_filter=action.status_filter)
-        return GetAllImagesActionResult(data=images)
+        return PublicGetAllImagesActionResult(data=images)
 
     async def get_image_by_id(self, action: GetImageByIdAction) -> GetImageByIdActionResult:
         user = current_user()

--- a/src/ai/backend/manager/services/image/service.py
+++ b/src/ai/backend/manager/services/image/service.py
@@ -49,12 +49,12 @@ from ai.backend.manager.services.image.actions.get_image_installed_agents import
     GetImageInstalledAgentsActionResult,
 )
 from ai.backend.manager.services.image.actions.get_images import (
-    GetImageByIdAction,
-    GetImageByIdActionResult,
-    GetImageByIdentifierAction,
-    GetImageByIdentifierActionResult,
-    GetImagesByCanonicalsAction,
-    GetImagesByCanonicalsActionResult,
+    PublicGetImageByIdAction,
+    PublicGetImageByIdActionResult,
+    PublicGetImageByIdentifierAction,
+    PublicGetImageByIdentifierActionResult,
+    PublicGetImagesByCanonicalsAction,
+    PublicGetImagesByCanonicalsActionResult,
 )
 from ai.backend.manager.services.image.actions.preload_image import (
     PreloadImageAction,
@@ -137,8 +137,8 @@ class ImageService:
             raise ImageAccessForbiddenError()
 
     async def get_images_by_canonicals(
-        self, action: GetImagesByCanonicalsAction
-    ) -> GetImagesByCanonicalsActionResult:
+        self, action: PublicGetImagesByCanonicalsAction
+    ) -> PublicGetImagesByCanonicalsActionResult:
         """
         Deprecated. Use get_images_by_ids instead.
         """
@@ -152,13 +152,13 @@ class ImageService:
             status_filter=action.image_status,
             hide_agents=hide_agents,
         )
-        return GetImagesByCanonicalsActionResult(
+        return PublicGetImagesByCanonicalsActionResult(
             images_with_agent_install_status=images_with_agent_install_status
         )
 
     async def get_image_by_identifier(
-        self, action: GetImageByIdentifierAction
-    ) -> GetImageByIdentifierActionResult:
+        self, action: PublicGetImageByIdentifierAction
+    ) -> PublicGetImageByIdentifierActionResult:
         """
         Deprecated. Use get_image_by_id instead.
         """
@@ -172,7 +172,7 @@ class ImageService:
                 hide_agents=hide_agents,
             )
         )
-        return GetImageByIdentifierActionResult(
+        return PublicGetImageByIdentifierActionResult(
             image_with_agent_install_status=image_with_agent_install_status
         )
 
@@ -189,7 +189,9 @@ class ImageService:
         images = await self._image_repository.get_all_images(status_filter=action.status_filter)
         return PublicGetAllImagesActionResult(data=images)
 
-    async def get_image_by_id(self, action: GetImageByIdAction) -> GetImageByIdActionResult:
+    async def get_image_by_id(
+        self, action: PublicGetImageByIdAction
+    ) -> PublicGetImageByIdActionResult:
         user = current_user()
         is_superadmin = user is not None and user.role == UserRole.SUPERADMIN
         hide_agents = False if is_superadmin else self._config_provider.config.manager.hide_agents
@@ -201,7 +203,7 @@ class ImageService:
                 hide_agents=hide_agents,
             )
         )
-        return GetImageByIdActionResult(
+        return PublicGetImageByIdActionResult(
             image_with_agent_install_status=image_with_agent_install_status
         )
 

--- a/tests/component/image/test_image_registry.py
+++ b/tests/component/image/test_image_registry.py
@@ -28,7 +28,6 @@ from .conftest import ImageFactoryHelper
 
 class TestImageRescan:
     @pytest.mark.xfail(reason="Requires live container registry", strict=False)
-    @pytest.mark.timeout(10)
     async def test_rescan_returns_response(
         self,
         admin_registry: BackendAIClientRegistry,

--- a/tests/unit/manager/api/image/test_handler.py
+++ b/tests/unit/manager/api/image/test_handler.py
@@ -40,7 +40,7 @@ from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.services.image.actions.alias_image import AliasImageByIdAction
 from ai.backend.manager.services.image.actions.dealias_image import DealiasImageAction
 from ai.backend.manager.services.image.actions.forget_image import ForgetImageByIdAction
-from ai.backend.manager.services.image.actions.get_images import GetImageByIdAction
+from ai.backend.manager.services.image.actions.get_images import PublicGetImageByIdAction
 from ai.backend.manager.services.image.actions.purge_images import PurgeImageByIdAction
 from ai.backend.manager.services.image.actions.scan_image import ScanImageAction
 from ai.backend.manager.services.image.actions.search_images import SearchImagesAction
@@ -408,7 +408,9 @@ class TestImageAPIHandler:
         processors.image.search_images.wait_for_complete = AsyncMock(
             return_value=mock_search_result
         )
-        processors.image.get_image_by_id.wait_for_complete = AsyncMock(return_value=mock_get_result)
+        processors.image.public_get_image_by_id.wait_for_complete = AsyncMock(
+            return_value=mock_get_result
+        )
         processors.image.scan_image.wait_for_complete = AsyncMock(return_value=mock_scan_result)
         processors.image.alias_image_by_id.wait_for_complete = AsyncMock(
             return_value=mock_alias_result
@@ -465,10 +467,10 @@ class TestImageAPIHandler:
     ) -> None:
         """Get handler should call get_image_by_id processor."""
         image_id = ImageID(UUID("11111111-1111-1111-1111-111111111111"))
-        await mock_processors.image.get_image_by_id.wait_for_complete(
-            GetImageByIdAction(image_id=image_id, image_status=None)
+        await mock_processors.image.public_get_image_by_id.wait_for_complete(
+            PublicGetImageByIdAction(image_id=image_id, image_status=None)
         )
-        mock_processors.image.get_image_by_id.wait_for_complete.assert_called_once()
+        mock_processors.image.public_get_image_by_id.wait_for_complete.assert_called_once()
 
     async def test_get_image_converts_detailed_dto(
         self,
@@ -476,8 +478,8 @@ class TestImageAPIHandler:
     ) -> None:
         """Get result should be convertible to detailed DTO."""
         image_id = ImageID(UUID("11111111-1111-1111-1111-111111111111"))
-        result = await mock_processors.image.get_image_by_id.wait_for_complete(
-            GetImageByIdAction(image_id=image_id, image_status=None)
+        result = await mock_processors.image.public_get_image_by_id.wait_for_complete(
+            PublicGetImageByIdAction(image_id=image_id, image_status=None)
         )
         adapter = ImageAdapter()
         dto = adapter.convert_detailed_to_dto(result.image_with_agent_install_status.image)


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 2-PR stack. **Merge in order:**

1. 👉 **#14399** — `fix(BA-7772): open the image reads that a wiring swap can fix` ← you are here
2. ⬇️ #14413 — `fix(BA-7773): open the last two image read paths that still require super-admin`

## Summary
- Four image reads — `get_all_images`, `get_image_by_id`, `get_image_by_identifier`, `get_images_by_canonicals` — were wired through `ProcessorGroup.global_scope`. `GlobalActionProcessor` always prepends `SuperAdminActionValidator`, so the legacy `images` and `image` queries and `image_node` answered `user_auth_forbidden` to a non-superadmin, and the WebUI session launcher could not list environments.
- The layer above already decides what each role may read: `resolve_images` narrows ADMIN/USER through `Image.filter_allowed()` (the domain's allowed registries) and `matches_filter()` (customized images by owner), and all three `get_*` service methods read the caller's role to set `hide_agents`. That last one is a degradation path no non-superadmin could reach while the gate stood in front of it.
- Wire the four through `ProcessorGroup.public` / `PublicActionProcessor`, which replaces the SUPERADMIN gate with an authentication check and accepts read operations only. Naming follows the public shape rule in `services/AGENTS.md`.
- Drop the `# Actions without RBAC validation` comment in `services/image/processors.py`: `global_scope` gates on SUPERADMIN, so the line described neither half of the block it sat above.
- Remove `@pytest.mark.timeout(10)` from `tests/component/image/test_image_registry.py`. It sits on the file's first test, whose setup is what first starts the session-scoped postgres, redis and etcd containers; pytest-timeout covers setup, so three container starts had a ten-second budget. The test is `xfail`, which swallowed the setup error, and the session fixture was then cached as failed, erroring the ten DB-backed tests below it. The run takes ~42s and passes once the marker is gone.

### Verified against a running server
A regular user (`role=user`) was used throughout. Reproduced on the merge base first: `images`, `image(id:)` and `image(reference:, architecture:)` each returned `Insufficient privilege. (This operation requires super-admin privileges.)` / `user_auth_forbidden`. After the change all three return data, and a session created by that user reaches RUNNING with its container up. Superadmin behaviour is unchanged.

`get_images_by_canonicals` is the exception: `Image.batch_load_by_image_ref` is its only route into the GQL layer and nothing calls that, so it had no reachable caller to break. It moves with the other three for consistency rather than to fix an observed failure. Session creation through REST v2 `enqueue` was never affected either — it takes `image_id` directly and touches none of these actions.

### Left alone here
- `get_image_installed_agents` — moved in BA-7773 instead, so this PR stays one reviewable unit.
- `search_images` / `search_aliases` — one action backs both `admin_search*` (superadmin by design, per `api/AGENTS.md`) and the DataLoader `batch_load_by_ids` used across `gql/data_loader/data_loaders.py`. One action cannot carry two gates; splitting it is BA-7774.

Backport: none

The gate does not exist on either maintained version: on 26.8 and 26.4 these actions are wired as `ActionProcessor(service.…, action_monitors)` with no validators, and `resolve_images` filters ADMIN/USER the same way it does here. It arrived on `main` with the v2 processor migration, so there is nothing to backport.

Resolves BA-7772.