### PR TITLE
refactor(BA-7743): drop the dead Sentinel branch from GQL SDL generation and switch DTO docs to Unset

### DIFF
--- a/.claude/skills/knowledge/SKILL.md
+++ b/.claude/skills/knowledge/SKILL.md
@@ -36,7 +36,8 @@ Judge by the printed description; open only the files you actually need.
 | `scope` | yes | directory the knowledge applies to |
 | `keywords` | no | 5-10 terms; include code identifiers (class/function names) |
 | `sources` | no | file/directory paths the content is grounded in — never PR or issue numbers |
-| `generated` | yes | `{by, at}` — actor and date of the last meaningful change |
+| `generated` | yes | `{by, at}` — actor and date of the first version. Never changes |
+| `updated` | no | `{by, at}` — actor and date of the last meaningful change after generation |
 | `verified` | no | list of `{by, at}` — human review sign-off for the current content |
 | `status` | no | `draft` / `stable` (default) / `deprecated` |
 
@@ -45,9 +46,9 @@ Actor convention: `<producer>/<version>` for agents (e.g. `claude-code/fable-5`)
 
 ## Lifecycle rules
 
-- A meaningful change (content, judgment, table) updates `generated` and
-  **removes `verified`** — the sign-off applied to the old content. Typo and
-  formatting fixes touch neither.
+- A meaningful change (content, judgment, table) sets `updated` and
+  **removes `verified`** — the sign-off applied to the old content. `generated`
+  stays. Typo and formatting fixes touch none of them.
 - `verified` is added only for a human review of the current content.
 - Set `status: deprecated` before deleting a document, so inbound links get a
   window to migrate.

--- a/changes/14424.doc.md
+++ b/changes/14424.doc.md
@@ -1,0 +1,1 @@
+Drop the dead `Sentinel` branch from GraphQL SDL generation and rewrite the v2 DTO docs around `Unset`

--- a/scripts/knowledge/frontmatter.py
+++ b/scripts/knowledge/frontmatter.py
@@ -50,6 +50,7 @@ class KnowledgeDocument:
     generated: Signature
     keywords: tuple[str, ...] = ()
     sources: tuple[str, ...] = ()
+    updated: Signature | None = None
     verified: tuple[Signature, ...] = ()
     status: str = DEFAULT_STATUS
 
@@ -81,13 +82,17 @@ def build_document(
 
     keywords = _str_tuple(raw, "keywords", problems)
     sources = _str_tuple(raw, "sources", problems)
+    updated = _optional_signature(raw.get("updated"), "updated", problems)
     verified = _verified_tuple(raw.get("verified"), problems)
 
-    if generated and verified:
+    if generated and updated and updated.at < generated.at:
+        problems.append(f"updated ({updated.at}) is older than generated ({generated.at})")
+    changed = updated or generated
+    if changed and verified:
         latest = max(entry.at for entry in verified)
-        if latest < generated.at:
+        if latest < changed.at:
             problems.append(
-                f"verified ({latest}) is older than generated ({generated.at}) — "
+                f"verified ({latest}) is older than the last change ({changed.at}) — "
                 "a meaningful change must clear 'verified'"
             )
 
@@ -101,6 +106,7 @@ def build_document(
         generated=generated,
         keywords=keywords,
         sources=sources,
+        updated=updated,
         verified=verified,
         status=status,
     )
@@ -136,6 +142,14 @@ def _signature(value: object, key: str, problems: list[str]) -> Signature | None
         problems.append(f"{key}.at must be YYYY-MM-DD, got {at!r}")
         return None
     return Signature(by=str(value["by"]), at=at)
+
+
+def _optional_signature(
+    value: object, key: str, problems: list[str]
+) -> Signature | None:
+    if value is None:
+        return None
+    return _signature(value, key, problems)
 
 
 def _verified_tuple(value: object, problems: list[str]) -> tuple[Signature, ...]:

--- a/src/ai/backend/common/dto/manager/v2/AGENTS.md
+++ b/src/ai/backend/common/dto/manager/v2/AGENTS.md
@@ -39,8 +39,7 @@ Per domain: `v2/{domain}/types.py`, `request.py`, `response.py`, `__init__.py`
 
 - Use `Field()` constraints: `min_length`, `max_length`, `ge`, `le`, `pattern`.
 - Use `field_validator` for cross-field/format validation (e.g., stripping whitespace, verifying non-empty after strip).
-- nullable-clearable fields: SENTINEL pattern (sentinel value = "clear this field", None = "no change").
-- All optional update fields default to `None` to mean "no change".
+- Update fields follow the "Update" section of `src/ai/backend/common/dto/AGENTS.md`: `X | None | Unset = Field(default=UNSET)`.
 
 ## Conversion
 

--- a/src/ai/backend/common/dto/manager/v2/KNOWLEDGE.md
+++ b/src/ai/backend/common/dto/manager/v2/KNOWLEDGE.md
@@ -11,6 +11,9 @@ sources:
   - scripts/generate-graphql-schema.sh
 generated:
   by: claude-code/fable-5
+  at: 2026-08-10
+updated:
+  by: claude-code/fable-5
   at: 2026-09-08
 status: stable
 ---
@@ -35,7 +38,7 @@ where a field is defined exactly one, so the surfaces cannot diverge.
 ## Update fields separate omitted from null with `Unset`
 
 - An update field is `X | None | Unset = Field(default=UNSET)` — omitted = no change, null = clear, value = set.
-- `UNSET` is pydantic `MISSING`, so an omitted field puts nothing on the wire and nothing in the JSON schema.
+- An omitted field puts nothing on the wire and nothing in the JSON schema.
 - Which of null and unset a column honours is the adapter's decision; the rule table lives in the "Update" section of `../../AGENTS.md`, the sentinel's rationale in [`../../../tristate/KNOWLEDGE.md`](../../../tristate/KNOWLEDGE.md).
 - Fields still declared with the legacy `Sentinel` enum are being migrated one domain at a time; do not add new ones.
 

--- a/src/ai/backend/common/dto/manager/v2/KNOWLEDGE.md
+++ b/src/ai/backend/common/dto/manager/v2/KNOWLEDGE.md
@@ -1,15 +1,17 @@
 ---
 name: dto-v2-compat-policy
 type: design-rationale
-description: why the shared v2 DTO schema is additive-only (GQL and REST break together, version-branch schema policy), why clearable fields use the SENTINEL pattern, the current limitation of expressing nullify
+description: why the shared v2 DTO schema is additive-only (GQL and REST break together, version-branch schema policy), why update fields separate omitted from null with Unset, why the DTO default never reaches the GraphQL SDL
 scope: src/ai/backend/common/dto/manager/v2
-keywords: [SSOT, additive-only, SENTINEL, nullify, BaseRequestModel, BaseResponseModel, supergraph, schema-inspector]
+keywords: [SSOT, additive-only, Unset, UNSET, nullify, BaseRequestModel, BaseResponseModel, supergraph, schema-inspector, gql_pydantic_input]
 sources:
   - src/ai/backend/common/dto/manager/v2
+  - src/ai/backend/common/tristate/unset.py
+  - src/ai/backend/manager/api/gql/decorators.py
   - scripts/generate-graphql-schema.sh
 generated:
   by: claude-code/fable-5
-  at: 2026-08-10
+  at: 2026-09-08
 status: stable
 ---
 
@@ -30,13 +32,15 @@ where a field is defined exactly one, so the surfaces cannot diverge.
 - The schema inspector sees v2 types only through the composed supergraph — name/type changes surface late and expensively.
 - Add fields and deprecate old ones — do not change a field's name or purpose.
 
-## Clearable fields use SENTINEL
+## Update fields separate omitted from null with `Unset`
 
-- Update inputs already use `None` as "no change" (all optional fields default to `None`).
-- So "clear it" needs a separate sentinel value — absent/None = keep, sentinel = clear, value = set.
-- Collapsing onto `None` alone makes clearing impossible without per-field flags.
+- An update field is `X | None | Unset = Field(default=UNSET)` — omitted = no change, null = clear, value = set.
+- `UNSET` is pydantic `MISSING`, so an omitted field puts nothing on the wire and nothing in the JSON schema.
+- Which of null and unset a column honours is the adapter's decision; the rule table lives in the "Update" section of `../../AGENTS.md`, the sentinel's rationale in [`../../../tristate/KNOWLEDGE.md`](../../../tristate/KNOWLEDGE.md).
+- Fields still declared with the legacy `Sentinel` enum are being migrated one domain at a time; do not add new ones.
 
-## Current limitation — expressing nullify
+## The DTO default never reaches the GraphQL SDL
 
-- The current DTOs cannot properly express "clear a field (nullify)" — there are cases that break at pydantic model creation time.
-- This will be improved with the SENTINEL approach; until then, adding a clearable field means checking this limitation first.
+- `gql_pydantic_input` is a plain `@strawberry.input` plus `PydanticInputMixin`; strawberry's pydantic integration, which copies pydantic defaults into the schema, is banned by ruff for inputs.
+- So a GQL input field's default is its own `gql_field(default=strawberry.UNSET)`, which prints as "no default"; the DTO's `UNSET` is applied only when `to_pydantic()` skips the field.
+- `tests/unit/manager/api/gql/test_schema_defaults.py` fails if an `Unset` or legacy `Sentinel` value ever appears as an input default.

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -3,12 +3,10 @@ from typing import override
 
 import strawberry
 from graphql import GraphQLError
-from graphql.pyutils.undefined import Undefined as GraphQLUndefined
 from strawberry.federation import Schema
 from strawberry.schema.config import StrawberryConfig
 from strawberry.types import ExecutionContext
 
-from ai.backend.common.api_handlers import Sentinel as BackendSentinel
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import BackendAIGQLMeta, gql_root_field
 from ai.backend.manager.api.gql.extensions import (
@@ -1090,15 +1088,6 @@ class CustomizedSchema(Schema):
 
     @override
     def as_str(self) -> str:
-        # Strawberry picks up pydantic field defaults (including SENTINEL) as GraphQL
-        # schema field default_values.  SENTINEL is not a valid GraphQL scalar value, so
-        # replace any SENTINEL default with Undefined (= "no default" in the schema SDL).
-        for type_def in self._schema.type_map.values():
-            if not hasattr(type_def, "fields"):
-                continue
-            for field in type_def.fields.values():
-                if isinstance(getattr(field, "default_value", None), BackendSentinel):
-                    field.default_value = GraphQLUndefined
         sdl = super().as_str()
         sdl = sdl.replace("type PageInfo", "type PageInfo @shareable")
         # PageInfo is force-marked @shareable above, so the directive must be imported from the

--- a/tests/unit/manager/api/gql/test_schema_defaults.py
+++ b/tests/unit/manager/api/gql/test_schema_defaults.py
@@ -1,0 +1,30 @@
+"""Request-DTO "unset" markers never reach the GraphQL schema as input defaults."""
+
+from __future__ import annotations
+
+from ai.backend.common.api_handlers import Sentinel
+from ai.backend.common.tristate.unset import Unset
+from ai.backend.manager.api.gql.schema import schema
+
+
+def _input_defaults() -> list[tuple[str, str, object]]:
+    found: list[tuple[str, str, object]] = []
+    for type_name, type_def in schema._schema.type_map.items():
+        for field_name, field in getattr(type_def, "fields", {}).items():
+            found.append((type_name, field_name, getattr(field, "default_value", None)))
+    return found
+
+
+class TestUnsetDefaultsInSchema:
+    def test_no_input_field_defaults_to_an_unset_marker(self) -> None:
+        leaked = [
+            (type_name, field_name)
+            for type_name, field_name, default in _input_defaults()
+            if isinstance(default, (Sentinel, Unset))
+        ]
+        assert leaked == []
+
+    def test_sdl_prints_no_unset_marker(self) -> None:
+        sdl = schema.as_str()
+        assert '= "MISSING"' not in sdl
+        assert "= SENTINEL" not in sdl


### PR DESCRIPTION
Remove the dead `Sentinel` handling from GraphQL SDL generation and rewrite the v2 DTO docs around `Unset`.

- `manager/api/gql/schema.py`: the loop in `CustomizedSchema.as_str()` that swapped `Sentinel` field defaults for `Undefined` is deleted along with its `Sentinel` and `Undefined` imports. GQL input types are plain `@strawberry.input` + `PydanticInputMixin`, so a DTO default never reaches the schema and the loop matched nothing.
- `tests/unit/manager/api/gql/test_schema_defaults.py` (new): fails if any schema field default is a `Sentinel` or `Unset` value, or if the SDL prints `= "MISSING"` / `= SENTINEL`.
- `common/dto/manager/v2/AGENTS.md`: the update-field rule now points at the `X | None | Unset = Field(default=UNSET)` pattern in `common/dto/AGENTS.md`.
- `common/dto/manager/v2/KNOWLEDGE.md`: the two `SENTINEL` sections are replaced with "Update fields separate omitted from null with `Unset`" and "The DTO default never reaches the GraphQL SDL".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017idp6rKVV33XrzJG1yWYXo