### PR TITLE
refactor(BA-7766): switch model_card update DTO to Unset

### DIFF
--- a/changes/14430.enhance.md
+++ b/changes/14430.enhance.md
@@ -1,0 +1,1 @@
+Switch the model_card update DTO from the legacy `Sentinel` marker to `Unset`, so an omitted field leaves the value unchanged and `null` clears it

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -22247,43 +22247,43 @@ input UpdateModelCardV2Input
   id: UUID!
 
   """New name."""
-  name: String = null
+  name: String
 
   """Author."""
-  author: String = null
+  author: String
 
   """Title."""
-  title: String = null
+  title: String
 
   """Version."""
-  modelVersion: String = null
+  modelVersion: String
 
   """Description."""
-  description: String = null
+  description: String
 
   """ML task."""
-  task: String = null
+  task: String
 
   """Category."""
-  category: String = null
+  category: String
 
   """Architecture."""
-  architecture: String = null
+  architecture: String
 
   """Frameworks."""
-  framework: [String!] = null
+  framework: [String!]
 
   """Labels."""
-  label: [String!] = null
+  label: [String!]
 
   """License."""
-  license: String = null
+  license: String
 
   """README content."""
-  readme: String = null
+  readme: String
 
   """Access level (public or internal)."""
-  accessLevel: ModelCardV2AccessLevel = null
+  accessLevel: ModelCardV2AccessLevel
 }
 
 """

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -16078,43 +16078,43 @@ input UpdateModelCardV2Input {
   id: UUID!
 
   """New name."""
-  name: String = null
+  name: String
 
   """Author."""
-  author: String = null
+  author: String
 
   """Title."""
-  title: String = null
+  title: String
 
   """Version."""
-  modelVersion: String = null
+  modelVersion: String
 
   """Description."""
-  description: String = null
+  description: String
 
   """ML task."""
-  task: String = null
+  task: String
 
   """Category."""
-  category: String = null
+  category: String
 
   """Architecture."""
-  architecture: String = null
+  architecture: String
 
   """Frameworks."""
-  framework: [String!] = null
+  framework: [String!]
 
   """Labels."""
-  label: [String!] = null
+  label: [String!]
 
   """License."""
-  license: String = null
+  license: String
 
   """README content."""
-  readme: String = null
+  readme: String
 
   """Access level (public or internal)."""
-  accessLevel: ModelCardV2AccessLevel = null
+  accessLevel: ModelCardV2AccessLevel
 }
 
 """

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26423,7 +26423,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
+            "description": "Model card name. Omit to leave unchanged.",
             "title": "Name"
           },
           "author": {
@@ -26522,7 +26522,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
+            "description": "Frameworks. Omit to leave unchanged.",
             "title": "Framework"
           },
           "label": {
@@ -26537,7 +26537,7 @@
                 "type": "null"
               }
             ],
-            "default": null,
+            "description": "Labels. Omit to leave unchanged.",
             "title": "Label"
           },
           "license": {

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -26432,13 +26432,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model card author. Omit to leave unchanged; null clears.",
             "title": "Author"
           },
           "title": {
@@ -26447,13 +26444,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model card title. Omit to leave unchanged; null clears.",
             "title": "Title"
           },
           "model_version": {
@@ -26462,13 +26456,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model version. Omit to leave unchanged; null clears.",
             "title": "Model Version"
           },
           "description": {
@@ -26477,13 +26468,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model card description. Omit to leave unchanged; null clears.",
             "title": "Description"
           },
           "task": {
@@ -26492,13 +26480,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Task type. Omit to leave unchanged; null clears.",
             "title": "Task"
           },
           "category": {
@@ -26507,13 +26492,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model category. Omit to leave unchanged; null clears.",
             "title": "Category"
           },
           "architecture": {
@@ -26522,13 +26504,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model architecture. Omit to leave unchanged; null clears.",
             "title": "Architecture"
           },
           "framework": {
@@ -26567,13 +26546,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model license. Omit to leave unchanged; null clears.",
             "title": "License"
           },
           "min_resource": {
@@ -26585,13 +26561,10 @@
                 "type": "array"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Minimum resource requirements. Omit to leave unchanged; null clears.",
             "title": "Min Resource"
           },
           "readme": {
@@ -26600,13 +26573,10 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Model readme. Omit to leave unchanged; null clears.",
             "title": "Readme"
           },
           "access_level": {
@@ -26615,13 +26585,10 @@
                 "$ref": "#/components/schemas/ModelCardAccessLevel"
               },
               {
-                "$ref": "#/components/schemas/Sentinel"
-              },
-              {
                 "type": "null"
               }
             ],
-            "default": 1,
+            "description": "Access level. Omit to leave unchanged.",
             "title": "Access Level"
           }
         },

--- a/src/ai/backend/common/dto/manager/v2/model_card/request.py
+++ b/src/ai/backend/common/dto/manager/v2/model_card/request.py
@@ -57,7 +57,12 @@ class CreateModelCardInput(BaseRequestModel):
 
 class UpdateModelCardInput(BaseRequestModel):
     id: UUID = Field(description="Model card ID.")
-    name: str | None = Field(default=None, min_length=1, max_length=512)
+    name: str | None | Unset = Field(
+        default=UNSET,
+        min_length=1,
+        max_length=512,
+        description="Model card name. Omit to leave unchanged.",
+    )
     author: str | None | Unset = Field(
         default=UNSET, description="Model card author. Omit to leave unchanged; null clears."
     )
@@ -79,8 +84,12 @@ class UpdateModelCardInput(BaseRequestModel):
     architecture: str | None | Unset = Field(
         default=UNSET, description="Model architecture. Omit to leave unchanged; null clears."
     )
-    framework: list[str] | None = Field(default=None)
-    label: list[str] | None = Field(default=None)
+    framework: list[str] | None | Unset = Field(
+        default=UNSET, description="Frameworks. Omit to leave unchanged."
+    )
+    label: list[str] | None | Unset = Field(
+        default=UNSET, description="Labels. Omit to leave unchanged."
+    )
     license: str | None | Unset = Field(
         default=UNSET, description="Model license. Omit to leave unchanged; null clears."
     )

--- a/src/ai/backend/common/dto/manager/v2/model_card/request.py
+++ b/src/ai/backend/common/dto/manager/v2/model_card/request.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from pydantic import Field, field_validator
 
-from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
+from ai.backend.common.api_handlers import BaseRequestModel
 from ai.backend.common.data.entity.deployment_preset import DeploymentPresetID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
@@ -14,6 +14,7 @@ from ai.backend.common.dto.manager.v2.model_card.types import (
     ModelCardAccessLevel,
     ModelCardOrderField,
 )
+from ai.backend.common.tristate.unset import UNSET, Unset
 
 
 class ResourceSlotEntryInput(BaseRequestModel):
@@ -57,19 +58,42 @@ class CreateModelCardInput(BaseRequestModel):
 class UpdateModelCardInput(BaseRequestModel):
     id: UUID = Field(description="Model card ID.")
     name: str | None = Field(default=None, min_length=1, max_length=512)
-    author: str | Sentinel | None = Field(default=SENTINEL)
-    title: str | Sentinel | None = Field(default=SENTINEL)
-    model_version: str | Sentinel | None = Field(default=SENTINEL)
-    description: str | Sentinel | None = Field(default=SENTINEL)
-    task: str | Sentinel | None = Field(default=SENTINEL)
-    category: str | Sentinel | None = Field(default=SENTINEL)
-    architecture: str | Sentinel | None = Field(default=SENTINEL)
+    author: str | None | Unset = Field(
+        default=UNSET, description="Model card author. Omit to leave unchanged; null clears."
+    )
+    title: str | None | Unset = Field(
+        default=UNSET, description="Model card title. Omit to leave unchanged; null clears."
+    )
+    model_version: str | None | Unset = Field(
+        default=UNSET, description="Model version. Omit to leave unchanged; null clears."
+    )
+    description: str | None | Unset = Field(
+        default=UNSET, description="Model card description. Omit to leave unchanged; null clears."
+    )
+    task: str | None | Unset = Field(
+        default=UNSET, description="Task type. Omit to leave unchanged; null clears."
+    )
+    category: str | None | Unset = Field(
+        default=UNSET, description="Model category. Omit to leave unchanged; null clears."
+    )
+    architecture: str | None | Unset = Field(
+        default=UNSET, description="Model architecture. Omit to leave unchanged; null clears."
+    )
     framework: list[str] | None = Field(default=None)
     label: list[str] | None = Field(default=None)
-    license: str | Sentinel | None = Field(default=SENTINEL)
-    min_resource: list[ResourceSlotEntryInput] | Sentinel | None = Field(default=SENTINEL)
-    readme: str | Sentinel | None = Field(default=SENTINEL)
-    access_level: ModelCardAccessLevel | Sentinel | None = Field(default=SENTINEL)
+    license: str | None | Unset = Field(
+        default=UNSET, description="Model license. Omit to leave unchanged; null clears."
+    )
+    min_resource: list[ResourceSlotEntryInput] | None | Unset = Field(
+        default=UNSET,
+        description="Minimum resource requirements. Omit to leave unchanged; null clears.",
+    )
+    readme: str | None | Unset = Field(
+        default=UNSET, description="Model readme. Omit to leave unchanged; null clears."
+    )
+    access_level: ModelCardAccessLevel | None | Unset = Field(
+        default=UNSET, description="Access level. Omit to leave unchanged."
+    )
 
 
 class ModelCardFilter(BaseRequestModel):

--- a/src/ai/backend/manager/api/adapters/model_card/adapter.py
+++ b/src/ai/backend/manager/api/adapters/model_card/adapter.py
@@ -306,9 +306,7 @@ class ModelCardAdapter(BaseAdapter):
     ) -> UpdateModelCardPayload:
         updater = ModelCardUpdater(
             card_id=ModelCardID(input.id),
-            name=(
-                OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
-            ),
+            name=OptionalState.from_unset(input.name),
             author=TriState.from_unset(input.author),
             title=TriState.from_unset(input.title),
             model_version=TriState.from_unset(input.model_version),
@@ -316,16 +314,8 @@ class ModelCardAdapter(BaseAdapter):
             task=TriState.from_unset(input.task),
             category=TriState.from_unset(input.category),
             architecture=TriState.from_unset(input.architecture),
-            framework=(
-                OptionalState.update(input.framework)
-                if input.framework is not None
-                else OptionalState.nop()
-            ),
-            label=(
-                OptionalState.update(input.label)
-                if input.label is not None
-                else OptionalState.nop()
-            ),
+            framework=OptionalState.from_unset(input.framework),
+            label=OptionalState.from_unset(input.label),
             license=TriState.from_unset(input.license),
             min_resource=TriState.from_unset(input.min_resource).map(_entries_to_requirements),
             readme=TriState.from_unset(input.readme),

--- a/src/ai/backend/manager/api/adapters/model_card/adapter.py
+++ b/src/ai/backend/manager/api/adapters/model_card/adapter.py
@@ -4,7 +4,6 @@ import secrets
 from collections.abc import Sequence
 from uuid import UUID
 
-from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.entity.model_card import ModelCardID
 from ai.backend.common.data.entity.project import ProjectID
@@ -305,67 +304,18 @@ class ModelCardAdapter(BaseAdapter):
         self,
         input: UpdateModelCardInput,
     ) -> UpdateModelCardPayload:
-        min_resource_state: TriState[list[ResourceRequirementEntry]] = TriState.nop()
-        if input.min_resource is not SENTINEL:
-            if input.min_resource is None:
-                min_resource_state = TriState.nullify()
-            else:
-                min_resource_state = TriState.update(_entries_to_requirements(input.min_resource))
-
         updater = ModelCardUpdater(
             card_id=ModelCardID(input.id),
             name=(
                 OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
             ),
-            author=(
-                TriState.nop()
-                if input.author is SENTINEL
-                else TriState.nullify()
-                if input.author is None
-                else TriState.update(input.author)
-            ),
-            title=(
-                TriState.nop()
-                if input.title is SENTINEL
-                else TriState.nullify()
-                if input.title is None
-                else TriState.update(input.title)
-            ),
-            model_version=(
-                TriState.nop()
-                if input.model_version is SENTINEL
-                else TriState.nullify()
-                if input.model_version is None
-                else TriState.update(input.model_version)
-            ),
-            description=(
-                TriState.nop()
-                if input.description is SENTINEL
-                else TriState.nullify()
-                if input.description is None
-                else TriState.update(input.description)
-            ),
-            task=(
-                TriState.nop()
-                if input.task is SENTINEL
-                else TriState.nullify()
-                if input.task is None
-                else TriState.update(input.task)
-            ),
-            category=(
-                TriState.nop()
-                if input.category is SENTINEL
-                else TriState.nullify()
-                if input.category is None
-                else TriState.update(input.category)
-            ),
-            architecture=(
-                TriState.nop()
-                if input.architecture is SENTINEL
-                else TriState.nullify()
-                if input.architecture is None
-                else TriState.update(input.architecture)
-            ),
+            author=TriState.from_unset(input.author),
+            title=TriState.from_unset(input.title),
+            model_version=TriState.from_unset(input.model_version),
+            description=TriState.from_unset(input.description),
+            task=TriState.from_unset(input.task),
+            category=TriState.from_unset(input.category),
+            architecture=TriState.from_unset(input.architecture),
             framework=(
                 OptionalState.update(input.framework)
                 if input.framework is not None
@@ -376,28 +326,10 @@ class ModelCardAdapter(BaseAdapter):
                 if input.label is not None
                 else OptionalState.nop()
             ),
-            license=(
-                TriState.nop()
-                if input.license is SENTINEL
-                else TriState.nullify()
-                if input.license is None
-                else TriState.update(input.license)
-            ),
-            min_resource=min_resource_state,
-            readme=(
-                TriState.nop()
-                if input.readme is SENTINEL
-                else TriState.nullify()
-                if input.readme is None
-                else TriState.update(input.readme)
-            ),
-            access_level=(
-                OptionalState.nop()
-                if input.access_level is SENTINEL
-                else OptionalState.update(input.access_level.value)
-                if input.access_level is not None
-                else OptionalState.nop()
-            ),
+            license=TriState.from_unset(input.license),
+            min_resource=TriState.from_unset(input.min_resource).map(_entries_to_requirements),
+            readme=TriState.from_unset(input.readme),
+            access_level=OptionalState.from_unset(input.access_level).map(lambda x: x.value),
         )
         result = await self._processors.model_card.update.run(
             UpdateModelCardAction(model_card_id=ModelCardID(input.id), updater=updater)

--- a/src/ai/backend/manager/api/gql/model_card/types.py
+++ b/src/ai/backend/manager/api/gql/model_card/types.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Annotated, Self
 from uuid import UUID
 
 import strawberry
-from strawberry import Info
+from strawberry import UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.dto.manager.v2.common import OrderDirection
@@ -444,20 +444,20 @@ class CreateModelCardInputGQL(PydanticInputMixin[CreateInputDTO]):
 )
 class UpdateModelCardInputGQL(PydanticInputMixin[UpdateInputDTO]):
     id: UUID = gql_field(description="Model card ID.")
-    name: str | None = gql_field(default=None, description="New name.")
-    author: str | None = gql_field(default=None, description="Author.")
-    title: str | None = gql_field(default=None, description="Title.")
-    model_version: str | None = gql_field(default=None, description="Version.")
-    description: str | None = gql_field(default=None, description="Description.")
-    task: str | None = gql_field(default=None, description="ML task.")
-    category: str | None = gql_field(default=None, description="Category.")
-    architecture: str | None = gql_field(default=None, description="Architecture.")
-    framework: list[str] | None = gql_field(default=None, description="Frameworks.")
-    label: list[str] | None = gql_field(default=None, description="Labels.")
-    license: str | None = gql_field(default=None, description="License.")
-    readme: str | None = gql_field(default=None, description="README content.")
+    name: str | None = gql_field(default=UNSET, description="New name.")
+    author: str | None = gql_field(default=UNSET, description="Author.")
+    title: str | None = gql_field(default=UNSET, description="Title.")
+    model_version: str | None = gql_field(default=UNSET, description="Version.")
+    description: str | None = gql_field(default=UNSET, description="Description.")
+    task: str | None = gql_field(default=UNSET, description="ML task.")
+    category: str | None = gql_field(default=UNSET, description="Category.")
+    architecture: str | None = gql_field(default=UNSET, description="Architecture.")
+    framework: list[str] | None = gql_field(default=UNSET, description="Frameworks.")
+    label: list[str] | None = gql_field(default=UNSET, description="Labels.")
+    license: str | None = gql_field(default=UNSET, description="License.")
+    readme: str | None = gql_field(default=UNSET, description="README content.")
     access_level: ModelCardAccessLevelGQL | None = gql_field(
-        default=None, description="Access level (public or internal)."
+        default=UNSET, description="Access level (public or internal)."
     )
 
 

--- a/tests/unit/common/dto/manager/v2/model_card/BUILD
+++ b/tests/unit/common/dto/manager/v2/model_card/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/common/dto/manager/v2/model_card/test_request.py
+++ b/tests/unit/common/dto/manager/v2/model_card/test_request.py
@@ -1,0 +1,39 @@
+"""Tests for ai.backend.common.dto.manager.v2.model_card.request module."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from ai.backend.common.dto.manager.v2.model_card.request import UpdateModelCardInput
+from ai.backend.common.tristate.unset import UNSET
+
+
+class TestUpdateModelCardInput:
+    def test_omitted_fields_are_unset(self) -> None:
+        inp = UpdateModelCardInput(id=uuid.uuid4())
+        assert inp.name is UNSET
+        assert inp.author is UNSET
+        assert inp.framework is UNSET
+        assert inp.label is UNSET
+        assert inp.access_level is UNSET
+
+    def test_explicit_none_stays_none(self) -> None:
+        inp = UpdateModelCardInput(id=uuid.uuid4(), name=None, framework=None, label=None)
+        assert inp.name is None
+        assert inp.framework is None
+        assert inp.label is None
+
+    def test_values_are_kept(self) -> None:
+        inp = UpdateModelCardInput(
+            id=uuid.uuid4(), name="card", framework=["pytorch"], label=["nlp"]
+        )
+        assert inp.name == "card"
+        assert inp.framework == ["pytorch"]
+        assert inp.label == ["nlp"]
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            UpdateModelCardInput(id=uuid.uuid4(), name="")


### PR DESCRIPTION
Switch the `model_card` update DTO from the legacy `Sentinel` marker to `Unset` (omitted = no change, `null` = clear).

- `common/dto/manager/v2/model_card/request.py`: the eleven `UpdateModelCardInput` fields (`author`, `title`, `model_version`, `description`, `task`, `category`, `architecture`, `license`, `readme`, `min_resource`, `access_level`) change from `X | Sentinel | None = SENTINEL` to `X | None | Unset = UNSET`; the field descriptions now read "Omit to leave unchanged; null clears." (`access_level` is non-nullable, so its description stops at "Omit to leave unchanged.").
- `manager/api/adapters/model_card/adapter.py`: the eleven `SENTINEL` branches are replaced with `TriState.from_unset(...)`, `min_resource` mapped through `_entries_to_requirements`, and `access_level` with `OptionalState.from_unset(...).map(lambda x: x.value)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017idp6rKVV33XrzJG1yWYXo

<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14430.org.readthedocs.build/en/14430/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14430.org.readthedocs.build/ko/14430/

<!-- readthedocs-preview sorna-ko end -->