### PR TITLE
fix(BA-7726): grant the keypair permissions and scope edge at runtime (#14433)

### DIFF
--- a/changes/14433.fix.md
+++ b/changes/14433.fix.md
@@ -1,0 +1,1 @@
+Grant a user's self role the permissions on the keypairs it owns, and write the keypair scope edge on the paths that create a keypair outside the RBAC creator, so a user created after the keypair RBAC migration is no longer refused on /auth/ssh-keypair.

--- a/src/ai/backend/common/data/permission/types.py
+++ b/src/ai/backend/common/data/permission/types.py
@@ -278,8 +278,12 @@ class EntityType(enum.StrEnum):
     def owner_accessible_entity_types_in_user(cls) -> set[EntityType]:
         """
         Returns a set of entity types that are accessible by owner roles in user scope.
+
+        ``KEYPAIR`` is not a resource type, but a user owns its own keypairs and reaches
+        them through ``/auth/ssh-keypair``, so the self role has to carry it. Without it a
+        user created after the keypair RBAC migration holds no grant on its own keypairs.
         """
-        return cls._resource_types()
+        return {*cls._resource_types(), cls.KEYPAIR}
 
     @classmethod
     def admin_accessible_entity_types_in_project(cls) -> set[EntityType]:

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -9,7 +9,9 @@ import graphene
 import sqlalchemy as sa
 from dateutil.parser import parse as dtparse
 from graphene.types.datetime import DateTime as GQLDateTime
+from sqlalchemy.engine.result import Result
 from sqlalchemy.engine.row import Row
+from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 
 from ai.backend.common.clients.valkey_client.valkey_rate_limit.client import ValkeyRateLimitClient
 from ai.backend.common.defs import REDIS_RATE_LIMIT_DB, RedisRole
@@ -19,6 +21,9 @@ from ai.backend.manager.data.keypair.types import KeyPairCreator, KeyPairData
 from ai.backend.manager.models.keypair import (
     keypairs,
     prepare_new_keypair,
+)
+from ai.backend.manager.models.rbac_models.association_scopes_entities import (
+    keypair_owner_association_stmt,
 )
 
 from .session import ComputeSession
@@ -572,7 +577,18 @@ class CreateKeyPair(graphene.Mutation):  # type: ignore[misc]
             **data,
             user=sa.select(users.c.uuid).where(users.c.email == user_id).as_scalar(),
         )
-        return await simple_db_mutate_returning_item(cls, graph_ctx, insert_query, item_cls=KeyPair)
+
+        async def _bind_to_owner_scope(conn: SAConnection, result: Result[Any]) -> Row[Any]:
+            # This mutation inserts the keypair row directly rather than through
+            # RBACEntityCreator, so the scope edge that resolves the keypair to its owner
+            # has to be written here.
+            row = cast(Row[Any], result.first())
+            await conn.execute(keypair_owner_association_stmt(row.user, row.access_key))
+            return row
+
+        return await simple_db_mutate_returning_item(
+            cls, graph_ctx, insert_query, item_cls=KeyPair, post_func=_bind_to_owner_scope
+        )
 
 
 class ModifyKeyPair(graphene.Mutation):  # type: ignore[misc]

--- a/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
+++ b/src/ai/backend/manager/models/rbac_models/association_scopes_entities.py
@@ -4,6 +4,8 @@ import uuid
 from datetime import datetime
 
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import Insert
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.manager.data.permission.association_scopes_entities import (
@@ -95,3 +97,28 @@ class AssociationScopesEntitiesRow(Base):  # type: ignore[misc]
             permission_cap=self.permission_cap,
             registered_at=self.registered_at,
         )
+
+
+def keypair_owner_association_stmt(user_id: uuid.UUID, access_key: str) -> Insert:
+    """The scope edge binding a keypair to the user that owns it.
+
+    ``RBACEntityCreator`` writes this edge for every keypair it creates. The paths that
+    insert a keypair row directly -- signup, the legacy ``create_keypair`` mutation and
+    OpenID user provisioning -- write it through this statement instead. Without the edge
+    the scope chain cannot resolve a keypair to its owner, so every permission check on
+    that keypair is refused.
+
+    Idempotent: a keypair that already carries the edge conflicts on
+    ``uq_scope_id_entity_id`` and the insert is dropped.
+    """
+    return (
+        pg_insert(AssociationScopesEntitiesRow.__table__)
+        .values(
+            scope_type=ScopeType.USER,
+            scope_id=str(user_id),
+            entity_type=EntityType.KEYPAIR,
+            entity_id=access_key,
+            relation_type=RelationType.AUTO,
+        )
+        .on_conflict_do_nothing()
+    )

--- a/src/ai/backend/manager/models/rbac_models/migration/enums.py
+++ b/src/ai/backend/manager/models/rbac_models/migration/enums.py
@@ -120,6 +120,9 @@ class EntityType(enum.StrEnum):
     MODEL_DEPLOYMENT = "model_deployment"
     MODEL_CARD = "model_card"
 
+    # Not a resource type: a keypair belongs to the user that owns it.
+    KEYPAIR = "keypair"
+
     def to_original(self) -> OriginalEntityType:
         return OriginalEntityType(self.value)
 
@@ -152,8 +155,11 @@ class EntityType(enum.StrEnum):
     def owner_accessible_entity_types_in_user(cls) -> set[EntityType]:
         """
         Returns a set of entity types that are accessible by owner roles in user scope.
+
+        Mirrors the original: ``KEYPAIR`` is not a resource type, but a user owns its own
+        keypairs and the self role has to carry them.
         """
-        return cls._resource_types()
+        return {*cls._resource_types(), cls.KEYPAIR}
 
     @classmethod
     def admin_accessible_entity_types_in_project(cls) -> set[EntityType]:

--- a/src/ai/backend/manager/plugin/openid/webapp.py
+++ b/src/ai/backend/manager/plugin/openid/webapp.py
@@ -33,6 +33,7 @@ from ai.backend.manager.models.hasher.types import PasswordInfo
 from ai.backend.manager.models.keypair import KeyPairRow, generate_keypair, generate_ssh_keypair
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
+    keypair_owner_association_stmt,
 )
 from ai.backend.manager.models.user import UserRole, UserRow, UserStatus
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -221,6 +222,11 @@ async def create_user_if_not_exists(
             )
             dbsess.add(keypair)
             await dbsess.flush()
+            # Bind the keypair to its owner's scope, as RBACEntityCreator does on the
+            # regular user-creation path.
+            await conn.execute(
+                keypair_owner_association_stmt(user.uuid, keypair_data["access_key"])
+            )
 
             # Associate the user with the default and model-store group, if exists.
             await associate_user_with_group(conn, user, user_info["project"])

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -36,6 +36,7 @@ from ai.backend.manager.models.login_session.enums import LoginAttemptResult, Lo
 from ai.backend.manager.models.login_session.row import LoginHistoryRow, LoginSessionRow
 from ai.backend.manager.models.rbac_models.association_scopes_entities import (
     AssociationScopesEntitiesRow,
+    keypair_owner_association_stmt,
 )
 from ai.backend.manager.models.user import (
     UserRole,
@@ -156,6 +157,9 @@ class AuthDBSource:
             keypair_data["user"] = user_row.uuid
             keypair_query = keypairs.insert().values(keypair_data)
             await conn.execute(keypair_query)
+            await conn.execute(
+                keypair_owner_association_stmt(user_row.uuid, keypair_data["access_key"])
+            )
 
             # Create RBAC system role and map user to role
             role_spec = UserSystemRoleSpec(user_id=user_row.uuid)

--- a/tests/unit/manager/rbac/test_permission_types.py
+++ b/tests/unit/manager/rbac/test_permission_types.py
@@ -61,7 +61,7 @@ class TestOperationType:
 
 class TestEntityType:
     def test_owner_accessible_entity_types_in_user(self) -> None:
-        """Test that owner_accessible_entity_types_in_user contains resource types."""
+        """Test that owner_accessible_entity_types_in_user contains resource types and KEYPAIR."""
         owner_accessible = EntityType.owner_accessible_entity_types_in_user()
 
         # Should contain all resource types
@@ -69,13 +69,17 @@ class TestEntityType:
         assert EntityType.IMAGE in owner_accessible
         assert EntityType.SESSION in owner_accessible
 
+        # A user owns its own keypairs, so the self role has to carry them even though
+        # KEYPAIR is not a resource type.
+        assert EntityType.KEYPAIR in owner_accessible
+
         # Should NOT contain scope types
         assert EntityType.USER not in owner_accessible
         assert EntityType.PROJECT not in owner_accessible
         assert EntityType.DOMAIN not in owner_accessible
 
-        # Verify it equals _resource_types()
-        assert owner_accessible == EntityType._resource_types()
+        # Verify it equals _resource_types() plus KEYPAIR
+        assert owner_accessible == {*EntityType._resource_types(), EntityType.KEYPAIR}
 
     def test_admin_accessible_entity_types_in_project(self) -> None:
         """Test that admin_accessible_entity_types_in_project contains resource types and USER."""


### PR DESCRIPTION
## Summary

Backport of #14433 to `26.4`.

- #14326 (backported as #14423, migration `e1b7f3d20a94`) backfills the keypair permission rows and scope edges a database already carries. On 26.4 nothing writes them again, so the fix does not hold: every user created after the migration runs reproduces the `403 NotEnoughPermission` on `/auth/ssh-keypair`, and a fresh 26.4 install — where the backfill runs against an empty database — never benefits at all. This PR closes that runtime gap; the #14326 backport stays responsible for the existing rows.
- `EntityType.owner_accessible_entity_types_in_user()` now carries `KEYPAIR`, so the self role a user creation provisions grants the owner operations on the keypairs it owns. Both self-role creators on this branch (`UserData` and `UserSystemRoleSpec`) route through this one classmethod. `_resource_types()` is untouched, so the admin and project scope sets are unaffected.
- The three paths that insert a keypair row directly rather than through `RBACEntityCreator` — signup, the legacy `create_keypair` mutation and OpenID provisioning — now write the `keypair -> user` AUTO edge through a shared `keypair_owner_association_stmt`. Without it the scope chain cannot resolve a keypair to its owner and the `GET` path is refused. Idempotent via `ON CONFLICT DO NOTHING`.
- The frozen migration enum snapshot mirrors the change so `test_migration_enums.py` stays green. No alembic revision calls that classmethod, so migration behaviour is unchanged.

**No counterpart is needed on main**: there a keypair is a field of its owner (`UserEntityAction` names `USER_ENTITY_TYPE`), so an operation on it reads the `user` permission the self role already holds.

## Backport notes

The source commit cherry-picked onto `26.4` with no conflicts. Each site was then re-verified against this branch's own context rather than assumed from 26.8:

| Check | Result on 26.4 |
|---|---|
| `EntityType.KEYPAIR` / `RBACElementType.KEYPAIR` (needed by `to_element()`) | both present |
| `simple_db_mutate_returning_item(..., post_func=...)` | present, same `Awaitable[Row[Any]]` contract |
| `models/rbac_models/association_scopes_entities.py` | identical to 26.8; `uq_scope_id_entity_id` present |
| keypair direct-insert paths (`keypairs.insert()` / `KeyPairRow(`) | the same three, none missed |
| regular user-creation path | already writes the edge via `RBACEntityCreator(element_type=RBACElementType.KEYPAIR)` |
| alembic revisions calling `owner_accessible_entity_types_in_user()` | none |

One difference from #14433: 26.4 has **two** self-role creators, not four — 26.8 routes signup and OpenID through separate specs. Both still go through the single classmethod, so the one-line change covers them.

The 26.8-only followup migration `f4a2b7c9e105` has no counterpart here: it re-issues the backfill on the 26.8 release head, which 26.4 sits behind. `e1b7f3d20a94` already covers this branch.

## Test plan

- [x] `pants fmt` / `fix` / `lint` on every touched file, and `pants lint --changed-since=origin/26.4`.
- [x] `pants check` — no issues found in 7 source files.
- [x] `pants test tests/unit/manager/rbac::` — 4/4.
- [ ] Live A/B on a 26.4 halfstack (`PATCH /auth/ssh-keypair` for a newly created user: 403 → 200) — verified on 26.8 in #14433, not re-run here.
- [ ] OpenID provisioning — no local IdP; the code path is the same shape as signup.

Resolves BA-7726

🤖 Generated with [Claude Code](https://claude.com/claude-code)
