### PR TITLE
refactor(BA-7747): switch idle_checker update DTO to Unset

### DIFF
--- a/changes/14404.enhance.md
+++ b/changes/14404.enhance.md
@@ -1,0 +1,1 @@
+Switch the idle_checker update DTO from the legacy `Sentinel` marker to `Unset`, so an omitted field leaves the value unchanged and `null` clears it

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -10837,7 +10837,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
+            "description": "Updated name. Omit to leave unchanged.",
             "title": "Name"
           },
           "description": {
@@ -10858,27 +10858,27 @@
                 "items": {
                   "$ref": "#/components/schemas/SessionTypes"
                 },
-                "minItems": 1,
+                "minLength": 1,
                 "type": "array"
               },
               {
                 "type": "null"
               }
             ],
-            "default": null,
+            "description": "Updated target session types. Omit to leave unchanged.",
             "title": "Target Session Types"
           },
           "initial_grace_period_seconds": {
             "anyOf": [
               {
-                "minimum": 0,
+                "ge": 0,
                 "type": "integer"
               },
               {
                 "type": "null"
               }
             ],
-            "default": null,
+            "description": "Updated initial grace period in seconds. Omit to leave unchanged.",
             "title": "Initial Grace Period Seconds"
           },
           "checker_spec": {
@@ -10890,7 +10890,8 @@
                 "type": "null"
               }
             ],
-            "default": null
+            "description": "Updated checker specification. Omit to leave unchanged.",
+            "title": "Checker Spec"
           }
         },
         "required": [

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -10846,14 +10846,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
-            "description": "Updated description. Omit to leave unchanged or pass null to clear.",
+            "description": "Updated description. Omit to leave unchanged; null clears.",
             "title": "Description"
           },
           "target_session_types": {

--- a/src/ai/backend/client/cli/v2/admin/idle_checker.py
+++ b/src/ai/backend/client/cli/v2/admin/idle_checker.py
@@ -191,12 +191,12 @@ def update(
     checker_spec: str | None,
 ) -> None:
     """Update an idle checker."""
-    from ai.backend.common.api_handlers import SENTINEL
     from ai.backend.common.data.entity.idle_checker import IdleCheckerID
     from ai.backend.common.dto.manager.v2.idle_checker.request import (
         IdleCheckerSpecInputDTO,
         UpdateIdleCheckerInput,
     )
+    from ai.backend.common.tristate.unset import UNSET
 
     if description is not None and clear_description:
         raise click.UsageError("--description and --clear-description cannot be used together")
@@ -206,7 +206,7 @@ def update(
         id=checker_id,
         name=name,
         description=(
-            None if clear_description else description if description is not None else SENTINEL
+            None if clear_description else description if description is not None else UNSET
         ),
         target_session_types=(
             [SessionTypes(session_type) for session_type in target_session_types]

--- a/src/ai/backend/client/cli/v2/admin/idle_checker.py
+++ b/src/ai/backend/client/cli/v2/admin/idle_checker.py
@@ -204,18 +204,20 @@ def update(
     checker_id = IdleCheckerID(idle_checker_id)
     input_ = UpdateIdleCheckerInput(
         id=checker_id,
-        name=name,
+        name=name if name is not None else UNSET,
         description=(
             None if clear_description else description if description is not None else UNSET
         ),
         target_session_types=(
             [SessionTypes(session_type) for session_type in target_session_types]
             if target_session_types
-            else None
+            else UNSET
         ),
-        initial_grace_period_seconds=initial_grace_period_seconds,
+        initial_grace_period_seconds=(
+            initial_grace_period_seconds if initial_grace_period_seconds is not None else UNSET
+        ),
         checker_spec=(
-            load_model(checker_spec, IdleCheckerSpecInputDTO) if checker_spec is not None else None
+            load_model(checker_spec, IdleCheckerSpecInputDTO) if checker_spec is not None else UNSET
         ),
     )
 

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
@@ -87,14 +87,30 @@ class CreateIdleCheckerInput(BaseRequestModel):
 
 class UpdateIdleCheckerInput(BaseRequestModel):
     id: IdleCheckerID = Field(description="Idle checker ID to update.")
-    name: str | None = Field(default=None, min_length=1, max_length=128)
+    name: str | None | Unset = Field(
+        default=UNSET,
+        min_length=1,
+        max_length=128,
+        description="Updated name. Omit to leave unchanged.",
+    )
     description: str | None | Unset = Field(
         default=UNSET,
         description="Updated description. Omit to leave unchanged; null clears.",
     )
-    target_session_types: list[SessionTypes] | None = Field(default=None, min_length=1)
-    initial_grace_period_seconds: int | None = Field(default=None, ge=0)
-    checker_spec: IdleCheckerSpecInputDTO | None = Field(default=None)
+    target_session_types: list[SessionTypes] | None | Unset = Field(
+        default=UNSET,
+        min_length=1,
+        description="Updated target session types. Omit to leave unchanged.",
+    )
+    initial_grace_period_seconds: int | None | Unset = Field(
+        default=UNSET,
+        ge=0,
+        description="Updated initial grace period in seconds. Omit to leave unchanged.",
+    )
+    checker_spec: IdleCheckerSpecInputDTO | None | Unset = Field(
+        default=UNSET,
+        description="Updated checker specification. Omit to leave unchanged.",
+    )
 
 
 class PurgeIdleCheckerInput(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
+++ b/src/ai/backend/common/dto/manager/v2/idle_checker/request.py
@@ -5,7 +5,7 @@ from typing import Self
 
 from pydantic import ConfigDict, Field, model_validator
 
-from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.data.entity.idle_checker import IdleCheckerID
 from ai.backend.common.data.entity.prometheus_query_preset import PrometheusQueryPresetID
 from ai.backend.common.data.idle_checker.types import SESSION_ID_LABEL
@@ -17,6 +17,7 @@ from ai.backend.common.dto.manager.v2.idle_checker.types import (
     IdleCheckerOrderField,
 )
 from ai.backend.common.dto.manager.v2.prometheus_query_preset.request import MetricLabelEntry
+from ai.backend.common.tristate.unset import UNSET, Unset
 from ai.backend.common.types import SessionTypes
 
 
@@ -87,9 +88,9 @@ class CreateIdleCheckerInput(BaseRequestModel):
 class UpdateIdleCheckerInput(BaseRequestModel):
     id: IdleCheckerID = Field(description="Idle checker ID to update.")
     name: str | None = Field(default=None, min_length=1, max_length=128)
-    description: str | Sentinel | None = Field(
-        default=SENTINEL,
-        description="Updated description. Omit to leave unchanged or pass null to clear.",
+    description: str | None | Unset = Field(
+        default=UNSET,
+        description="Updated description. Omit to leave unchanged; null clears.",
     )
     target_session_types: list[SessionTypes] | None = Field(default=None, min_length=1)
     initial_grace_period_seconds: int | None = Field(default=None, ge=0)

--- a/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from functools import lru_cache
 from typing import cast
 
-from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.data.entity.idle_checker import IdleCheckerID
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
@@ -147,13 +146,7 @@ class IdleCheckerAdapter(BaseAdapter):
         updater = IdleCheckerUpdater(
             checker_id=input.id,
             name=OptionalState.from_nullable(input.name),
-            description=(
-                TriState.nop()
-                if input.description is SENTINEL
-                else TriState.nullify()
-                if input.description is None
-                else TriState.update(input.description)
-            ),
+            description=TriState.from_unset(input.description),
             target_session_types=OptionalState.from_nullable(input.target_session_types),
             initial_grace_period_seconds=OptionalState.from_nullable(
                 input.initial_grace_period_seconds

--- a/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
@@ -145,13 +145,13 @@ class IdleCheckerAdapter(BaseAdapter):
     ) -> UpdateIdleCheckerPayload:
         updater = IdleCheckerUpdater(
             checker_id=input.id,
-            name=OptionalState.from_nullable(input.name),
+            name=OptionalState.from_unset(input.name),
             description=TriState.from_unset(input.description),
-            target_session_types=OptionalState.from_nullable(input.target_session_types),
-            initial_grace_period_seconds=OptionalState.from_nullable(
+            target_session_types=OptionalState.from_unset(input.target_session_types),
+            initial_grace_period_seconds=OptionalState.from_unset(
                 input.initial_grace_period_seconds
             ),
-            spec=self._build_spec_update(input.checker_spec),
+            spec=OptionalState.from_unset(input.checker_spec).map(self._build_spec),
         )
         action_result = await self._processors.idle_checker.update.run(
             UpdateIdleCheckerAction(updater=updater)
@@ -265,15 +265,6 @@ class IdleCheckerAdapter(BaseAdapter):
                 ),
             ),
         )
-
-    @classmethod
-    def _build_spec_update(
-        cls,
-        checker_spec: IdleCheckerSpecInputDTO | None,
-    ) -> OptionalState[IdleCheckerSpec]:
-        if checker_spec is None:
-            return OptionalState.nop()
-        return OptionalState.update(cls._build_spec(checker_spec))
 
     def _convert_filter(self, filter_: IdleCheckerFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []

--- a/tests/unit/common/dto/manager/v2/idle_checker/test_request.py
+++ b/tests/unit/common/dto/manager/v2/idle_checker/test_request.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
 
+from ai.backend.common.data.entity.idle_checker import IdleCheckerID
 from ai.backend.common.dto.manager.v2.idle_checker.request import (
     CreateIdleCheckerInput,
     IdleCheckerSpecInputDTO,
     NetworkTimeoutSpecInputDTO,
     SessionLifetimeSpecInputDTO,
+    UpdateIdleCheckerInput,
 )
 from ai.backend.common.dto.manager.v2.idle_checker.types import IdleCheckerInputTypeDTO
 from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.common.tristate.unset import UNSET
 from ai.backend.common.types import SessionTypes
 
 
@@ -59,3 +64,54 @@ class TestCreateIdleCheckerInput:
     def test_rejects_zero_max_lifetime(self) -> None:
         with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
             SessionLifetimeSpecInputDTO(max_lifetime_seconds=0)
+
+
+class TestUpdateIdleCheckerInput:
+    def test_omitted_fields_are_unset(self) -> None:
+        inp = UpdateIdleCheckerInput(id=IdleCheckerID(uuid4()))
+        assert inp.name is UNSET
+        assert inp.description is UNSET
+        assert inp.target_session_types is UNSET
+        assert inp.initial_grace_period_seconds is UNSET
+        assert inp.checker_spec is UNSET
+
+    def test_explicit_none_stays_none(self) -> None:
+        inp = UpdateIdleCheckerInput(
+            id=IdleCheckerID(uuid4()),
+            name=None,
+            description=None,
+            target_session_types=None,
+            initial_grace_period_seconds=None,
+            checker_spec=None,
+        )
+        assert inp.name is None
+        assert inp.description is None
+        assert inp.target_session_types is None
+        assert inp.initial_grace_period_seconds is None
+        assert inp.checker_spec is None
+
+    def test_values_are_kept(self) -> None:
+        spec = _session_lifetime_spec()
+        inp = UpdateIdleCheckerInput(
+            id=IdleCheckerID(uuid4()),
+            name="renamed",
+            target_session_types=[SessionTypes.BATCH],
+            initial_grace_period_seconds=30,
+            checker_spec=spec,
+        )
+        assert inp.name == "renamed"
+        assert inp.target_session_types == [SessionTypes.BATCH]
+        assert inp.initial_grace_period_seconds == 30
+        assert inp.checker_spec is spec
+
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UpdateIdleCheckerInput(id=IdleCheckerID(uuid4()), name="")
+
+    def test_rejects_empty_target_session_types(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UpdateIdleCheckerInput(id=IdleCheckerID(uuid4()), target_session_types=[])
+
+    def test_rejects_negative_grace_period(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UpdateIdleCheckerInput(id=IdleCheckerID(uuid4()), initial_grace_period_seconds=-1)


### PR DESCRIPTION
Switch the `idle_checker` update DTO from the legacy `Sentinel` marker to `Unset` (omitted = no change, `null` = clear).

- `common/dto/manager/v2/idle_checker/request.py`: `UpdateIdleCheckerInput.description` changes from `str | Sentinel | None = SENTINEL` to `str | None | Unset = UNSET`; the field description now reads "Omit to leave unchanged; null clears."
- `manager/api/adapters/idle_checker/adapter.py`: the `SENTINEL` branch for `description` is replaced with `TriState.from_unset(input.description)`.
- `client/cli/v2/admin/idle_checker.py`: an omitted `--description` now defaults to `UNSET` instead of `SENTINEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017idp6rKVV33XrzJG1yWYXo

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14404.org.readthedocs.build/en/14404/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14404.org.readthedocs.build/ko/14404/

<!-- readthedocs-preview sorna-ko end -->