### PR TITLE
fix(BA-6697): report GPU allocation as a per-device ratio (#14327)

### DIFF
--- a/changes/14327.fix.md
+++ b/changes/14327.fix.md
@@ -1,0 +1,1 @@
+Fix the GPU allocation map to report each device's allocated ratio (0 to 1) instead of the raw share amount, which exceeded 1 when several sessions shared one fractional GPU.

--- a/src/ai/backend/agent/resources.py
+++ b/src/ai/backend/agent/resources.py
@@ -79,9 +79,11 @@ if TYPE_CHECKING:
 
 
 type DeviceAllocation = Mapping[SlotName, Mapping[DeviceId, Decimal]]
+type DeviceCapacityMap = Mapping[tuple[SlotName, DeviceId], Decimal]
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 known_slot_types: Mapping[SlotName, SlotTypes] = {}
+_GPU_ALLOC_RATIO_PRECISION = Decimal("0.0001")
 
 
 def _combine_mappings(mappings: list[Mapping[SlotName, Decimal]]) -> dict[SlotName, Decimal]:
@@ -915,11 +917,52 @@ async def scan_resource_usage_per_slot(
     return slot_allocs
 
 
+def collect_device_capacities(
+    computers: Mapping[DeviceName, ComputerContext],
+) -> DeviceCapacityMap:
+    """
+    Collect the allocatable capacity of each device in its own slot unit,
+    which is the denominator to normalize recorded allocations into ratios.
+    """
+    capacities: dict[tuple[SlotName, DeviceId], Decimal] = {}
+    for computer_ctx in computers.values():
+        for device_id, slot_info in computer_ctx.alloc_map.device_slots.items():
+            capacities[(slot_info.slot_name, device_id)] = slot_info.amount
+    return capacities
+
+
+def _normalize_device_alloc(
+    device_capacities: DeviceCapacityMap,
+    slot_name: SlotName,
+    device_id: DeviceId,
+    alloc: Decimal,
+) -> Decimal:
+    """
+    Convert a recorded allocation into a ratio (0 to 1) of the device's capacity.
+    """
+    capacity = device_capacities.get((slot_name, device_id))
+    if capacity is None or capacity <= 0:
+        # The device is no longer in the alloc map (e.g. removed or masked),
+        # so the ratio is unknown and the raw amount is reported as-is.
+        log.warning(
+            "scan_gpu_alloc_map(): no capacity found, reporting the raw allocation "
+            "(slot:{}, device:{}, capacity:{!r}, alloc:{})",
+            slot_name,
+            device_id,
+            capacity,
+            alloc,
+        )
+        return alloc
+    return alloc / capacity
+
+
 async def scan_gpu_alloc_map(
-    kernel_ids: Sequence[KernelId], scratch_root: Path
+    kernel_ids: Sequence[KernelId],
+    scratch_root: Path,
+    device_capacities: DeviceCapacityMap,
 ) -> dict[DeviceId, Decimal]:
     """
-    Fetch the current allocated amounts for fractional gpu from
+    Fetch the current allocated ratio (0 to 1) of each gpu device from
     ``/home/config/resource.txt`` files in the kernel containers managed by this agent.
     """
 
@@ -933,13 +976,11 @@ async def scan_gpu_alloc_map(
             resource_spec = KernelResourceSpec.read_from_string(content)
 
             if cuda := resource_spec.allocations.get(DeviceName("cuda")):
-                if cuda_shares := cuda.get(SlotName("cuda.shares")):
-                    for device_id, shares in cuda_shares.items():
-                        alloc_map[device_id] += Decimal(shares)
-
-                if cuda_device := cuda.get(SlotName("cuda.device")):
-                    for device_id, device in cuda_device.items():
-                        alloc_map[device_id] += Decimal(device)
+                for slot_name, per_device_alloc in cuda.items():
+                    for device_id, alloc in per_device_alloc.items():
+                        alloc_map[device_id] += _normalize_device_alloc(
+                            device_capacities, slot_name, device_id, Decimal(alloc)
+                        )
 
         except FileNotFoundError:
             return {}
@@ -972,7 +1013,10 @@ async def scan_gpu_alloc_map(
         for device_id, alloc in alloc_map.items():
             gpu_alloc_map[device_id] += alloc
 
-    return gpu_alloc_map
+    return {
+        device_id: alloc.quantize(_GPU_ALLOC_RATIO_PRECISION)
+        for device_id, alloc in gpu_alloc_map.items()
+    }
 
 
 def allocate(

--- a/src/ai/backend/agent/server.py
+++ b/src/ai/backend/agent/server.py
@@ -59,7 +59,7 @@ from ai.backend.agent.errors import (
 from ai.backend.agent.health.docker import DockerHealthChecker
 from ai.backend.agent.metrics.metric import RPCMetricObserver
 from ai.backend.agent.monitor import AgentErrorPluginContext, AgentStatsPluginContext
-from ai.backend.agent.resources import scan_gpu_alloc_map
+from ai.backend.agent.resources import collect_device_capacities, scan_gpu_alloc_map
 from ai.backend.agent.rpc.health.registry import register_health_domain
 from ai.backend.agent.rpc.hwinfo.registry import register_hwinfo_domain
 from ai.backend.agent.rpc.kernel.registry import register_kernel_domain
@@ -1285,7 +1285,11 @@ class AgentRPCServer(aobject):
         log.debug("rpc::scan_gpu_alloc_map()")
         agent = self.runtime.get_agent(agent_id)
         scratch_root = agent.local_config.container.scratch_root
-        result = await scan_gpu_alloc_map(list(agent.kernel_registry.keys()), scratch_root)
+        result = await scan_gpu_alloc_map(
+            list(agent.kernel_registry.keys()),
+            scratch_root,
+            collect_device_capacities(agent.computers),
+        )
         return {k: str(v) for k, v in result.items()}
 
 

--- a/tests/unit/agent/test_resources.py
+++ b/tests/unit/agent/test_resources.py
@@ -5,9 +5,10 @@ import tempfile
 import textwrap
 import unittest.mock
 import uuid
+from collections.abc import Mapping
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, cast
 from unittest import mock
 
 import pytest
@@ -17,11 +18,30 @@ from pytest_mock import MockerFixture
 from ai.backend.accelerator.mock.plugin import MockPlugin
 from ai.backend.agent import resources
 from ai.backend.agent.affinity_map import AffinityMap, AffinityPolicy
+from ai.backend.agent.alloc_map import (
+    DeviceSlotInfo,
+    DiscretePropertyAllocMap,
+    FractionAllocMap,
+)
 from ai.backend.agent.dummy.intrinsic import CPUPlugin, MemoryPlugin
 from ai.backend.agent.errors import FractionalResourceFragmented, InsufficientResource
-from ai.backend.agent.resources import ComputerContext, align_memory, scan_resource_usage_per_slot
+from ai.backend.agent.resources import (
+    AbstractComputePlugin,
+    ComputerContext,
+    align_memory,
+    collect_device_capacities,
+    scan_gpu_alloc_map,
+    scan_resource_usage_per_slot,
+)
 from ai.backend.agent.vendor import linux
-from ai.backend.common.types import DeviceId, DeviceName, KernelId, ResourceSlot, SlotName
+from ai.backend.common.types import (
+    DeviceId,
+    DeviceName,
+    KernelId,
+    ResourceSlot,
+    SlotName,
+    SlotTypes,
+)
 
 
 def test_parse_cpuset() -> None:
@@ -509,3 +529,175 @@ def test_align_memory() -> None:
         assert usable % align == 0
         assert usable + actual_reserved == orig
         assert 990 <= actual_reserved <= 1010
+
+
+class WriteResourceSpec(Protocol):
+    def __call__(self, kernel_id: KernelId, share_lines: Mapping[str, str]) -> None: ...
+
+
+@pytest.fixture
+def scratch_root(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def write_resource_spec(scratch_root: Path) -> WriteResourceSpec:
+    def _write(kernel_id: KernelId, share_lines: Mapping[str, str]) -> None:
+        config_dir = scratch_root / str(kernel_id) / "config"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        header = textwrap.dedent("""\
+            SCRATCH_SIZE=0
+            MOUNTS=
+            SLOTS={"cpu":"1","mem":"1024"}
+        """)
+        body = "".join(f"{key}={value}\n" for key, value in share_lines.items())
+        (config_dir / "resource.txt").write_text(header + body)
+
+    return _write
+
+
+class TestNormalizeDeviceAlloc:
+    def test_returns_the_ratio_against_the_device_capacity(self) -> None:
+        capacities = {(SlotName("cuda.shares"), DeviceId("0")): Decimal("2")}
+        assert resources._normalize_device_alloc(
+            capacities, SlotName("cuda.shares"), DeviceId("0"), Decimal("0.5")
+        ) == Decimal("0.25")
+
+    def test_reports_the_raw_allocation_when_the_device_has_no_capacity(self) -> None:
+        assert resources._normalize_device_alloc(
+            {}, SlotName("cuda.shares"), DeviceId("0"), Decimal("0.5")
+        ) == Decimal("0.5")
+
+    def test_reports_the_raw_allocation_when_the_capacity_is_not_positive(self) -> None:
+        capacities = {(SlotName("cuda.shares"), DeviceId("0")): Decimal("0")}
+        assert resources._normalize_device_alloc(
+            capacities, SlotName("cuda.shares"), DeviceId("0"), Decimal("0.5")
+        ) == Decimal("0.5")
+
+
+class TestCollectDeviceCapacities:
+    def test_flattens_the_device_slots_of_every_computer(self) -> None:
+        cpu_alloc_map = DiscretePropertyAllocMap(
+            device_slots={
+                DeviceId("0"): DeviceSlotInfo(SlotTypes.COUNT, SlotName("cpu"), Decimal("1")),
+                DeviceId("1"): DeviceSlotInfo(SlotTypes.COUNT, SlotName("cpu"), Decimal("1")),
+            },
+        )
+        cuda_alloc_map = FractionAllocMap(
+            device_slots={
+                DeviceId("gpu0"): DeviceSlotInfo(
+                    SlotTypes.COUNT, SlotName("cuda.shares"), Decimal("2")
+                ),
+            },
+        )
+        computers = {
+            DeviceName("cpu"): ComputerContext(
+                cast(AbstractComputePlugin, mock.Mock()), [], cpu_alloc_map
+            ),
+            DeviceName("cuda"): ComputerContext(
+                cast(AbstractComputePlugin, mock.Mock()), [], cuda_alloc_map
+            ),
+        }
+
+        assert collect_device_capacities(computers) == {
+            (SlotName("cpu"), DeviceId("0")): Decimal("1"),
+            (SlotName("cpu"), DeviceId("1")): Decimal("1"),
+            (SlotName("cuda.shares"), DeviceId("gpu0")): Decimal("2"),
+        }
+
+    def test_returns_an_empty_map_without_computers(self) -> None:
+        assert collect_device_capacities({}) == {}
+
+
+class TestScanGPUAllocMap:
+    async def test_normalizes_the_allocation_into_a_capacity_ratio(
+        self, scratch_root: Path, write_resource_spec: WriteResourceSpec
+    ) -> None:
+        kernel_id = KernelId(uuid.uuid4())
+        write_resource_spec(kernel_id, {"CUDA.SHARES_SHARES": "0:0.5"})
+
+        result = await scan_gpu_alloc_map(
+            [kernel_id],
+            scratch_root,
+            {(SlotName("cuda.shares"), DeviceId("0")): Decimal("2")},
+        )
+
+        assert result == {DeviceId("0"): Decimal("0.2500")}
+
+    async def test_sums_the_allocations_of_every_kernel_on_the_same_device(
+        self, scratch_root: Path, write_resource_spec: WriteResourceSpec
+    ) -> None:
+        kernel_ids = [KernelId(uuid.uuid4()) for _ in range(3)]
+        write_resource_spec(kernel_ids[0], {"CUDA.SHARES_SHARES": "0:0.5"})
+        write_resource_spec(kernel_ids[1], {"CUDA.SHARES_SHARES": "0:0.25,1:1"})
+        write_resource_spec(kernel_ids[2], {"CUDA.SHARES_SHARES": "1:0.5"})
+
+        result = await scan_gpu_alloc_map(
+            kernel_ids,
+            scratch_root,
+            {
+                (SlotName("cuda.shares"), DeviceId("0")): Decimal("1"),
+                (SlotName("cuda.shares"), DeviceId("1")): Decimal("2"),
+            },
+        )
+
+        assert result == {
+            DeviceId("0"): Decimal("0.7500"),
+            DeviceId("1"): Decimal("0.7500"),
+        }
+
+    async def test_skips_a_kernel_whose_resource_spec_is_gone(
+        self, scratch_root: Path, write_resource_spec: WriteResourceSpec
+    ) -> None:
+        alive_kernel_id = KernelId(uuid.uuid4())
+        terminated_kernel_id = KernelId(uuid.uuid4())
+        write_resource_spec(alive_kernel_id, {"CUDA.SHARES_SHARES": "0:1"})
+
+        result = await scan_gpu_alloc_map(
+            [alive_kernel_id, terminated_kernel_id],
+            scratch_root,
+            {(SlotName("cuda.shares"), DeviceId("0")): Decimal("2")},
+        )
+
+        assert result == {DeviceId("0"): Decimal("0.5000")}
+
+    async def test_reports_the_raw_allocation_when_the_capacity_is_unknown(
+        self, scratch_root: Path, write_resource_spec: WriteResourceSpec
+    ) -> None:
+        kernel_id = KernelId(uuid.uuid4())
+        write_resource_spec(kernel_id, {"CUDA.SHARES_SHARES": "0:0.5"})
+
+        result = await scan_gpu_alloc_map([kernel_id], scratch_root, {})
+
+        assert result == {DeviceId("0"): Decimal("0.5000")}
+
+    async def test_ignores_the_devices_other_than_cuda(
+        self, scratch_root: Path, write_resource_spec: WriteResourceSpec
+    ) -> None:
+        kernel_id = KernelId(uuid.uuid4())
+        write_resource_spec(kernel_id, {"CPU_SHARES": "0:2", "MEM_SHARES": "root:1024"})
+
+        result = await scan_gpu_alloc_map(
+            [kernel_id],
+            scratch_root,
+            {(SlotName("cpu"), DeviceId("0")): Decimal("4")},
+        )
+
+        assert result == {}
+
+    async def test_quantizes_the_ratio_to_four_decimal_places(
+        self, scratch_root: Path, write_resource_spec: WriteResourceSpec
+    ) -> None:
+        kernel_id = KernelId(uuid.uuid4())
+        write_resource_spec(kernel_id, {"CUDA.SHARES_SHARES": "0:1"})
+
+        result = await scan_gpu_alloc_map(
+            [kernel_id],
+            scratch_root,
+            {(SlotName("cuda.shares"), DeviceId("0")): Decimal("3")},
+        )
+
+        assert result == {DeviceId("0"): Decimal("0.3333")}
+
+    async def test_returns_an_empty_map_without_kernels(self, scratch_root: Path) -> None:
+        assert await scan_gpu_alloc_map([], scratch_root, {}) == {}


### PR DESCRIPTION
This is an auto-generated backport of #14327 to the 26.4 release.