### PR TITLE
refactor(BA-7748): switch image update DTO to Unset

### DIFF
--- a/changes/14405.enhance.md
+++ b/changes/14405.enhance.md
@@ -1,0 +1,1 @@
+Switch the image update DTO from the legacy `Sentinel` marker to `Unset`, so an omitted field leaves the value unchanged and `null` clears it

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -12089,8 +12089,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated canonical name.",
+            "description": "Updated canonical name. Omit to leave unchanged.",
             "title": "Name"
           },
           "registry": {
@@ -12102,8 +12101,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated registry hostname.",
+            "description": "Updated registry hostname. Omit to leave unchanged.",
             "title": "Registry"
           },
           "image": {
@@ -12115,8 +12113,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated namespace/path within registry.",
+            "description": "Updated namespace/path within registry. Omit to leave unchanged.",
             "title": "Image"
           },
           "tag": {
@@ -12128,8 +12125,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated image tag.",
+            "description": "Updated image tag. Omit to leave unchanged.",
             "title": "Tag"
           },
           "architecture": {
@@ -12141,8 +12137,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated CPU architecture.",
+            "description": "Updated CPU architecture. Omit to leave unchanged.",
             "title": "Architecture"
           },
           "is_local": {
@@ -12154,8 +12149,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated local-only status.",
+            "description": "Updated local-only status. Omit to leave unchanged.",
             "title": "Is Local"
           },
           "size_bytes": {
@@ -12167,8 +12161,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated image size in bytes.",
+            "description": "Updated image size in bytes. Omit to leave unchanged.",
             "title": "Size Bytes"
           },
           "type": {
@@ -12180,8 +12173,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated image type (compute, system, service).",
+            "description": "Updated image type (compute, system, service). Omit to leave unchanged.",
             "title": "Type"
           },
           "config_digest": {
@@ -12193,8 +12185,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated config digest.",
+            "description": "Updated config digest. Omit to leave unchanged.",
             "title": "Config Digest"
           },
           "labels": {
@@ -12209,8 +12200,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated labels dict.",
+            "description": "Updated labels dict. Omit to leave unchanged.",
             "title": "Labels"
           },
           "supported_accelerators": {
@@ -12235,8 +12225,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
-            "description": "Updated resource limits dict.",
+            "description": "Updated resource limits dict. Omit to leave unchanged.",
             "title": "Resource Limits"
           }
         },

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -12219,14 +12219,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
-            "description": "Updated accelerator string. Set to null to clear.",
+            "description": "Updated accelerator string. Omit to leave unchanged; null clears.",
             "title": "Supported Accelerators"
           },
           "resource_limits": {

--- a/src/ai/backend/common/dto/manager/v2/image/request.py
+++ b/src/ai/backend/common/dto/manager/v2/image/request.py
@@ -235,22 +235,42 @@ class UpdateImageInput(BaseRequestModel):
     """Input for updating an image by ID. All fields optional -- only provided fields will be updated."""
 
     image_id: UUID = Field(description="ID of the image to update.")
-    name: str | None = Field(default=None, description="Updated canonical name.")
-    registry: str | None = Field(default=None, description="Updated registry hostname.")
-    image: str | None = Field(default=None, description="Updated namespace/path within registry.")
-    tag: str | None = Field(default=None, description="Updated image tag.")
-    architecture: str | None = Field(default=None, description="Updated CPU architecture.")
-    is_local: bool | None = Field(default=None, description="Updated local-only status.")
-    size_bytes: int | None = Field(default=None, description="Updated image size in bytes.")
-    type: str | None = Field(
-        default=None, description="Updated image type (compute, system, service)."
+    name: str | None | Unset = Field(
+        default=UNSET, description="Updated canonical name. Omit to leave unchanged."
     )
-    config_digest: str | None = Field(default=None, description="Updated config digest.")
-    labels: dict[str, str] | None = Field(default=None, description="Updated labels dict.")
+    registry: str | None | Unset = Field(
+        default=UNSET, description="Updated registry hostname. Omit to leave unchanged."
+    )
+    image: str | None | Unset = Field(
+        default=UNSET,
+        description="Updated namespace/path within registry. Omit to leave unchanged.",
+    )
+    tag: str | None | Unset = Field(
+        default=UNSET, description="Updated image tag. Omit to leave unchanged."
+    )
+    architecture: str | None | Unset = Field(
+        default=UNSET, description="Updated CPU architecture. Omit to leave unchanged."
+    )
+    is_local: bool | None | Unset = Field(
+        default=UNSET, description="Updated local-only status. Omit to leave unchanged."
+    )
+    size_bytes: int | None | Unset = Field(
+        default=UNSET, description="Updated image size in bytes. Omit to leave unchanged."
+    )
+    type: str | None | Unset = Field(
+        default=UNSET,
+        description="Updated image type (compute, system, service). Omit to leave unchanged.",
+    )
+    config_digest: str | None | Unset = Field(
+        default=UNSET, description="Updated config digest. Omit to leave unchanged."
+    )
+    labels: dict[str, str] | None | Unset = Field(
+        default=UNSET, description="Updated labels dict. Omit to leave unchanged."
+    )
     supported_accelerators: str | None | Unset = Field(
         default=UNSET,
         description="Updated accelerator string. Omit to leave unchanged; null clears.",
     )
-    resource_limits: dict[str, Any] | None = Field(
-        default=None, description="Updated resource limits dict."
+    resource_limits: dict[str, Any] | None | Unset = Field(
+        default=UNSET, description="Updated resource limits dict. Omit to leave unchanged."
     )

--- a/src/ai/backend/common/dto/manager/v2/image/request.py
+++ b/src/ai/backend/common/dto/manager/v2/image/request.py
@@ -9,8 +9,9 @@ from uuid import UUID
 
 from pydantic import Field, field_validator
 
-from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.dto.manager.query import DateTimeFilter, StringFilter, UUIDFilter
+from ai.backend.common.tristate.unset import UNSET, Unset
 
 from .types import ImageOrderField, ImageStatusType, OrderDirection
 
@@ -246,8 +247,9 @@ class UpdateImageInput(BaseRequestModel):
     )
     config_digest: str | None = Field(default=None, description="Updated config digest.")
     labels: dict[str, str] | None = Field(default=None, description="Updated labels dict.")
-    supported_accelerators: str | Sentinel | None = Field(
-        default=SENTINEL, description="Updated accelerator string. Set to null to clear."
+    supported_accelerators: str | None | Unset = Field(
+        default=UNSET,
+        description="Updated accelerator string. Omit to leave unchanged; null clears.",
     )
     resource_limits: dict[str, Any] | None = Field(
         default=None, description="Updated resource limits dict."

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -7,7 +7,6 @@ from collections.abc import Sequence
 from decimal import Decimal
 from functools import lru_cache
 
-from ai.backend.common.api_handlers import Sentinel
 from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryID
 from ai.backend.common.dto.manager.v2.image.request import (
     AdminSearchImageAliasesInput,
@@ -317,13 +316,7 @@ class ImageAdapter(BaseAdapter):
                 if input.labels is not None
                 else OptionalState.nop()
             ),
-            accelerators=(
-                TriState.nop()
-                if isinstance(input.supported_accelerators, Sentinel)
-                else TriState.nullify()
-                if input.supported_accelerators is None
-                else TriState.update(input.supported_accelerators)
-            ),
+            accelerators=TriState.from_unset(input.supported_accelerators),
             resources=(
                 OptionalState.update(input.resource_limits)
                 if input.resource_limits is not None

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -272,56 +272,18 @@ class ImageAdapter(BaseAdapter):
     async def admin_update(self, input: UpdateImageInput) -> UpdateImagePayload:
         """Update an image by ID (superadmin only)."""
         update = ImageUpdate(
-            name=(
-                OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
-            ),
-            registry=(
-                OptionalState.update(input.registry)
-                if input.registry is not None
-                else OptionalState.nop()
-            ),
-            image=(
-                OptionalState.update(input.image)
-                if input.image is not None
-                else OptionalState.nop()
-            ),
-            tag=(OptionalState.update(input.tag) if input.tag is not None else OptionalState.nop()),
-            architecture=(
-                OptionalState.update(input.architecture)
-                if input.architecture is not None
-                else OptionalState.nop()
-            ),
-            is_local=(
-                OptionalState.update(input.is_local)
-                if input.is_local is not None
-                else OptionalState.nop()
-            ),
-            size_bytes=(
-                OptionalState.update(input.size_bytes)
-                if input.size_bytes is not None
-                else OptionalState.nop()
-            ),
-            image_type=(
-                OptionalState.update(ImageType(input.type))
-                if input.type is not None
-                else OptionalState.nop()
-            ),
-            config_digest=(
-                OptionalState.update(input.config_digest)
-                if input.config_digest is not None
-                else OptionalState.nop()
-            ),
-            labels=(
-                OptionalState.update(input.labels)
-                if input.labels is not None
-                else OptionalState.nop()
-            ),
+            name=OptionalState.from_unset(input.name),
+            registry=OptionalState.from_unset(input.registry),
+            image=OptionalState.from_unset(input.image),
+            tag=OptionalState.from_unset(input.tag),
+            architecture=OptionalState.from_unset(input.architecture),
+            is_local=OptionalState.from_unset(input.is_local),
+            size_bytes=OptionalState.from_unset(input.size_bytes),
+            image_type=OptionalState.from_unset(input.type).map(ImageType),
+            config_digest=OptionalState.from_unset(input.config_digest),
+            labels=OptionalState.from_unset(input.labels),
             accelerators=TriState.from_unset(input.supported_accelerators),
-            resources=(
-                OptionalState.update(input.resource_limits)
-                if input.resource_limits is not None
-                else OptionalState.nop()
-            ),
+            resources=OptionalState.from_unset(input.resource_limits),
         )
         result = await self._processors.image.update_image_by_id.run(
             UpdateImageByIdAction(image_id=ImageID(input.image_id), update=update)

--- a/tests/unit/common/dto/manager/v2/image/test_request.py
+++ b/tests/unit/common/dto/manager/v2/image/test_request.py
@@ -17,9 +17,11 @@ from ai.backend.common.dto.manager.v2.image.request import (
     PurgeImageInput,
     RescanImagesInput,
     SearchImagesInput,
+    UpdateImageInput,
 )
 from ai.backend.common.dto.manager.v2.image.types import ImageOrderField, OrderDirection
 from ai.backend.common.exception import BackendAISchemaValidationFailed
+from ai.backend.common.tristate.unset import UNSET
 
 
 class TestSearchImagesInput:
@@ -268,3 +270,57 @@ class TestPurgeImageInput:
         json_str = req.model_dump_json()
         restored = PurgeImageInput.model_validate_json(json_str)
         assert restored.image_id == image_id
+
+
+class TestUpdateImageInput:
+    """Tests for UpdateImageInput."""
+
+    def test_omitted_fields_default_to_unset(self) -> None:
+        req = UpdateImageInput(image_id=uuid.uuid4())
+        assert req.name is UNSET
+        assert req.registry is UNSET
+        assert req.image is UNSET
+        assert req.tag is UNSET
+        assert req.architecture is UNSET
+        assert req.is_local is UNSET
+        assert req.size_bytes is UNSET
+        assert req.type is UNSET
+        assert req.config_digest is UNSET
+        assert req.labels is UNSET
+        assert req.supported_accelerators is UNSET
+        assert req.resource_limits is UNSET
+
+    def test_explicit_none_stays_none(self) -> None:
+        req = UpdateImageInput.model_validate({
+            "image_id": str(uuid.uuid4()),
+            "name": None,
+            "labels": None,
+            "supported_accelerators": None,
+        })
+        assert req.name is None
+        assert req.labels is None
+        assert req.supported_accelerators is None
+        assert req.tag is UNSET
+
+    def test_provided_values_kept(self) -> None:
+        req = UpdateImageInput(
+            image_id=uuid.uuid4(),
+            name="cr.example.com/ns/app:1.0",
+            is_local=True,
+            size_bytes=1024,
+            type="compute",
+            labels={"a": "b"},
+            supported_accelerators="cuda",
+            resource_limits={"cpu": {"min": "1"}},
+        )
+        assert req.name == "cr.example.com/ns/app:1.0"
+        assert req.is_local is True
+        assert req.size_bytes == 1024
+        assert req.type == "compute"
+        assert req.labels == {"a": "b"}
+        assert req.supported_accelerators == "cuda"
+        assert req.resource_limits == {"cpu": {"min": "1"}}
+
+    def test_missing_image_id_raises_error(self) -> None:
+        with pytest.raises((BackendAISchemaValidationFailed, ValidationError)):
+            UpdateImageInput.model_validate({})


### PR DESCRIPTION
Switch the `image` update DTO from the legacy `Sentinel` marker to `Unset` (omitted = no change, `null` = clear).

- `common/dto/manager/v2/image/request.py`: `UpdateImageInput.supported_accelerators` changes from `str | Sentinel | None = SENTINEL` to `str | None | Unset = UNSET`; the field description now reads "Omit to leave unchanged; null clears."
- `manager/api/adapters/image/adapter.py`: the `Sentinel` branch for `accelerators` is replaced with `TriState.from_unset(input.supported_accelerators)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017idp6rKVV33XrzJG1yWYXo

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14405.org.readthedocs.build/en/14405/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14405.org.readthedocs.build/ko/14405/

<!-- readthedocs-preview sorna-ko end -->