### PR TITLE
fix(BA-7773): open the last two image read paths that still require super-admin

### DIFF
--- a/changes/14413.fix.md
+++ b/changes/14413.fix.md
@@ -1,0 +1,1 @@
+Restore the `installed` field and image reference resolution in GraphQL for non-superadmin users.

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -60,11 +60,15 @@ from ai.backend.manager.models.image.conditions import (
 from ai.backend.manager.models.image.orders import ImageAliasOrders, ImageOrders
 from ai.backend.manager.models.image.row import ImageAliasRow, ImageRow
 from ai.backend.manager.models.image.updaters import ImageUpdate
-from ai.backend.manager.models.specs.pagination import NoPagination, OffsetPagination
+from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.image.actions.alias_image import AliasImageByIdAction
 from ai.backend.manager.services.image.actions.dealias_image import DealiasImageAction
 from ai.backend.manager.services.image.actions.forget_image import ForgetImageByIdAction
+from ai.backend.manager.services.image.actions.get_images_by_ids import (
+    PublicGetImageAliasesByIdsAction,
+    PublicGetImagesByIdsAction,
+)
 from ai.backend.manager.services.image.actions.purge_images import PurgeImageByIdAction
 from ai.backend.manager.services.image.actions.restore_image import RestoreImageByIdAction
 from ai.backend.manager.services.image.actions.search_aliases import SearchAliasesAction
@@ -111,12 +115,8 @@ class ImageAdapter(BaseAdapter):
         """
         if not image_ids:
             return []
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[ImageConditions.by_ids(image_ids)],
-        )
-        action_result = await self._processors.image.search_images.run(
-            SearchImagesAction(querier=querier)
+        action_result = await self._processors.image.public_get_images_by_ids.run(
+            PublicGetImagesByIdsAction(image_ids=list(image_ids))
         )
         image_map: dict[ImageID, ImageNode] = {
             ImageID(item.id): self._data_to_dto(item) for item in action_result.data
@@ -132,12 +132,8 @@ class ImageAdapter(BaseAdapter):
         """
         if not alias_ids:
             return []
-        querier = BatchQuerier(
-            pagination=NoPagination(),
-            conditions=[ImageAliasConditions.by_ids(alias_ids)],
-        )
-        action_result = await self._processors.image.search_aliases.run(
-            SearchAliasesAction(querier=querier)
+        action_result = await self._processors.image.public_get_image_aliases_by_ids.run(
+            PublicGetImageAliasesByIdsAction(alias_ids=list(alias_ids))
         )
         alias_map: dict[uuid.UUID, ImageAliasNode] = {
             item.id: self._alias_data_to_dto(item) for item in action_result.data

--- a/src/ai/backend/manager/api/gql_legacy/image.py
+++ b/src/ai/backend/manager/api/gql_legacy/image.py
@@ -78,7 +78,7 @@ from ai.backend.manager.services.image.actions.forget_image import (
 )
 from ai.backend.manager.services.image.actions.get_all_images import PublicGetAllImagesAction
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
-    GetImageInstalledAgentsAction,
+    PublicGetImageInstalledAgentsAction,
 )
 from ai.backend.manager.services.image.actions.get_images import (
     PublicGetImageByIdAction,
@@ -461,8 +461,8 @@ class ImageNode(graphene.ObjectType):  # type: ignore[misc]
     async def _batch_load_installed_agents(
         cls, ctx: GraphQueryContext, image_ids: Sequence[ImageID]
     ) -> list[set[AgentId]]:
-        result = await ctx.processors.image.get_image_installed_agents.run(
-            GetImageInstalledAgentsAction(image_ids=list(image_ids))
+        result = await ctx.processors.image.public_get_image_installed_agents.run(
+            PublicGetImageInstalledAgentsAction(image_ids=list(image_ids))
         )
         installed_agent_ids_per_image: Mapping[ImageID, set[AgentId]] = result.data
         return [installed_agent_ids_per_image.get(image_id, set()) for image_id in image_ids]

--- a/src/ai/backend/manager/services/image/actions/get_image_installed_agents.py
+++ b/src/ai/backend/manager/services/image/actions/get_image_installed_agents.py
@@ -8,13 +8,13 @@ from ai.backend.manager.services.image.actions.base import ImageAction
 
 
 @dataclass
-class GetImageInstalledAgentsAction(ImageAction):
+class PublicGetImageInstalledAgentsAction(ImageAction):
     image_ids: list[ImageID]
 
     @override
     @classmethod
     def action_name(cls) -> str:
-        return "get_image_installed_agents"
+        return "public_get_image_installed_agents"
 
     @override
     @classmethod
@@ -23,5 +23,5 @@ class GetImageInstalledAgentsAction(ImageAction):
 
 
 @dataclass
-class GetImageInstalledAgentsActionResult:
+class PublicGetImageInstalledAgentsActionResult:
     data: Mapping[ImageID, set[AgentId]]

--- a/src/ai/backend/manager/services/image/actions/get_images_by_ids.py
+++ b/src/ai/backend/manager/services/image/actions/get_images_by_ids.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.types import ImageID
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.data.image.types import ImageAliasData, ImageData
+from ai.backend.manager.services.image.actions.alias_base import ImageAliasAction
+from ai.backend.manager.services.image.actions.base import ImageAction
+
+
+@dataclass
+class PublicGetImagesByIdsAction(ImageAction):
+    image_ids: list[ImageID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_get_images_by_ids"
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class PublicGetImagesByIdsActionResult:
+    data: list[ImageData]
+
+
+@dataclass
+class PublicGetImageAliasesByIdsAction(ImageAliasAction):
+    alias_ids: list[uuid.UUID]
+
+    @override
+    @classmethod
+    def action_name(cls) -> str:
+        return "public_get_image_aliases_by_ids"
+
+    @override
+    @classmethod
+    def operation_type(cls) -> ActionOperationType:
+        return ActionOperationType.GET
+
+
+@dataclass
+class PublicGetImageAliasesByIdsActionResult:
+    data: list[ImageAliasData]

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -43,6 +43,12 @@ from ai.backend.manager.services.image.actions.get_images import (
     PublicGetImagesByCanonicalsAction,
     PublicGetImagesByCanonicalsActionResult,
 )
+from ai.backend.manager.services.image.actions.get_images_by_ids import (
+    PublicGetImageAliasesByIdsAction,
+    PublicGetImageAliasesByIdsActionResult,
+    PublicGetImagesByIdsAction,
+    PublicGetImagesByIdsActionResult,
+)
 from ai.backend.manager.services.image.actions.preload_image import (
     PreloadImageAction,
     PreloadImageActionResult,
@@ -143,6 +149,12 @@ class ImageProcessors:
     public_get_all_images: PublicActionProcessor[
         PublicGetAllImagesAction, PublicGetAllImagesActionResult
     ]
+    public_get_images_by_ids: PublicActionProcessor[
+        PublicGetImagesByIdsAction, PublicGetImagesByIdsActionResult
+    ]
+    public_get_image_aliases_by_ids: PublicActionProcessor[
+        PublicGetImageAliasesByIdsAction, PublicGetImageAliasesByIdsActionResult
+    ]
     search_images: GlobalActionProcessor[SearchImagesAction, SearchImagesActionResult]
     search_aliases: GlobalActionProcessor[SearchAliasesAction, SearchAliasesActionResult]
 
@@ -153,6 +165,12 @@ class ImageProcessors:
         )
         self.public_get_image_by_identifier = group.public(
             PublicGetImageByIdentifierAction, service.get_image_by_identifier
+        )
+        self.public_get_images_by_ids = group.public(
+            PublicGetImagesByIdsAction, service.get_images_by_ids
+        )
+        self.public_get_image_aliases_by_ids = group.public(
+            PublicGetImageAliasesByIdsAction, service.get_image_aliases_by_ids
         )
         self.public_get_images_by_canonicals = group.public(
             PublicGetImagesByCanonicalsAction, service.get_images_by_canonicals

--- a/src/ai/backend/manager/services/image/processors.py
+++ b/src/ai/backend/manager/services/image/processors.py
@@ -32,8 +32,8 @@ from ai.backend.manager.services.image.actions.get_all_images import (
     PublicGetAllImagesActionResult,
 )
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
-    GetImageInstalledAgentsAction,
-    GetImageInstalledAgentsActionResult,
+    PublicGetImageInstalledAgentsAction,
+    PublicGetImageInstalledAgentsActionResult,
 )
 from ai.backend.manager.services.image.actions.get_images import (
     PublicGetImageByIdAction,
@@ -137,8 +137,8 @@ class ImageProcessors:
     public_get_images_by_canonicals: PublicActionProcessor[
         PublicGetImagesByCanonicalsAction, PublicGetImagesByCanonicalsActionResult
     ]
-    get_image_installed_agents: GlobalActionProcessor[
-        GetImageInstalledAgentsAction, GetImageInstalledAgentsActionResult
+    public_get_image_installed_agents: PublicActionProcessor[
+        PublicGetImageInstalledAgentsAction, PublicGetImageInstalledAgentsActionResult
     ]
     public_get_all_images: PublicActionProcessor[
         PublicGetAllImagesAction, PublicGetAllImagesActionResult
@@ -158,8 +158,8 @@ class ImageProcessors:
             PublicGetImagesByCanonicalsAction, service.get_images_by_canonicals
         )
 
-        self.get_image_installed_agents = group.global_scope(
-            GetImageInstalledAgentsAction, service.get_image_installed_agents
+        self.public_get_image_installed_agents = group.public(
+            PublicGetImageInstalledAgentsAction, service.get_image_installed_agents
         )
         self.forget_image = group.global_scope(ForgetImageAction, service.forget_image)
         self.search_images = group.global_scope(SearchImagesAction, service.search_images)

--- a/src/ai/backend/manager/services/image/service.py
+++ b/src/ai/backend/manager/services/image/service.py
@@ -13,10 +13,13 @@ from ai.backend.manager.errors.image import ImageAccessForbiddenError, ImageNotF
 from ai.backend.manager.models.image import (
     ImageIdentifier,
 )
+from ai.backend.manager.models.image.conditions import ImageAliasConditions, ImageConditions
 from ai.backend.manager.models.image.creators import ImageAliasCreator
 from ai.backend.manager.models.image.updaters import ImageUpdater
+from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.models.user import UserRole
 from ai.backend.manager.registry import AgentRegistry
+from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.repositories.image.repository import ImageRepository
 from ai.backend.manager.services.image.actions.alias_image import (
     AliasImageAction,
@@ -55,6 +58,12 @@ from ai.backend.manager.services.image.actions.get_images import (
     PublicGetImageByIdentifierActionResult,
     PublicGetImagesByCanonicalsAction,
     PublicGetImagesByCanonicalsActionResult,
+)
+from ai.backend.manager.services.image.actions.get_images_by_ids import (
+    PublicGetImageAliasesByIdsAction,
+    PublicGetImageAliasesByIdsActionResult,
+    PublicGetImagesByIdsAction,
+    PublicGetImagesByIdsActionResult,
 )
 from ai.backend.manager.services.image.actions.preload_image import (
     PreloadImageAction,
@@ -410,6 +419,26 @@ class ImageService:
             action.image_canonical, action.architecture
         )
         return ClearImageCustomResourceLimitActionResult(image_data=image_data)
+
+    async def get_images_by_ids(
+        self, action: PublicGetImagesByIdsAction
+    ) -> PublicGetImagesByIdsActionResult:
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[ImageConditions.by_ids(action.image_ids)],
+        )
+        result = await self._image_repository.search_images(querier)
+        return PublicGetImagesByIdsActionResult(data=result.items)
+
+    async def get_image_aliases_by_ids(
+        self, action: PublicGetImageAliasesByIdsAction
+    ) -> PublicGetImageAliasesByIdsActionResult:
+        querier = BatchQuerier(
+            pagination=NoPagination(),
+            conditions=[ImageAliasConditions.by_ids(action.alias_ids)],
+        )
+        result = await self._image_repository.search_aliases(querier)
+        return PublicGetImageAliasesByIdsActionResult(data=result.items)
 
     async def search_images(self, action: SearchImagesAction) -> SearchImagesActionResult:
         """

--- a/src/ai/backend/manager/services/image/service.py
+++ b/src/ai/backend/manager/services/image/service.py
@@ -45,8 +45,8 @@ from ai.backend.manager.services.image.actions.get_all_images import (
     PublicGetAllImagesActionResult,
 )
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
-    GetImageInstalledAgentsAction,
-    GetImageInstalledAgentsActionResult,
+    PublicGetImageInstalledAgentsAction,
+    PublicGetImageInstalledAgentsActionResult,
 )
 from ai.backend.manager.services.image.actions.get_images import (
     PublicGetImageByIdAction,
@@ -177,11 +177,11 @@ class ImageService:
         )
 
     async def get_image_installed_agents(
-        self, action: GetImageInstalledAgentsAction
-    ) -> GetImageInstalledAgentsActionResult:
+        self, action: PublicGetImageInstalledAgentsAction
+    ) -> PublicGetImageInstalledAgentsActionResult:
         image_ids = action.image_ids
         agent_counts_per_image = await self._image_repository.get_image_installed_agents(image_ids)
-        return GetImageInstalledAgentsActionResult(data=agent_counts_per_image)
+        return PublicGetImageInstalledAgentsActionResult(data=agent_counts_per_image)
 
     async def get_all_images(
         self, action: PublicGetAllImagesAction

--- a/tests/unit/manager/services/image/test_image_service.py
+++ b/tests/unit/manager/services/image/test_image_service.py
@@ -59,7 +59,7 @@ from ai.backend.manager.services.image.actions.forget_image import (
     ForgetImageByIdAction,
 )
 from ai.backend.manager.services.image.actions.get_image_installed_agents import (
-    GetImageInstalledAgentsAction,
+    PublicGetImageInstalledAgentsAction,
 )
 from ai.backend.manager.services.image.actions.preload_image import PreloadImageAction
 from ai.backend.manager.services.image.actions.purge_images import (
@@ -1220,7 +1220,7 @@ class TestGetImageInstalledAgents(ImageServiceBaseFixtures):
             return_value={image_data.id: {agent_id_1, agent_id_2}}
         )
 
-        action = GetImageInstalledAgentsAction(image_ids=[image_data.id])
+        action = PublicGetImageInstalledAgentsAction(image_ids=[image_data.id])
 
         result = await image_service.get_image_installed_agents(action)
 
@@ -1238,7 +1238,7 @@ class TestGetImageInstalledAgents(ImageServiceBaseFixtures):
             return_value={image_data.id: set()}
         )
 
-        action = GetImageInstalledAgentsAction(image_ids=[image_data.id])
+        action = PublicGetImageInstalledAgentsAction(image_ids=[image_data.id])
 
         result = await image_service.get_image_installed_agents(action)
 
@@ -1252,7 +1252,7 @@ class TestGetImageInstalledAgents(ImageServiceBaseFixtures):
         """Non-existent image returns empty mapping."""
         mock_image_repository.get_image_installed_agents = AsyncMock(return_value={})
 
-        action = GetImageInstalledAgentsAction(image_ids=[ImageID(uuid.uuid4())])
+        action = PublicGetImageInstalledAgentsAction(image_ids=[ImageID(uuid.uuid4())])
 
         result = await image_service.get_image_installed_agents(action)
 


### PR DESCRIPTION
## 📚 Stacked PRs

This PR is part of a 2-PR stack. **Merge in order:**

1. ✅ #14399 — `fix(BA-7772): open the image reads that a wiring swap can fix` (merged)
2. 👉 **#14413** — `fix(BA-7773): open the last two image read paths that still require super-admin` ← you are here

Rebased onto `main` now that #14399 has merged, so this PR's diff stands on its own.

## Summary
Two commits, one per issue. Together with #14399 they finish opening the image reads that the v2 processor migration put behind the SUPERADMIN gate.

**`get_image_installed_agents` (BA-7773).** #14399 left this one out, on the stated grounds that opening it would expose the agent list. That was wrong. Its only production caller is `ImageNode._batch_load_installed_agents`, and the resolver reduces the answer to `len(agent_ids) > 0`. `ImageNode` declares no `installed_agents` field — that one belongs to the legacy `Image` type, which reads it off `agent_install_status.agent_names` at construction, on a path already applying `hide_agents`. No agent name leaves the manager through this action, so the gate only cost every non-superadmin the `installed` boolean. Wired through `ProcessorGroup.public`; no `hide_agents` branch needed.

**`search_images` / `search_aliases` (BA-7774).** One action served two audiences needing opposite gates: `admin_search*` (superadmin by design, per `api/AGENTS.md`) and the DataLoader `batch_load_by_ids` / `batch_load_aliases_by_ids`, reached from more than ten places in `gql/data_loader/data_loaders.py` by every authenticated caller. One action cannot carry two gates, so add the read the DataLoader actually performs — it names rows by id, which `actions/AGENTS.md` classifies as a bulk get, not a search. `PublicGetImagesByIdsAction` and `PublicGetImageAliasesByIdsAction` build the same by-ids querier inside the service and run behind the public gate. The search actions keep their gate; the admin handlers are untouched.

This also lands the `get_images_by_ids` that the deprecation notes on `get_images_by_canonicals` already point at, in both the repository and the service.

Backport: none

Same reasoning as #14399: on 26.8 and 26.4 these actions are wired as `ActionProcessor(service.…, action_monitors)` with no validators. The gate arrived on `main` with the v2 processor migration.

Resolves BA-7773.
Resolves BA-7774.