### PR TITLE
refactor(BA-7745): switch artifact update DTO to Unset

### DIFF
--- a/changes/14401.enhance.md
+++ b/changes/14401.enhance.md
@@ -1,0 +1,1 @@
+Switch the artifact update DTO from the legacy `Sentinel` marker to `Unset`, so an omitted field leaves the value unchanged and `null` clears it

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -2287,14 +2287,6 @@
         "title": "AdminSearchArtifactsInput",
         "type": "object"
       },
-      "Sentinel": {
-        "description": "A sentinel value to represent an unset value.",
-        "enum": [
-          1
-        ],
-        "title": "Sentinel",
-        "type": "integer"
-      },
       "UpdateArtifactInput": {
         "description": "Input for updating artifact metadata.",
         "properties": {
@@ -2317,14 +2309,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
-            "description": "Updated description. Use SENTINEL to clear the field; None means no change.",
+            "description": "Updated description. Omit to leave unchanged; null clears.",
             "title": "Description"
           }
         },
@@ -5411,6 +5399,14 @@
         },
         "title": "AdminSearchDeploymentsInput",
         "type": "object"
+      },
+      "Sentinel": {
+        "description": "A sentinel value to represent an unset value.",
+        "enum": [
+          1
+        ],
+        "title": "Sentinel",
+        "type": "integer"
       },
       "UpdateDeploymentInput": {
         "description": "Input for updating a deployment.",

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -2299,8 +2299,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Whether the artifact should be readonly. None means no change.",
+            "description": "Whether the artifact should be readonly. Omit to leave unchanged.",
             "title": "Readonly"
           },
           "description": {

--- a/src/ai/backend/client/cli/v2/artifact/commands.py
+++ b/src/ai/backend/client/cli/v2/artifact/commands.py
@@ -57,18 +57,16 @@ def update(
     from ai.backend.common.dto.manager.v2.artifact.request import UpdateArtifactInput
     from ai.backend.common.tristate.unset import UNSET, Unset
 
-    # UNSET means "no change" in the DTO; None means "clear the field".
-    # When the CLI user does not pass --description, keep UNSET (no change).
-    desc_value: str | None | Unset = UNSET
-    if description is not None:
-        desc_value = description
+    # Options the user did not pass stay UNSET (no change); an empty --description clears it.
+    readonly_value: bool | Unset = UNSET if readonly is None else readonly
+    desc_value: str | Unset = UNSET if description is None else description
 
     async def _run() -> None:
         registry = await create_v2_registry(load_v2_config())
         try:
             result = await registry.artifact.update(
                 UUID(artifact_id),
-                UpdateArtifactInput(readonly=readonly, description=desc_value),
+                UpdateArtifactInput(readonly=readonly_value, description=desc_value),
             )
             print_result(result)
         finally:

--- a/src/ai/backend/client/cli/v2/artifact/commands.py
+++ b/src/ai/backend/client/cli/v2/artifact/commands.py
@@ -54,12 +54,12 @@ def update(
     """Update artifact metadata."""
     from uuid import UUID
 
-    from ai.backend.common.api_handlers import SENTINEL, Sentinel
     from ai.backend.common.dto.manager.v2.artifact.request import UpdateArtifactInput
+    from ai.backend.common.tristate.unset import UNSET, Unset
 
-    # SENTINEL means "no change" in the DTO; None means "clear the field".
-    # When the CLI user does not pass --description, keep SENTINEL (no change).
-    desc_value: str | Sentinel | None = SENTINEL
+    # UNSET means "no change" in the DTO; None means "clear the field".
+    # When the CLI user does not pass --description, keep UNSET (no change).
+    desc_value: str | None | Unset = UNSET
     if description is not None:
         desc_value = description
 

--- a/src/ai/backend/common/dto/manager/v2/artifact/request.py
+++ b/src/ai/backend/common/dto/manager/v2/artifact/request.py
@@ -8,8 +8,9 @@ from uuid import UUID
 
 from pydantic import Field, field_validator
 
-from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import IntFilter, StringFilter, UUIDFilter
+from ai.backend.common.tristate.unset import UNSET, Unset
 
 from .types import (
     ArtifactAvailability,
@@ -62,14 +63,14 @@ class UpdateArtifactInput(BaseRequestModel):
         default=None,
         description="Whether the artifact should be readonly. None means no change.",
     )
-    description: str | Sentinel | None = Field(
-        default=SENTINEL,
-        description="Updated description. Use SENTINEL to clear the field; None means no change.",
+    description: str | None | Unset = Field(
+        default=UNSET,
+        description="Updated description. Omit to leave unchanged; null clears.",
     )
 
     @field_validator("description", mode="before")
     @classmethod
-    def description_strip_whitespace(cls, v: str | Sentinel | None) -> str | Sentinel | None:
+    def description_strip_whitespace(cls, v: str | None | Unset) -> str | None | Unset:
         if isinstance(v, str):
             stripped = v.strip()
             return stripped if stripped else None

--- a/src/ai/backend/common/dto/manager/v2/artifact/request.py
+++ b/src/ai/backend/common/dto/manager/v2/artifact/request.py
@@ -59,9 +59,9 @@ __all__ = (
 class UpdateArtifactInput(BaseRequestModel):
     """Input for updating artifact metadata."""
 
-    readonly: bool | None = Field(
-        default=None,
-        description="Whether the artifact should be readonly. None means no change.",
+    readonly: bool | None | Unset = Field(
+        default=UNSET,
+        description="Whether the artifact should be readonly. Omit to leave unchanged.",
     )
     description: str | None | Unset = Field(
         default=UNSET,
@@ -392,7 +392,11 @@ class UpdateArtifactGQLInput(BaseRequestModel):
     """GQL input for updating artifact metadata."""
 
     artifact_id: UUID = Field(description="ID of the artifact to update.")
-    readonly: bool | None = Field(
-        default=None, description="Whether the artifact should be readonly."
+    readonly: bool | None | Unset = Field(
+        default=UNSET,
+        description="Whether the artifact should be readonly. Omit to leave unchanged.",
     )
-    description: str | None = Field(default=None, description="Updated description.")
+    description: str | None | Unset = Field(
+        default=UNSET,
+        description="Updated description. Omit to leave unchanged; null clears.",
+    )

--- a/src/ai/backend/manager/api/adapters/artifact/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact/adapter.py
@@ -261,11 +261,7 @@ class ArtifactAdapter(BaseAdapter):
         """Update artifact metadata (readonly flag and description)."""
         updater = ArtifactUpdater(
             artifact_id=ArtifactID(artifact_id),
-            readonly=(
-                TriState.update(input.readonly)
-                if input.readonly is not None
-                else TriState[bool].nop()
-            ),
+            readonly=TriState.from_unset(input.readonly),
             description=TriState.from_unset(input.description),
         )
         action_result = await self._processors.artifact.update.run(

--- a/src/ai/backend/manager/api/adapters/artifact/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact/adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from uuid import UUID
 
-from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.data.entity.artifact import ArtifactID
 from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryID
 from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionID
@@ -267,11 +266,7 @@ class ArtifactAdapter(BaseAdapter):
                 if input.readonly is not None
                 else TriState[bool].nop()
             ),
-            description=(
-                TriState[str].nop()
-                if isinstance(input.description, Sentinel)
-                else TriState[str].from_graphql(input.description)
-            ),
+            description=TriState.from_unset(input.description),
         )
         action_result = await self._processors.artifact.update.run(
             UpdateArtifactAction(artifact_id=ArtifactID(artifact_id), updater=updater)

--- a/src/ai/backend/manager/api/adapters/artifact/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact/adapter.py
@@ -126,7 +126,7 @@ from ai.backend.manager.services.artifact.revision.actions.reject import (
 from ai.backend.manager.services.artifact.revision.actions.search import (
     SearchArtifactRevisionsAction,
 )
-from ai.backend.manager.types import TriState
+from ai.backend.manager.types import OptionalState, TriState
 
 DEFAULT_PAGINATION_LIMIT = 10
 
@@ -261,7 +261,7 @@ class ArtifactAdapter(BaseAdapter):
         """Update artifact metadata (readonly flag and description)."""
         updater = ArtifactUpdater(
             artifact_id=ArtifactID(artifact_id),
-            readonly=TriState.from_unset(input.readonly),
+            readonly=OptionalState.from_unset(input.readonly),
             description=TriState.from_unset(input.description),
         )
         action_result = await self._processors.artifact.update.run(

--- a/src/ai/backend/manager/api/gql/artifact/resolver.py
+++ b/src/ai/backend/manager/api/gql/artifact/resolver.py
@@ -6,7 +6,6 @@ from uuid import UUID
 import strawberry
 from strawberry import ID, UNSET, Info
 
-from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryID
 from ai.backend.common.data.storage.registries.types import ModelSortKey
 from ai.backend.common.dto.manager.v2.artifact.request import (
@@ -16,6 +15,7 @@ from ai.backend.common.dto.manager.v2.artifact.request import (
 from ai.backend.common.dto.manager.v2.artifact.request import (
     UpdateArtifactInput as UpdateArtifactInputDTO,
 )
+from ai.backend.common.tristate.unset import UNSET as DTO_UNSET
 from ai.backend.manager.api.gql.base import (
     encode_cursor,
 )
@@ -420,7 +420,7 @@ async def update_artifact(
 ) -> UpdateArtifactPayload | None:
     pydantic_input = UpdateArtifactInputDTO(
         readonly=input.readonly if input.readonly is not UNSET else None,
-        description=input.description if input.description is not UNSET else SENTINEL,
+        description=input.description if input.description is not UNSET else DTO_UNSET,
     )
     payload = await info.context.adapters.artifact.update(pydantic_input, UUID(input.artifact_id))
 

--- a/src/ai/backend/manager/api/gql/artifact/resolver.py
+++ b/src/ai/backend/manager/api/gql/artifact/resolver.py
@@ -419,7 +419,7 @@ async def update_artifact(
     input: UpdateArtifactInput, info: Info[StrawberryGQLContext]
 ) -> UpdateArtifactPayload | None:
     pydantic_input = UpdateArtifactInputDTO(
-        readonly=input.readonly if input.readonly is not UNSET else None,
+        readonly=input.readonly if input.readonly is not UNSET else DTO_UNSET,
         description=input.description if input.description is not UNSET else DTO_UNSET,
     )
     payload = await info.context.adapters.artifact.update(pydantic_input, UUID(input.artifact_id))

--- a/src/ai/backend/manager/api/rest/artifact/handler.py
+++ b/src/ai/backend/manager/api/rest/artifact/handler.py
@@ -67,7 +67,7 @@ from ai.backend.manager.services.artifact.revision.actions.import_revision impor
 from ai.backend.manager.services.artifact.revision.actions.reject import (
     RejectArtifactRevisionAction,
 )
-from ai.backend.manager.types import TriState
+from ai.backend.manager.types import OptionalState, TriState
 
 if TYPE_CHECKING:
     from ai.backend.manager.services.artifact.processors import ArtifactProcessors
@@ -249,7 +249,7 @@ class ArtifactHandler:
                 artifact_id=ArtifactID(path.parsed.artifact_id),
                 updater=ArtifactUpdater(
                     artifact_id=ArtifactID(path.parsed.artifact_id),
-                    readonly=TriState.from_nullable(body.parsed.readonly),
+                    readonly=OptionalState.from_nullable(body.parsed.readonly),
                     description=TriState.from_nullable(body.parsed.description),
                 ),
             )

--- a/src/ai/backend/manager/models/artifact/updaters.py
+++ b/src/ai/backend/manager/models/artifact/updaters.py
@@ -22,7 +22,7 @@ from ai.backend.manager.models.specs.updater import (
     DataUpdater,
     GuardedDataUpdater,
 )
-from ai.backend.manager.types import TriState
+from ai.backend.manager.types import OptionalState, TriState
 
 
 @dataclass
@@ -33,7 +33,7 @@ class ArtifactUpdater(GuardedDataUpdater[ArtifactRow, ArtifactData]):
     """
 
     artifact_id: ArtifactID
-    readonly: TriState[bool] = field(default_factory=TriState[bool].nop)
+    readonly: OptionalState[bool] = field(default_factory=OptionalState[bool].nop)
     description: TriState[str] = field(default_factory=TriState[str].nop)
 
     @property

--- a/tests/unit/common/dto/manager/v2/artifact/test_request.py
+++ b/tests/unit/common/dto/manager/v2/artifact/test_request.py
@@ -30,7 +30,7 @@ class TestUpdateArtifactInput:
         req = UpdateArtifactInput(description=UNSET)
         assert req.description is UNSET
 
-    def test_none_description_means_no_change(self) -> None:
+    def test_none_description_stays_none(self) -> None:
         req = UpdateArtifactInput(description=None)
         assert req.description is None
 
@@ -46,8 +46,16 @@ class TestUpdateArtifactInput:
         req = UpdateArtifactInput(description="   ")
         assert req.description is None
 
-    def test_readonly_default_is_none(self) -> None:
+    def test_readonly_default_is_unset(self) -> None:
         req = UpdateArtifactInput()
+        assert req.readonly is UNSET
+
+    def test_explicit_unset_readonly_signals_no_change(self) -> None:
+        req = UpdateArtifactInput(readonly=UNSET)
+        assert req.readonly is UNSET
+
+    def test_none_readonly_stays_none(self) -> None:
+        req = UpdateArtifactInput(readonly=None)
         assert req.readonly is None
 
     def test_readonly_true(self) -> None:

--- a/tests/unit/common/dto/manager/v2/artifact/test_request.py
+++ b/tests/unit/common/dto/manager/v2/artifact/test_request.py
@@ -7,7 +7,6 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
-from ai.backend.common.api_handlers import SENTINEL, Sentinel
 from ai.backend.common.dto.manager.v2.artifact.request import (
     CancelImportTaskInput,
     CleanupRevisionsInput,
@@ -16,19 +15,20 @@ from ai.backend.common.dto.manager.v2.artifact.request import (
     UpdateArtifactInput,
 )
 from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.common.tristate.unset import UNSET, Unset
 
 
 class TestUpdateArtifactInput:
     """Tests for UpdateArtifactInput model creation and validation."""
 
-    def test_default_description_is_sentinel(self) -> None:
+    def test_default_description_is_unset(self) -> None:
         req = UpdateArtifactInput()
-        assert req.description is SENTINEL
-        assert isinstance(req.description, Sentinel)
+        assert req.description is UNSET
+        assert isinstance(req.description, Unset)
 
-    def test_explicit_sentinel_description_signals_clear(self) -> None:
-        req = UpdateArtifactInput(description=SENTINEL)
-        assert req.description is SENTINEL
+    def test_explicit_unset_description_signals_no_change(self) -> None:
+        req = UpdateArtifactInput(description=UNSET)
+        assert req.description is UNSET
 
     def test_none_description_means_no_change(self) -> None:
         req = UpdateArtifactInput(description=None)

--- a/tests/unit/manager/repositories/artifact/test_artifact_repository.py
+++ b/tests/unit/manager/repositories/artifact/test_artifact_repository.py
@@ -55,7 +55,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.models.vfolder import VFolderRow
 from ai.backend.manager.repositories.artifact.repository import ArtifactRepository
 from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
-from ai.backend.manager.types import TriState
+from ai.backend.manager.types import OptionalState, TriState
 from ai.backend.testutils.db import with_tables
 
 
@@ -318,12 +318,14 @@ class TestArtifactRepository:
         """Test updating artifact"""
         updater = ArtifactUpdater(
             artifact_id=ArtifactID(sample_artifact_id),
+            readonly=OptionalState.update(False),
             description=TriState.update("Updated description"),
         )
 
         updated_artifact = await artifact_repository.update_artifact(updater)
 
         assert updated_artifact is not None
+        assert updated_artifact.readonly is False
         assert updated_artifact.description == "Updated description"
 
     # =========================================================================

--- a/tests/unit/manager/services/artifact/test_artifact_service.py
+++ b/tests/unit/manager/services/artifact/test_artifact_service.py
@@ -86,6 +86,7 @@ from ai.backend.manager.services.artifact.actions.upsert_multi import (
 )
 from ai.backend.manager.services.artifact.service import ArtifactService
 from ai.backend.manager.types import (
+    OptionalState,
     TriState,
 )
 
@@ -286,6 +287,7 @@ class TestArtifactService:
         """Test updating an artifact"""
         updater = ArtifactUpdater(
             artifact_id=sample_artifact_data.id,
+            readonly=OptionalState.update(True),
             description=TriState.update("Updated description"),
         )
         updated_artifact = ArtifactData(


### PR DESCRIPTION
Switch the `artifact` update DTO from the legacy `Sentinel` marker to `Unset` (omitted = no change, `null` = clear).

- `common/dto/manager/v2/artifact/request.py`: `UpdateArtifactInput.description` changes from `str | Sentinel | None = SENTINEL` to `str | None | Unset = UNSET`; the field description now reads "Omit to leave unchanged; null clears."; the validator type hint is updated to match.
- `manager/api/adapters/artifact/adapter.py`: the `Sentinel` branch for `description` is replaced with `TriState.from_unset(input.description)`.
- `client/cli/v2/artifact/commands.py`: an omitted `--description` now defaults to `UNSET` instead of `SENTINEL`.
- `tests/unit/common/dto/manager/v2/artifact/test_request.py`: `SENTINEL`/`Sentinel` assertions become `UNSET`/`Unset`; the two default/explicit-marker tests are renamed accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017idp6rKVV33XrzJG1yWYXo

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14401.org.readthedocs.build/en/14401/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14401.org.readthedocs.build/ko/14401/

<!-- readthedocs-preview sorna-ko end -->