### PR TITLE
refactor(BA-7777): hand each adapter the processors it uses

### DIFF
--- a/changes/14442.enhance.md
+++ b/changes/14442.enhance.md
@@ -1,0 +1,1 @@
+Narrow each API adapter's constructor to the processors it uses so the dependency graph reflects real service chains.

--- a/src/ai/backend/manager/api/adapters/agent/adapter.py
+++ b/src/ai/backend/manager/api/adapters/agent/adapter.py
@@ -68,6 +68,7 @@ from ai.backend.manager.services.agent.actions.search_agents import SearchAgents
 from ai.backend.manager.services.agent.actions.update_resource_group import (
     UpdateAgentResourceGroupAction,
 )
+from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.agent.types import ConflictingSessionCleanupPolicy
 
 _AGENT_PAGINATION_SPEC = PaginationSpec(
@@ -81,6 +82,11 @@ _AGENT_PAGINATION_SPEC = PaginationSpec(
 
 class AgentAdapter(BaseAdapter):
     """Adapter for agent domain operations."""
+
+    _agent: AgentProcessors
+
+    def __init__(self, agent: AgentProcessors) -> None:
+        self._agent = agent
 
     # ------------------------------------------------------------------ batch load (DataLoader)
 
@@ -96,11 +102,9 @@ class AgentAdapter(BaseAdapter):
         """
         if not agent_ids:
             return []
-        lookup = await self._processors.agent.bulk_lookup.run(
-            BulkLookupAgentsAction(agent_ids=agent_ids)
-        )
+        lookup = await self._agent.bulk_lookup.run(BulkLookupAgentsAction(agent_ids=agent_ids))
         uuids = [lookup.resolved[agent_id] for agent_id in agent_ids if agent_id in lookup.resolved]
-        got = await self._processors.agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
+        got = await self._agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
         agents = got.values()
         errors = got.errors()
         permitted = [agent.uuid for agent in agents.values()]
@@ -133,7 +137,7 @@ class AgentAdapter(BaseAdapter):
         """What the caller holds on each named agent."""
         if not agent_uuids:
             return {}
-        result = await self._processors.agent.bulk_load_permissions.run(
+        result = await self._agent.bulk_load_permissions.run(
             BulkLoadAgentPermissionsAction(agent_uuids=agent_uuids)
         )
         return result.values()
@@ -144,7 +148,7 @@ class AgentAdapter(BaseAdapter):
         """The slot rows of the named agents, keyed by the agent's name column."""
         if not agent_uuids:
             return {}
-        result = await self._processors.agent.scoped_search_resources.run(
+        result = await self._agent.scoped_search_resources.run(
             ScopedSearchAgentResourcesAction(
                 agent_uuids=agent_uuids,
                 searcher=AgentResourceSearcher(pagination=NoPagination()),
@@ -166,16 +170,14 @@ class AgentAdapter(BaseAdapter):
         """
         if not agent_ids:
             return []
-        lookup = await self._processors.agent.bulk_lookup.run(
-            BulkLookupAgentsAction(agent_ids=agent_ids)
-        )
+        lookup = await self._agent.bulk_lookup.run(BulkLookupAgentsAction(agent_ids=agent_ids))
         uuids = [lookup.resolved[agent_id] for agent_id in agent_ids if agent_id in lookup.resolved]
-        got = await self._processors.agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
+        got = await self._agent.bulk_get.run(BulkGetAgentsAction(ids=uuids))
         permitted = [uuid for uuid in uuids if uuid in got.values()]
         counts: Mapping[EntityIdentifier, int] = {}
         count_errors: Mapping[EntityIdentifier, Exception] = {}
         if permitted:
-            counted = await self._processors.agent.bulk_load_container_counts.run(
+            counted = await self._agent.bulk_load_container_counts.run(
                 BulkLoadContainerCountsAction(agent_uuids=permitted)
             )
             counts = counted.values()
@@ -213,9 +215,7 @@ class AgentAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.agent.search_agents.run(
-            SearchAgentsAction(querier=querier)
-        )
+        action_result = await self._agent.search_agents.run(SearchAgentsAction(querier=querier))
         return AdminSearchAgentsPayload(
             items=[self._data_to_dto(item) for item in action_result.agents],
             total_count=action_result.total_count,
@@ -328,7 +328,7 @@ class AgentAdapter(BaseAdapter):
     ) -> UpdateAgentResourceGroupPayload:
         """Change an agent's resource group, cleaning up conflicting sessions per policy."""
         applied_policy = input.policy or ConflictingSessionCleanupPolicyEnum.TERMINATE
-        action_result = await self._processors.agent.update_resource_group.run(
+        action_result = await self._agent.update_resource_group.run(
             UpdateAgentResourceGroupAction(
                 agent_id=input.agent_id,
                 resource_group_id=input.resource_group_id,
@@ -350,8 +350,8 @@ class AgentAdapter(BaseAdapter):
 
     async def get_total_resources(self) -> TotalResourceData:
         """Retrieve aggregate resource capacity/usage across all agents."""
-        action_result: GetTotalResourcesActionResult = (
-            await self._processors.agent.get_total_resources.run(GetTotalResourcesAction())
+        action_result: GetTotalResourcesActionResult = await self._agent.get_total_resources.run(
+            GetTotalResourcesAction()
         )
         return action_result.total_resources
 

--- a/src/ai/backend/manager/api/adapters/app_config/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config/adapter.py
@@ -19,10 +19,16 @@ from ai.backend.manager.services.app_config.actions.search import (
     AnonymousSearchAppConfigsAction,
     SearchAppConfigsAction,
 )
+from ai.backend.manager.services.app_config.processors import AppConfigProcessors
 
 
 class AppConfigAdapter(BaseAdapter):
     """Adapter for the merged AppConfig (read) operations."""
+
+    _app_config: AppConfigProcessors
+
+    def __init__(self, app_config: AppConfigProcessors) -> None:
+        self._app_config = app_config
 
     # --- merged AppConfig read ---
 
@@ -32,7 +38,7 @@ class AppConfigAdapter(BaseAdapter):
         if me is None:
             # ``auth_required`` guarantees a session on this route, so this is never hit.
             raise UnreachableError("User context is not available")
-        action_result = await self._processors.app_config.search_app_configs.run(
+        action_result = await self._app_config.search_app_configs.run(
             SearchAppConfigsAction(
                 config_names=input.config_names,
                 user_id=UserID(me.user_id),
@@ -47,7 +53,7 @@ class AppConfigAdapter(BaseAdapter):
 
     async def public_app_configs(self, input: PublicGetAppConfigsInput) -> GetAppConfigsPayload:
         """Merged AppConfigs from public fragments only; naming no principal is what makes it anonymous."""
-        action_result = await self._processors.app_config.anonymous_search_app_configs.run(
+        action_result = await self._app_config.anonymous_search_app_configs.run(
             AnonymousSearchAppConfigsAction(config_names=input.config_names)
         )
         return GetAppConfigsPayload(

--- a/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_allow_list/adapter.py
@@ -72,6 +72,7 @@ from ai.backend.manager.services.app_config.actions.allow_list.purge import (
 from ai.backend.manager.services.app_config.actions.allow_list.update import (
     UpdateAppConfigAllowListAction,
 )
+from ai.backend.manager.services.app_config.processors import AppConfigProcessors
 from ai.backend.manager.types import OptionalState
 
 
@@ -89,6 +90,11 @@ def _get_app_config_allow_list_pagination_spec() -> PaginationSpec:
 class AppConfigAllowListAdapter(BaseAdapter):
     """Adapter for app config allow-list domain operations (admin-only)."""
 
+    _app_config: AppConfigProcessors
+
+    def __init__(self, app_config: AppConfigProcessors) -> None:
+        self._app_config = app_config
+
     async def admin_create(
         self, input: CreateAppConfigAllowListInput
     ) -> CreateAppConfigAllowListPayload:
@@ -97,7 +103,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
             scope_type=AppConfigScopeType(input.scope_type.value),
             rank=input.rank,
         )
-        action_result = await self._processors.app_config.allow_list_global_create.run(
+        action_result = await self._app_config.allow_list_global_create.run(
             CreateAppConfigAllowListAction(creator=creator)
         )
         return CreateAppConfigAllowListPayload(
@@ -105,7 +111,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
         )
 
     async def admin_get(self, allow_list_id: AppConfigAllowListID) -> AppConfigAllowListNode:
-        action_result = await self._processors.app_config.allow_list_get.run(
+        action_result = await self._app_config.allow_list_get.run(
             GetAppConfigAllowListAction(
                 querier=AppConfigAllowListQuerier(allow_list_id=allow_list_id)
             )
@@ -123,7 +129,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
         if not ids:
             return []
         entity_ids = [AppConfigAllowListID(value) for value in ids]
-        result = await self._processors.app_config.allow_list_bulk_get.run(
+        result = await self._app_config.allow_list_bulk_get.run(
             BulkGetAppConfigAllowListsAction(ids=entity_ids)
         )
         return [
@@ -150,7 +156,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.app_config.allow_list_global_search.run(
+        action_result = await self._app_config.allow_list_global_search.run(
             AdminSearchAppConfigAllowListAction(searcher=searcher)
         )
         return SearchAppConfigAllowListPayload(
@@ -169,7 +175,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
                 OptionalState.update(input.rank) if input.rank is not None else OptionalState.nop()
             ),
         )
-        action_result = await self._processors.app_config.allow_list_update.run(
+        action_result = await self._app_config.allow_list_update.run(
             UpdateAppConfigAllowListAction(updater=updater)
         )
         return UpdateAppConfigAllowListPayload(
@@ -180,7 +186,7 @@ class AppConfigAllowListAdapter(BaseAdapter):
         self, input: PurgeAppConfigAllowListInput
     ) -> PurgeAppConfigAllowListPayload:
         purger = AppConfigAllowListPurger(allow_list_id=AppConfigAllowListID(input.id))
-        action_result = await self._processors.app_config.allow_list_purge.run(
+        action_result = await self._app_config.allow_list_purge.run(
             PurgeAppConfigAllowListAction(purger=purger)
         )
         return PurgeAppConfigAllowListPayload(id=action_result.data.id)

--- a/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_definition/adapter.py
@@ -53,6 +53,7 @@ from ai.backend.manager.services.app_config.actions.definition.get import (
 from ai.backend.manager.services.app_config.actions.definition.purge import (
     PurgeAppConfigDefinitionAction,
 )
+from ai.backend.manager.services.app_config.processors import AppConfigProcessors
 
 
 @lru_cache(maxsize=1)
@@ -69,11 +70,16 @@ def _get_app_config_definition_pagination_spec() -> PaginationSpec:
 class AppConfigDefinitionAdapter(BaseAdapter):
     """Adapter for app config definition domain operations (admin-only)."""
 
+    _app_config: AppConfigProcessors
+
+    def __init__(self, app_config: AppConfigProcessors) -> None:
+        self._app_config = app_config
+
     async def admin_create(
         self, input: CreateAppConfigDefinitionInput
     ) -> CreateAppConfigDefinitionPayload:
         creator = AppConfigDefinitionCreator(config_name=input.config_name)
-        action_result = await self._processors.app_config.definition_global_create.run(
+        action_result = await self._app_config.definition_global_create.run(
             CreateAppConfigDefinitionAction(creator=creator)
         )
         return CreateAppConfigDefinitionPayload(
@@ -81,7 +87,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
         )
 
     async def admin_get(self, definition_id: AppConfigDefinitionID) -> AppConfigDefinitionNode:
-        action_result = await self._processors.app_config.definition_get.run(
+        action_result = await self._app_config.definition_get.run(
             GetAppConfigDefinitionAction(definition_id=definition_id)
         )
         return self._data_to_node(action_result.data)
@@ -97,7 +103,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
         if not ids:
             return []
         entity_ids = [AppConfigDefinitionID(value) for value in ids]
-        result = await self._processors.app_config.definition_bulk_get.run(
+        result = await self._app_config.definition_bulk_get.run(
             BulkGetAppConfigDefinitionsAction(ids=entity_ids)
         )
         return [
@@ -124,7 +130,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.app_config.definition_global_search.run(
+        action_result = await self._app_config.definition_global_search.run(
             AdminSearchAppConfigDefinitionsAction(searcher=searcher)
         )
         return SearchAppConfigDefinitionsPayload(
@@ -137,7 +143,7 @@ class AppConfigDefinitionAdapter(BaseAdapter):
     async def admin_purge(
         self, input: PurgeAppConfigDefinitionInput
     ) -> PurgeAppConfigDefinitionPayload:
-        action_result = await self._processors.app_config.definition_purge.run(
+        action_result = await self._app_config.definition_purge.run(
             PurgeAppConfigDefinitionAction(definition_id=AppConfigDefinitionID(input.id))
         )
         return PurgeAppConfigDefinitionPayload(id=action_result.data.id)

--- a/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/app_config_fragment/adapter.py
@@ -85,6 +85,7 @@ from ai.backend.manager.services.app_config.actions.fragment.purge import (
 from ai.backend.manager.services.app_config.actions.fragment.scoped_search import (
     ScopedSearchAppConfigFragmentAction,
 )
+from ai.backend.manager.services.app_config.processors import AppConfigProcessors
 
 
 @lru_cache(maxsize=1)
@@ -100,6 +101,11 @@ def _get_app_config_fragment_pagination_spec() -> PaginationSpec:
 
 class AppConfigFragmentAdapter(BaseAdapter):
     """Adapter for raw app config fragment write and search operations."""
+
+    _app_config: AppConfigProcessors
+
+    def __init__(self, app_config: AppConfigProcessors) -> None:
+        self._app_config = app_config
 
     # --- fragment writes and reads (RBAC-gated at the processor) ---
 
@@ -129,7 +135,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         """Route by who owns the fragments: a public write answers to no scope, so it runs
         behind the SUPERADMIN gate instead."""
         if owner is None:
-            written = await self._processors.app_config.fragment_global_bulk_upsert.run(
+            written = await self._app_config.fragment_global_bulk_upsert.run(
                 GlobalBulkUpsertAppConfigFragmentsAction(
                     upserters=[
                         PublicAppConfigFragmentUpserter(
@@ -140,7 +146,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
                 )
             )
         else:
-            written = await self._processors.app_config.fragment_bulk_upsert.run(
+            written = await self._app_config.fragment_bulk_upsert.run(
                 BulkUpsertAppConfigFragmentsAction(
                     owner=owner,
                     upserters=[
@@ -157,13 +163,13 @@ class AppConfigFragmentAdapter(BaseAdapter):
         )
 
     async def get(self, fragment_id: AppConfigFragmentID) -> AppConfigFragmentNode:
-        action_result = await self._processors.app_config.fragment_get.run(
+        action_result = await self._app_config.fragment_get.run(
             GetAppConfigFragmentAction(querier=AppConfigFragmentQuerier(fragment_id=fragment_id))
         )
         return self._fragment_to_node(action_result.data)
 
     async def purge(self, fragment_id: AppConfigFragmentID) -> PurgeAppConfigFragmentPayload:
-        action_result = await self._processors.app_config.fragment_purge.run(
+        action_result = await self._app_config.fragment_purge.run(
             PurgeAppConfigFragmentAction(purger=AppConfigFragmentPurger(fragment_id=fragment_id))
         )
         return PurgeAppConfigFragmentPayload(id=action_result.data.id)
@@ -171,7 +177,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
     async def bulk_purge(
         self, input: BulkPurgeAppConfigFragmentInput
     ) -> BulkPurgeAppConfigFragmentPayload:
-        action_result = await self._processors.app_config.fragment_bulk_purge.run(
+        action_result = await self._app_config.fragment_bulk_purge.run(
             BulkPurgeAppConfigFragmentAction(
                 purgers=[
                     AppConfigFragmentPurger(fragment_id=fragment_id) for fragment_id in input.ids
@@ -200,7 +206,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
         if not fragment_ids:
             return []
         entity_ids = [AppConfigFragmentID(value) for value in fragment_ids]
-        result = await self._processors.app_config.fragment_bulk_get.run(
+        result = await self._app_config.fragment_bulk_get.run(
             BulkGetAppConfigFragmentsAction(ids=entity_ids)
         )
         return [
@@ -245,7 +251,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             pagination_spec=_get_app_config_fragment_pagination_spec(),
             limit=len(config_names),
         )
-        action_result = await self._processors.app_config.fragment_scoped_search.run(
+        action_result = await self._app_config.fragment_scoped_search.run(
             ScopedSearchAppConfigFragmentAction(owner=owner, searcher=searcher)
         )
         # Answer at the position each name was asked for, so a name with no fragment at this
@@ -277,7 +283,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.app_config.fragment_admin_search.run(
+        action_result = await self._app_config.fragment_admin_search.run(
             AdminSearchAppConfigFragmentAction(searcher=searcher)
         )
         return SearchAppConfigFragmentPayload(
@@ -306,7 +312,7 @@ class AppConfigFragmentAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.app_config.fragment_scoped_search.run(
+        action_result = await self._app_config.fragment_scoped_search.run(
             ScopedSearchAppConfigFragmentAction(
                 owner=self._scope_owner(input.scope), searcher=searcher
             )

--- a/src/ai/backend/manager/api/adapters/artifact/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact/adapter.py
@@ -104,6 +104,7 @@ from ai.backend.manager.services.artifact.actions.scan import (
 )
 from ai.backend.manager.services.artifact.actions.search import SearchArtifactsAction
 from ai.backend.manager.services.artifact.actions.update import UpdateArtifactAction
+from ai.backend.manager.services.artifact.processors import ArtifactProcessors
 from ai.backend.manager.services.artifact.revision.actions.approve import (
     ApproveArtifactRevisionAction,
 )
@@ -135,12 +136,17 @@ DEFAULT_PAGINATION_LIMIT = 10
 class ArtifactAdapter(BaseAdapter):
     """Adapter for artifact domain operations."""
 
+    _artifact: ArtifactProcessors
+
+    def __init__(self, artifact: ArtifactProcessors) -> None:
+        self._artifact = artifact
+
     async def admin_search(
         self,
         input: AdminSearchArtifactsInput,
     ) -> AdminSearchArtifactsPayload:
         """Search artifacts (admin, no scope) with filters, orders, and pagination."""
-        action_result = await self._processors.artifact.search_artifacts.run(
+        action_result = await self._artifact.search_artifacts.run(
             SearchArtifactsAction(searcher=self.build_searcher(input))
         )
 
@@ -169,7 +175,7 @@ class ArtifactAdapter(BaseAdapter):
         orders.append(TIEBREAKER_ORDER)
 
         pagination = self._build_gql_pagination_artifacts(input)
-        action_result = await self._processors.artifact.search_artifacts.run(
+        action_result = await self._artifact.search_artifacts.run(
             SearchArtifactsAction(
                 searcher=ArtifactSearcher(
                     pagination=pagination, conditions=conditions, orders=orders
@@ -202,7 +208,7 @@ class ArtifactAdapter(BaseAdapter):
         orders.append(ArtifactRevisionRow.id.asc())  # tiebreaker
 
         pagination = self._build_gql_pagination_revisions(input)
-        action_result = await self._processors.artifact.revision.search_revision.run(
+        action_result = await self._artifact.revision.search_revision.run(
             SearchArtifactRevisionsAction(
                 searcher=ArtifactRevisionSearcher(
                     pagination=pagination, conditions=conditions, orders=orders
@@ -223,7 +229,7 @@ class ArtifactAdapter(BaseAdapter):
         """Batch load artifacts by their IDs for DataLoader use, checked per artifact."""
         if not artifact_ids:
             return []
-        result = await self._processors.artifact.bulk_get.run(
+        result = await self._artifact.bulk_get.run(
             BulkGetArtifactsAction(ids=[ArtifactID(artifact_id) for artifact_id in artifact_ids])
         )
         return [
@@ -241,7 +247,7 @@ class ArtifactAdapter(BaseAdapter):
             return []
         ids = [ArtifactRevisionID(revision_id) for revision_id in revision_ids]
         return await self.batch_load_fields(
-            self._processors.artifact.revision.bulk_get,
+            self._artifact.revision.bulk_get,
             BulkGetArtifactRevisionsAction(ids=ids),
             ids,
             self._revision_data_to_dto,
@@ -249,7 +255,7 @@ class ArtifactAdapter(BaseAdapter):
 
     async def get(self, artifact_id: UUID) -> ArtifactNode:
         """Retrieve a single artifact by ID."""
-        action_result = await self._processors.artifact.get.run(
+        action_result = await self._artifact.get.run(
             GetArtifactAction(artifact_id=ArtifactID(artifact_id))
         )
         return self._data_to_dto(action_result.result)
@@ -273,14 +279,14 @@ class ArtifactAdapter(BaseAdapter):
                 else TriState[str].from_graphql(input.description)
             ),
         )
-        action_result = await self._processors.artifact.update.run(
+        action_result = await self._artifact.update.run(
             UpdateArtifactAction(artifact_id=ArtifactID(artifact_id), updater=updater)
         )
         return UpdateArtifactPayload(artifact=self._data_to_dto(action_result.result))
 
     async def delete(self, input: DeleteArtifactsInput) -> DeleteArtifactsPayload:
         """Delete multiple artifacts by ID."""
-        action_result = await self._processors.artifact.delete_artifacts.run(
+        action_result = await self._artifact.delete_artifacts.run(
             DeleteArtifactsAction(artifact_ids=input.artifact_ids)
         )
         return DeleteArtifactsPayload(
@@ -289,7 +295,7 @@ class ArtifactAdapter(BaseAdapter):
 
     async def get_revision(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
         """Retrieve a single artifact revision by ID."""
-        action_result = await self._processors.artifact.revision.get.run(
+        action_result = await self._artifact.revision.get.run(
             GetArtifactRevisionAction(artifact_revision_id=ArtifactRevisionID(artifact_revision_id))
         )
         return self._revision_data_to_dto(action_result.data)
@@ -303,7 +309,7 @@ class ArtifactAdapter(BaseAdapter):
         search: str | None,
     ) -> list[ArtifactNode]:
         """Scan external registries to discover available artifacts."""
-        action_result: ScanArtifactsActionResult = await self._processors.artifact.scan.run(
+        action_result: ScanArtifactsActionResult = await self._artifact.scan.run(
             ScanArtifactsAction(
                 artifact_type=artifact_type,
                 registry_id=ArtifactRegistryID(registry_id) if registry_id is not None else None,
@@ -322,7 +328,7 @@ class ArtifactAdapter(BaseAdapter):
         force: bool,
     ) -> tuple[ArtifactRevisionNode, UUID | None]:
         """Import a single artifact revision and return (revision_node, task_id)."""
-        action_result = await self._processors.artifact.revision.import_revision.run(
+        action_result = await self._artifact.revision.import_revision.run(
             ImportArtifactRevisionAction(
                 artifact_revision_id=ArtifactRevisionID(artifact_revision_id),
                 vfolder_id=vfolder_id,
@@ -352,16 +358,14 @@ class ArtifactAdapter(BaseAdapter):
             if delegatee_target is not None
             else None
         )
-        action_result: DelegateScanArtifactsActionResult = (
-            await self._processors.artifact.delegate_scan.run(
-                DelegateScanArtifactsAction(
-                    delegator_reservoir_id=delegator_reservoir_id,
-                    delegatee_target=service_target,
-                    artifact_type=artifact_type,
-                    limit=limit,
-                    order=order,
-                    search=search,
-                )
+        action_result: DelegateScanArtifactsActionResult = await self._artifact.delegate_scan.run(
+            DelegateScanArtifactsAction(
+                delegator_reservoir_id=delegator_reservoir_id,
+                delegatee_target=service_target,
+                artifact_type=artifact_type,
+                limit=limit,
+                order=order,
+                search=search,
             )
         )
         return [self._data_to_dto(item) for item in action_result.result]
@@ -388,7 +392,7 @@ class ArtifactAdapter(BaseAdapter):
             if delegatee_target is not None
             else None
         )
-        action_result = await self._processors.artifact.revision.delegate_import_revision_batch.run(
+        action_result = await self._artifact.revision.delegate_import_revision_batch.run(
             DelegateImportArtifactRevisionBatchAction(
                 delegator_reservoir_id=delegator_reservoir_id,
                 delegatee_target=service_target,
@@ -402,7 +406,7 @@ class ArtifactAdapter(BaseAdapter):
 
     async def cleanup_revision(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
         """Clean up stored artifact revision data and revert to SCANNED status."""
-        action_result = await self._processors.artifact.revision.cleanup.run(
+        action_result = await self._artifact.revision.cleanup.run(
             CleanupArtifactRevisionAction(
                 artifact_revision_id=ArtifactRevisionID(artifact_revision_id)
             )
@@ -411,23 +415,21 @@ class ArtifactAdapter(BaseAdapter):
 
     async def restore(self, artifact_ids: list[UUID]) -> list[ArtifactNode]:
         """Restore previously deleted artifacts."""
-        action_result: RestoreArtifactsActionResult = (
-            await self._processors.artifact.restore_artifacts.run(
-                RestoreArtifactsAction(artifact_ids=artifact_ids)
-            )
+        action_result: RestoreArtifactsActionResult = await self._artifact.restore_artifacts.run(
+            RestoreArtifactsAction(artifact_ids=artifact_ids)
         )
         return [self._data_to_dto(item) for item in action_result.artifacts]
 
     async def cancel_import(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
         """Cancel an in-progress artifact import and revert to SCANNED status."""
-        action_result = await self._processors.artifact.revision.cancel_import.run(
+        action_result = await self._artifact.revision.cancel_import.run(
             CancelImportAction(artifact_revision_id=ArtifactRevisionID(artifact_revision_id))
         )
         return self._revision_data_to_dto(action_result.result)
 
     async def approve_revision(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
         """Approve an artifact revision for general use."""
-        action_result = await self._processors.artifact.revision.approve.run(
+        action_result = await self._artifact.revision.approve.run(
             ApproveArtifactRevisionAction(
                 artifact_revision_id=ArtifactRevisionID(artifact_revision_id)
             )
@@ -436,7 +438,7 @@ class ArtifactAdapter(BaseAdapter):
 
     async def reject_revision(self, artifact_revision_id: UUID) -> ArtifactRevisionNode:
         """Reject an artifact revision, preventing its use."""
-        action_result = await self._processors.artifact.revision.reject.run(
+        action_result = await self._artifact.revision.reject.run(
             RejectArtifactRevisionAction(
                 artifact_revision_id=ArtifactRevisionID(artifact_revision_id)
             )
@@ -452,14 +454,10 @@ class ArtifactAdapter(BaseAdapter):
         storage_models = [
             StorageModelTarget(model_id=m.model_id, revision=m.revision) for m in models
         ]
-        action_result: RetrieveModelsActionResult = (
-            await self._processors.artifact.retrieve_models.run(
-                RetrieveModelsAction(
-                    models=storage_models,
-                    registry_id=ArtifactRegistryID(registry_id)
-                    if registry_id is not None
-                    else None,
-                )
+        action_result: RetrieveModelsActionResult = await self._artifact.retrieve_models.run(
+            RetrieveModelsAction(
+                models=storage_models,
+                registry_id=ArtifactRegistryID(registry_id) if registry_id is not None else None,
             )
         )
         return [self._data_with_revisions_to_dto(item) for item in action_result.result]

--- a/src/ai/backend/manager/api/adapters/artifact_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/artifact_registry/adapter.py
@@ -25,10 +25,16 @@ from ai.backend.manager.services.artifact_registry.actions.common.search import 
 from ai.backend.manager.services.artifact_registry.actions.lookup import (
     LookupArtifactRegistryAction,
 )
+from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
 
 
 class ArtifactRegistryAdapter(BaseAdapter):
     """Adapter for artifact registry metadata operations."""
+
+    _artifact_registry: ArtifactRegistryProcessors
+
+    def __init__(self, artifact_registry: ArtifactRegistryProcessors) -> None:
+        self._artifact_registry = artifact_registry
 
     async def get_registry_meta(
         self, registry_name: str | None = None, registry_id: uuid.UUID | None = None
@@ -38,16 +44,16 @@ class ArtifactRegistryAdapter(BaseAdapter):
         The two are different reads: an id names the registry, a name resolves to it.
         """
         if registry_id is not None:
-            action_result = await self._processors.artifact_registry.get_registry_meta.run(
+            action_result = await self._artifact_registry.get_registry_meta.run(
                 GetArtifactRegistryMetaAction(registry_id=ArtifactRegistryID(registry_id))
             )
             return self._data_to_dto(action_result.result)
         if registry_name is None:
             raise InvalidAPIParameters("One of (`registry_id` or `registry_name`) is required")
-        resolved = await self._processors.artifact_registry.lookup.run(
+        resolved = await self._artifact_registry.lookup.run(
             LookupArtifactRegistryAction(name=registry_name)
         )
-        action_result = await self._processors.artifact_registry.get_registry_meta.run(
+        action_result = await self._artifact_registry.get_registry_meta.run(
             GetArtifactRegistryMetaAction(registry_id=resolved.entity_id())
         )
         return self._data_to_dto(action_result.result)
@@ -60,7 +66,7 @@ class ArtifactRegistryAdapter(BaseAdapter):
         An id the caller may not read is left out beside one matching no row, so the
         caller cannot tell a denied registry from an absent one.
         """
-        result = await self._processors.artifact_registry.get_registry_metas.run(
+        result = await self._artifact_registry.get_registry_metas.run(
             GetArtifactRegistryMetasAction(
                 registry_ids=[ArtifactRegistryID(registry_id) for registry_id in registry_ids]
             )
@@ -76,7 +82,7 @@ class ArtifactRegistryAdapter(BaseAdapter):
         """
         if not ids:
             return []
-        action_result = await self._processors.artifact_registry.search_artifact_registries.run(
+        action_result = await self._artifact_registry.search_artifact_registries.run(
             SearchArtifactRegistriesAction(
                 searcher=ArtifactRegistrySearcher(
                     pagination=OffsetPagination(limit=len(ids)),

--- a/src/ai/backend/manager/api/adapters/audit_log/adapter.py
+++ b/src/ai/backend/manager/api/adapters/audit_log/adapter.py
@@ -41,6 +41,7 @@ from ai.backend.manager.services.audit_log.actions.scoped_search import (
     TriggeredByAuditLogScopeItem,
 )
 from ai.backend.manager.services.audit_log.actions.search import SearchAuditLogsAction
+from ai.backend.manager.services.audit_log.processors import AuditLogProcessors
 
 _AUDIT_LOG_PAGINATION_SPEC = PaginationSpec(
     forward_order=AuditLogOrders.created_at(ascending=False),
@@ -54,6 +55,11 @@ _AUDIT_LOG_PAGINATION_SPEC = PaginationSpec(
 class AuditLogAdapter(BaseAdapter):
     """Adapter for audit log domain operations."""
 
+    _audit_log: AuditLogProcessors
+
+    def __init__(self, audit_log: AuditLogProcessors) -> None:
+        self._audit_log = audit_log
+
     async def batch_load_by_ids(self, ids: Sequence[uuid.UUID]) -> list[AuditLogNode | None]:
         """Batch load audit logs by their IDs for DataLoader use.
 
@@ -65,7 +71,7 @@ class AuditLogAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[AuditLogConditions.by_ids(ids)],
         )
-        action_result = await self._processors.audit_log.global_search.run(
+        action_result = await self._audit_log.global_search.run(
             SearchAuditLogsAction(searcher=searcher)
         )
         audit_log_map = {item.id: self._data_to_node(item) for item in action_result.items}
@@ -87,7 +93,7 @@ class AuditLogAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.audit_log.global_search.run(
+        action_result = await self._audit_log.global_search.run(
             SearchAuditLogsAction(searcher=searcher)
         )
         return SearchAuditLogsPayload(
@@ -115,7 +121,7 @@ class AuditLogAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.audit_log.scoped_search.run(
+        action_result = await self._audit_log.scoped_search.run(
             ScopedSearchAuditLogsAction(items=self._scope_items(input), searcher=searcher)
         )
         return SearchAuditLogsPayload(

--- a/src/ai/backend/manager/api/adapters/base.py
+++ b/src/ai/backend/manager/api/adapters/base.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
         EntityLabelFilter,
         EntityLabelNestedFilter,
     )
-    from ai.backend.manager.services.processors import Processors
 
 
 class BaseAdapter(BaseFilterAdapter):
@@ -45,9 +44,6 @@ class BaseAdapter(BaseFilterAdapter):
     Adapters do NOT contain business logic — they translate between
     the DTO layer and the Processor/Action layer.
     """
-
-    def __init__(self, processors: Processors) -> None:
-        self._processors = processors
 
     def _convert_entity_label_filter(self, f: EntityLabelFilter) -> list[QueryCondition]:
         """Conditions matching a single label row.

--- a/src/ai/backend/manager/api/adapters/client_ip_masking/adapter.py
+++ b/src/ai/backend/manager/api/adapters/client_ip_masking/adapter.py
@@ -42,6 +42,7 @@ from ai.backend.manager.services.client_ip_masking.actions.search import (
 from ai.backend.manager.services.client_ip_masking.actions.upsert import (
     UpsertClientIPMaskingPolicyAction,
 )
+from ai.backend.manager.services.client_ip_masking.processors import ClientIPMaskingProcessors
 
 
 def _pagination_spec() -> PaginationSpec:
@@ -56,6 +57,11 @@ def _pagination_spec() -> PaginationSpec:
 
 class ClientIPMaskingAdapter(BaseAdapter):
     """Adapter for the client IP masking policies."""
+
+    _client_ip_masking: ClientIPMaskingProcessors
+
+    def __init__(self, client_ip_masking: ClientIPMaskingProcessors) -> None:
+        self._client_ip_masking = client_ip_masking
 
     async def admin_search(
         self, input: AdminSearchClientIPMaskingPoliciesInput
@@ -74,7 +80,7 @@ class ClientIPMaskingAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.client_ip_masking.global_search.run(
+        result = await self._client_ip_masking.global_search.run(
             SearchClientIPMaskingPoliciesAction(searcher=searcher)
         )
         return AdminSearchClientIPMaskingPoliciesPayload(
@@ -87,7 +93,7 @@ class ClientIPMaskingAdapter(BaseAdapter):
     async def admin_upsert(
         self, input: AdminUpsertClientIPMaskingPolicyInput
     ) -> ClientIPMaskingPolicyPayload:
-        result = await self._processors.client_ip_masking.global_upsert.run(
+        result = await self._client_ip_masking.global_upsert.run(
             UpsertClientIPMaskingPolicyAction(
                 target_type=ClientIPMaskingTarget(input.target_type.value),
                 mode=ClientIPMaskingMode(input.mode.value),
@@ -98,7 +104,7 @@ class ClientIPMaskingAdapter(BaseAdapter):
         return ClientIPMaskingPolicyPayload(policy=self._data_to_node(result.data))
 
     async def admin_purge(self, policy_id: ClientIPMaskingPolicyID) -> ClientIPMaskingPolicyPayload:
-        result = await self._processors.client_ip_masking.purge.run(
+        result = await self._client_ip_masking.purge.run(
             PurgeClientIPMaskingPolicyAction(id=policy_id)
         )
         return ClientIPMaskingPolicyPayload(policy=self._data_to_node(result.data))

--- a/src/ai/backend/manager/api/adapters/container_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/container_registry/adapter.py
@@ -59,9 +59,11 @@ from ai.backend.manager.services.container_registry.actions.search_container_reg
 from ai.backend.manager.services.container_registry.actions.update_container_registry import (
     UpdateContainerRegistryAction,
 )
+from ai.backend.manager.services.container_registry.processors import ContainerRegistryProcessors
 from ai.backend.manager.services.rbac.actions.relation.base import RelationPair
 from ai.backend.manager.services.rbac.actions.relation.create import CreateRelationAction
 from ai.backend.manager.services.rbac.actions.relation.purge import PurgeRelationAction
+from ai.backend.manager.services.rbac.processors import RbacProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -69,6 +71,17 @@ DEFAULT_PAGINATION_LIMIT = 10
 
 class ContainerRegistryAdapter(BaseAdapter):
     """Adapter for container registry domain operations."""
+
+    _container_registry: ContainerRegistryProcessors
+    _rbac: RbacProcessors
+
+    def __init__(
+        self,
+        container_registry: ContainerRegistryProcessors,
+        rbac: RbacProcessors,
+    ) -> None:
+        self._container_registry = container_registry
+        self._rbac = rbac
 
     async def admin_search(
         self,
@@ -84,7 +97,7 @@ class ContainerRegistryAdapter(BaseAdapter):
         """
         querier = self.build_querier(input)
 
-        action_result = await self._processors.container_registry.search_container_registries.run(
+        action_result = await self._container_registry.search_container_registries.run(
             SearchContainerRegistriesAction(querier=querier)
         )
 
@@ -111,7 +124,7 @@ class ContainerRegistryAdapter(BaseAdapter):
             ssl_verify=input.ssl_verify,
             extra=input.extra,
         )
-        result = await self._processors.container_registry.create_container_registry.run(
+        result = await self._container_registry.create_container_registry.run(
             CreateContainerRegistryAction(creator=creator)
         )
         if input.allowed_groups is not None:
@@ -167,7 +180,7 @@ class ContainerRegistryAdapter(BaseAdapter):
             ),
             extra=(TriState.update(input.extra) if input.extra is not None else TriState.nop()),
         )
-        result = await self._processors.container_registry.update_container_registry.run(
+        result = await self._container_registry.update_container_registry.run(
             UpdateContainerRegistryAction(updater=updater)
         )
         return UpdateContainerRegistryPayload(registry=self._data_to_dto(result.data))
@@ -186,7 +199,7 @@ class ContainerRegistryAdapter(BaseAdapter):
         repository wrote these rows beside the update.
         """
         if allowed_groups.add:
-            await self._processors.rbac.create_relation.run(
+            await self._rbac.create_relation.run(
                 CreateRelationAction(
                     pairs=[
                         RelationPair(scope=ProjectID(uuid.UUID(raw)), target=registry_id)
@@ -197,7 +210,7 @@ class ContainerRegistryAdapter(BaseAdapter):
             )
         if not allowed_groups.remove:
             return
-        result = await self._processors.rbac.purge_relation.run(
+        result = await self._rbac.purge_relation.run(
             PurgeRelationAction(
                 pairs=[
                     RelationPair(scope=ProjectID(uuid.UUID(raw)), target=registry_id)
@@ -218,7 +231,7 @@ class ContainerRegistryAdapter(BaseAdapter):
     ) -> DeleteContainerRegistryPayload:
         """Delete a container registry (superadmin only). This is a hard delete."""
         purger = ContainerRegistryPurger(registry_id=ContainerRegistryID(input.id))
-        await self._processors.container_registry.delete_container_registry.run(
+        await self._container_registry.delete_container_registry.run(
             DeleteContainerRegistryAction(purger=purger)
         )
         return DeleteContainerRegistryPayload(id=input.id)
@@ -306,7 +319,7 @@ class ContainerRegistryAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[ContainerRegistryConditions.by_ids(ids)],
         )
-        action_result = await self._processors.container_registry.search_container_registries.run(
+        action_result = await self._container_registry.search_container_registries.run(
             SearchContainerRegistriesAction(querier=querier)
         )
         registry_map = {item.id: self._data_to_dto(item) for item in action_result.data}

--- a/src/ai/backend/manager/api/adapters/deployment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment/adapter.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 if TYPE_CHECKING:
-    from ai.backend.manager.services.processors import Processors
     from ai.backend.manager.sokovan.deployment.coordinator import DeploymentCoordinator
 
 from ai.backend.common.api_handlers import Sentinel
@@ -357,6 +356,7 @@ from ai.backend.manager.services.deployment.actions.search_deployments import (
 from ai.backend.manager.services.deployment.actions.search_replicas import SearchReplicasAction
 from ai.backend.manager.services.deployment.actions.sync_replicas import SyncReplicaAction
 from ai.backend.manager.services.deployment.actions.update_deployment import UpdateDeploymentAction
+from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -585,12 +585,15 @@ def _statuses_to_lifecycles(
 class DeploymentAdapter(BaseAdapter):
     """Adapter for deployment domain operations."""
 
+    _deployment: DeploymentProcessors
+    _deployment_coordinator: DeploymentCoordinator
+
     def __init__(
         self,
-        processors: Processors,
+        deployment: DeploymentProcessors,
         deployment_coordinator: DeploymentCoordinator,
     ) -> None:
-        super().__init__(processors)
+        self._deployment = deployment
         # ``deployment_coordinator`` is the authoritative source for the
         # live set of registered handler names; we consult it when
         # validating ``DeploymentOptions.handler_options.by_handler`` keys so an
@@ -711,7 +714,7 @@ class DeploymentAdapter(BaseAdapter):
             model_revision=model_revision_creator,
             policy=policy,
         )
-        action_result = await self._processors.deployment.create_deployment.run(
+        action_result = await self._deployment.create_deployment.run(
             CreateDeploymentAction(
                 project_id=ProjectID(creator.metadata.project),
                 creator=creator,
@@ -728,7 +731,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> AdminSearchDeploymentsPayload:
         """Search deployments (admin, no scope)."""
         querier = self._build_deployment_querier(input)
-        action_result = await self._processors.deployment.global_search.run(
+        action_result = await self._deployment.global_search.run(
             GlobalSearchDeploymentsAction(querier=querier)
         )
         return AdminSearchDeploymentsPayload(
@@ -746,7 +749,7 @@ class DeploymentAdapter(BaseAdapter):
         user = current_user()
         if user is None:
             raise RuntimeError("No authenticated user in context")
-        action_result = await self._processors.deployment.scoped_search.run(
+        action_result = await self._deployment.scoped_search.run(
             ScopedSearchDeploymentsAction(
                 items=[UserDeploymentScopeItem(user_id=UserID(user.user_id))],
                 querier=self._build_deployment_querier(input),
@@ -765,7 +768,7 @@ class DeploymentAdapter(BaseAdapter):
         input: AdminSearchDeploymentsInput,
     ) -> AdminSearchDeploymentsPayload:
         """Search deployments within a specific project."""
-        action_result = await self._processors.deployment.scoped_search.run(
+        action_result = await self._deployment.scoped_search.run(
             ScopedSearchDeploymentsAction(
                 items=[ProjectDeploymentScopeItem(project_id=ProjectID(project_id))],
                 querier=self._build_deployment_querier(input),
@@ -780,7 +783,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def get(self, deployment_id: DeploymentID) -> DeploymentNode:
         """Retrieve a single deployment by ID."""
-        action_result = await self._processors.deployment.get_deployment_by_id.run(
+        action_result = await self._deployment.get_deployment_by_id.run(
             GetDeploymentByIdAction(deployment_id=deployment_id)
         )
         return self._deployment_data_to_dto(action_result.data)
@@ -824,7 +827,7 @@ class DeploymentAdapter(BaseAdapter):
                 else OptionalState[bool].nop()
             ),
         )
-        action_result = await self._processors.deployment.update_deployment.run(
+        action_result = await self._deployment.update_deployment.run(
             UpdateDeploymentAction(deployment_id=deployment_id, updater=updater)
         )
         return UpdateDeploymentPayload(deployment=self._deployment_data_to_dto(action_result.data))
@@ -850,7 +853,7 @@ class DeploymentAdapter(BaseAdapter):
                 h.name() for h in self._deployment_coordinator.registered_handlers()
             ),
         )
-        action_result = await self._processors.deployment.replace_deployment_options.run(
+        action_result = await self._deployment.replace_deployment_options.run(
             ReplaceDeploymentOptionsAction(
                 deployment_id=deployment_id,
                 options=options,
@@ -863,14 +866,14 @@ class DeploymentAdapter(BaseAdapter):
 
     async def sync_replicas(self, input: SyncReplicaInput) -> SyncReplicaPayload:
         """Force sync replica information for a deployment."""
-        await self._processors.deployment.sync_replicas.run(
+        await self._deployment.sync_replicas.run(
             SyncReplicaAction(deployment_id=DeploymentID(input.model_deployment_id))
         )
         return SyncReplicaPayload(success=True)
 
     async def activate_revision(self, input: ActivateRevisionInput) -> ActivateRevisionPayload:
         """Activate a specific revision as the current revision."""
-        action_result = await self._processors.deployment.activate_revision.run(
+        action_result = await self._deployment.activate_revision.run(
             ActivateRevisionAction(
                 deployment_id=DeploymentID(input.deployment_id),
                 revision_id=DeploymentRevisionID(input.revision_id),
@@ -887,7 +890,7 @@ class DeploymentAdapter(BaseAdapter):
         self,
     ) -> AdminRefreshDeploymentRevisionsPayload:
         """Create and activate a fresh revision for every active deployment."""
-        action_result = await self._processors.deployment.global_refresh_revisions.run(
+        action_result = await self._deployment.global_refresh_revisions.run(
             GlobalRefreshDeploymentRevisionsAction()
         )
         return AdminRefreshDeploymentRevisionsPayload(
@@ -904,7 +907,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def delete(self, input: DeleteDeploymentInput) -> DeleteDeploymentPayload:
         """Delete a deployment."""
-        await self._processors.deployment.destroy_deployment.run(
+        await self._deployment.destroy_deployment.run(
             DestroyDeploymentAction(deployment_id=DeploymentID(input.id))
         )
         return DeleteDeploymentPayload(id=input.id)
@@ -914,7 +917,7 @@ class DeploymentAdapter(BaseAdapter):
     # ------------------------------------------------------------------
 
     async def _auto_scaling_rule_deployment(self, rule_id: UUID) -> DeploymentID:
-        result = await self._processors.deployment.lookup_auto_scaling_rule_deployment.run(
+        result = await self._deployment.lookup_auto_scaling_rule_deployment.run(
             LookupAutoScalingRuleDeploymentAction(rule_id=rule_id)
         )
         return DeploymentID(result.entity_id())
@@ -928,7 +931,7 @@ class DeploymentAdapter(BaseAdapter):
             model_deployment_id=DeploymentID(input.model_deployment_id),
             expires_at=input.expires_at,
         )
-        action_result = await self._processors.deployment.create_access_token.run(
+        action_result = await self._deployment.create_access_token.run(
             CreateAccessTokenAction(
                 deployment_id=DeploymentID(input.model_deployment_id), creator=creator
             )
@@ -942,7 +945,7 @@ class DeploymentAdapter(BaseAdapter):
         token_id: UUID,
     ) -> GetAccessTokenPayload:
         """Get a single access token by ID."""
-        action_result = await self._processors.deployment.get_access_token.run(
+        action_result = await self._deployment.get_access_token.run(
             GetAccessTokenAction(access_token_id=DeploymentTokenID(token_id))
         )
         return GetAccessTokenPayload(
@@ -954,7 +957,7 @@ class DeploymentAdapter(BaseAdapter):
         input: DeleteAccessTokenInput,
     ) -> DeleteAccessTokenPayload:
         """Delete an access token."""
-        action_result = await self._processors.deployment.delete_access_token.run(
+        action_result = await self._deployment.delete_access_token.run(
             DeleteAccessTokenAction(access_token_id=DeploymentTokenID(input.id))
         )
         if not action_result.success:
@@ -966,7 +969,7 @@ class DeploymentAdapter(BaseAdapter):
         input: BulkDeleteAccessTokensInput,
     ) -> BulkDeleteAccessTokensPayload:
         """Bulk delete access tokens."""
-        action_result = await self._processors.deployment.bulk_delete_access_tokens.run(
+        action_result = await self._deployment.bulk_delete_access_tokens.run(
             BulkDeleteAccessTokensAction(access_token_ids=input.ids)
         )
         return BulkDeleteAccessTokensPayload(ids=action_result.deleted_ids)
@@ -978,7 +981,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchAccessTokensPayload:
         """Search access tokens scoped to a specific deployment."""
         searcher = self._build_access_token_searcher(input)
-        action_result = await self._processors.deployment.search_access_tokens.run(
+        action_result = await self._deployment.search_access_tokens.run(
             SearchAccessTokensAction(
                 deployment_id=DeploymentID(scope.deployment_id), searcher=searcher
             )
@@ -1011,7 +1014,7 @@ class DeploymentAdapter(BaseAdapter):
             max_replicas=input.max_replicas,
             prometheus_query_preset_id=input.prometheus_query_preset_id,
         )
-        action_result = await self._processors.deployment.create_auto_scaling_rule.run(
+        action_result = await self._deployment.create_auto_scaling_rule.run(
             CreateAutoScalingRuleAction(
                 deployment_id=DeploymentID(input.model_deployment_id), creator=creator
             )
@@ -1027,7 +1030,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchAutoScalingRulesPayload:
         """Search auto-scaling rules scoped to a specific deployment."""
         querier = self._build_auto_scaling_rule_querier(input, scope=scope)
-        action_result = await self._processors.deployment.search_auto_scaling_rules.run(
+        action_result = await self._deployment.search_auto_scaling_rules.run(
             SearchAutoScalingRulesAction(querier=querier)
         )
         return SearchAutoScalingRulesPayload(
@@ -1039,7 +1042,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def get_rule(self, rule_id: UUID) -> GetAutoScalingRulePayload:
         """Retrieve a single auto-scaling rule by ID."""
-        action_result = await self._processors.deployment.get_auto_scaling_rule.run(
+        action_result = await self._deployment.get_auto_scaling_rule.run(
             GetAutoScalingRuleAction(
                 deployment_id=await self._auto_scaling_rule_deployment(rule_id),
                 auto_scaling_rule_id=rule_id,
@@ -1081,7 +1084,7 @@ class DeploymentAdapter(BaseAdapter):
             max_replicas=_tristate_from_input(input.max_replicas),
             prometheus_query_preset_id=_tristate_from_input(input.prometheus_query_preset_id),
         )
-        action_result = await self._processors.deployment.update_auto_scaling_rule.run(
+        action_result = await self._deployment.update_auto_scaling_rule.run(
             UpdateAutoScalingRuleAction(
                 deployment_id=await self._auto_scaling_rule_deployment(input.id),
                 auto_scaling_rule_id=input.id,
@@ -1094,7 +1097,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def delete_rule(self, input: DeleteAutoScalingRuleInput) -> DeleteAutoScalingRulePayload:
         """Delete an auto-scaling rule."""
-        await self._processors.deployment.delete_auto_scaling_rule.run(
+        await self._deployment.delete_auto_scaling_rule.run(
             DeleteAutoScalingRuleAction(
                 deployment_id=await self._auto_scaling_rule_deployment(input.id),
                 auto_scaling_rule_id=input.id,
@@ -1106,7 +1109,7 @@ class DeploymentAdapter(BaseAdapter):
         self, input: BulkDeleteAutoScalingRulesInput
     ) -> BulkDeleteAutoScalingRulesPayload:
         """Bulk delete auto-scaling rules."""
-        action_result = await self._processors.deployment.bulk_delete_auto_scaling_rules.run(
+        action_result = await self._deployment.bulk_delete_auto_scaling_rules.run(
             BulkDeleteAutoScalingRulesAction(auto_scaling_rule_ids=input.ids)
         )
         return BulkDeleteAutoScalingRulesPayload(ids=action_result.deleted_ids)
@@ -1117,7 +1120,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def get_policy(self, deployment_id: DeploymentID) -> GetDeploymentPolicyPayload:
         """Retrieve a deployment policy by deployment ID."""
-        action_result = await self._processors.deployment.get_deployment_policy.run(
+        action_result = await self._deployment.get_deployment_policy.run(
             GetDeploymentPolicyAction(deployment_id=deployment_id)
         )
         return GetDeploymentPolicyPayload(policy=self._policy_data_to_dto(action_result.data))
@@ -1128,7 +1131,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchDeploymentPoliciesPayload:
         """Search deployment policies with filters and pagination."""
         querier = self._build_policy_querier(input)
-        action_result = await self._processors.deployment.search_deployment_policies.run(
+        action_result = await self._deployment.search_deployment_policies.run(
             SearchDeploymentPoliciesAction(querier=querier)
         )
         return SearchDeploymentPoliciesPayload(
@@ -1160,7 +1163,7 @@ class DeploymentAdapter(BaseAdapter):
                     auto_promote=bg.auto_promote if bg is not None else False,
                     promote_delay_seconds=bg.promote_delay_seconds if bg is not None else 0,
                 )
-        action_result = await self._processors.deployment.upsert_deployment_policy.run(
+        action_result = await self._deployment.upsert_deployment_policy.run(
             UpsertDeploymentPolicyAction(
                 deployment_id=DeploymentID(input.deployment_id),
                 upserter=DeploymentPolicyUpserter(
@@ -1264,7 +1267,7 @@ class DeploymentAdapter(BaseAdapter):
             revision_preset_id=input.revision_preset_id,
             runtime_variant_preset_values=runtime_variant_preset_values,
         )
-        action_result = await self._processors.deployment.add_model_revision.run(
+        action_result = await self._deployment.add_model_revision.run(
             AddModelRevisionAction(
                 deployment_id=DeploymentID(input.deployment_id),
                 adder=adder,
@@ -1275,7 +1278,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def get_revision(self, revision_id: DeploymentRevisionID) -> RevisionNode:
         """Retrieve a single revision by ID."""
-        action_result = await self._processors.deployment.get_revision_by_id.run(
+        action_result = await self._deployment.get_revision_by_id.run(
             GetRevisionByIdAction(revision_id=revision_id)
         )
         return self._revision_data_to_dto(action_result.data)
@@ -1287,7 +1290,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> AdminSearchRevisionsPayload:
         """Search model revisions scoped to a specific deployment."""
         searcher = self._build_revision_searcher(input)
-        action_result = await self._processors.deployment.search_revisions.run(
+        action_result = await self._deployment.search_revisions.run(
             SearchRevisionsAction(
                 deployment_id=DeploymentID(scope.deployment_id), searcher=searcher
             )
@@ -1305,7 +1308,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> AdminSearchRevisionsPayload:
         """Search model revisions without scope (admin, all deployments)."""
         searcher = self._build_revision_searcher(input)
-        action_result = await self._processors.deployment.global_search_revisions.run(
+        action_result = await self._deployment.global_search_revisions.run(
             GlobalSearchRevisionsAction(searcher=searcher)
         )
         return AdminSearchRevisionsPayload(
@@ -1326,7 +1329,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchAllocatedResourceSlotsPayload:
         """Search resource slots allocated to a deployment revision."""
         querier = self._build_revision_resource_slot_querier(input, revision_id=revision_id)
-        action_result = await self._processors.deployment.search_revision_resource_slots.run(
+        action_result = await self._deployment.search_revision_resource_slots.run(
             SearchRevisionResourceSlotsAction(
                 revision_id=revision_id,
                 querier=querier,
@@ -1353,7 +1356,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchRoutesPayload:
         """Search routes scoped to a specific deployment."""
         querier = self._build_route_querier(input, scope=scope)
-        action_result = await self._processors.deployment.search_routes.run(
+        action_result = await self._deployment.search_routes.run(
             SearchRoutesAction(querier=querier)
         )
         return SearchRoutesPayload(
@@ -1374,7 +1377,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchReplicasPayload:
         """Search replicas scoped to a specific deployment."""
         searcher = self._build_replica_searcher(input)
-        action_result = await self._processors.deployment.search_replicas.run(
+        action_result = await self._deployment.search_replicas.run(
             SearchReplicasAction(deployment_id=DeploymentID(scope.deployment_id), searcher=searcher)
         )
         return SearchReplicasPayload(
@@ -1390,7 +1393,7 @@ class DeploymentAdapter(BaseAdapter):
     ) -> SearchReplicasPayload:
         """Search replicas without scope (admin, all deployments)."""
         searcher = self._build_replica_searcher(input)
-        action_result = await self._processors.deployment.global_search_replicas.run(
+        action_result = await self._deployment.global_search_replicas.run(
             GlobalSearchReplicasAction(searcher=searcher)
         )
         return SearchReplicasPayload(
@@ -1402,7 +1405,7 @@ class DeploymentAdapter(BaseAdapter):
 
     async def get_replica(self, replica_id: UUID) -> ReplicaNode | None:
         """Retrieve a single replica by ID."""
-        action_result = await self._processors.deployment.get_replica_by_id.run(
+        action_result = await self._deployment.get_replica_by_id.run(
             GetReplicaByIdAction(replica_id=ReplicaID(replica_id))
         )
         return self._replica_data_to_dto(action_result.data)
@@ -1413,7 +1416,7 @@ class DeploymentAdapter(BaseAdapter):
         traffic_status: RouteTrafficStatus,
     ) -> RouteNode:
         """Update the traffic status of a route."""
-        action_result = await self._processors.deployment.update_route_traffic_status.run(
+        action_result = await self._deployment.update_route_traffic_status.run(
             UpdateRouteTrafficStatusAction(
                 route_id=ReplicaID(route_id),
                 traffic_status=ManagerRouteTrafficStatus(traffic_status.value),
@@ -1439,7 +1442,7 @@ class DeploymentAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(deployment_ids)),
             conditions=[DeploymentConditions.by_ids(deployment_ids)],
         )
-        action_result = await self._processors.deployment.global_search.run(
+        action_result = await self._deployment.global_search.run(
             GlobalSearchDeploymentsAction(querier=querier)
         )
         deployment_map = {
@@ -1456,7 +1459,7 @@ class DeploymentAdapter(BaseAdapter):
             return []
         ids = [DeploymentRevisionID(revision_id) for revision_id in revision_ids]
         return await self.batch_load_fields(
-            self._processors.deployment.bulk_get_revisions,
+            self._deployment.bulk_get_revisions,
             BulkGetRevisionsAction(ids=ids),
             ids,
             self._revision_data_to_dto,
@@ -1471,7 +1474,7 @@ class DeploymentAdapter(BaseAdapter):
             return []
         ids = [ReplicaID(replica_id) for replica_id in replica_ids]
         return await self.batch_load_fields(
-            self._processors.deployment.bulk_get_replicas,
+            self._deployment.bulk_get_replicas,
             BulkGetReplicasAction(ids=ids),
             ids,
             self._replica_data_to_dto,
@@ -1486,7 +1489,7 @@ class DeploymentAdapter(BaseAdapter):
             return []
         ids = [ReplicaID(route_id) for route_id in route_ids]
         return await self.batch_load_fields(
-            self._processors.deployment.bulk_get_routes,
+            self._deployment.bulk_get_routes,
             BulkGetRoutesAction(ids=ids),
             ids,
             self._route_info_to_dto,
@@ -1501,7 +1504,7 @@ class DeploymentAdapter(BaseAdapter):
             return []
         ids = [DeploymentTokenID(token_id) for token_id in token_ids]
         return await self.batch_load_fields(
-            self._processors.deployment.bulk_get_access_tokens,
+            self._deployment.bulk_get_access_tokens,
             BulkGetAccessTokensAction(ids=ids),
             ids,
             self._access_token_data_to_dto,
@@ -1521,7 +1524,7 @@ class DeploymentAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(rule_ids)),
             conditions=[AutoScalingRuleConditions.by_ids(rule_ids)],
         )
-        action_result = await self._processors.deployment.search_auto_scaling_rules.run(
+        action_result = await self._deployment.search_auto_scaling_rules.run(
             SearchAutoScalingRulesAction(querier=querier)
         )
         rule_map = {
@@ -1540,7 +1543,7 @@ class DeploymentAdapter(BaseAdapter):
         if not endpoint_ids:
             return []
         ids = [DeploymentID(endpoint_id) for endpoint_id in endpoint_ids]
-        result = await self._processors.deployment.bulk_get_deployment_policies.run(
+        result = await self._deployment.bulk_get_deployment_policies.run(
             BulkGetDeploymentPoliciesAction(deployment_ids=ids)
         )
         return [

--- a/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/deployment_revision_preset/adapter.py
@@ -110,6 +110,9 @@ from ai.backend.manager.services.deployment_revision_preset.actions.search_resou
 from ai.backend.manager.services.deployment_revision_preset.actions.update import (
     UpdateDeploymentPresetAction,
 )
+from ai.backend.manager.services.deployment_revision_preset.processors import (
+    DeploymentPresetProcessors,
+)
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -207,6 +210,11 @@ def _model_definition_to_dto(
 
 
 class DeploymentRevisionPresetAdapter(BaseAdapter):
+    _deployment_revision_preset: DeploymentPresetProcessors
+
+    def __init__(self, deployment_revision_preset: DeploymentPresetProcessors) -> None:
+        self._deployment_revision_preset = deployment_revision_preset
+
     async def search(
         self,
         input: SearchDeploymentRevisionPresetsInput,
@@ -225,7 +233,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.deployment_revision_preset.global_search.run(
+        result = await self._deployment_revision_preset.global_search.run(
             GlobalSearchDeploymentPresetsAction(searcher=searcher)
         )
         return SearchDeploymentRevisionPresetsPayload(
@@ -236,7 +244,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
         )
 
     async def get(self, preset_id: UUID) -> DeploymentRevisionPresetNode:
-        result = await self._processors.deployment_revision_preset.get.run(
+        result = await self._deployment_revision_preset.get.run(
             GetDeploymentPresetAction(preset_id=DeploymentPresetID(preset_id))
         )
         return self._data_to_node(result.data)
@@ -276,7 +284,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
             deployment_strategy=strategy,
             deployment_strategy_spec=strategy_spec,
         )
-        result = await self._processors.deployment_revision_preset.create.run(
+        result = await self._deployment_revision_preset.create.run(
             CreateDeploymentPresetAction(creator=creator, slot_creators=slot_creators)
         )
         return CreateDeploymentRevisionPresetPayload(preset=self._data_to_node(result.data))
@@ -374,13 +382,13 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
                 input.deployment_strategy
             ),
         )
-        result = await self._processors.deployment_revision_preset.update.run(
+        result = await self._deployment_revision_preset.update.run(
             UpdateDeploymentPresetAction(updater=updater, slot_creators=slot_creators)
         )
         return UpdateDeploymentRevisionPresetPayload(preset=self._data_to_node(result.data))
 
     async def delete(self, preset_id: UUID) -> DeleteDeploymentRevisionPresetPayload:
-        result = await self._processors.deployment_revision_preset.purge.run(
+        result = await self._deployment_revision_preset.purge.run(
             PurgeDeploymentPresetAction(preset_id=DeploymentPresetID(preset_id))
         )
         return DeleteDeploymentRevisionPresetPayload(id=result.data.id)
@@ -392,7 +400,7 @@ class DeploymentRevisionPresetAdapter(BaseAdapter):
     ) -> SearchAllocatedResourceSlotsPayload:
         """Search resource slots allocated to a deployment revision preset."""
         searcher = self._build_preset_resource_slot_searcher(input)
-        action_result = await self._processors.deployment_revision_preset.search_resource_slots.run(
+        action_result = await self._deployment_revision_preset.search_resource_slots.run(
             SearchPresetResourceSlotsAction(
                 preset_id=DeploymentPresetID(preset_id),
                 searcher=searcher,

--- a/src/ai/backend/manager/api/adapters/domain/adapter.py
+++ b/src/ai/backend/manager/api/adapters/domain/adapter.py
@@ -59,7 +59,9 @@ from ai.backend.manager.services.domain.actions.scoped_search import (
 )
 from ai.backend.manager.services.domain.actions.search_domains import GlobalSearchDomainsAction
 from ai.backend.manager.services.domain.actions.update_domain_node import UpdateDomainNodeAction
+from ai.backend.manager.services.domain.processors import DomainProcessors
 from ai.backend.manager.services.resource_group.actions.lookup import LookupResourceGroupAction
+from ai.backend.manager.services.resource_group.processors import ResourceGroupProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 _DOMAIN_PAGINATION_SPEC = PaginationSpec(
@@ -74,6 +76,13 @@ _DOMAIN_PAGINATION_SPEC = PaginationSpec(
 class DomainAdapter(BaseAdapter):
     """Adapter for domain operations."""
 
+    _domain: DomainProcessors
+    _resource_group: ResourceGroupProcessors
+
+    def __init__(self, domain: DomainProcessors, resource_group: ResourceGroupProcessors) -> None:
+        self._domain = domain
+        self._resource_group = resource_group
+
     async def batch_load_by_names(
         self, names: Sequence[str]
     ) -> list[DomainNode | Exception | None]:
@@ -85,9 +94,9 @@ class DomainAdapter(BaseAdapter):
         if not names:
             return []
         keys = [DomainName(name) for name in names]
-        lookup = await self._processors.domain.bulk_lookup.run(BulkLookupDomainsAction(names=keys))
+        lookup = await self._domain.bulk_lookup.run(BulkLookupDomainsAction(names=keys))
         ids = [lookup.resolved[key] for key in keys if key in lookup.resolved]
-        got = await self._processors.domain.bulk_get.run(BulkGetDomainsAction(ids=ids))
+        got = await self._domain.bulk_get.run(BulkGetDomainsAction(ids=ids))
         domains = got.values()
         errors = got.errors()
         nodes: list[DomainNode | Exception | None] = []
@@ -109,7 +118,7 @@ class DomainAdapter(BaseAdapter):
         """Batch load domains by UUID for DataLoader use."""
         if not ids:
             return []
-        result = await self._processors.domain.bulk_get.run(BulkGetDomainsAction(ids=list(ids)))
+        result = await self._domain.bulk_get.run(BulkGetDomainsAction(ids=list(ids)))
         return [
             self._domain_data_to_node(item.value)
             if item.value is not None
@@ -119,12 +128,8 @@ class DomainAdapter(BaseAdapter):
 
     async def get(self, domain_name: str) -> DomainNode:
         """Retrieve a single domain by name."""
-        resolved = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
-        result = await self._processors.domain.get.run(
-            GetDomainAction(domain_id=resolved.entity_id())
-        )
+        resolved = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
+        result = await self._domain.get.run(GetDomainAction(domain_id=resolved.entity_id()))
         return self._domain_data_to_node(result.data)
 
     async def admin_search(
@@ -147,9 +152,7 @@ class DomainAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.domain.global_search.run(
-            GlobalSearchDomainsAction(searcher=searcher)
-        )
+        result = await self._domain.global_search.run(GlobalSearchDomainsAction(searcher=searcher))
 
         return AdminSearchDomainsPayload(
             items=[self._domain_data_to_node(item) for item in result.items],
@@ -164,7 +167,7 @@ class DomainAdapter(BaseAdapter):
         input: AdminSearchDomainsInput,
     ) -> AdminSearchDomainsPayload:
         """Search the domains a resource group serves."""
-        resource_group = await self._processors.resource_group.lookup.run(
+        resource_group = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(resource_group_name))
         )
         conditions = self._convert_domain_filter(input.filter) if input.filter else []
@@ -182,7 +185,7 @@ class DomainAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.domain.scoped_search.run(
+        result = await self._domain.scoped_search.run(
             ScopedSearchDomainsAction(
                 items=[ResourceGroupDomainScopeItem(resource_group_id=resource_group.entity_id())],
                 searcher=searcher,
@@ -202,7 +205,7 @@ class DomainAdapter(BaseAdapter):
         user_info: UserInfo,
     ) -> DomainPayload:
         """Create a new domain (superadmin only)."""
-        result = await self._processors.domain.create_domain_node.run(
+        result = await self._domain.create_domain_node.run(
             CreateDomainNodeAction(
                 user_info=user_info,
                 creator=DomainCreator(
@@ -223,9 +226,7 @@ class DomainAdapter(BaseAdapter):
         user_info: UserInfo,
     ) -> DomainPayload:
         """Update an existing domain (superadmin only)."""
-        target = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
+        target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
         updater = DomainUpdater(
             domain_id=target.entity_id(),
             description=(
@@ -255,7 +256,7 @@ class DomainAdapter(BaseAdapter):
                 else TriState.update(input.integration_name)
             ),
         )
-        result = await self._processors.domain.update_domain_node.run(
+        result = await self._domain.update_domain_node.run(
             UpdateDomainNodeAction(
                 updater=updater,
                 user_info=user_info,
@@ -265,10 +266,8 @@ class DomainAdapter(BaseAdapter):
 
     async def admin_delete(self, input: DeleteDomainInput) -> DeleteDomainPayload:
         """Soft-delete a domain (superadmin only)."""
-        target = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(input.name))
-        )
-        await self._processors.domain.delete_domain.run(
+        target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(input.name)))
+        await self._domain.delete_domain.run(
             DeleteDomainAction(
                 updater=DomainSoftDeleteUpdater(domain_id=target.entity_id()),
             )
@@ -277,10 +276,8 @@ class DomainAdapter(BaseAdapter):
 
     async def admin_restore(self, input: RestoreDomainInput) -> RestoreDomainPayload:
         """Restore a soft-deleted domain (superadmin only)."""
-        target = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(input.name))
-        )
-        await self._processors.domain.restore_domain.run(
+        target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(input.name)))
+        await self._domain.restore_domain.run(
             RestoreDomainAction(
                 updater=DomainRestoreUpdater(domain_id=target.entity_id()),
             )
@@ -289,10 +286,8 @@ class DomainAdapter(BaseAdapter):
 
     async def admin_purge(self, input: PurgeDomainInput) -> PurgeDomainPayload:
         """Permanently purge a domain (superadmin only)."""
-        target = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(input.name))
-        )
-        await self._processors.domain.purge_domain.run(
+        target = await self._domain.lookup.run(LookupDomainAction(name=DomainName(input.name)))
+        await self._domain.purge_domain.run(
             PurgeDomainAction(domain_id=target.entity_id(), name=input.name)
         )
         return PurgeDomainPayload(purged=True)

--- a/src/ai/backend/manager/api/adapters/entity_label/adapter.py
+++ b/src/ai/backend/manager/api/adapters/entity_label/adapter.py
@@ -36,7 +36,7 @@ from ai.backend.manager.models.entity_label.upserters import EntityLabelUpserter
 from ai.backend.manager.services.entity_label.actions.purge import PurgeEntityLabelAction
 from ai.backend.manager.services.entity_label.actions.search import SearchEntityLabelsAction
 from ai.backend.manager.services.entity_label.actions.upsert import UpsertEntityLabelAction
-from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.entity_label.processors import EntityLabelProcessors
 
 _LABEL_PAGINATION_SPEC = PaginationSpec(
     forward_order=EntityLabelOrders.created_at(ascending=False),
@@ -50,15 +50,16 @@ _LABEL_PAGINATION_SPEC = PaginationSpec(
 class EntityLabelAdapter(BaseAdapter):
     """Adapter for label domain operations."""
 
+    _entity_label: EntityLabelProcessors
     _entity_types: WiredEntityTypes
 
-    def __init__(self, processors: Processors, entity_types: WiredEntityTypes) -> None:
-        super().__init__(processors)
+    def __init__(self, entity_label: EntityLabelProcessors, entity_types: WiredEntityTypes) -> None:
+        self._entity_label = entity_label
         self._entity_types = entity_types
 
     async def upsert(self, input: UpsertEntityLabelInput) -> UpsertEntityLabelPayload:
         """Set one key on the entity the request names, replacing the value it carries."""
-        action_result = await self._processors.entity_label.upsert.run(
+        action_result = await self._entity_label.upsert.run(
             UpsertEntityLabelAction(
                 owner=self._target(input.target),
                 upserter=EntityLabelUpserter(key=EntityLabelKey(input.key), value=input.value),
@@ -72,7 +73,7 @@ class EntityLabelAdapter(BaseAdapter):
         Which entity answers for it is read from the row before the delete runs, so a
         caller reaching for a label on an entity they cannot see is refused there.
         """
-        action_result = await self._processors.entity_label.purge.run(
+        action_result = await self._entity_label.purge.run(
             PurgeEntityLabelAction(label_id=label_id)
         )
         return PurgeEntityLabelPayload(label=self._data_to_node(action_result.data))
@@ -106,7 +107,7 @@ class EntityLabelAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.entity_label.search.run(
+        action_result = await self._entity_label.search.run(
             SearchEntityLabelsAction(owners=owners, searcher=searcher)
         )
         return SearchEntityLabelsPayload(

--- a/src/ai/backend/manager/api/adapters/entity_share/adapter.py
+++ b/src/ai/backend/manager/api/adapters/entity_share/adapter.py
@@ -60,6 +60,7 @@ from ai.backend.manager.services.entity_share.actions.search import (
     EntityShareTargetScopeItem,
     SearchEntitySharesAction,
 )
+from ai.backend.manager.services.entity_share.processors import EntityShareProcessors
 
 __all__ = ("EntityShareAdapter",)
 
@@ -81,6 +82,11 @@ class EntityShareAdapter(BaseAdapter):
     one is that offer's answer, not the run's.
     """
 
+    _entity_share: EntityShareProcessors
+
+    def __init__(self, entity_share: EntityShareProcessors) -> None:
+        self._entity_share = entity_share
+
     async def create(self, input: CreateEntityShareInput) -> EntitySharePayload:
         me = current_user()
         if me is None:
@@ -92,7 +98,7 @@ class EntityShareAdapter(BaseAdapter):
             recipient = ProjectID(named.project_id)
         elif named.user_id is not None:
             recipient = UserID(named.user_id)
-        result = await self._processors.entity_share.create.run(
+        result = await self._entity_share.create.run(
             CreateEntityShareAction(
                 creator=EntityShareCreator(
                     sharer_user_id=UserID(me.user_id),
@@ -106,16 +112,14 @@ class EntityShareAdapter(BaseAdapter):
         return EntitySharePayload(share=self._to_node(result.data))
 
     async def get(self, share_id: EntityShareID) -> EntitySharePayload:
-        result = await self._processors.entity_share.get.run(
-            GetEntityShareAction(share_id=share_id)
-        )
+        result = await self._entity_share.get.run(GetEntityShareAction(share_id=share_id))
         return EntitySharePayload(share=self._to_node(result.data))
 
     async def accept(self, share_id: EntityShareID) -> EntitySharePayload:
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        result = await self._processors.entity_share.accept.run(
+        result = await self._entity_share.accept.run(
             AcceptEntityShareAction(share_id=share_id, answering_scope=UserID(me.user_id))
         )
         return EntitySharePayload(share=self._to_node(result.data))
@@ -124,28 +128,24 @@ class EntityShareAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        result = await self._processors.entity_share.reject.run(
+        result = await self._entity_share.reject.run(
             RejectEntityShareAction(share_id=share_id, answering_scope=UserID(me.user_id))
         )
         return EntitySharePayload(share=self._to_node(result.data))
 
     async def cancel(self, share_id: EntityShareID) -> EntitySharePayload:
-        result = await self._processors.entity_share.cancel.run(
-            CancelEntityShareAction(share_id=share_id)
-        )
+        result = await self._entity_share.cancel.run(CancelEntityShareAction(share_id=share_id))
         return EntitySharePayload(share=self._to_node(result.data))
 
     async def revoke(self, share_id: EntityShareID) -> EntitySharePayload:
-        result = await self._processors.entity_share.revoke.run(
-            RevokeEntityShareAction(share_id=share_id)
-        )
+        result = await self._entity_share.revoke.run(RevokeEntityShareAction(share_id=share_id))
         return EntitySharePayload(share=self._to_node(result.data))
 
     async def leave(self, share_id: EntityShareID) -> EntitySharePayload:
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        result = await self._processors.entity_share.leave.run(
+        result = await self._entity_share.leave.run(
             LeaveEntityShareAction(share_id=share_id, answering_scope=UserID(me.user_id))
         )
         return EntitySharePayload(share=self._to_node(result.data))
@@ -223,7 +223,7 @@ class EntityShareAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        result = await self._processors.entity_share.search.run(
+        result = await self._entity_share.search.run(
             SearchEntitySharesAction(items=items, searcher=searcher)
         )
         return SearchEntitySharesPayload(

--- a/src/ai/backend/manager/api/adapters/fair_share/adapter.py
+++ b/src/ai/backend/manager/api/adapters/fair_share/adapter.py
@@ -112,7 +112,9 @@ from ai.backend.manager.services.fair_share.actions import (
     UpsertUserFairShareWeightAction,
     UserWeightInput,
 )
+from ai.backend.manager.services.fair_share.processors import FairShareProcessors
 from ai.backend.manager.services.resource_group.actions.lookup import LookupResourceGroupAction
+from ai.backend.manager.services.resource_group.processors import ResourceGroupProcessors
 
 
 def _domain_fair_share_pagination_spec() -> PaginationSpec:
@@ -148,14 +150,25 @@ def _user_fair_share_pagination_spec() -> PaginationSpec:
 class FairShareAdapter(BaseAdapter):
     """Adapter for fair share domain operations (domain / project / user)."""
 
+    _fair_share: FairShareProcessors
+    _resource_group: ResourceGroupProcessors
+
+    def __init__(
+        self,
+        fair_share: FairShareProcessors,
+        resource_group: ResourceGroupProcessors,
+    ) -> None:
+        self._fair_share = fair_share
+        self._resource_group = resource_group
+
     # ------------------------------------------------------------------ domain
 
     async def get_domain(self, input: GetDomainFairShareInput) -> GetDomainFairSharePayload:
         """Get a single domain fair share record."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group))
         )
-        result = await self._processors.fair_share.get_domain_fair_share.run(
+        result = await self._fair_share.get_domain_fair_share.run(
             GetDomainFairShareAction(
                 resource_group_id=resource_group_id_result.entity_id(),
                 domain_name=input.domain_name,
@@ -183,7 +196,7 @@ class FairShareAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.fair_share.search_domain_fair_shares.run(
+        result = await self._fair_share.search_domain_fair_shares.run(
             GlobalSearchDomainFairSharesAction(
                 pagination=querier.pagination,
                 conditions=querier.conditions,
@@ -201,7 +214,7 @@ class FairShareAdapter(BaseAdapter):
         resource_group: str,
     ) -> SearchDomainFairSharesPayload:
         """Search domain fair shares within a resource group (entity-based, cursor/offset)."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(resource_group))
         )
         conditions = self._convert_domain_filter_rg(input.filter) if input.filter else []
@@ -218,7 +231,7 @@ class FairShareAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.fair_share.search_rg_domain_fair_shares.run(
+        result = await self._fair_share.search_rg_domain_fair_shares.run(
             SearchRGDomainFairSharesAction(
                 resource_group_id=resource_group_id_result.entity_id(),
                 scope=DomainFairShareOperationScope(
@@ -237,10 +250,10 @@ class FairShareAdapter(BaseAdapter):
         input: UpsertDomainFairShareWeightInput,
     ) -> UpsertDomainFairShareWeightPayload:
         """Upsert domain fair share weight."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group_name))
         )
-        result = await self._processors.fair_share.upsert_domain_fair_share_weight.run(
+        result = await self._fair_share.upsert_domain_fair_share_weight.run(
             UpsertDomainFairShareWeightAction(
                 resource_group=input.resource_group_name,
                 resource_group_id=resource_group_id_result.entity_id(),
@@ -257,10 +270,10 @@ class FairShareAdapter(BaseAdapter):
         input: BulkUpsertDomainFairShareWeightInput,
     ) -> BulkUpsertDomainFairShareWeightPayload:
         """Bulk upsert domain fair share weights."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group_name))
         )
-        result = await self._processors.fair_share.bulk_upsert_domain_fair_share_weight.run(
+        result = await self._fair_share.bulk_upsert_domain_fair_share_weight.run(
             BulkUpsertDomainFairShareWeightAction(
                 resource_group=input.resource_group_name,
                 resource_group_id=resource_group_id_result.entity_id(),
@@ -276,10 +289,10 @@ class FairShareAdapter(BaseAdapter):
 
     async def get_project(self, input: GetProjectFairShareInput) -> GetProjectFairSharePayload:
         """Get a single project fair share record."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group))
         )
-        result = await self._processors.fair_share.get_project_fair_share.run(
+        result = await self._fair_share.get_project_fair_share.run(
             GetProjectFairShareAction(
                 resource_group_id=resource_group_id_result.entity_id(),
                 project_id=input.project_id,
@@ -305,7 +318,7 @@ class FairShareAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.fair_share.search_project_fair_shares.run(
+        result = await self._fair_share.search_project_fair_shares.run(
             GlobalSearchProjectFairSharesAction(
                 pagination=querier.pagination,
                 conditions=querier.conditions,
@@ -324,7 +337,7 @@ class FairShareAdapter(BaseAdapter):
         domain_name: str,
     ) -> SearchProjectFairSharesPayload:
         """Search project fair shares within a resource group scope (entity-based, cursor/offset)."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(resource_group))
         )
         conditions = self._convert_project_filter_rg(input.filter) if input.filter else []
@@ -341,7 +354,7 @@ class FairShareAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.fair_share.search_rg_project_fair_shares.run(
+        result = await self._fair_share.search_rg_project_fair_shares.run(
             SearchRGProjectFairSharesAction(
                 resource_group_id=resource_group_id_result.entity_id(),
                 scope=ProjectFairShareOperationScope(
@@ -361,10 +374,10 @@ class FairShareAdapter(BaseAdapter):
         input: UpsertProjectFairShareWeightInput,
     ) -> UpsertProjectFairShareWeightPayload:
         """Upsert project fair share weight."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group_name))
         )
-        result = await self._processors.fair_share.upsert_project_fair_share_weight.run(
+        result = await self._fair_share.upsert_project_fair_share_weight.run(
             UpsertProjectFairShareWeightAction(
                 resource_group=input.resource_group_name,
                 resource_group_id=resource_group_id_result.entity_id(),
@@ -382,10 +395,10 @@ class FairShareAdapter(BaseAdapter):
         input: BulkUpsertProjectFairShareWeightInput,
     ) -> BulkUpsertProjectFairShareWeightPayload:
         """Bulk upsert project fair share weights."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group_name))
         )
-        result = await self._processors.fair_share.bulk_upsert_project_fair_share_weight.run(
+        result = await self._fair_share.bulk_upsert_project_fair_share_weight.run(
             BulkUpsertProjectFairShareWeightAction(
                 resource_group=input.resource_group_name,
                 resource_group_id=resource_group_id_result.entity_id(),
@@ -405,10 +418,10 @@ class FairShareAdapter(BaseAdapter):
 
     async def get_user(self, input: GetUserFairShareInput) -> GetUserFairSharePayload:
         """Get a single user fair share record."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group))
         )
-        result = await self._processors.fair_share.get_user_fair_share.run(
+        result = await self._fair_share.get_user_fair_share.run(
             GetUserFairShareAction(
                 resource_group_id=resource_group_id_result.entity_id(),
                 project_id=input.project_id,
@@ -433,7 +446,7 @@ class FairShareAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.fair_share.search_user_fair_shares.run(
+        result = await self._fair_share.search_user_fair_shares.run(
             GlobalSearchUserFairSharesAction(
                 pagination=querier.pagination,
                 conditions=querier.conditions,
@@ -453,7 +466,7 @@ class FairShareAdapter(BaseAdapter):
         project_id: UUID,
     ) -> SearchUserFairSharesPayload:
         """Search user fair shares within a resource group scope (entity-based, cursor/offset)."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(resource_group))
         )
         conditions = self._convert_user_filter_rg(input.filter) if input.filter else []
@@ -470,7 +483,7 @@ class FairShareAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.fair_share.search_rg_user_fair_shares.run(
+        result = await self._fair_share.search_rg_user_fair_shares.run(
             SearchRGUserFairSharesAction(
                 resource_group_id=resource_group_id_result.entity_id(),
                 scope=UserFairShareOperationScope(
@@ -491,10 +504,10 @@ class FairShareAdapter(BaseAdapter):
         input: UpsertUserFairShareWeightInput,
     ) -> UpsertUserFairShareWeightPayload:
         """Upsert user fair share weight."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group_name))
         )
-        result = await self._processors.fair_share.upsert_user_fair_share_weight.run(
+        result = await self._fair_share.upsert_user_fair_share_weight.run(
             UpsertUserFairShareWeightAction(
                 resource_group=input.resource_group_name,
                 resource_group_id=resource_group_id_result.entity_id(),
@@ -511,10 +524,10 @@ class FairShareAdapter(BaseAdapter):
         input: BulkUpsertUserFairShareWeightInput,
     ) -> BulkUpsertUserFairShareWeightPayload:
         """Bulk upsert user fair share weights."""
-        resource_group_id_result = await self._processors.resource_group.lookup.run(
+        resource_group_id_result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(input.resource_group_name))
         )
-        result = await self._processors.fair_share.bulk_upsert_user_fair_share_weight.run(
+        result = await self._fair_share.bulk_upsert_user_fair_share_weight.run(
             BulkUpsertUserFairShareWeightAction(
                 resource_group=input.resource_group_name,
                 resource_group_id=resource_group_id_result.entity_id(),

--- a/src/ai/backend/manager/api/adapters/huggingface_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/huggingface_registry/adapter.py
@@ -48,6 +48,7 @@ from ai.backend.manager.services.artifact_registry.actions.huggingface.search im
 from ai.backend.manager.services.artifact_registry.actions.huggingface.update import (
     UpdateHuggingFaceRegistryAction,
 )
+from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
 from ai.backend.manager.types import OptionalState
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -56,11 +57,16 @@ DEFAULT_PAGINATION_LIMIT = 10
 class HuggingFaceRegistryAdapter(BaseAdapter):
     """Adapter for HuggingFace registry domain operations."""
 
+    _artifact_registry: ArtifactRegistryProcessors
+
+    def __init__(self, artifact_registry: ArtifactRegistryProcessors) -> None:
+        self._artifact_registry = artifact_registry
+
     async def create(
         self, input: CreateHuggingFaceRegistryInput
     ) -> CreateHuggingFaceRegistryPayload:
         """Create a new HuggingFace registry."""
-        action_result = await self._processors.artifact_registry.create_huggingface_registry.run(
+        action_result = await self._artifact_registry.create_huggingface_registry.run(
             CreateHuggingFaceRegistryAction(
                 creator=HuggingFaceRegistryCreator(url=input.url, token=input.token),
                 meta=ArtifactRegistryCreatorMeta(name=input.name),
@@ -79,7 +85,7 @@ class HuggingFaceRegistryAdapter(BaseAdapter):
             offset=input.offset if input.offset is not None else 0,
         )
         searcher = HuggingFaceRegistrySearcher(pagination=pagination, conditions=[], orders=[])
-        action_result = await self._processors.artifact_registry.search_huggingface_registries.run(
+        action_result = await self._artifact_registry.search_huggingface_registries.run(
             SearchHuggingFaceRegistriesAction(searcher=searcher)
         )
         return AdminSearchHuggingFaceRegistriesPayload(
@@ -93,7 +99,7 @@ class HuggingFaceRegistryAdapter(BaseAdapter):
 
     async def get(self, registry_id: UUID) -> HuggingFaceRegistryNode:
         """Retrieve a single HuggingFace registry by ID."""
-        action_result = await self._processors.artifact_registry.get_huggingface_registry.run(
+        action_result = await self._artifact_registry.get_huggingface_registry.run(
             GetHuggingFaceRegistryAction(registry_id=ArtifactRegistryID(registry_id))
         )
         return self._huggingface_registry_data_to_dto(action_result.result)
@@ -116,7 +122,7 @@ class HuggingFaceRegistryAdapter(BaseAdapter):
                 OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
             ),
         )
-        action_result = await self._processors.artifact_registry.update_huggingface_registry.run(
+        action_result = await self._artifact_registry.update_huggingface_registry.run(
             UpdateHuggingFaceRegistryAction(
                 registry_id=ArtifactRegistryID(input.id),
                 updater=updater,
@@ -129,7 +135,7 @@ class HuggingFaceRegistryAdapter(BaseAdapter):
 
     async def get_many(self, registry_ids: list[UUID]) -> list[HuggingFaceRegistryNode]:
         """Retrieve multiple HuggingFace registries by IDs."""
-        action_result = await self._processors.artifact_registry.get_huggingface_registries.run(
+        action_result = await self._artifact_registry.get_huggingface_registries.run(
             GetHuggingFaceRegistriesAction(registry_ids=registry_ids)
         )
         return [self._huggingface_registry_data_to_dto(item) for item in action_result.result]
@@ -145,7 +151,7 @@ class HuggingFaceRegistryAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[HuggingFaceRegistryConditions.by_ids(ids)],
         )
-        action_result = await self._processors.artifact_registry.search_huggingface_registries.run(
+        action_result = await self._artifact_registry.search_huggingface_registries.run(
             SearchHuggingFaceRegistriesAction(searcher=searcher)
         )
         registry_map = {
@@ -158,7 +164,7 @@ class HuggingFaceRegistryAdapter(BaseAdapter):
         self, input: DeleteHuggingFaceRegistryInput
     ) -> DeleteHuggingFaceRegistryPayload:
         """Delete a HuggingFace registry."""
-        action_result = await self._processors.artifact_registry.delete_huggingface_registry.run(
+        action_result = await self._artifact_registry.delete_huggingface_registry.run(
             DeleteHuggingFaceRegistryAction(registry_id=ArtifactRegistryID(input.id))
         )
         return DeleteHuggingFaceRegistryPayload(id=action_result.deleted_registry_id)

--- a/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker/adapter.py
@@ -62,6 +62,7 @@ from ai.backend.manager.services.idle_checker.actions.admin_search import (
 from ai.backend.manager.services.idle_checker.actions.create import CreateIdleCheckerAction
 from ai.backend.manager.services.idle_checker.actions.purge import BulkPurgeIdleCheckersAction
 from ai.backend.manager.services.idle_checker.actions.update import UpdateIdleCheckerAction
+from ai.backend.manager.services.idle_checker.processors import IdleCheckerProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -79,6 +80,11 @@ def _get_idle_checker_pagination_spec() -> PaginationSpec:
 class IdleCheckerAdapter(BaseAdapter):
     """Adapter for global idle checker operations (admin-only)."""
 
+    _idle_checker: IdleCheckerProcessors
+
+    def __init__(self, idle_checker: IdleCheckerProcessors) -> None:
+        self._idle_checker = idle_checker
+
     async def admin_create(
         self,
         input: CreateIdleCheckerInput,
@@ -90,7 +96,7 @@ class IdleCheckerAdapter(BaseAdapter):
             initial_grace_period_seconds=input.initial_grace_period_seconds,
             spec=self._build_spec(input.checker_spec),
         )
-        action_result = await self._processors.idle_checker.create.run(
+        action_result = await self._idle_checker.create.run(
             CreateIdleCheckerAction(creator=creator)
         )
         return CreateIdleCheckerPayload(
@@ -109,7 +115,7 @@ class IdleCheckerAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[IdleCheckerConditions.by_ids(ids)],
         )
-        action_result = await self._processors.idle_checker.admin_search.run(
+        action_result = await self._idle_checker.admin_search.run(
             AdminSearchIdleCheckersAction(searcher=searcher)
         )
         node_map = {node.id: node for node in map(self._data_to_node, action_result.items)}
@@ -130,7 +136,7 @@ class IdleCheckerAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.idle_checker.admin_search.run(
+        action_result = await self._idle_checker.admin_search.run(
             AdminSearchIdleCheckersAction(searcher=searcher)
         )
         return SearchIdleCheckerPayload(
@@ -160,7 +166,7 @@ class IdleCheckerAdapter(BaseAdapter):
             ),
             spec=self._build_spec_update(input.checker_spec),
         )
-        action_result = await self._processors.idle_checker.update.run(
+        action_result = await self._idle_checker.update.run(
             UpdateIdleCheckerAction(updater=updater)
         )
         return UpdateIdleCheckerPayload(
@@ -176,7 +182,7 @@ class IdleCheckerAdapter(BaseAdapter):
         The action answers per entity, so the single failure it can report is raised
         here: the API names one checker and either removes it or fails.
         """
-        action_result = await self._processors.idle_checker.bulk_purge.run(
+        action_result = await self._idle_checker.bulk_purge.run(
             BulkPurgeIdleCheckersAction(ids=[input.id])
         )
         error = action_result.errors().get(input.id)

--- a/src/ai/backend/manager/api/adapters/idle_checker_assignment/adapter.py
+++ b/src/ai/backend/manager/api/adapters/idle_checker_assignment/adapter.py
@@ -60,6 +60,9 @@ from ai.backend.manager.services.idle_checker_assignment.actions.lookup import (
 from ai.backend.manager.services.idle_checker_assignment.actions.scoped_search import (
     ScopedSearchIdleCheckerAssignmentsAction,
 )
+from ai.backend.manager.services.idle_checker_assignment.processors import (
+    IdleCheckerAssignmentProcessors,
+)
 from ai.backend.manager.services.rbac.actions.relation.base import RelationPair
 from ai.backend.manager.services.rbac.actions.relation.create import CreateRelationAction
 from ai.backend.manager.services.rbac.actions.relation.purge import PurgeRelationAction
@@ -67,6 +70,7 @@ from ai.backend.manager.services.rbac.actions.relation.switch import (
     DeleteRelationAction,
     RestoreRelationAction,
 )
+from ai.backend.manager.services.rbac.processors import RbacProcessors
 
 
 @lru_cache(maxsize=1)
@@ -83,11 +87,22 @@ def _get_idle_checker_assignment_pagination_spec() -> PaginationSpec:
 class IdleCheckerAssignmentAdapter(BaseAdapter):
     """Adapter for idle checker assignment domain operations."""
 
+    _idle_checker_assignment: IdleCheckerAssignmentProcessors
+    _rbac: RbacProcessors
+
+    def __init__(
+        self,
+        idle_checker_assignment: IdleCheckerAssignmentProcessors,
+        rbac: RbacProcessors,
+    ) -> None:
+        self._idle_checker_assignment = idle_checker_assignment
+        self._rbac = rbac
+
     async def admin_create(
         self, input: CreateIdleCheckerAssignmentInput
     ) -> CreateIdleCheckerAssignmentPayload:
         scope = self._scope_entity(input.scope.scope_type, input.scope.scope_id)
-        result = await self._processors.rbac.create_relation.run(
+        result = await self._rbac.create_relation.run(
             CreateRelationAction(
                 pairs=[RelationPair(scope=scope, target=input.idle_checker_id)],
                 creator=IdleCheckerAssignmentCreator(enabled=input.enabled),
@@ -110,11 +125,11 @@ class IdleCheckerAssignmentAdapter(BaseAdapter):
         current = await self._resolve(input.id)
         pairs = [RelationPair(scope=current.scope_entity(), target=current.idle_checker_id)]
         if input.enabled:
-            await self._processors.rbac.restore_relation.run(
+            await self._rbac.restore_relation.run(
                 RestoreRelationAction(pairs=pairs, updater=IdleCheckerAssignmentEnabler())
             )
         else:
-            await self._processors.rbac.delete_relation.run(
+            await self._rbac.delete_relation.run(
                 DeleteRelationAction(pairs=pairs, updater=IdleCheckerAssignmentDisabler())
             )
         return UpdateIdleCheckerAssignmentPayload(
@@ -127,7 +142,7 @@ class IdleCheckerAssignmentAdapter(BaseAdapter):
         self, input: PurgeIdleCheckerAssignmentInput
     ) -> PurgeIdleCheckerAssignmentPayload:
         current = await self._resolve(input.id)
-        result = await self._processors.rbac.purge_relation.run(
+        result = await self._rbac.purge_relation.run(
             PurgeRelationAction(
                 pairs=[RelationPair(scope=current.scope_entity(), target=current.idle_checker_id)],
                 purger=IdleCheckerAssignmentPurger(),
@@ -141,7 +156,7 @@ class IdleCheckerAssignmentAdapter(BaseAdapter):
         self, scope: EntityIdentifier, idle_checker_id: IdleCheckerID
     ) -> IdleCheckerAssignmentData:
         """Read the binding back: a relation write answers with the pair alone."""
-        result = await self._processors.idle_checker_assignment.lookup_by_pair.run(
+        result = await self._idle_checker_assignment.lookup_by_pair.run(
             LookupIdleCheckerAssignmentByPairAction(scope=scope, idle_checker_id=idle_checker_id)
         )
         return result.data
@@ -163,7 +178,7 @@ class IdleCheckerAssignmentAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.idle_checker_assignment.admin_search.run(
+        action_result = await self._idle_checker_assignment.admin_search.run(
             AdminSearchIdleCheckerAssignmentsAction(searcher=searcher)
         )
         return SearchIdleCheckerAssignmentPayload(
@@ -193,7 +208,7 @@ class IdleCheckerAssignmentAdapter(BaseAdapter):
             offset=input.offset,
         )
         scopes = [self._scope_entity(ref.scope_type, ref.scope_id) for ref in input.scope.items]
-        action_result = await self._processors.idle_checker_assignment.scoped_search.run(
+        action_result = await self._idle_checker_assignment.scoped_search.run(
             ScopedSearchIdleCheckerAssignmentsAction(scopes=scopes, searcher=searcher)
         )
         return SearchIdleCheckerAssignmentPayload(
@@ -286,7 +301,7 @@ class IdleCheckerAssignmentAdapter(BaseAdapter):
 
     async def _resolve(self, assignment_id: IdleCheckerAssignmentID) -> IdleCheckerAssignmentData:
         """The pair the id names. Costs READ on the binding's scope."""
-        result = await self._processors.idle_checker_assignment.lookup.run(
+        result = await self._idle_checker_assignment.lookup.run(
             LookupIdleCheckerAssignmentAction(assignment_id=assignment_id)
         )
         return result.data

--- a/src/ai/backend/manager/api/adapters/image/adapter.py
+++ b/src/ai/backend/manager/api/adapters/image/adapter.py
@@ -70,6 +70,7 @@ from ai.backend.manager.services.image.actions.restore_image import RestoreImage
 from ai.backend.manager.services.image.actions.search_aliases import SearchAliasesAction
 from ai.backend.manager.services.image.actions.search_images import SearchImagesAction
 from ai.backend.manager.services.image.actions.update_image_by_id import UpdateImageByIdAction
+from ai.backend.manager.services.image.processors import ImageProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 DEFAULT_PAGINATION_LIMIT = 50
@@ -102,6 +103,11 @@ def _get_alias_pagination_spec() -> PaginationSpec:
 class ImageAdapter(BaseAdapter):
     """Adapter for image domain operations."""
 
+    _image: ImageProcessors
+
+    def __init__(self, image: ImageProcessors) -> None:
+        self._image = image
+
     # ------------------------------------------------------------------ batch load (DataLoader)
 
     async def batch_load_by_ids(self, image_ids: Sequence[ImageID]) -> list[ImageNode | None]:
@@ -115,9 +121,7 @@ class ImageAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[ImageConditions.by_ids(image_ids)],
         )
-        action_result = await self._processors.image.search_images.run(
-            SearchImagesAction(querier=querier)
-        )
+        action_result = await self._image.search_images.run(SearchImagesAction(querier=querier))
         image_map: dict[ImageID, ImageNode] = {
             ImageID(item.id): self._data_to_dto(item) for item in action_result.data
         }
@@ -136,9 +140,7 @@ class ImageAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[ImageAliasConditions.by_ids(alias_ids)],
         )
-        action_result = await self._processors.image.search_aliases.run(
-            SearchAliasesAction(querier=querier)
-        )
+        action_result = await self._image.search_aliases.run(SearchAliasesAction(querier=querier))
         alias_map: dict[uuid.UUID, ImageAliasNode] = {
             item.id: self._alias_data_to_dto(item) for item in action_result.data
         }
@@ -150,9 +152,7 @@ class ImageAdapter(BaseAdapter):
         """Search images with admin scope using offset pagination."""
         querier = self._build_offset_querier(input)
 
-        action_result = await self._processors.image.search_images.run(
-            SearchImagesAction(querier=querier)
-        )
+        action_result = await self._image.search_images.run(SearchImagesAction(querier=querier))
 
         return AdminSearchImagesPayload(
             items=[self._data_to_dto(item) for item in action_result.data],
@@ -182,9 +182,7 @@ class ImageAdapter(BaseAdapter):
             base_conditions=list(base_conditions) if base_conditions else None,
         )
 
-        action_result = await self._processors.image.search_images.run(
-            SearchImagesAction(querier=querier)
-        )
+        action_result = await self._image.search_images.run(SearchImagesAction(querier=querier))
 
         return AdminSearchImagesPayload(
             items=[self._data_to_dto(item) for item in action_result.data],
@@ -214,9 +212,7 @@ class ImageAdapter(BaseAdapter):
             base_conditions=list(base_conditions) if base_conditions else None,
         )
 
-        action_result = await self._processors.image.search_aliases.run(
-            SearchAliasesAction(querier=querier)
-        )
+        action_result = await self._image.search_aliases.run(SearchAliasesAction(querier=querier))
 
         return AdminSearchImageAliasesPayload(
             items=[self._alias_data_to_dto(item) for item in action_result.data],
@@ -229,28 +225,28 @@ class ImageAdapter(BaseAdapter):
 
     async def admin_forget(self, input: ForgetImageInput) -> ForgetImagePayload:
         """Forget (soft-delete) an image by ID."""
-        result = await self._processors.image.forget_image_by_id.run(
+        result = await self._image.forget_image_by_id.run(
             ForgetImageByIdAction(image_id=ImageID(input.image_id))
         )
         return ForgetImagePayload(item=self._data_to_dto(result.image))
 
     async def admin_restore(self, input: RestoreImageInput) -> RestoreImagePayload:
         """Restore a forgotten (soft-deleted) image by ID."""
-        result = await self._processors.image.restore_image_by_id.run(
+        result = await self._image.restore_image_by_id.run(
             RestoreImageByIdAction(image_id=ImageID(input.image_id))
         )
         return RestoreImagePayload(item=self._data_to_dto(result.image))
 
     async def admin_purge(self, input: PurgeImageInput) -> PurgeImagePayload:
         """Purge (hard-delete) an image by ID."""
-        result = await self._processors.image.purge_image_by_id.run(
+        result = await self._image.purge_image_by_id.run(
             PurgeImageByIdAction(image_id=ImageID(input.image_id))
         )
         return PurgeImagePayload(item=self._data_to_dto(result.image))
 
     async def admin_alias(self, input: AliasImageInput) -> AliasImagePayload:
         """Create an alias for an image."""
-        result = await self._processors.image.alias_image_by_id.run(
+        result = await self._image.alias_image_by_id.run(
             AliasImageByIdAction(image_id=ImageID(input.image_id), alias=input.alias)
         )
         return AliasImagePayload(
@@ -261,9 +257,7 @@ class ImageAdapter(BaseAdapter):
 
     async def admin_dealias(self, input: DealiasImageInput) -> AliasImagePayload:
         """Remove an image alias."""
-        result = await self._processors.image.dealias_image.run(
-            DealiasImageAction(alias=input.alias)
-        )
+        result = await self._image.dealias_image.run(DealiasImageAction(alias=input.alias))
         return AliasImagePayload(
             alias_id=result.image_alias.id,
             alias=result.image_alias.alias,
@@ -330,7 +324,7 @@ class ImageAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.image.update_image_by_id.run(
+        result = await self._image.update_image_by_id.run(
             UpdateImageByIdAction(image_id=ImageID(input.image_id), update=update)
         )
         return UpdateImagePayload(item=self._data_to_dto(result.image))

--- a/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_client_type/adapter.py
@@ -49,6 +49,7 @@ from ai.backend.manager.services.login_client_type.actions.search import (
 from ai.backend.manager.services.login_client_type.actions.update import (
     UpdateLoginClientTypeAction,
 )
+from ai.backend.manager.services.login_client_type.processors import LoginClientTypeProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 DEFAULT_PAGINATION_LIMIT = 50
@@ -56,6 +57,11 @@ DEFAULT_PAGINATION_LIMIT = 50
 
 class LoginClientTypeAdapter(BaseAdapter):
     """Adapter for login client type domain operations."""
+
+    _login_client_type: LoginClientTypeProcessors
+
+    def __init__(self, login_client_type: LoginClientTypeProcessors) -> None:
+        self._login_client_type = login_client_type
 
     # --- Static helpers (grouped at top) ---
 
@@ -86,7 +92,7 @@ class LoginClientTypeAdapter(BaseAdapter):
     # --- Non-admin methods ---
 
     async def get(self, type_id: UUID) -> LoginClientTypeNode:
-        action_result = await self._processors.login_client_type.public_get.run(
+        action_result = await self._login_client_type.public_get.run(
             GetLoginClientTypeAction(id=LoginClientTypeID(type_id))
         )
         return self._data_to_node(action_result.data)
@@ -95,7 +101,7 @@ class LoginClientTypeAdapter(BaseAdapter):
         """Search login client types with filter/order/pagination."""
         searcher = self._build_search_searcher(input)
 
-        action_result = await self._processors.login_client_type.public_search.run(
+        action_result = await self._login_client_type.public_search.run(
             SearchLoginClientTypesAction(searcher=searcher)
         )
 
@@ -113,7 +119,7 @@ class LoginClientTypeAdapter(BaseAdapter):
             name=input.name,
             description=input.description,
         )
-        action_result = await self._processors.login_client_type.global_create.run(
+        action_result = await self._login_client_type.global_create.run(
             CreateLoginClientTypeAction(creator=creator)
         )
         return CreateLoginClientTypePayload(
@@ -136,7 +142,7 @@ class LoginClientTypeAdapter(BaseAdapter):
                 else TriState.update(input.description)
             ),
         )
-        action_result = await self._processors.login_client_type.update.run(
+        action_result = await self._login_client_type.update.run(
             UpdateLoginClientTypeAction(updater=updater)
         )
         return UpdateLoginClientTypePayload(
@@ -144,7 +150,7 @@ class LoginClientTypeAdapter(BaseAdapter):
         )
 
     async def admin_delete(self, type_id: UUID) -> DeleteLoginClientTypePayload:
-        action_result = await self._processors.login_client_type.purge.run(
+        action_result = await self._login_client_type.purge.run(
             PurgeLoginClientTypeAction(id=type_id)
         )
         return DeleteLoginClientTypePayload(id=action_result.data.id)

--- a/src/ai/backend/manager/api/adapters/login_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_history/adapter.py
@@ -34,6 +34,7 @@ from ai.backend.manager.services.auth.actions.search_login_history import (
     GlobalSearchLoginHistoryAction,
     SearchLoginHistoryAction,
 )
+from ai.backend.manager.services.auth.processors import AuthProcessors
 
 _LOGIN_HISTORY_PAGINATION_SPEC = PaginationSpec(
     forward_order=LoginHistoryOrders.created_at(ascending=False),
@@ -46,6 +47,11 @@ _LOGIN_HISTORY_PAGINATION_SPEC = PaginationSpec(
 
 class LoginHistoryAdapter(BaseAdapter):
     """Adapter for login history domain operations."""
+
+    _auth: AuthProcessors
+
+    def __init__(self, auth: AuthProcessors) -> None:
+        self._auth = auth
 
     async def admin_search(
         self, input: AdminSearchLoginHistoryInput
@@ -65,7 +71,7 @@ class LoginHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.global_search_login_history.run(
+        action_result = await self._auth.global_search_login_history.run(
             GlobalSearchLoginHistoryAction(searcher=searcher)
         )
         return AdminSearchLoginHistoryPayload(
@@ -97,7 +103,7 @@ class LoginHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.search_login_history.run(
+        action_result = await self._auth.search_login_history.run(
             SearchLoginHistoryAction(user_id=UserID(me.user_id), searcher=searcher)
         )
         return MySearchLoginHistoryPayload(

--- a/src/ai/backend/manager/api/adapters/login_session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/login_session/adapter.py
@@ -45,6 +45,7 @@ from ai.backend.manager.services.auth.actions.search_login_sessions import (
     SearchLoginSessionsAction,
 )
 from ai.backend.manager.services.auth.actions.unblock_user import GlobalUnblockUserAction
+from ai.backend.manager.services.auth.processors import AuthProcessors
 
 _LOGIN_SESSION_PAGINATION_SPEC = PaginationSpec(
     forward_order=LoginSessionOrders.created_at(ascending=False),
@@ -57,6 +58,11 @@ _LOGIN_SESSION_PAGINATION_SPEC = PaginationSpec(
 
 class LoginSessionAdapter(BaseAdapter):
     """Adapter for login session domain operations."""
+
+    _auth: AuthProcessors
+
+    def __init__(self, auth: AuthProcessors) -> None:
+        self._auth = auth
 
     async def admin_search(
         self, input: AdminSearchLoginSessionsInput
@@ -76,7 +82,7 @@ class LoginSessionAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.global_search_login_sessions.run(
+        action_result = await self._auth.global_search_login_sessions.run(
             GlobalSearchLoginSessionsAction(searcher=searcher)
         )
         return AdminSearchLoginSessionsPayload(
@@ -108,7 +114,7 @@ class LoginSessionAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.auth.search_login_sessions.run(
+        action_result = await self._auth.search_login_sessions.run(
             SearchLoginSessionsAction(user_id=UserID(me.user_id), searcher=searcher)
         )
         return MySearchLoginSessionsPayload(
@@ -120,14 +126,14 @@ class LoginSessionAdapter(BaseAdapter):
 
     async def my_revoke(self, input: MyRevokeLoginSessionInput) -> RevokeLoginSessionPayload:
         """Revoke a login session owned by the current user."""
-        action_result = await self._processors.auth.revoke_login_session.run(
+        action_result = await self._auth.revoke_login_session.run(
             RevokeLoginSessionAction(session_id=LoginSessionID(input.session_id))
         )
         return RevokeLoginSessionPayload(success=action_result.success)
 
     async def admin_revoke(self, input: AdminRevokeLoginSessionInput) -> RevokeLoginSessionPayload:
         """Revoke any login session (admin, no ownership check)."""
-        action_result = await self._processors.auth.global_revoke_login_session.run(
+        action_result = await self._auth.global_revoke_login_session.run(
             GlobalRevokeLoginSessionAction(
                 session_id=input.session_id,
             )
@@ -136,7 +142,7 @@ class LoginSessionAdapter(BaseAdapter):
 
     async def admin_unblock_user(self, input: AdminUnblockUserInput) -> UnblockUserPayload:
         """Clear the failed-login rate limit block for a user (admin only)."""
-        action_result = await self._processors.auth.global_unblock_user.run(
+        action_result = await self._auth.global_unblock_user.run(
             GlobalUnblockUserAction(username=input.username)
         )
         return UnblockUserPayload(success=action_result.success)

--- a/src/ai/backend/manager/api/adapters/model_card/adapter.py
+++ b/src/ai/backend/manager/api/adapters/model_card/adapter.py
@@ -84,6 +84,7 @@ from ai.backend.manager.models.model_card.searchers import (
 from ai.backend.manager.models.model_card.updaters import ModelCardUpdater
 from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.services.deployment.actions.create_deployment import CreateDeploymentAction
+from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.model_card.actions.available_presets import (
     AvailablePresetsAction,
 )
@@ -102,6 +103,7 @@ from ai.backend.manager.services.model_card.actions.search_in_project import (
     SearchModelCardsInProjectAction,
 )
 from ai.backend.manager.services.model_card.actions.update import UpdateModelCardAction
+from ai.backend.manager.services.model_card.processors import ModelCardProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -167,6 +169,13 @@ def _requirements_to_entries(
 
 
 class ModelCardAdapter(BaseAdapter):
+    _model_card: ModelCardProcessors
+    _deployment: DeploymentProcessors
+
+    def __init__(self, model_card: ModelCardProcessors, deployment: DeploymentProcessors) -> None:
+        self._model_card = model_card
+        self._deployment = deployment
+
     async def admin_search(
         self,
         input: SearchModelCardsInput,
@@ -185,7 +194,7 @@ class ModelCardAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.model_card.global_search.run(
+        result = await self._model_card.global_search.run(
             GlobalSearchModelCardsAction(searcher=searcher)
         )
         return SearchModelCardsPayload(
@@ -214,7 +223,7 @@ class ModelCardAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.model_card.search_in_project.run(
+        result = await self._model_card.search_in_project.run(
             SearchModelCardsInProjectAction(project_id=ProjectID(project_id), searcher=searcher)
         )
         return SearchModelCardsPayload(
@@ -251,7 +260,7 @@ class ModelCardAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.model_card.global_search.run(
+        result = await self._model_card.global_search.run(
             GlobalSearchModelCardsAction(searcher=searcher)
         )
         return SearchModelCardsPayload(
@@ -262,7 +271,7 @@ class ModelCardAdapter(BaseAdapter):
         )
 
     async def get(self, card_id: UUID) -> ModelCardNode:
-        result = await self._processors.model_card.get.run(
+        result = await self._model_card.get.run(
             GetModelCardAction(model_card_id=ModelCardID(card_id))
         )
         return (await self._nodes_with_min_resources([result.data]))[0]
@@ -294,7 +303,7 @@ class ModelCardAdapter(BaseAdapter):
             readme=input.readme,
             access_level=input.access_level.value,
         )
-        result = await self._processors.model_card.create.run(
+        result = await self._model_card.create.run(
             CreateModelCardAction(creator=creator, min_resource=min_resource)
         )
         return CreateModelCardPayload(
@@ -399,7 +408,7 @@ class ModelCardAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.model_card.update.run(
+        result = await self._model_card.update.run(
             UpdateModelCardAction(model_card_id=ModelCardID(input.id), updater=updater)
         )
         return UpdateModelCardPayload(
@@ -411,7 +420,7 @@ class ModelCardAdapter(BaseAdapter):
         card_id: UUID,
         options: DeleteModelCardOptions,
     ) -> DeleteModelCardPayload:
-        result = await self._processors.model_card.delete.run(
+        result = await self._model_card.delete.run(
             DeleteModelCardAction(
                 model_card_id=ModelCardID(card_id),
                 purger=ModelCardPurger(card_id=ModelCardID(card_id)),
@@ -426,7 +435,7 @@ class ModelCardAdapter(BaseAdapter):
         options: DeleteModelCardOptions,
     ) -> BulkDeleteModelCardsPayload:
         """Bulk-delete model cards and surface per-card success/failure breakdown."""
-        result = await self._processors.model_card.bulk_delete.run(
+        result = await self._model_card.bulk_delete.run(
             BulkDeleteModelCardAction(
                 ids=[ModelCardID(card_id) for card_id in input.ids],
                 options=options,
@@ -444,7 +453,7 @@ class ModelCardAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        result = await self._processors.model_card.scan.run(
+        result = await self._model_card.scan.run(
             ScanProjectModelCardsAction(
                 project_id=project_id,
                 requester_id=me.user_id,
@@ -527,7 +536,7 @@ class ModelCardAdapter(BaseAdapter):
             policy=policy,
         )
 
-        result = await self._processors.deployment.create_deployment.run(
+        result = await self._deployment.create_deployment.run(
             CreateDeploymentAction(
                 project_id=ProjectID(creator.metadata.project),
                 creator=creator,
@@ -544,7 +553,7 @@ class ModelCardAdapter(BaseAdapter):
         model_card_id: UUID,
         input: SearchDeploymentRevisionPresetsInput,
     ) -> SearchDeploymentRevisionPresetsPayload:
-        action_result = await self._processors.model_card.available_presets.run(
+        action_result = await self._model_card.available_presets.run(
             AvailablePresetsAction(
                 model_card_id=ModelCardID(model_card_id),
                 search_input=input,
@@ -560,7 +569,7 @@ class ModelCardAdapter(BaseAdapter):
 
     async def _get_model_card_data(self, card_id: UUID) -> ModelCardData:
         """Fetch a single model card by ID."""
-        result = await self._processors.model_card.get.run(
+        result = await self._model_card.get.run(
             GetModelCardAction(model_card_id=ModelCardID(card_id))
         )
         return result.data
@@ -653,7 +662,7 @@ class ModelCardAdapter(BaseAdapter):
         """
         if not card_ids:
             return {}
-        result = await self._processors.model_card.scoped_search_requirements.run(
+        result = await self._model_card.scoped_search_requirements.run(
             ScopedSearchModelCardResourceRequirementsAction(
                 card_ids=[ModelCardID(card_id) for card_id in card_ids],
                 searcher=ModelCardResourceRequirementSearcher(pagination=NoPagination()),

--- a/src/ai/backend/manager/api/adapters/notification/adapter.py
+++ b/src/ai/backend/manager/api/adapters/notification/adapter.py
@@ -111,6 +111,7 @@ from ai.backend.manager.services.notification.actions.bulk_get_channels import (
     BulkGetChannelsAction,
 )
 from ai.backend.manager.services.notification.actions.bulk_get_rules import BulkGetRulesAction
+from ai.backend.manager.services.notification.processors import NotificationProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -164,13 +165,18 @@ def _rule_pagination_spec() -> PaginationSpec:
 class NotificationAdapter(BaseAdapter):
     """Adapter for notification domain operations (channel + rule)."""
 
+    _notification: NotificationProcessors
+
+    def __init__(self, notification: NotificationProcessors) -> None:
+        self._notification = notification
+
     async def batch_load_channels_by_ids(
         self, ids: Sequence[UUID]
     ) -> list[NotificationChannelNode | Exception | None]:
         """Batch load notification channels by ID for DataLoader use, checked per channel."""
         if not ids:
             return []
-        result = await self._processors.notification.bulk_get_channels.run(
+        result = await self._notification.bulk_get_channels.run(
             BulkGetChannelsAction(ids=[NotificationChannelID(channel_id) for channel_id in ids])
         )
         return [
@@ -186,7 +192,7 @@ class NotificationAdapter(BaseAdapter):
         """Batch load notification rules by ID for DataLoader use, checked per rule."""
         if not ids:
             return []
-        result = await self._processors.notification.bulk_get_rules.run(
+        result = await self._notification.bulk_get_rules.run(
             BulkGetRulesAction(ids=[NotificationRuleID(rule_id) for rule_id in ids])
         )
         return [
@@ -213,7 +219,7 @@ class NotificationAdapter(BaseAdapter):
             created_by=created_by,
         )
 
-        action_result = await self._processors.notification.create_channel.run(
+        action_result = await self._notification.create_channel.run(
             CreateChannelAction(creator=creator)
         )
 
@@ -223,7 +229,7 @@ class NotificationAdapter(BaseAdapter):
 
     async def get_channel(self, channel_id: UUID) -> GetNotificationChannelPayload:
         """Get a notification channel by ID."""
-        action_result = await self._processors.notification.get_channel.run(
+        action_result = await self._notification.get_channel.run(
             GetChannelAction(channel_id=NotificationChannelID(channel_id))
         )
 
@@ -237,7 +243,7 @@ class NotificationAdapter(BaseAdapter):
         """Update an existing notification channel."""
         updater = self._build_channel_updater(NotificationChannelID(channel_id), input)
 
-        action_result = await self._processors.notification.update_channel.run(
+        action_result = await self._notification.update_channel.run(
             UpdateChannelAction(updater=updater)
         )
 
@@ -249,7 +255,7 @@ class NotificationAdapter(BaseAdapter):
         self, input: DeleteNotificationChannelInput
     ) -> DeleteNotificationChannelPayload:
         """Delete a notification channel."""
-        await self._processors.notification.purge_channel.run(
+        await self._notification.purge_channel.run(
             PurgeChannelAction(channel_id=NotificationChannelID(input.id))
         )
 
@@ -273,15 +279,13 @@ class NotificationAdapter(BaseAdapter):
             created_by=created_by,
         )
 
-        action_result = await self._processors.notification.create_rule.run(
-            CreateRuleAction(creator=creator)
-        )
+        action_result = await self._notification.create_rule.run(CreateRuleAction(creator=creator))
 
         return CreateNotificationRulePayload(rule=self._rule_data_to_dto(action_result.data))
 
     async def get_rule(self, rule_id: UUID) -> GetNotificationRulePayload:
         """Get a notification rule by ID."""
-        action_result = await self._processors.notification.get_rule.run(
+        action_result = await self._notification.get_rule.run(
             GetRuleAction(rule_id=NotificationRuleID(rule_id))
         )
 
@@ -295,9 +299,7 @@ class NotificationAdapter(BaseAdapter):
         """Update an existing notification rule."""
         updater = self._build_rule_updater(NotificationRuleID(rule_id), input)
 
-        action_result = await self._processors.notification.update_rule.run(
-            UpdateRuleAction(updater=updater)
-        )
+        action_result = await self._notification.update_rule.run(UpdateRuleAction(updater=updater))
 
         return UpdateNotificationRulePayload(rule=self._rule_data_to_dto(action_result.data))
 
@@ -305,7 +307,7 @@ class NotificationAdapter(BaseAdapter):
         self, input: DeleteNotificationRuleInput
     ) -> DeleteNotificationRulePayload:
         """Delete a notification rule."""
-        await self._processors.notification.purge_rule.run(
+        await self._notification.purge_rule.run(
             PurgeRuleAction(rule_id=NotificationRuleID(input.id))
         )
 
@@ -315,7 +317,7 @@ class NotificationAdapter(BaseAdapter):
         self, input: ValidateNotificationChannelInput
     ) -> ValidateNotificationChannelPayload:
         """Validate a notification channel by sending a test message."""
-        await self._processors.notification.validate_channel.run(
+        await self._notification.validate_channel.run(
             ValidateChannelAction(
                 channel_id=NotificationChannelID(input.id), test_message=input.test_message
             )
@@ -326,7 +328,7 @@ class NotificationAdapter(BaseAdapter):
         self, input: ValidateNotificationRuleInput
     ) -> ValidateNotificationRulePayload:
         """Validate a notification rule by rendering its template with test data."""
-        action_result = await self._processors.notification.validate_rule.run(
+        action_result = await self._notification.validate_rule.run(
             ValidateRuleAction(
                 rule_id=NotificationRuleID(input.id),
                 notification_data=input.notification_data or {},
@@ -353,7 +355,7 @@ class NotificationAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        action_result = await self._processors.notification.search_channels.run(
+        action_result = await self._notification.search_channels.run(
             SearchChannelsAction(searcher=searcher)
         )
 
@@ -383,7 +385,7 @@ class NotificationAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        action_result = await self._processors.notification.search_rules.run(
+        action_result = await self._notification.search_rules.run(
             SearchRulesAction(searcher=searcher)
         )
 

--- a/src/ai/backend/manager/api/adapters/object_storage/adapter.py
+++ b/src/ai/backend/manager/api/adapters/object_storage/adapter.py
@@ -50,6 +50,7 @@ from ai.backend.manager.services.object_storage.actions.get_upload_presigned_url
 from ai.backend.manager.services.object_storage.actions.purge import PurgeObjectStorageAction
 from ai.backend.manager.services.object_storage.actions.search import SearchObjectStoragesAction
 from ai.backend.manager.services.object_storage.actions.update import UpdateObjectStorageAction
+from ai.backend.manager.services.object_storage.processors import ObjectStorageProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 DEFAULT_PAGINATION_LIMIT = 50
@@ -57,6 +58,11 @@ DEFAULT_PAGINATION_LIMIT = 50
 
 class ObjectStorageAdapter(BaseAdapter):
     """Adapter for object storage domain operations."""
+
+    _object_storage: ObjectStorageProcessors
+
+    def __init__(self, object_storage: ObjectStorageProcessors) -> None:
+        self._object_storage = object_storage
 
     async def admin_search(
         self, input: AdminSearchObjectStoragesInput
@@ -71,7 +77,7 @@ class ObjectStorageAdapter(BaseAdapter):
         """
         searcher = self.build_searcher(input)
 
-        action_result = await self._processors.object_storage.global_search_object_storages.run(
+        action_result = await self._object_storage.global_search_object_storages.run(
             SearchObjectStoragesAction(searcher=searcher)
         )
 
@@ -151,7 +157,7 @@ class ObjectStorageAdapter(BaseAdapter):
         if not ids:
             return []
         entity_ids = [ObjectStorageID(value) for value in ids]
-        result = await self._processors.object_storage.bulk_get.run(
+        result = await self._object_storage.bulk_get.run(
             BulkGetObjectStoragesAction(ids=entity_ids)
         )
         return [
@@ -163,14 +169,14 @@ class ObjectStorageAdapter(BaseAdapter):
 
     async def get(self, storage_id: UUID) -> ObjectStorageNode:
         """Retrieve a single object storage by ID."""
-        action_result = await self._processors.object_storage.get.run(
+        action_result = await self._object_storage.get.run(
             GetObjectStorageAction(storage_id=ObjectStorageID(storage_id))
         )
         return self._data_to_dto(action_result.data)
 
     async def create(self, input: CreateObjectStorageInput) -> CreateObjectStoragePayload:
         """Create a new object storage."""
-        action_result = await self._processors.object_storage.global_create.run(
+        action_result = await self._object_storage.global_create.run(
             CreateObjectStorageAction(
                 creator=ObjectStorageCreator(
                     name=input.name,
@@ -211,14 +217,14 @@ class ObjectStorageAdapter(BaseAdapter):
                 else TriState.update(input.region)
             ),
         )
-        action_result = await self._processors.object_storage.update.run(
+        action_result = await self._object_storage.update.run(
             UpdateObjectStorageAction(updater=updater)
         )
         return UpdateObjectStoragePayload(object_storage=self._data_to_dto(action_result.data))
 
     async def delete(self, input: DeleteObjectStorageInput) -> DeleteObjectStoragePayload:
         """Delete an object storage."""
-        action_result = await self._processors.object_storage.purge.run(
+        action_result = await self._object_storage.purge.run(
             PurgeObjectStorageAction(storage_id=input.id)
         )
         return DeleteObjectStoragePayload(id=action_result.data.id)
@@ -230,7 +236,7 @@ class ObjectStorageAdapter(BaseAdapter):
         expiration: int | None = None,
     ) -> PresignedDownloadURLPayload:
         """Generate a presigned download URL for an artifact revision."""
-        action_result = await self._processors.object_storage.get_presigned_download_url.run(
+        action_result = await self._object_storage.get_presigned_download_url.run(
             GetDownloadPresignedURLAction(
                 artifact_revision_id=ArtifactRevisionID(artifact_revision_id),
                 key=key,
@@ -245,7 +251,7 @@ class ObjectStorageAdapter(BaseAdapter):
         key: str,
     ) -> PresignedUploadURLPayload:
         """Generate a presigned upload URL for an artifact revision."""
-        action_result = await self._processors.object_storage.get_presigned_upload_url.run(
+        action_result = await self._object_storage.get_presigned_upload_url.run(
             GetUploadPresignedURLAction(
                 artifact_revision_id=ArtifactRevisionID(artifact_revision_id),
                 key=key,

--- a/src/ai/backend/manager/api/adapters/project/adapter.py
+++ b/src/ai/backend/manager/api/adapters/project/adapter.py
@@ -71,6 +71,7 @@ from ai.backend.manager.models.project.updaters import (
 )
 from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.services.domain.actions.lookup import LookupDomainAction
+from ai.backend.manager.services.domain.processors import DomainProcessors
 from ai.backend.manager.services.project.actions.create_project import CreateProjectAction
 from ai.backend.manager.services.project.actions.delete_project import DeleteProjectAction
 from ai.backend.manager.services.project.actions.purge_project import PurgeProjectAction
@@ -85,13 +86,16 @@ from ai.backend.manager.services.project.actions.search_projects import (
     GlobalSearchProjectsAction,
 )
 from ai.backend.manager.services.project.actions.update_project import UpdateProjectAction
+from ai.backend.manager.services.project.processors import ProjectProcessors
 from ai.backend.manager.services.rbac.actions.roster.join_project import (
     JoinProjectAction,
 )
 from ai.backend.manager.services.rbac.actions.roster.leave_project import (
     LeaveProjectAction,
 )
+from ai.backend.manager.services.rbac.processors import RbacProcessors
 from ai.backend.manager.services.user.actions.keypair_ops import GetDefaultKeypairsAction
+from ai.backend.manager.services.user.processors import UserProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 _PROJECT_PAGINATION_SPEC = PaginationSpec(
@@ -110,10 +114,25 @@ _PROJECT_PAGINATION_SPEC = PaginationSpec(
 class ProjectAdapter(BaseAdapter):
     """Adapter for project (group) operations."""
 
+    _project: ProjectProcessors
+    _rbac: RbacProcessors
+    _domain: DomainProcessors
+    _user: UserProcessors
+
+    def __init__(
+        self,
+        project: ProjectProcessors,
+        rbac: RbacProcessors,
+        domain: DomainProcessors,
+        user: UserProcessors,
+    ) -> None:
+        self._project = project
+        self._rbac = rbac
+        self._domain = domain
+        self._user = user
+
     async def _resolve_domain_id(self, domain_name: str) -> DomainID:
-        result = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
+        result = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
         return result.entity_id()
 
     # ------------------------------------------------------------------ batch load (DataLoader)
@@ -131,7 +150,7 @@ class ProjectAdapter(BaseAdapter):
                 ProjectConditions.by_id_in(UUIDInMatchSpec(values=list(group_ids), negated=False))
             ],
         )
-        result = await self._processors.project.global_search.run(
+        result = await self._project.global_search.run(
             GlobalSearchProjectsAction(searcher=searcher)
         )
         project_map = {group.id: self._group_data_to_node(group) for group in result.items}
@@ -141,7 +160,7 @@ class ProjectAdapter(BaseAdapter):
 
     async def get(self, project_id: UUID) -> ProjectNode:
         """Retrieve a single project by UUID."""
-        action_result = await self._processors.project.get_project.run(
+        action_result = await self._project.get_project.run(
             GetProjectAction(project_id=ProjectID(project_id))
         )
         return self._group_data_to_node(action_result.data)
@@ -166,7 +185,7 @@ class ProjectAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.project.global_search.run(
+        result = await self._project.global_search.run(
             GlobalSearchProjectsAction(searcher=searcher)
         )
 
@@ -180,7 +199,7 @@ class ProjectAdapter(BaseAdapter):
     async def admin_create(self, input: CreateProjectInput) -> ProjectPayload:
         """Create a new project (superadmin only)."""
         domain_id = await self._resolve_domain_id(input.domain_name)
-        result = await self._processors.project.create_project.run(
+        result = await self._project.create_project.run(
             CreateProjectAction(
                 domain_id=domain_id,
                 creator=ProjectCreator(
@@ -228,9 +247,7 @@ class ProjectAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.project.update_project.run(
-            UpdateProjectAction(updater=updater)
-        )
+        result = await self._project.update_project.run(UpdateProjectAction(updater=updater))
         if result.data is None:
             raise UnreachableError("modify_group must return data")
         return ProjectPayload(project=self._group_data_to_node(result.data))
@@ -238,7 +255,7 @@ class ProjectAdapter(BaseAdapter):
     async def admin_delete(self, input: DeleteProjectInput) -> DeleteProjectPayload:
         """Soft-delete a project (superadmin only)."""
         project_id = ProjectID(input.group_id)
-        await self._processors.project.delete_project.run(
+        await self._project.delete_project.run(
             DeleteProjectAction(updater=ProjectSoftDeleteUpdater(project_id=project_id))
         )
         return DeleteProjectPayload(deleted=True)
@@ -246,14 +263,14 @@ class ProjectAdapter(BaseAdapter):
     async def admin_restore(self, input: RestoreProjectInput) -> RestoreProjectPayload:
         """Restore a soft-deleted project (superadmin only)."""
         project_id = ProjectID(input.group_id)
-        await self._processors.project.restore_project.run(
+        await self._project.restore_project.run(
             RestoreProjectAction(updater=ProjectRestoreUpdater(project_id=project_id))
         )
         return RestoreProjectPayload(restored=True)
 
     async def admin_purge(self, input: PurgeProjectInput) -> PurgeProjectPayload:
         """Permanently purge a project (superadmin only)."""
-        await self._processors.project.purge_project.run(
+        await self._project.purge_project.run(
             PurgeProjectAction(project_id=ProjectID(input.group_id))
         )
         return PurgeProjectPayload(purged=True)
@@ -262,7 +279,7 @@ class ProjectAdapter(BaseAdapter):
         self, project_id: UUID, input: UnassignUsersFromProjectInput
     ) -> UnassignUsersFromProjectPayload:
         """Unassign users from a project."""
-        result = await self._processors.rbac.leave_project.run(
+        result = await self._rbac.leave_project.run(
             LeaveProjectAction(
                 project_id=ProjectID(project_id),
                 user_ids=[UserID(uid) for uid in input.user_ids],
@@ -297,7 +314,7 @@ class ProjectAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.project.scoped_search.run(
+        result = await self._project.scoped_search.run(
             ScopedSearchProjectsAction(
                 items=[DomainProjectScopeItem(domain_id=domain_id)], searcher=searcher
             )
@@ -331,7 +348,7 @@ class ProjectAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        result = await self._processors.project.scoped_search.run(
+        result = await self._project.scoped_search.run(
             ScopedSearchProjectsAction(
                 items=[UserProjectScopeItem(user_id=user_id)], searcher=searcher
             )
@@ -350,7 +367,7 @@ class ProjectAdapter(BaseAdapter):
         input: AssignUsersToProjectInput,
     ) -> AssignUsersToProjectPayload:
         """Assign users to a project."""
-        result = await self._processors.rbac.join_project.run(
+        result = await self._rbac.join_project.run(
             JoinProjectAction(
                 project_id=ProjectID(project_id),
                 user_ids=[UserID(uid) for uid in input.user_ids],
@@ -365,7 +382,7 @@ class ProjectAdapter(BaseAdapter):
         """Convert users, reading the key each authorizes with for all of them at once."""
         if not users:
             return []
-        result = await self._processors.user.get_default_keypairs.run(
+        result = await self._user.get_default_keypairs.run(
             GetDefaultKeypairsAction(user_ids=[UserID(user.id) for user in users])
         )
         keys = {owner: AccessKey(kp.access_key) for owner, kp in result.designated.items()}

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset/adapter.py
@@ -73,11 +73,19 @@ from ai.backend.manager.services.prometheus_query_preset.actions import (
     SearchPresetsAction,
     UpdatePresetAction,
 )
+from ai.backend.manager.services.prometheus_query_preset.processors import (
+    PrometheusQueryPresetProcessors,
+)
 from ai.backend.manager.types import OptionalState, TriState
 
 
 class PrometheusQueryPresetAdapter(BaseAdapter):
     """Adapter for prometheus query preset domain operations."""
+
+    _prometheus_query_preset: PrometheusQueryPresetProcessors
+
+    def __init__(self, prometheus_query_preset: PrometheusQueryPresetProcessors) -> None:
+        self._prometheus_query_preset = prometheus_query_preset
 
     async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[QueryDefinitionNode | None]:
         if not ids:
@@ -86,7 +94,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[PrometheusQueryPresetConditions.by_ids(ids)],
         )
-        action_result = await self._processors.prometheus_query_preset.public_search_presets.run(
+        action_result = await self._prometheus_query_preset.public_search_presets.run(
             SearchPresetsAction(searcher=searcher)
         )
         preset_map = {item.id: self._data_to_dto(item) for item in action_result.items}
@@ -110,7 +118,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
             group_labels=input.options.group_labels,
         )
 
-        action_result = await self._processors.prometheus_query_preset.global_create_preset.run(
+        action_result = await self._prometheus_query_preset.global_create_preset.run(
             CreatePresetAction(creator=creator)
         )
 
@@ -124,7 +132,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
         """
         searcher = self.build_searcher(input)
 
-        action_result = await self._processors.prometheus_query_preset.public_search_presets.run(
+        action_result = await self._prometheus_query_preset.public_search_presets.run(
             SearchPresetsAction(searcher=searcher)
         )
 
@@ -137,7 +145,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
 
     async def get(self, preset_id: UUID) -> GetQueryDefinitionPayload:
         """Get a single query definition by ID."""
-        action_result = await self._processors.prometheus_query_preset.public_get_preset.run(
+        action_result = await self._prometheus_query_preset.public_get_preset.run(
             GetPresetAction(preset_id=PrometheusQueryPresetID(preset_id))
         )
 
@@ -147,7 +155,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
         self, preset_id: UUID, input: ModifyQueryDefinitionInput
     ) -> ModifyQueryDefinitionPayload:
         """Update an existing query definition."""
-        action_result = await self._processors.prometheus_query_preset.update_preset.run(
+        action_result = await self._prometheus_query_preset.update_preset.run(
             UpdatePresetAction(
                 updater=self._build_updater(PrometheusQueryPresetID(preset_id), input)
             )
@@ -157,7 +165,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
 
     async def admin_preview(self, input: PreviewQueryDefinitionInput) -> QueryDefinitionResultInfo:
         """Preview a prometheus query template (admin only)."""
-        action_result = await self._processors.prometheus_query_preset.global_preview_preset.run(
+        action_result = await self._prometheus_query_preset.global_preview_preset.run(
             PreviewPresetAction(query_template=input.query_template)
         )
         return self._prometheus_response_to_result_info(action_result.response)
@@ -185,7 +193,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
             if time_range is not None
             else None
         )
-        action_result = await self._processors.prometheus_query_preset.execute_preset.run(
+        action_result = await self._prometheus_query_preset.execute_preset.run(
             ExecutePresetAction(
                 preset_id=PrometheusQueryPresetID(preset_id),
                 options=execute_options,
@@ -217,7 +225,7 @@ class PrometheusQueryPresetAdapter(BaseAdapter):
 
     async def delete(self, input: DeleteQueryDefinitionInput) -> DeleteQueryDefinitionPayload:
         """Delete a query definition by ID."""
-        action_result = await self._processors.prometheus_query_preset.purge_preset.run(
+        action_result = await self._prometheus_query_preset.purge_preset.run(
             PurgePresetAction(preset_id=PrometheusQueryPresetID(input.id))
         )
 

--- a/src/ai/backend/manager/api/adapters/prometheus_query_preset_category/adapter.py
+++ b/src/ai/backend/manager/api/adapters/prometheus_query_preset_category/adapter.py
@@ -56,10 +56,21 @@ from ai.backend.manager.services.prometheus_query_preset_category.actions import
 from ai.backend.manager.services.prometheus_query_preset_category.actions.bulk_get import (
     PublicBulkGetCategoriesAction,
 )
+from ai.backend.manager.services.prometheus_query_preset_category.processors import (
+    PrometheusQueryPresetCategoryProcessors,
+)
 
 
 class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
     """Adapter for prometheus query preset category domain operations."""
+
+    _prometheus_query_preset_category: PrometheusQueryPresetCategoryProcessors
+
+    def __init__(
+        self,
+        prometheus_query_preset_category: PrometheusQueryPresetCategoryProcessors,
+    ) -> None:
+        self._prometheus_query_preset_category = prometheus_query_preset_category
 
     async def batch_load_by_ids(self, ids: Sequence[UUID]) -> list[CategoryNode | Exception | None]:
         """Batch load categories by id for DataLoader use.
@@ -70,10 +81,8 @@ class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
         if not ids:
             return []
         entity_ids = [PrometheusQueryPresetCategoryID(value) for value in ids]
-        result = (
-            await self._processors.prometheus_query_preset_category.public_bulk_get_categories.run(
-                PublicBulkGetCategoriesAction(ids=entity_ids)
-            )
+        result = await self._prometheus_query_preset_category.public_bulk_get_categories.run(
+            PublicBulkGetCategoriesAction(ids=entity_ids)
         )
         return [
             self._data_to_dto(item.value)
@@ -89,10 +98,8 @@ class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
             description=input.description,
         )
 
-        action_result = (
-            await self._processors.prometheus_query_preset_category.global_create_category.run(
-                CreateCategoryAction(creator=creator)
-            )
+        action_result = await self._prometheus_query_preset_category.global_create_category.run(
+            CreateCategoryAction(creator=creator)
         )
 
         return CreateCategoryPayload(item=self._data_to_dto(action_result.data))
@@ -105,10 +112,8 @@ class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
         """
         searcher = self.build_searcher(input)
 
-        action_result = (
-            await self._processors.prometheus_query_preset_category.public_search_categories.run(
-                SearchCategoriesAction(searcher=searcher)
-            )
+        action_result = await self._prometheus_query_preset_category.public_search_categories.run(
+            SearchCategoriesAction(searcher=searcher)
         )
 
         return SearchCategoriesPayload(
@@ -120,17 +125,15 @@ class PrometheusQueryPresetCategoryAdapter(BaseAdapter):
 
     async def get(self, category_id: UUID) -> GetCategoryPayload:
         """Get a single category by ID."""
-        action_result = (
-            await self._processors.prometheus_query_preset_category.public_get_category.run(
-                GetCategoryAction(category_id=PrometheusQueryPresetCategoryID(category_id))
-            )
+        action_result = await self._prometheus_query_preset_category.public_get_category.run(
+            GetCategoryAction(category_id=PrometheusQueryPresetCategoryID(category_id))
         )
 
         return GetCategoryPayload(item=self._data_to_dto(action_result.data))
 
     async def delete(self, input: DeleteCategoryInput) -> DeleteCategoryPayload:
         """Remove a category by ID."""
-        action_result = await self._processors.prometheus_query_preset_category.purge_category.run(
+        action_result = await self._prometheus_query_preset_category.purge_category.run(
             PurgeCategoryAction(category_id=PrometheusQueryPresetCategoryID(input.id))
         )
 

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -269,6 +269,9 @@ from ai.backend.manager.services.permission_contoller.actions.update_permission 
     UpdatePermissionAction,
 )
 from ai.backend.manager.services.permission_contoller.actions.update_role import UpdateRoleAction
+from ai.backend.manager.services.permission_contoller.processors import (
+    PermissionControllerProcessors,
+)
 from ai.backend.manager.services.rbac.actions.role.assign import AssignRoleAction
 from ai.backend.manager.services.rbac.actions.role.bulk_assign import (
     BulkAssignRoleAction,
@@ -277,6 +280,7 @@ from ai.backend.manager.services.rbac.actions.role.bulk_revoke import (
     BulkRevokeRoleAction,
 )
 from ai.backend.manager.services.rbac.actions.role.revoke import RevokeRoleAction
+from ai.backend.manager.services.rbac.processors import RbacProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 # ------------------------------------------------------------------ pagination specs
@@ -334,6 +338,17 @@ class RBACAdapter(BaseAdapter):
     yet bridged through this adapter.
     """
 
+    _rbac: RbacProcessors
+    _permission_controller: PermissionControllerProcessors
+
+    def __init__(
+        self,
+        rbac: RbacProcessors,
+        permission_controller: PermissionControllerProcessors,
+    ) -> None:
+        self._rbac = rbac
+        self._permission_controller = permission_controller
+
     def _validate_scope_id(self, scope_type: RBACElementType, scope_id: str) -> None:
         """Raise InvalidScope if scope_id is not a valid UUID for scope types that require one."""
         match scope_type:
@@ -377,7 +392,7 @@ class RBACAdapter(BaseAdapter):
             conditions=[RoleConditions.by_ids(role_ids)],
         )
         action_result: SearchRolesActionResult = (
-            await self._processors.permission_controller.search_roles.wait_for_complete(
+            await self._permission_controller.search_roles.wait_for_complete(
                 SearchRolesAction(querier=querier)
             )
         )
@@ -400,7 +415,7 @@ class RBACAdapter(BaseAdapter):
             conditions=[ScopedPermissionConditions.by_ids(permission_ids)],
         )
         action_result: SearchPermissionsActionResult = (
-            await self._processors.permission_controller.search_permissions.wait_for_complete(
+            await self._permission_controller.search_permissions.wait_for_complete(
                 SearchPermissionsAction(querier=querier)
             )
         )
@@ -422,8 +437,10 @@ class RBACAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[AssignedUserConditions.by_ids(assignment_ids)],
         )
-        action_result: SearchUsersAssignedToRoleActionResult = await self._processors.permission_controller.search_users_assigned_to_role.wait_for_complete(
-            SearchUsersAssignedToRoleAction(querier=querier)
+        action_result: SearchUsersAssignedToRoleActionResult = (
+            await self._permission_controller.search_users_assigned_to_role.wait_for_complete(
+                SearchUsersAssignedToRoleAction(querier=querier)
+            )
         )
         assignment_map: dict[UUID, RoleAssignmentNode] = {
             data.id: self._assignment_data_to_node(data) for data in action_result.result.items
@@ -444,7 +461,7 @@ class RBACAdapter(BaseAdapter):
             conditions=[EntityScopeConditions.by_object_ids(object_ids)],
         )
         action_result: SearchEntitiesActionResult = (
-            await self._processors.permission_controller.search_entities.wait_for_complete(
+            await self._permission_controller.search_entities.wait_for_complete(
                 SearchEntitiesAction(querier=querier)
             )
         )
@@ -467,8 +484,10 @@ class RBACAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[EntityScopeConditions.by_ids(association_ids)],
         )
-        action_result: SearchElementAssociationsActionResult = await self._processors.permission_controller.search_element_associations.wait_for_complete(
-            SearchElementAssociationsAction(querier=querier)
+        action_result: SearchElementAssociationsActionResult = (
+            await self._permission_controller.search_element_associations.wait_for_complete(
+                SearchElementAssociationsAction(querier=querier)
+            )
         )
         association_map: dict[UUID, AssociationScopesEntitiesNode] = {
             data.id: self._association_data_to_node(data) for data in action_result.result.items
@@ -489,7 +508,7 @@ class RBACAdapter(BaseAdapter):
             conditions=[ScopedPermissionConditions.by_role_ids(role_ids)],
         )
         action_result: SearchPermissionsActionResult = (
-            await self._processors.permission_controller.search_permissions.wait_for_complete(
+            await self._permission_controller.search_permissions.wait_for_complete(
                 SearchPermissionsAction(querier=querier)
             )
         )
@@ -511,8 +530,10 @@ class RBACAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[AssignedUserConditions.by_user_ids(user_ids)],
         )
-        action_result: SearchUsersAssignedToRoleActionResult = await self._processors.permission_controller.search_users_assigned_to_role.wait_for_complete(
-            SearchUsersAssignedToRoleAction(querier=querier)
+        action_result: SearchUsersAssignedToRoleActionResult = (
+            await self._permission_controller.search_users_assigned_to_role.wait_for_complete(
+                SearchUsersAssignedToRoleAction(querier=querier)
+            )
         )
         result_map: dict[UUID, list[RoleAssignmentNode]] = defaultdict(list)
         for item in action_result.result.items:
@@ -532,8 +553,10 @@ class RBACAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[AssignedUserConditions.by_role_ids(role_ids)],
         )
-        action_result: SearchUsersAssignedToRoleActionResult = await self._processors.permission_controller.search_users_assigned_to_role.wait_for_complete(
-            SearchUsersAssignedToRoleAction(querier=querier)
+        action_result: SearchUsersAssignedToRoleActionResult = (
+            await self._permission_controller.search_users_assigned_to_role.wait_for_complete(
+                SearchUsersAssignedToRoleAction(querier=querier)
+            )
         )
         result_map: dict[UUID, list[RoleAssignmentNode]] = defaultdict(list)
         for item in action_result.result.items:
@@ -553,8 +576,10 @@ class RBACAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[AssignedUserConditions.by_role_and_user_ids(pairs)],
         )
-        action_result: SearchUsersAssignedToRoleActionResult = await self._processors.permission_controller.search_users_assigned_to_role.wait_for_complete(
-            SearchUsersAssignedToRoleAction(querier=querier)
+        action_result: SearchUsersAssignedToRoleActionResult = (
+            await self._permission_controller.search_users_assigned_to_role.wait_for_complete(
+                SearchUsersAssignedToRoleAction(querier=querier)
+            )
         )
         result_map: dict[tuple[uuid.UUID, uuid.UUID], RoleAssignmentNode] = {
             (item.role_id, item.user_id): self._assignment_data_to_node(item)
@@ -566,10 +591,8 @@ class RBACAdapter(BaseAdapter):
 
     async def get_permission_matrix(self) -> list[ScopeEntityOperationCombinationInfo]:
         """Return the complete RBAC scope-entity-operation permission matrix."""
-        action_result = (
-            await self._processors.permission_controller.get_permission_matrix.wait_for_complete(
-                GetPermissionMatrixAction()
-            )
+        action_result = await self._permission_controller.get_permission_matrix.wait_for_complete(
+            GetPermissionMatrixAction()
         )
         matrix = action_result.matrix
         return [
@@ -611,7 +634,7 @@ class RBACAdapter(BaseAdapter):
         ]
         source = InternalRoleSource(input.source.value)
         if scopes:
-            result = await self._processors.permission_controller.create_role.run(
+            result = await self._permission_controller.create_role.run(
                 CreateRoleAction(
                     creator=RoleCreator(
                         name=input.name,
@@ -623,7 +646,7 @@ class RBACAdapter(BaseAdapter):
                 )
             )
         else:
-            result = await self._processors.permission_controller.create_global_role.run(
+            result = await self._permission_controller.create_global_role.run(
                 CreateGlobalRoleAction(
                     creator=GlobalRoleCreator(
                         name=input.name,
@@ -640,7 +663,7 @@ class RBACAdapter(BaseAdapter):
     async def admin_search(self, input: SearchRolesRequest) -> SearchRolesResponse:
         """Search roles with no scope restriction (admin only)."""
         querier = self._build_search_querier(input)
-        action_result = await self._processors.permission_controller.search_roles.wait_for_complete(
+        action_result = await self._permission_controller.search_roles.wait_for_complete(
             SearchRolesAction(querier=querier)
         )
         result = action_result.result
@@ -676,7 +699,7 @@ class RBACAdapter(BaseAdapter):
             base_conditions=base_conditions,
         )
         action_result: SearchPermissionsActionResult = (
-            await self._processors.permission_controller.search_permissions.wait_for_complete(
+            await self._permission_controller.search_permissions.wait_for_complete(
                 SearchPermissionsAction(querier=querier)
             )
         )
@@ -707,7 +730,7 @@ class RBACAdapter(BaseAdapter):
             offset=input.offset,
         )
         action_result: SearchRolesActionResult = (
-            await self._processors.permission_controller.search_roles.wait_for_complete(
+            await self._permission_controller.search_roles.wait_for_complete(
                 SearchRolesAction(querier=querier)
             )
         )
@@ -739,7 +762,7 @@ class RBACAdapter(BaseAdapter):
             offset=input.offset,
         )
         action_result: SearchRolesInScopeActionResult = (
-            await self._processors.permission_controller.search_roles_in_scope.wait_for_complete(
+            await self._permission_controller.search_roles_in_scope.wait_for_complete(
                 SearchRolesInScopeAction(scope=scope, querier=querier)
             )
         )
@@ -792,8 +815,10 @@ class RBACAdapter(BaseAdapter):
             offset=input.offset,
             base_conditions=base_conditions,
         )
-        action_result: SearchUsersAssignedToRoleActionResult = await self._processors.permission_controller.search_users_assigned_to_role.wait_for_complete(
-            SearchUsersAssignedToRoleAction(querier=querier)
+        action_result: SearchUsersAssignedToRoleActionResult = (
+            await self._permission_controller.search_users_assigned_to_role.wait_for_complete(
+                SearchUsersAssignedToRoleAction(querier=querier)
+            )
         )
         raw = action_result.result
         return SearchResult(
@@ -823,8 +848,10 @@ class RBACAdapter(BaseAdapter):
             offset=input.offset,
             base_conditions=base_conditions,
         )
-        action_result: SearchElementAssociationsActionResult = await self._processors.permission_controller.search_element_associations.wait_for_complete(
-            SearchElementAssociationsAction(querier=querier)
+        action_result: SearchElementAssociationsActionResult = (
+            await self._permission_controller.search_element_associations.wait_for_complete(
+                SearchElementAssociationsAction(querier=querier)
+            )
         )
         raw = action_result.result
         return SearchResult(
@@ -852,10 +879,8 @@ class RBACAdapter(BaseAdapter):
 
     async def get(self, role_id: UUID) -> RoleNode:
         """Get a role by ID."""
-        action_result = (
-            await self._processors.permission_controller.get_role_detail.wait_for_complete(
-                GetRoleDetailAction(role_id=role_id)
-            )
+        action_result = await self._permission_controller.get_role_detail.wait_for_complete(
+            GetRoleDetailAction(role_id=role_id)
         )
         return self._role_detail_to_node(action_result.role)
 
@@ -864,7 +889,7 @@ class RBACAdapter(BaseAdapter):
     async def update(self, role_id: UUID, input: UpdateRoleInput) -> UpdateRolePayload:
         """Update an existing role."""
         updater = self._build_updater(role_id, input)
-        result = await self._processors.permission_controller.update_role.run(
+        result = await self._permission_controller.update_role.run(
             UpdateRoleAction(updater=updater)
         )
         return UpdateRolePayload(role=self._role_data_to_node(result.data))
@@ -873,7 +898,7 @@ class RBACAdapter(BaseAdapter):
 
     async def delete(self, role_id: UUID) -> DeleteRolePayload:
         """Soft-delete a role (marks status as DELETED)."""
-        result = await self._processors.permission_controller.delete_role.run(
+        result = await self._permission_controller.delete_role.run(
             DeleteRoleAction(updater=RoleSoftDeleteUpdater(role_id=RoleID(role_id)))
         )
         return DeleteRolePayload(id=result.data.id)
@@ -882,7 +907,7 @@ class RBACAdapter(BaseAdapter):
 
     async def purge(self, role_id: UUID) -> PurgeRolePayload:
         """Hard-delete a role from the database."""
-        result = await self._processors.permission_controller.purge_role.run(
+        result = await self._permission_controller.purge_role.run(
             PurgeRoleAction(role_id=RoleID(role_id))
         )
         return PurgeRolePayload(id=result.data.id)
@@ -894,7 +919,7 @@ class RBACAdapter(BaseAdapter):
         purger: Purger[PermissionRow] = Purger(
             spec=PermissionPurgerSpec(permission_id=permission_id)
         )
-        await self._processors.permission_controller.delete_permission.wait_for_complete(
+        await self._permission_controller.delete_permission.wait_for_complete(
             DeletePermissionAction(purger=purger)
         )
         return DeletePermissionPayloadDTO(id=permission_id)
@@ -914,10 +939,8 @@ class RBACAdapter(BaseAdapter):
                 permission=self._permission_bit(input.operation),
             )
         )
-        action_result = (
-            await self._processors.permission_controller.create_permission.wait_for_complete(
-                CreatePermissionAction(creator=creator)
-            )
+        action_result = await self._permission_controller.create_permission.wait_for_complete(
+            CreatePermissionAction(creator=creator)
         )
         return self._permission_data_to_node(action_result.data)
 
@@ -947,10 +970,8 @@ class RBACAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        action_result = (
-            await self._processors.permission_controller.update_permission.wait_for_complete(
-                UpdatePermissionAction(updater=Updater(spec=spec, pk_value=input.id))
-            )
+        action_result = await self._permission_controller.update_permission.wait_for_complete(
+            UpdatePermissionAction(updater=Updater(spec=spec, pk_value=input.id))
         )
         return self._permission_data_to_node(action_result.data)
 
@@ -958,7 +979,7 @@ class RBACAdapter(BaseAdapter):
 
     async def assign_role(self, input: AssignRoleInputDTO) -> RoleAssignmentNode:
         """Assign a role to a user."""
-        action_result = await self._processors.rbac.assign_role.wait_for_complete(
+        action_result = await self._rbac.assign_role.wait_for_complete(
             AssignRoleAction(
                 input=UserRoleAssignmentInput(
                     user_id=input.user_id,
@@ -978,7 +999,7 @@ class RBACAdapter(BaseAdapter):
 
     async def revoke_role(self, input: RevokeRoleInputDTO) -> RoleAssignmentNode:
         """Revoke a role from a user."""
-        action_result = await self._processors.rbac.revoke_role.wait_for_complete(
+        action_result = await self._rbac.revoke_role.wait_for_complete(
             RevokeRoleAction(
                 input=UserRoleRevocationInput(user_id=input.user_id, role_id=input.role_id)
             )
@@ -997,7 +1018,7 @@ class RBACAdapter(BaseAdapter):
     async def bulk_assign_role(self, input: BulkAssignRoleInputDTO) -> BulkAssignRoleResultPayload:
         """Bulk-assign a role to multiple users."""
         specs = [UserRoleCreatorSpec(user_id=uid, role_id=input.role_id) for uid in input.user_ids]
-        action_result = await self._processors.rbac.bulk_assign_role.wait_for_complete(
+        action_result = await self._rbac.bulk_assign_role.wait_for_complete(
             BulkAssignRoleAction(
                 bulk_creator=BulkCreator(specs=specs),
                 project_id=input.project_id,
@@ -1033,7 +1054,7 @@ class RBACAdapter(BaseAdapter):
         failed: list[BulkAddRolePermissionFailureInfo] = []
         for entry in input.permissions:
             try:
-                result = await self._processors.permission_controller.add_role_permission.run(
+                result = await self._permission_controller.add_role_permission.run(
                     AddRolePermissionAction(
                         role_id=RoleID(entry.role_id),
                         creator=self._role_permission_creator(entry),
@@ -1063,7 +1084,7 @@ class RBACAdapter(BaseAdapter):
         if not input.permission_ids:
             return BulkRemoveRolePermissionsPayload(items=[], failed=[])
         try:
-            result = await self._processors.permission_controller.bulk_remove_role_permissions.run(
+            result = await self._permission_controller.bulk_remove_role_permissions.run(
                 BulkRemoveRolePermissionsAction(
                     permission_ids=[PermissionID(pid) for pid in input.permission_ids]
                 )
@@ -1094,7 +1115,7 @@ class RBACAdapter(BaseAdapter):
                 )
         specs = [self._permission_creator_spec(entry) for entry in input.permissions]
         action_result = (
-            await self._processors.permission_controller.replace_role_permissions.wait_for_complete(
+            await self._permission_controller.replace_role_permissions.wait_for_complete(
                 ReplaceRolePermissionsAction(
                     role_id=input.role_id,
                     creator=BulkCreator(specs=specs),
@@ -1138,7 +1159,7 @@ class RBACAdapter(BaseAdapter):
 
     async def bulk_revoke_role(self, input: BulkRevokeRoleInputDTO) -> BulkRevokeRoleResultPayload:
         """Bulk-revoke a role from multiple users."""
-        action_result = await self._processors.rbac.bulk_revoke_role.wait_for_complete(
+        action_result = await self._rbac.bulk_revoke_role.wait_for_complete(
             BulkRevokeRoleAction(
                 input=BulkUserRoleRevocationInput(role_id=input.role_id, user_ids=input.user_ids)
             )

--- a/src/ai/backend/manager/api/adapters/registry.py
+++ b/src/ai/backend/manager/api/adapters/registry.py
@@ -211,7 +211,7 @@ class Adapters:
         schedule_coordinator: ScheduleCoordinator,
         config_provider: ManagerConfigProvider | None = None,
     ) -> Adapters:
-        """Factory that wires up all adapters from the shared Processors.
+        """Factory that hands each adapter the processors it uses.
 
         ``deployment_coordinator`` / ``schedule_coordinator`` are
         threaded through to adapters that validate or enumerate live
@@ -222,58 +222,91 @@ class Adapters:
         """
         entity_types = WiredEntityTypes(action_registry)
         return cls(
-            agent=AgentAdapter(processors),
-            app_config=AppConfigAdapter(processors),
-            app_config_fragment=AppConfigFragmentAdapter(processors),
-            app_config_allow_list=AppConfigAllowListAdapter(processors),
-            app_config_definition=AppConfigDefinitionAdapter(processors),
-            artifact=ArtifactAdapter(processors),
-            artifact_registry=ArtifactRegistryAdapter(processors),
-            audit_log=AuditLogAdapter(processors),
+            agent=AgentAdapter(processors.agent),
+            app_config=AppConfigAdapter(processors.app_config),
+            app_config_fragment=AppConfigFragmentAdapter(processors.app_config),
+            app_config_allow_list=AppConfigAllowListAdapter(processors.app_config),
+            app_config_definition=AppConfigDefinitionAdapter(processors.app_config),
+            artifact=ArtifactAdapter(processors.artifact),
+            artifact_registry=ArtifactRegistryAdapter(processors.artifact_registry),
+            audit_log=AuditLogAdapter(processors.audit_log),
             entity=EntityAdapter(entity_types),
-            entity_label=EntityLabelAdapter(processors, entity_types),
-            container_registry=ContainerRegistryAdapter(processors),
-            deployment=DeploymentAdapter(processors, deployment_coordinator),
-            domain=DomainAdapter(processors),
-            fair_share=FairShareAdapter(processors),
-            huggingface_registry=HuggingFaceRegistryAdapter(processors),
-            idle_checker=IdleCheckerAdapter(processors),
-            idle_checker_assignment=IdleCheckerAssignmentAdapter(processors),
-            image=ImageAdapter(processors),
-            login_client_type=LoginClientTypeAdapter(processors),
-            client_ip_masking=ClientIPMaskingAdapter(processors),
-            secret=SecretAdapter(processors),
-            login_history=LoginHistoryAdapter(processors),
-            login_session=LoginSessionAdapter(processors),
-            notification=NotificationAdapter(processors),
-            object_storage=ObjectStorageAdapter(processors),
-            project=ProjectAdapter(processors),
-            prometheus_query_preset=PrometheusQueryPresetAdapter(processors),
-            prometheus_query_preset_category=PrometheusQueryPresetCategoryAdapter(processors),
-            rbac=RBACAdapter(processors),
-            reservoir_registry=ReservoirRegistryAdapter(processors),
-            resource_allocation=ResourceAllocationAdapter(processors, config_provider),
-            resource_group=ResourceGroupAdapter(
-                processors, deployment_coordinator, schedule_coordinator
+            entity_label=EntityLabelAdapter(processors.entity_label, entity_types),
+            container_registry=ContainerRegistryAdapter(
+                processors.container_registry, processors.rbac
             ),
-            resource_policy=ResourcePolicyAdapter(processors),
-            resource_preset=ResourcePresetAdapter(processors),
-            resource_slot=ResourceSlotAdapter(processors),
-            entity_share=EntityShareAdapter(processors),
-            retention_policy=RetentionPolicyAdapter(processors),
-            runtime_variant=RuntimeVariantAdapter(processors),
-            runtime_variant_preset=RuntimeVariantPresetAdapter(processors),
-            deployment_revision_preset=DeploymentRevisionPresetAdapter(processors),
-            model_card=ModelCardAdapter(processors),
-            resource_usage=ResourceUsageAdapter(processors),
-            role_preset=RolePresetAdapter(processors),
+            deployment=DeploymentAdapter(processors.deployment, deployment_coordinator),
+            domain=DomainAdapter(processors.domain, processors.resource_group),
+            fair_share=FairShareAdapter(processors.fair_share, processors.resource_group),
+            huggingface_registry=HuggingFaceRegistryAdapter(processors.artifact_registry),
+            idle_checker=IdleCheckerAdapter(processors.idle_checker),
+            idle_checker_assignment=IdleCheckerAssignmentAdapter(
+                processors.idle_checker_assignment, processors.rbac
+            ),
+            image=ImageAdapter(processors.image),
+            login_client_type=LoginClientTypeAdapter(processors.login_client_type),
+            client_ip_masking=ClientIPMaskingAdapter(processors.client_ip_masking),
+            secret=SecretAdapter(processors.secret),
+            login_history=LoginHistoryAdapter(processors.auth),
+            login_session=LoginSessionAdapter(processors.auth),
+            notification=NotificationAdapter(processors.notification),
+            object_storage=ObjectStorageAdapter(processors.object_storage),
+            project=ProjectAdapter(
+                processors.project, processors.rbac, processors.domain, processors.user
+            ),
+            prometheus_query_preset=PrometheusQueryPresetAdapter(
+                processors.prometheus_query_preset
+            ),
+            prometheus_query_preset_category=PrometheusQueryPresetCategoryAdapter(
+                processors.prometheus_query_preset_category
+            ),
+            rbac=RBACAdapter(processors.rbac, processors.permission_controller),
+            reservoir_registry=ReservoirRegistryAdapter(processors.artifact_registry),
+            resource_allocation=ResourceAllocationAdapter(
+                processors.session, processors.domain, processors.user, config_provider
+            ),
+            resource_group=ResourceGroupAdapter(
+                processors.resource_group,
+                processors.rbac,
+                processors.domain,
+                deployment_coordinator,
+                schedule_coordinator,
+            ),
+            resource_policy=ResourcePolicyAdapter(
+                processors.keypair_resource_policy,
+                processors.user_resource_policy,
+                processors.project_resource_policy,
+            ),
+            resource_preset=ResourcePresetAdapter(processors.resource_preset),
+            resource_slot=ResourceSlotAdapter(
+                processors.resource_slot, processors.agent, processors.domain
+            ),
+            entity_share=EntityShareAdapter(processors.entity_share),
+            retention_policy=RetentionPolicyAdapter(processors.retention_policy),
+            runtime_variant=RuntimeVariantAdapter(processors.runtime_variant),
+            runtime_variant_preset=RuntimeVariantPresetAdapter(processors.runtime_variant_preset),
+            deployment_revision_preset=DeploymentRevisionPresetAdapter(
+                processors.deployment_revision_preset
+            ),
+            model_card=ModelCardAdapter(processors.model_card, processors.deployment),
+            resource_usage=ResourceUsageAdapter(
+                processors.resource_usage, processors.resource_group
+            ),
+            role_preset=RolePresetAdapter(processors.role_preset),
             scheduling_handler=SchedulingHandlerAdapter(deployment_coordinator),
-            scheduling_history=SchedulingHistoryAdapter(processors),
-            service_catalog=ServiceCatalogAdapter(processors),
-            session=SessionAdapter(processors),
-            storage_host=StorageHostAdapter(processors),
-            storage_namespace=StorageNamespaceAdapter(processors),
-            user=UserAdapter(processors, auth_config, key_provider_pool),
-            vfolder=VFolderAdapter(processors),
-            vfs_storage=VFSStorageAdapter(processors),
+            scheduling_history=SchedulingHistoryAdapter(
+                processors.scheduling_history, processors.resource_slot
+            ),
+            service_catalog=ServiceCatalogAdapter(processors.service_catalog),
+            session=SessionAdapter(processors.session, processors.idle_checker),
+            storage_host=StorageHostAdapter(processors.vfolder),
+            storage_namespace=StorageNamespaceAdapter(processors.storage_namespace),
+            user=UserAdapter(processors.user, processors.domain, auth_config, key_provider_pool),
+            vfolder=VFolderAdapter(
+                processors.vfolder,
+                processors.vfolder_file,
+                processors.vfolder_admin,
+                processors.deployment,
+            ),
+            vfs_storage=VFSStorageAdapter(processors.vfs_storage),
         )

--- a/src/ai/backend/manager/api/adapters/reservoir_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/reservoir_registry/adapter.py
@@ -48,6 +48,7 @@ from ai.backend.manager.services.artifact_registry.actions.reservoir.search impo
 from ai.backend.manager.services.artifact_registry.actions.reservoir.update import (
     UpdateReservoirRegistryAction,
 )
+from ai.backend.manager.services.artifact_registry.processors import ArtifactRegistryProcessors
 from ai.backend.manager.types import OptionalState
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -56,9 +57,14 @@ DEFAULT_PAGINATION_LIMIT = 10
 class ReservoirRegistryAdapter(BaseAdapter):
     """Adapter for Reservoir registry domain operations."""
 
+    _artifact_registry: ArtifactRegistryProcessors
+
+    def __init__(self, artifact_registry: ArtifactRegistryProcessors) -> None:
+        self._artifact_registry = artifact_registry
+
     async def create(self, input: CreateReservoirRegistryInput) -> CreateReservoirRegistryPayload:
         """Create a new Reservoir registry."""
-        action_result = await self._processors.artifact_registry.create_reservoir_registry.run(
+        action_result = await self._artifact_registry.create_reservoir_registry.run(
             CreateReservoirRegistryAction(
                 creator=ReservoirRegistryCreator(
                     endpoint=input.endpoint,
@@ -82,7 +88,7 @@ class ReservoirRegistryAdapter(BaseAdapter):
             offset=input.offset if input.offset is not None else 0,
         )
         searcher = ReservoirRegistrySearcher(pagination=pagination, conditions=[], orders=[])
-        action_result = await self._processors.artifact_registry.search_reservoir_registries.run(
+        action_result = await self._artifact_registry.search_reservoir_registries.run(
             SearchReservoirRegistriesAction(searcher=searcher)
         )
         return AdminSearchReservoirRegistriesPayload(
@@ -94,7 +100,7 @@ class ReservoirRegistryAdapter(BaseAdapter):
 
     async def get(self, registry_id: UUID) -> ReservoirRegistryNode:
         """Retrieve a single Reservoir registry by ID."""
-        action_result = await self._processors.artifact_registry.get_reservoir_registry.run(
+        action_result = await self._artifact_registry.get_reservoir_registry.run(
             GetReservoirRegistryAction(
                 registry_id=ArtifactRegistryID(registry_id), reservoir_id=registry_id
             )
@@ -131,7 +137,7 @@ class ReservoirRegistryAdapter(BaseAdapter):
                 OptionalState.update(input.name) if input.name is not None else OptionalState.nop()
             ),
         )
-        action_result = await self._processors.artifact_registry.update_reservoir_registry.run(
+        action_result = await self._artifact_registry.update_reservoir_registry.run(
             UpdateReservoirRegistryAction(
                 registry_id=ArtifactRegistryID(input.id),
                 updater=updater,
@@ -144,7 +150,7 @@ class ReservoirRegistryAdapter(BaseAdapter):
 
     async def get_many(self, registry_ids: list[UUID]) -> list[ReservoirRegistryNode]:
         """Retrieve multiple Reservoir registries by IDs."""
-        action_result = await self._processors.artifact_registry.get_reservoir_registries.run(
+        action_result = await self._artifact_registry.get_reservoir_registries.run(
             GetReservoirRegistriesAction(registry_ids=registry_ids)
         )
         return [self._reservoir_registry_data_to_dto(item) for item in action_result.result]
@@ -160,7 +166,7 @@ class ReservoirRegistryAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[ReservoirRegistryConditions.by_ids(ids)],
         )
-        action_result = await self._processors.artifact_registry.search_reservoir_registries.run(
+        action_result = await self._artifact_registry.search_reservoir_registries.run(
             SearchReservoirRegistriesAction(searcher=searcher)
         )
         registry_map = {
@@ -170,7 +176,7 @@ class ReservoirRegistryAdapter(BaseAdapter):
 
     async def delete(self, input: DeleteReservoirRegistryInput) -> DeleteReservoirRegistryPayload:
         """Delete a Reservoir registry."""
-        action_result = await self._processors.artifact_registry.delete_reservoir_registry.run(
+        action_result = await self._artifact_registry.delete_reservoir_registry.run(
             DeleteReservoirRegistryAction(registry_id=ArtifactRegistryID(input.id))
         )
         return DeleteReservoirRegistryPayload(id=action_result.deleted_reservoir_id)

--- a/src/ai/backend/manager/api/adapters/resource_allocation/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_allocation/adapter.py
@@ -41,7 +41,8 @@ from ai.backend.manager.data.resource_allocation.types import (
     ScopeUsageData,
 )
 from ai.backend.manager.services.domain.actions.lookup import LookupDomainAction
-from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.domain.processors import DomainProcessors
+from ai.backend.manager.services.session.processors import SessionProcessors
 from ai.backend.manager.services.session.resource_allocation.actions.check_preset_availability import (
     CheckPresetAvailabilityAction,
 )
@@ -66,19 +67,27 @@ from ai.backend.manager.services.session.resource_allocation.actions.resolve_key
 from ai.backend.manager.services.user.actions.lookup_keypair_owner import (
     LookupKeypairOwnerByAccessKeyAction,
 )
+from ai.backend.manager.services.user.processors import UserProcessors
 
 
 class ResourceAllocationAdapter(BaseAdapter):
     """Adapter for resource allocation operations."""
 
+    _session: SessionProcessors
+    _domain: DomainProcessors
+    _user: UserProcessors
     _config_provider: ManagerConfigProvider | None
 
     def __init__(
         self,
-        processors: Processors,
+        session: SessionProcessors,
+        domain: DomainProcessors,
+        user: UserProcessors,
         config_provider: ManagerConfigProvider | None,
     ) -> None:
-        super().__init__(processors)
+        self._session = session
+        self._domain = domain
+        self._user = user
         self._config_provider = config_provider
 
     def _visibility_settings(self) -> tuple[bool, bool]:
@@ -101,7 +110,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         Used by GQL resolvers where the request context does not carry
         keypair information directly.
         """
-        result = await self._processors.session.resource_allocation.resolve_keypair_context.run(
+        result = await self._session.resource_allocation.resolve_keypair_context.run(
             ResolveKeypairContextAction(user_id=UserID(user_id))
         )
         return str(result.access_key), result.resource_policy
@@ -175,7 +184,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         )
 
     async def _keypair_owner(self, access_key: AccessKey) -> UserID:
-        result = await self._processors.user.lookup_keypair_owner.run(
+        result = await self._user.lookup_keypair_owner.run(
             LookupKeypairOwnerByAccessKeyAction(access_key=access_key)
         )
         return UserID(result.entity_id())
@@ -186,7 +195,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         resource_policy: Mapping[str, Any],
     ) -> KeypairResourceAllocationPayload:
         """Get keypair resource usage for the current user."""
-        result = await self._processors.session.resource_allocation.get_keypair_usage.run(
+        result = await self._session.resource_allocation.get_keypair_usage.run(
             GetKeypairUsageAction(
                 user_id=await self._keypair_owner(AccessKey(access_key)),
                 access_key=AccessKey(access_key),
@@ -202,7 +211,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         project_id: UUID,
     ) -> ProjectResourceAllocationPayload:
         """Get project resource usage."""
-        result = await self._processors.session.resource_allocation.get_project_usage.run(
+        result = await self._session.resource_allocation.get_project_usage.run(
             GetProjectUsageAction(
                 project_id=ProjectID(project_id),
             )
@@ -216,10 +225,8 @@ class ResourceAllocationAdapter(BaseAdapter):
         domain_name: str,
     ) -> DomainResourceAllocationPayload:
         """Get domain resource usage (admin only)."""
-        domain = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
-        result = await self._processors.session.resource_allocation.get_domain_usage.run(
+        domain = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
+        result = await self._session.resource_allocation.get_domain_usage.run(
             GetDomainUsageAction(domain_id=domain.entity_id(), domain_name=domain_name)
         )
         return DomainResourceAllocationPayload(
@@ -231,7 +238,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         rg_name: str,
     ) -> ResourceGroupResourceAllocationPayload:
         """Get resource group usage."""
-        result = await self._processors.session.resource_allocation.get_resource_group_usage.run(
+        result = await self._session.resource_allocation.get_resource_group_usage.run(
             GetResourceGroupUsageAction(
                 rg_name=rg_name,
             )
@@ -251,7 +258,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         if me is None:
             raise PermissionError("Not authenticated")
         grv, hide = self._visibility_settings()
-        result = await self._processors.session.resource_allocation.get_effective_allocation.run(
+        result = await self._session.resource_allocation.get_effective_allocation.run(
             GetEffectiveAllocationAction(
                 access_key=AccessKey(access_key),
                 user_id=UserID(me.user_id),
@@ -274,7 +281,7 @@ class ResourceAllocationAdapter(BaseAdapter):
     ) -> EffectiveResourceAllocationPayload:
         """Get effective allocation for a specific user (admin only)."""
         grv, hide = self._visibility_settings()
-        result = await self._processors.session.resource_allocation.get_effective_allocation.run(
+        result = await self._session.resource_allocation.get_effective_allocation.run(
             GetEffectiveAllocationAction(
                 access_key=AccessKey(access_key),
                 user_id=UserID(input.user_id),
@@ -300,7 +307,7 @@ class ResourceAllocationAdapter(BaseAdapter):
         if me is None:
             raise PermissionError("Not authenticated")
         grv, hide = self._visibility_settings()
-        result = await self._processors.session.resource_allocation.check_preset_availability.run(
+        result = await self._session.resource_allocation.check_preset_availability.run(
             CheckPresetAvailabilityAction(
                 access_key=AccessKey(access_key),
                 user_id=UserID(me.user_id),

--- a/src/ai/backend/manager/api/adapters/resource_group/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_group/adapter.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 if TYPE_CHECKING:
-    from ai.backend.manager.services.processors import Processors
     from ai.backend.manager.sokovan.deployment.coordinator import DeploymentCoordinator
     from ai.backend.manager.sokovan.scheduler.coordinator import ScheduleCoordinator
 
@@ -103,9 +102,11 @@ from ai.backend.manager.models.resource_group.updaters import ResourceGroupUpdat
 from ai.backend.manager.models.specs.pagination import NoPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.domain.actions.lookup import LookupDomainAction
+from ai.backend.manager.services.domain.processors import DomainProcessors
 from ai.backend.manager.services.rbac.actions.relation.base import RelationPair
 from ai.backend.manager.services.rbac.actions.relation.create import CreateRelationAction
 from ai.backend.manager.services.rbac.actions.relation.purge import PurgeRelationAction
+from ai.backend.manager.services.rbac.processors import RbacProcessors
 from ai.backend.manager.services.resource_group.actions.bulk_get import (
     BulkGetResourceGroupsAction,
 )
@@ -155,6 +156,7 @@ from ai.backend.manager.services.resource_group.actions.update_fair_share_spec i
     ResourceWeightInput,
     UpdateFairShareSpecAction,
 )
+from ai.backend.manager.services.resource_group.processors import ResourceGroupProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -225,13 +227,23 @@ class ResourceGroupAdapter(BaseAdapter):
         exposed ``id`` field carries the resource group UUID.
     """
 
+    _resource_group: ResourceGroupProcessors
+    _rbac: RbacProcessors
+    _domain: DomainProcessors
+    _deployment_coordinator: DeploymentCoordinator
+    _schedule_coordinator: ScheduleCoordinator
+
     def __init__(
         self,
-        processors: Processors,
+        resource_group: ResourceGroupProcessors,
+        rbac: RbacProcessors,
+        domain: DomainProcessors,
         deployment_coordinator: DeploymentCoordinator,
         schedule_coordinator: ScheduleCoordinator,
     ) -> None:
-        super().__init__(processors)
+        self._resource_group = resource_group
+        self._rbac = rbac
+        self._domain = domain
         # ``deployment_coordinator`` is the authoritative source for the
         # live set of registered handler names; we consult it when
         # validating
@@ -256,13 +268,11 @@ class ResourceGroupAdapter(BaseAdapter):
         if not names:
             return []
         keys = [ResourceGroupName(name) for name in names]
-        lookup = await self._processors.resource_group.bulk_lookup.run(
+        lookup = await self._resource_group.bulk_lookup.run(
             BulkLookupResourceGroupsAction(names=keys)
         )
         ids = [lookup.resolved[key] for key in keys if key in lookup.resolved]
-        got = await self._processors.resource_group.bulk_get.run(
-            BulkGetResourceGroupsAction(ids=ids)
-        )
+        got = await self._resource_group.bulk_get.run(BulkGetResourceGroupsAction(ids=ids))
         groups = got.values()
         errors = got.errors()
         nodes: list[ResourceGroupDetailNode | Exception | None] = []
@@ -284,9 +294,7 @@ class ResourceGroupAdapter(BaseAdapter):
         """Batch load resource groups by UUID for DataLoader use, checked per resource group."""
         if not ids:
             return []
-        result = await self._processors.resource_group.bulk_get.run(
-            BulkGetResourceGroupsAction(ids=list(ids))
-        )
+        result = await self._resource_group.bulk_get.run(BulkGetResourceGroupsAction(ids=list(ids)))
         return [
             self._data_to_detail_node(item.value)
             if item.value is not None
@@ -310,7 +318,7 @@ class ResourceGroupAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.resource_group.search_resource_groups.run(
+        action_result = await self._resource_group.search_resource_groups.run(
             SearchResourceGroupsAction(querier=querier)
         )
         return ResourceGroupSearchPayload(
@@ -416,7 +424,7 @@ class ResourceGroupAdapter(BaseAdapter):
             is_active=True,
             is_default=input.is_default,
         )
-        action_result = await self._processors.resource_group.create_resource_group.run(
+        action_result = await self._resource_group.create_resource_group.run(
             CreateResourceGroupAction(creator=creator)
         )
 
@@ -456,7 +464,7 @@ class ResourceGroupAdapter(BaseAdapter):
                 )
             ),
         )
-        action_result = await self._processors.resource_group.update_resource_group.run(
+        action_result = await self._resource_group.update_resource_group.run(
             UpdateResourceGroupAction(resource_group_id=updater.resource_group_id, updater=updater)
         )
 
@@ -474,7 +482,7 @@ class ResourceGroupAdapter(BaseAdapter):
             ResourceInfoNode DTO with capacity, used, and free resource metrics.
             Quantities are normalized (trailing zeros removed, no scientific notation).
         """
-        action_result = await self._processors.resource_group.get_resource_info.run(
+        action_result = await self._resource_group.get_resource_info.run(
             GetResourceInfoAction(
                 resource_group_id=await self._resolve_resource_group_id(resource_group),
                 resource_group=resource_group,
@@ -510,7 +518,7 @@ class ResourceGroupAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[ResourceGroupConditions.by_name_equals(name_spec)],
         )
-        search_result = await self._processors.resource_group.search_resource_groups.run(
+        search_result = await self._resource_group.search_resource_groups.run(
             SearchResourceGroupsAction(querier=querier)
         )
         if not search_result.resource_groups:
@@ -569,7 +577,7 @@ class ResourceGroupAdapter(BaseAdapter):
                 for entry in input.resource_weights
             ]
 
-        action_result = await self._processors.resource_group.update_fair_share_spec.run(
+        action_result = await self._resource_group.update_fair_share_spec.run(
             UpdateFairShareSpecAction(
                 resource_group_id=await self._resolve_resource_group_id(input.resource_group_name),
                 resource_group=input.resource_group_name,
@@ -656,7 +664,7 @@ class ResourceGroupAdapter(BaseAdapter):
             preemption_config=preemption_config_state,
         )
 
-        action_result = await self._processors.resource_group.update_resource_group.run(
+        action_result = await self._resource_group.update_resource_group.run(
             UpdateResourceGroupAction(
                 resource_group_id=updater.resource_group_id,
                 updater=updater,
@@ -678,7 +686,7 @@ class ResourceGroupAdapter(BaseAdapter):
         Returns:
             Pydantic node representing the purged resource group.
         """
-        action_result = await self._processors.resource_group.purge_resource_group.run(
+        action_result = await self._resource_group.purge_resource_group.run(
             PurgeResourceGroupAction(resource_group_id=await self._resolve_resource_group_id(name))
         )
 
@@ -688,14 +696,12 @@ class ResourceGroupAdapter(BaseAdapter):
 
     async def _resolve_domain_id(self, domain_name: str) -> DomainID:
         """Resolve a domain name to its row id at the API boundary."""
-        result = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
+        result = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
         return result.entity_id()
 
     async def _resolve_resource_group_id(self, name: str) -> ResourceGroupID:
         """Resolve a resource group name to its row ID at the API boundary."""
-        result = await self._processors.resource_group.lookup.run(
+        result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(name))
         )
         return result.entity_id()
@@ -712,7 +718,7 @@ class ResourceGroupAdapter(BaseAdapter):
         names = [ResourceGroupName(name) for name in {*add, *remove}]
         if not names:
             return [], []
-        result = await self._processors.resource_group.resolve_resource_group_ids_by_names.run(
+        result = await self._resource_group.resolve_resource_group_ids_by_names.run(
             ResolveResourceGroupIDsByNamesAction(names=names)
         )
         ids_by_name = result.ids_by_name
@@ -732,7 +738,7 @@ class ResourceGroupAdapter(BaseAdapter):
         linked is left as it stands: naming one twice is not an error to the caller."""
         if not resource_group_ids:
             return
-        await self._processors.rbac.create_relation.run(
+        await self._rbac.create_relation.run(
             CreateRelationAction(
                 pairs=[
                     RelationPair(scope=domain_id, target=resource_group_id)
@@ -747,7 +753,7 @@ class ResourceGroupAdapter(BaseAdapter):
     ) -> None:
         if not resource_group_ids:
             return
-        await self._processors.rbac.purge_relation.run(
+        await self._rbac.purge_relation.run(
             PurgeRelationAction(
                 pairs=[
                     RelationPair(scope=domain_id, target=resource_group_id)
@@ -764,7 +770,7 @@ class ResourceGroupAdapter(BaseAdapter):
         linked is left as it stands: naming one twice is not an error to the caller."""
         if not resource_group_ids:
             return
-        await self._processors.rbac.create_relation.run(
+        await self._rbac.create_relation.run(
             CreateRelationAction(
                 pairs=[
                     RelationPair(scope=project_id, target=resource_group_id)
@@ -779,7 +785,7 @@ class ResourceGroupAdapter(BaseAdapter):
     ) -> None:
         if not resource_group_ids:
             return
-        await self._processors.rbac.purge_relation.run(
+        await self._rbac.purge_relation.run(
             PurgeRelationAction(
                 pairs=[
                     RelationPair(scope=project_id, target=resource_group_id)
@@ -795,7 +801,7 @@ class ResourceGroupAdapter(BaseAdapter):
         """The same link read from the resource group's side, in one run."""
         if not domain_ids:
             return
-        await self._processors.rbac.create_relation.run(
+        await self._rbac.create_relation.run(
             CreateRelationAction(
                 pairs=[
                     RelationPair(scope=domain_id, target=resource_group_id)
@@ -810,7 +816,7 @@ class ResourceGroupAdapter(BaseAdapter):
     ) -> None:
         if not domain_ids:
             return
-        await self._processors.rbac.purge_relation.run(
+        await self._rbac.purge_relation.run(
             PurgeRelationAction(
                 pairs=[
                     RelationPair(scope=domain_id, target=resource_group_id)
@@ -826,7 +832,7 @@ class ResourceGroupAdapter(BaseAdapter):
         """The same link read from the resource group's side, in one run."""
         if not project_ids:
             return
-        await self._processors.rbac.create_relation.run(
+        await self._rbac.create_relation.run(
             CreateRelationAction(
                 pairs=[
                     RelationPair(scope=project_id, target=resource_group_id)
@@ -841,7 +847,7 @@ class ResourceGroupAdapter(BaseAdapter):
     ) -> None:
         if not project_ids:
             return
-        await self._processors.rbac.purge_relation.run(
+        await self._rbac.purge_relation.run(
             PurgeRelationAction(
                 pairs=[
                     RelationPair(scope=project_id, target=resource_group_id)
@@ -880,7 +886,7 @@ class ResourceGroupAdapter(BaseAdapter):
         domain_id = await self._resolve_domain_id(input.domain_name)
         await self._unlink_resource_groups_from_domain(domain_id, remove_ids)
         await self._link_resource_groups_to_domain(domain_id, add_ids)
-        result = await self._processors.resource_group.get_allowed_rgs_for_domain.run(
+        result = await self._resource_group.get_allowed_rgs_for_domain.run(
             GetAllowedResourceGroupsForDomainAction(domain_id=domain_id)
         )
         return AllowedResourceGroupsPayload(items=result.items)
@@ -896,7 +902,7 @@ class ResourceGroupAdapter(BaseAdapter):
         project_id = ProjectID(input.project_id)
         await self._unlink_resource_groups_from_project(project_id, remove_ids)
         await self._link_resource_groups_to_project(project_id, add_ids)
-        result = await self._processors.resource_group.get_allowed_rgs_for_project.run(
+        result = await self._resource_group.get_allowed_rgs_for_project.run(
             GetAllowedResourceGroupsForProjectAction(project_id=project_id)
         )
         return AllowedResourceGroupsPayload(items=result.items)
@@ -912,7 +918,7 @@ class ResourceGroupAdapter(BaseAdapter):
         )
         await self._unlink_domains_from_resource_group(resource_group_id, remove_ids)
         await self._link_domains_to_resource_group(resource_group_id, add_ids)
-        result = await self._processors.resource_group.get_allowed_domains_for_rg.run(
+        result = await self._resource_group.get_allowed_domains_for_rg.run(
             GetAllowedDomainsForResourceGroupAction(resource_group_id=resource_group_id)
         )
         return AllowedDomainsPayload(items=result.items)
@@ -929,14 +935,14 @@ class ResourceGroupAdapter(BaseAdapter):
         await self._link_projects_to_resource_group(
             resource_group_id, [ProjectID(raw) for raw in input.add or []]
         )
-        result = await self._processors.resource_group.get_allowed_projects_for_rg.run(
+        result = await self._resource_group.get_allowed_projects_for_rg.run(
             GetAllowedProjectsForResourceGroupAction(resource_group_id=resource_group_id)
         )
         return AllowedProjectsPayload(items=result.items)
 
     async def _scoped_resource_group_names(self, item: ResourceGroupScopeItem) -> list[str]:
         """Read the resource groups one scope reaches, by name."""
-        result = await self._processors.resource_group.scoped_search_resource_groups.run(
+        result = await self._resource_group.scoped_search_resource_groups.run(
             ScopedSearchResourceGroupsAction(
                 items=[item],
                 searcher=ResourceGroupSearcher(
@@ -975,7 +981,7 @@ class ResourceGroupAdapter(BaseAdapter):
     ) -> AllowedDomainsPayload:
         """Get allowed domains for a resource group."""
         resource_group_id = await self._resolve_resource_group_id(resource_group_name)
-        result = await self._processors.resource_group.get_allowed_domains_for_rg.run(
+        result = await self._resource_group.get_allowed_domains_for_rg.run(
             GetAllowedDomainsForResourceGroupAction(resource_group_id=resource_group_id)
         )
         return AllowedDomainsPayload(items=result.items)
@@ -986,7 +992,7 @@ class ResourceGroupAdapter(BaseAdapter):
     ) -> AllowedProjectsPayload:
         """Get allowed projects for a resource group."""
         resource_group_id = await self._resolve_resource_group_id(resource_group_name)
-        result = await self._processors.resource_group.get_allowed_projects_for_rg.run(
+        result = await self._resource_group.get_allowed_projects_for_rg.run(
             GetAllowedProjectsForResourceGroupAction(resource_group_id=resource_group_id)
         )
         return AllowedProjectsPayload(items=result.items)
@@ -1046,13 +1052,11 @@ class ResourceGroupAdapter(BaseAdapter):
                 h.name() for h in self._deployment_coordinator.registered_handlers()
             ),
         )
-        action_result = (
-            await self._processors.resource_group.replace_default_deployment_options.run(
-                ReplaceDefaultDeploymentOptionsAction(
-                    resource_group_id=await self._resolve_resource_group_id(name),
-                    resource_group=name,
-                    options=options,
-                )
+        action_result = await self._resource_group.replace_default_deployment_options.run(
+            ReplaceDefaultDeploymentOptionsAction(
+                resource_group_id=await self._resolve_resource_group_id(name),
+                resource_group=name,
+                options=options,
             )
         )
         return ReplaceResourceGroupDefaultDeploymentOptionsPayload(
@@ -1081,7 +1085,7 @@ class ResourceGroupAdapter(BaseAdapter):
                 h.name() for h in self._schedule_coordinator.registered_lifecycle_handlers()
             ),
         )
-        action_result = await self._processors.resource_group.replace_default_session_options.run(
+        action_result = await self._resource_group.replace_default_session_options.run(
             ReplaceDefaultSessionOptionsAction(
                 resource_group_id=await self._resolve_resource_group_id(name),
                 resource_group=name,

--- a/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_policy/adapter.py
@@ -130,6 +130,9 @@ from ai.backend.manager.services.keypair_resource_policy.actions.search_keypair_
 from ai.backend.manager.services.keypair_resource_policy.actions.update_keypair_resource_policy import (
     UpdateKeyPairResourcePolicyAction,
 )
+from ai.backend.manager.services.keypair_resource_policy.processors import (
+    KeypairResourcePolicyProcessors,
+)
 from ai.backend.manager.services.project_resource_policy.actions.create_project_resource_policy import (
     CreateProjectResourcePolicyAction,
 )
@@ -147,6 +150,9 @@ from ai.backend.manager.services.project_resource_policy.actions.search_project_
 )
 from ai.backend.manager.services.project_resource_policy.actions.update_project_resource_policy import (
     UpdateProjectResourcePolicyAction,
+)
+from ai.backend.manager.services.project_resource_policy.processors import (
+    ProjectResourcePolicyProcessors,
 )
 from ai.backend.manager.services.user_resource_policy.actions.create_user_resource_policy import (
     CreateUserResourcePolicyAction,
@@ -167,6 +173,7 @@ from ai.backend.manager.services.user_resource_policy.actions.search_user_resour
 from ai.backend.manager.services.user_resource_policy.actions.update_user_resource_policy import (
     UpdateUserResourcePolicyAction,
 )
+from ai.backend.manager.services.user_resource_policy.processors import UserResourcePolicyProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 _KEYPAIR_RP_PAGINATION_SPEC = PaginationSpec(
@@ -197,13 +204,27 @@ _PROJECT_RP_PAGINATION_SPEC = PaginationSpec(
 class ResourcePolicyAdapter(BaseAdapter):
     """Unified adapter for keypair, user, and project resource policy operations."""
 
+    _keypair_resource_policy: KeypairResourcePolicyProcessors
+    _user_resource_policy: UserResourcePolicyProcessors
+    _project_resource_policy: ProjectResourcePolicyProcessors
+
+    def __init__(
+        self,
+        keypair_resource_policy: KeypairResourcePolicyProcessors,
+        user_resource_policy: UserResourcePolicyProcessors,
+        project_resource_policy: ProjectResourcePolicyProcessors,
+    ) -> None:
+        self._keypair_resource_policy = keypair_resource_policy
+        self._user_resource_policy = user_resource_policy
+        self._project_resource_policy = project_resource_policy
+
     # ── Keypair Resource Policy ──
 
     async def admin_get_keypair_resource_policy(self, name: str) -> KeypairResourcePolicyNode:
-        resolved = await self._processors.keypair_resource_policy.lookup.run(
+        resolved = await self._keypair_resource_policy.lookup.run(
             LookupKeypairResourcePolicyAction(name=name)
         )
-        result = await self._processors.keypair_resource_policy.get.run(
+        result = await self._keypair_resource_policy.get.run(
             GetKeyPairResourcePolicyAction(policy_id=resolved.entity_id())
         )
         return self._keypair_policy_data_to_node(result.data)
@@ -226,7 +247,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.keypair_resource_policy.global_search.run(
+        result = await self._keypair_resource_policy.global_search.run(
             GlobalSearchKeypairResourcePoliciesAction(searcher=searcher)
         )
         items = [self._keypair_policy_data_to_node(d) for d in result.items]
@@ -253,7 +274,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             idle_timeout=input.idle_timeout,
             allowed_vfolder_hosts=self._entries_to_vfolder_hosts(input.allowed_vfolder_hosts),
         )
-        result = await self._processors.keypair_resource_policy.global_create.run(
+        result = await self._keypair_resource_policy.global_create.run(
             CreateKeyPairResourcePolicyAction(creator=creator)
         )
         return CreateKeypairResourcePolicyPayload(
@@ -263,7 +284,7 @@ class ResourcePolicyAdapter(BaseAdapter):
     async def admin_update_keypair_resource_policy(
         self, name: str, input: UpdateKeypairResourcePolicyInput
     ) -> UpdateKeypairResourcePolicyPayload:
-        target = await self._processors.keypair_resource_policy.lookup.run(
+        target = await self._keypair_resource_policy.lookup.run(
             LookupKeypairResourcePolicyAction(name=name)
         )
         updater = KeyPairResourcePolicyUpdater(
@@ -340,7 +361,7 @@ class ResourcePolicyAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.keypair_resource_policy.update.run(
+        result = await self._keypair_resource_policy.update.run(
             UpdateKeyPairResourcePolicyAction(updater=updater)
         )
         return UpdateKeypairResourcePolicyPayload(
@@ -350,10 +371,10 @@ class ResourcePolicyAdapter(BaseAdapter):
     async def admin_delete_keypair_resource_policy(
         self, input: DeleteKeypairResourcePolicyInput
     ) -> DeleteKeypairResourcePolicyPayload:
-        target = await self._processors.keypair_resource_policy.lookup.run(
+        target = await self._keypair_resource_policy.lookup.run(
             LookupKeypairResourcePolicyAction(name=input.name)
         )
-        await self._processors.keypair_resource_policy.purge.run(
+        await self._keypair_resource_policy.purge.run(
             PurgeKeyPairResourcePolicyAction(name=input.name, policy_id=target.entity_id())
         )
         return DeleteKeypairResourcePolicyPayload(name=input.name)
@@ -362,7 +383,7 @@ class ResourcePolicyAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available.")
-        result = await self._processors.keypair_resource_policy.search.run(
+        result = await self._keypair_resource_policy.search.run(
             SearchKeypairResourcePoliciesAction(
                 user_id=UserID(me.user_id),
                 searcher=KeyPairResourcePolicySearcher(pagination=NoPagination()),
@@ -375,10 +396,10 @@ class ResourcePolicyAdapter(BaseAdapter):
     # ── User Resource Policy ──
 
     async def admin_get_user_resource_policy(self, name: str) -> UserResourcePolicyNode:
-        resolved = await self._processors.user_resource_policy.lookup.run(
+        resolved = await self._user_resource_policy.lookup.run(
             LookupUserResourcePolicyAction(name=name)
         )
-        result = await self._processors.user_resource_policy.get.run(
+        result = await self._user_resource_policy.get.run(
             GetUserResourcePolicyAction(policy_id=resolved.entity_id())
         )
         return self._user_policy_data_to_node(result.data)
@@ -401,7 +422,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.user_resource_policy.global_search.run(
+        result = await self._user_resource_policy.global_search.run(
             GlobalSearchUserResourcePoliciesAction(searcher=searcher)
         )
         items = [self._user_policy_data_to_node(d) for d in result.items]
@@ -418,7 +439,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             max_session_count_per_model_session=input.max_session_count_per_model_session,
             max_customized_image_count=input.max_customized_image_count,
         )
-        result = await self._processors.user_resource_policy.global_create.run(
+        result = await self._user_resource_policy.global_create.run(
             CreateUserResourcePolicyAction(creator=creator)
         )
         return CreateUserResourcePolicyPayload(
@@ -428,7 +449,7 @@ class ResourcePolicyAdapter(BaseAdapter):
     async def admin_update_user_resource_policy(
         self, name: str, input: UpdateUserResourcePolicyInput
     ) -> UpdateUserResourcePolicyPayload:
-        target = await self._processors.user_resource_policy.lookup.run(
+        target = await self._user_resource_policy.lookup.run(
             LookupUserResourcePolicyAction(name=name)
         )
         updater = UserResourcePolicyUpdater(
@@ -465,7 +486,7 @@ class ResourcePolicyAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.user_resource_policy.update.run(
+        result = await self._user_resource_policy.update.run(
             UpdateUserResourcePolicyAction(updater=updater)
         )
         return UpdateUserResourcePolicyPayload(
@@ -475,10 +496,10 @@ class ResourcePolicyAdapter(BaseAdapter):
     async def admin_delete_user_resource_policy(
         self, input: DeleteUserResourcePolicyInput
     ) -> DeleteUserResourcePolicyPayload:
-        target = await self._processors.user_resource_policy.lookup.run(
+        target = await self._user_resource_policy.lookup.run(
             LookupUserResourcePolicyAction(name=input.name)
         )
-        await self._processors.user_resource_policy.purge.run(
+        await self._user_resource_policy.purge.run(
             PurgeUserResourcePolicyAction(name=input.name, policy_id=target.entity_id())
         )
         return DeleteUserResourcePolicyPayload(name=input.name)
@@ -487,7 +508,7 @@ class ResourcePolicyAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available.")
-        result = await self._processors.user_resource_policy.search.run(
+        result = await self._user_resource_policy.search.run(
             SearchUserResourcePoliciesAction(
                 user_id=UserID(me.user_id),
                 searcher=UserResourcePolicySearcher(pagination=NoPagination()),
@@ -500,10 +521,10 @@ class ResourcePolicyAdapter(BaseAdapter):
     # ── Project Resource Policy ──
 
     async def admin_get_project_resource_policy(self, name: str) -> ProjectResourcePolicyNode:
-        resolved = await self._processors.project_resource_policy.lookup.run(
+        resolved = await self._project_resource_policy.lookup.run(
             LookupProjectResourcePolicyAction(name=name)
         )
-        result = await self._processors.project_resource_policy.get.run(
+        result = await self._project_resource_policy.get.run(
             GetProjectResourcePolicyAction(policy_id=resolved.entity_id())
         )
         return self._project_policy_data_to_node(result.data)
@@ -526,7 +547,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.project_resource_policy.global_search.run(
+        result = await self._project_resource_policy.global_search.run(
             SearchProjectResourcePoliciesAction(searcher=searcher)
         )
         items = [self._project_policy_data_to_node(d) for d in result.items]
@@ -541,7 +562,7 @@ class ResourcePolicyAdapter(BaseAdapter):
             max_quota_scope_size=input.max_quota_scope_size.bytes,
             max_network_count=input.max_network_count,
         )
-        result = await self._processors.project_resource_policy.global_create.run(
+        result = await self._project_resource_policy.global_create.run(
             CreateProjectResourcePolicyAction(creator=creator)
         )
         return CreateProjectResourcePolicyPayload(
@@ -551,7 +572,7 @@ class ResourcePolicyAdapter(BaseAdapter):
     async def admin_update_project_resource_policy(
         self, name: str, input: UpdateProjectResourcePolicyInput
     ) -> UpdateProjectResourcePolicyPayload:
-        target = await self._processors.project_resource_policy.lookup.run(
+        target = await self._project_resource_policy.lookup.run(
             LookupProjectResourcePolicyAction(name=name)
         )
         updater = ProjectResourcePolicyUpdater(
@@ -576,7 +597,7 @@ class ResourcePolicyAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.project_resource_policy.update.run(
+        result = await self._project_resource_policy.update.run(
             UpdateProjectResourcePolicyAction(updater=updater)
         )
         return UpdateProjectResourcePolicyPayload(
@@ -586,10 +607,10 @@ class ResourcePolicyAdapter(BaseAdapter):
     async def admin_delete_project_resource_policy(
         self, input: DeleteProjectResourcePolicyInput
     ) -> DeleteProjectResourcePolicyPayload:
-        target = await self._processors.project_resource_policy.lookup.run(
+        target = await self._project_resource_policy.lookup.run(
             LookupProjectResourcePolicyAction(name=input.name)
         )
-        await self._processors.project_resource_policy.purge.run(
+        await self._project_resource_policy.purge.run(
             PurgeProjectResourcePolicyAction(name=input.name, policy_id=target.entity_id())
         )
         return DeleteProjectResourcePolicyPayload(name=input.name)

--- a/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
@@ -59,6 +59,7 @@ from ai.backend.manager.services.resource_preset.actions.search_presets import (
 from ai.backend.manager.services.resource_preset.actions.update_preset import (
     UpdateResourcePresetAction,
 )
+from ai.backend.manager.services.resource_preset.processors import ResourcePresetProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -89,6 +90,11 @@ def _resource_preset_pagination_spec() -> PaginationSpec:
 class ResourcePresetAdapter(BaseAdapter):
     """Adapter for resource preset operations."""
 
+    _resource_preset: ResourcePresetProcessors
+
+    def __init__(self, resource_preset: ResourcePresetProcessors) -> None:
+        self._resource_preset = resource_preset
+
     async def search(
         self,
         input: AdminSearchResourcePresetsInput,
@@ -108,7 +114,7 @@ class ResourcePresetAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.resource_preset.search_presets_v2.run(
+        result = await self._resource_preset.search_presets_v2.run(
             SearchResourcePresetsV2Action(querier=querier)
         )
         return AdminSearchResourcePresetsPayload(
@@ -121,7 +127,7 @@ class ResourcePresetAdapter(BaseAdapter):
     async def get(self, preset_id: UUID) -> ResourcePresetNode:
         """Get a single resource preset by ID."""
         try:
-            result = await self._processors.resource_preset.get_preset.run(
+            result = await self._resource_preset.get_preset.run(
                 GetResourcePresetAction(preset_id=ResourcePresetID(preset_id))
             )
         except EntityNotFoundError as e:
@@ -147,7 +153,7 @@ class ResourcePresetAdapter(BaseAdapter):
                 resource_group_name=resource_group_name,
             )
         )
-        result = await self._processors.resource_preset.create_preset.run(
+        result = await self._resource_preset.create_preset.run(
             CreateResourcePresetAction(creator=creator)
         )
         return CreateResourcePresetPayload(
@@ -185,7 +191,7 @@ class ResourcePresetAdapter(BaseAdapter):
             resource_group_name=resource_group_state,
         )
         updater = Updater(spec=updater_spec, pk_value=input.id)
-        result = await self._processors.resource_preset.update_preset.run(
+        result = await self._resource_preset.update_preset.run(
             UpdateResourcePresetAction(preset_id=ResourcePresetID(input.id), updater=updater)
         )
         return UpdateResourcePresetPayload(
@@ -194,7 +200,7 @@ class ResourcePresetAdapter(BaseAdapter):
 
     async def delete(self, preset_id: UUID) -> DeleteResourcePresetPayload:
         """Delete a resource preset by ID."""
-        result = await self._processors.resource_preset.delete_preset.run(
+        result = await self._resource_preset.delete_preset.run(
             DeleteResourcePresetAction(preset_id=ResourcePresetID(preset_id))
         )
         return DeleteResourcePresetPayload(id=result.resource_preset.id)

--- a/src/ai/backend/manager/api/adapters/resource_slot/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_slot/adapter.py
@@ -75,7 +75,9 @@ from ai.backend.manager.models.resource_slot.updaters import ResourceSlotTypeUpd
 from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.agent.actions.lookup import LookupAgentAction
+from ai.backend.manager.services.agent.processors import AgentProcessors
 from ai.backend.manager.services.domain.actions.lookup import LookupDomainAction
+from ai.backend.manager.services.domain.processors import DomainProcessors
 from ai.backend.manager.services.resource_slot.actions.create import CreateResourceSlotTypeAction
 from ai.backend.manager.services.resource_slot.actions.get import GetResourceSlotTypeAction
 from ai.backend.manager.services.resource_slot.actions.get_agent_resource_by_slot import (
@@ -107,6 +109,7 @@ from ai.backend.manager.services.resource_slot.actions.search_resource_slot_type
     SearchResourceSlotTypesAction,
 )
 from ai.backend.manager.services.resource_slot.actions.update import UpdateResourceSlotTypeAction
+from ai.backend.manager.services.resource_slot.processors import ResourceSlotProcessors
 from ai.backend.manager.types import OptionalState
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -114,6 +117,20 @@ DEFAULT_PAGINATION_LIMIT = 10
 
 class ResourceSlotAdapter(BaseAdapter):
     """Adapter for resource slot domain operations."""
+
+    _resource_slot: ResourceSlotProcessors
+    _agent: AgentProcessors
+    _domain: DomainProcessors
+
+    def __init__(
+        self,
+        resource_slot: ResourceSlotProcessors,
+        agent: AgentProcessors,
+        domain: DomainProcessors,
+    ) -> None:
+        self._resource_slot = resource_slot
+        self._agent = agent
+        self._domain = domain
 
     # -------------------------------------------------------------------------
     # ResourceSlotType search
@@ -133,7 +150,7 @@ class ResourceSlotAdapter(BaseAdapter):
         """
         searcher = self._build_slot_type_searcher(input)
 
-        action_result = await self._processors.resource_slot.public_search_resource_slot_types.run(
+        action_result = await self._resource_slot.public_search_resource_slot_types.run(
             SearchResourceSlotTypesAction(searcher=searcher)
         )
 
@@ -209,7 +226,7 @@ class ResourceSlotAdapter(BaseAdapter):
             number_format=self._to_number_format(input.number_format),
             rank=input.rank,
         )
-        action_result = await self._processors.resource_slot.global_create_resource_slot_type.run(
+        action_result = await self._resource_slot.global_create_resource_slot_type.run(
             CreateResourceSlotTypeAction(creator=creator)
         )
         return CreateResourceSlotTypePayload(
@@ -220,7 +237,7 @@ class ResourceSlotAdapter(BaseAdapter):
         self, input: UpdateResourceSlotTypeInput
     ) -> UpdateResourceSlotTypePayload:
         """Update the display and scheduling flags of a resource slot type."""
-        target = await self._processors.resource_slot.public_lookup_resource_slot_type.run(
+        target = await self._resource_slot.public_lookup_resource_slot_type.run(
             LookupResourceSlotTypeAction(slot_name=input.slot_name)
         )
         updater = ResourceSlotTypeUpdater(
@@ -238,7 +255,7 @@ class ResourceSlotAdapter(BaseAdapter):
             ),
             rank=OptionalState.from_nullable(input.rank),
         )
-        action_result = await self._processors.resource_slot.global_update_resource_slot_type.run(
+        action_result = await self._resource_slot.global_update_resource_slot_type.run(
             UpdateResourceSlotTypeAction(updater=updater)
         )
         return UpdateResourceSlotTypePayload(
@@ -249,10 +266,10 @@ class ResourceSlotAdapter(BaseAdapter):
         self, input: PurgeResourceSlotTypeInput
     ) -> PurgeResourceSlotTypePayload:
         """Remove a resource slot type, refusing while anything still references it."""
-        target = await self._processors.resource_slot.public_lookup_resource_slot_type.run(
+        target = await self._resource_slot.public_lookup_resource_slot_type.run(
             LookupResourceSlotTypeAction(slot_name=input.slot_name)
         )
-        action_result = await self._processors.resource_slot.purge_resource_slot_type.run(
+        action_result = await self._resource_slot.purge_resource_slot_type.run(
             PurgeResourceSlotTypeAction(
                 purger=ResourceSlotTypePurger(
                     slot_name=input.slot_name, slot_type_id=target.entity_id()
@@ -306,7 +323,7 @@ class ResourceSlotAdapter(BaseAdapter):
         """
         querier = self._build_agent_resource_querier(input)
 
-        action_result = await self._processors.resource_slot.search_agent_resources.run(
+        action_result = await self._resource_slot.search_agent_resources.run(
             GlobalSearchAgentResourcesAction(querier=querier)
         )
 
@@ -405,7 +422,7 @@ class ResourceSlotAdapter(BaseAdapter):
         """
         querier = self._build_resource_allocation_querier(input)
 
-        action_result = await self._processors.resource_slot.search_resource_allocations.run(
+        action_result = await self._resource_slot.search_resource_allocations.run(
             GlobalSearchResourceAllocationsAction(querier=querier)
         )
 
@@ -493,20 +510,18 @@ class ResourceSlotAdapter(BaseAdapter):
 
     async def get_slot_type(self, slot_name: str) -> ResourceSlotTypeNode:
         """Retrieve a single resource slot type by slot name."""
-        resolved = await self._processors.resource_slot.public_lookup_resource_slot_type.run(
+        resolved = await self._resource_slot.public_lookup_resource_slot_type.run(
             LookupResourceSlotTypeAction(slot_name=slot_name)
         )
-        action_result = await self._processors.resource_slot.public_get_resource_slot_type.run(
+        action_result = await self._resource_slot.public_get_resource_slot_type.run(
             GetResourceSlotTypeAction(slot_type_id=resolved.entity_id())
         )
         return self._slot_type_data_to_node(action_result.data)
 
     async def get_agent_resource(self, agent_id: str, slot_name: str) -> AgentResourceNode:
         """Retrieve a single agent resource by agent ID and slot name."""
-        agent = await self._processors.agent.lookup.run(
-            LookupAgentAction(agent_id=AgentId(agent_id))
-        )
-        action_result = await self._processors.resource_slot.get_agent_resource_by_slot.run(
+        agent = await self._agent.lookup.run(LookupAgentAction(agent_id=AgentId(agent_id)))
+        action_result = await self._resource_slot.get_agent_resource_by_slot.run(
             GetAgentResourceBySlotAction(
                 agent_uuid=agent.entity_id(), agent_id=agent_id, slot_name=slot_name
             )
@@ -517,10 +532,10 @@ class ResourceSlotAdapter(BaseAdapter):
         self, kernel_id: uuid.UUID, slot_name: str
     ) -> ResourceAllocationNode:
         """Retrieve a single kernel resource allocation by kernel ID and slot name."""
-        owner = await self._processors.resource_slot.lookup_kernel_owner.run(
+        owner = await self._resource_slot.lookup_kernel_owner.run(
             LookupKernelOwnerAction(kernel_id=KernelID(kernel_id))
         )
-        action_result = await self._processors.resource_slot.get_kernel_allocation_by_slot.run(
+        action_result = await self._resource_slot.get_kernel_allocation_by_slot.run(
             GetKernelAllocationBySlotAction(
                 session_id=SessionID(owner.entity_id()),
                 kernel_id=KernelID(kernel_id),
@@ -535,10 +550,8 @@ class ResourceSlotAdapter(BaseAdapter):
 
     async def get_domain_resource_overview(self, domain_name: str) -> ActiveResourceOverviewInfoDTO:
         """Retrieve active resource occupancy overview for a domain."""
-        domain = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
-        action_result = await self._processors.resource_slot.get_domain_resource_overview.run(
+        domain = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
+        action_result = await self._resource_slot.get_domain_resource_overview.run(
             GetDomainResourceOverviewAction(domain_id=domain.entity_id(), domain_name=domain_name)
         )
         occupancy = action_result.item
@@ -559,7 +572,7 @@ class ResourceSlotAdapter(BaseAdapter):
         self, project_id: uuid.UUID
     ) -> ActiveResourceOverviewInfoDTO:
         """Retrieve active resource occupancy overview for a project."""
-        action_result = await self._processors.resource_slot.get_project_resource_overview.run(
+        action_result = await self._resource_slot.get_project_resource_overview.run(
             GetProjectResourceOverviewAction(project_id=ProjectID(project_id))
         )
         occupancy = action_result.item

--- a/src/ai/backend/manager/api/adapters/resource_usage/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_usage/adapter.py
@@ -75,6 +75,7 @@ from ai.backend.manager.repositories.resource_usage_history import (
     UserUsageBucketOrders,
 )
 from ai.backend.manager.services.resource_group.actions.lookup import LookupResourceGroupAction
+from ai.backend.manager.services.resource_group.processors import ResourceGroupProcessors
 from ai.backend.manager.services.resource_usage.actions.global_search_domain_usage_buckets import (
     GlobalSearchDomainUsageBucketsAction,
 )
@@ -98,6 +99,7 @@ from ai.backend.manager.services.resource_usage.actions.search_project_usage_buc
 from ai.backend.manager.services.resource_usage.actions.search_user_usage_buckets import (
     SearchUserUsageBucketsAction,
 )
+from ai.backend.manager.services.resource_usage.processors import ResourceUsageProcessors
 
 DEFAULT_PAGINATION_LIMIT = 20
 
@@ -148,6 +150,17 @@ def _build_date_filter_condition(
 class ResourceUsageAdapter(BaseAdapter):
     """Adapter for resource usage domain operations."""
 
+    _resource_usage: ResourceUsageProcessors
+    _resource_group: ResourceGroupProcessors
+
+    def __init__(
+        self,
+        resource_usage: ResourceUsageProcessors,
+        resource_group: ResourceGroupProcessors,
+    ) -> None:
+        self._resource_usage = resource_usage
+        self._resource_group = resource_group
+
     # Admin (unscoped) searches
 
     async def admin_search_domain(
@@ -163,14 +176,12 @@ class ResourceUsageAdapter(BaseAdapter):
         if input.resource_group is not None:
             conditions.append(DomainUsageBucketConditions.by_resource_group(input.resource_group))
         orders = [DomainUsageBucketOrders.by_period_start(ascending=False)]
-        action_result = (
-            await self._processors.resource_usage.global_search_domain_usage_buckets.run(
-                GlobalSearchDomainUsageBucketsAction(
-                    searcher=DomainUsageBucketSearcher(
-                        pagination=pagination,
-                        conditions=conditions,
-                        orders=orders,
-                    )
+        action_result = await self._resource_usage.global_search_domain_usage_buckets.run(
+            GlobalSearchDomainUsageBucketsAction(
+                searcher=DomainUsageBucketSearcher(
+                    pagination=pagination,
+                    conditions=conditions,
+                    orders=orders,
                 )
             )
         )
@@ -202,14 +213,12 @@ class ResourceUsageAdapter(BaseAdapter):
                 )
             )
         orders = [ProjectUsageBucketOrders.by_period_start(ascending=False)]
-        action_result = (
-            await self._processors.resource_usage.global_search_project_usage_buckets.run(
-                GlobalSearchProjectUsageBucketsAction(
-                    searcher=ProjectUsageBucketSearcher(
-                        pagination=pagination,
-                        conditions=conditions,
-                        orders=orders,
-                    )
+        action_result = await self._resource_usage.global_search_project_usage_buckets.run(
+            GlobalSearchProjectUsageBucketsAction(
+                searcher=ProjectUsageBucketSearcher(
+                    pagination=pagination,
+                    conditions=conditions,
+                    orders=orders,
                 )
             )
         )
@@ -247,7 +256,7 @@ class ResourceUsageAdapter(BaseAdapter):
                 )
             )
         orders = [UserUsageBucketOrders.by_period_start(ascending=False)]
-        action_result = await self._processors.resource_usage.global_search_user_usage_buckets.run(
+        action_result = await self._resource_usage.global_search_user_usage_buckets.run(
             GlobalSearchUserUsageBucketsAction(
                 searcher=UserUsageBucketSearcher(
                     pagination=pagination,
@@ -279,7 +288,7 @@ class ResourceUsageAdapter(BaseAdapter):
             orders=[DomainUsageBucketOrders.by_period_start(ascending=False)],
             pagination=OffsetPagination(limit=limit, offset=offset),
         )
-        action_result = await self._processors.resource_usage.search_domain_usage_buckets.run(
+        action_result = await self._resource_usage.search_domain_usage_buckets.run(
             SearchDomainUsageBucketsAction(
                 items=[
                     DomainUsageBucketScopeItem(
@@ -315,7 +324,7 @@ class ResourceUsageAdapter(BaseAdapter):
             orders=[ProjectUsageBucketOrders.by_period_start(ascending=False)],
             pagination=OffsetPagination(limit=limit, offset=offset),
         )
-        action_result = await self._processors.resource_usage.search_project_usage_buckets.run(
+        action_result = await self._resource_usage.search_project_usage_buckets.run(
             SearchProjectUsageBucketsAction(
                 items=[
                     ProjectUsageBucketScopeItem(
@@ -352,7 +361,7 @@ class ResourceUsageAdapter(BaseAdapter):
             orders=[UserUsageBucketOrders.by_period_start(ascending=False)],
             pagination=OffsetPagination(limit=limit, offset=offset),
         )
-        action_result = await self._processors.resource_usage.search_user_usage_buckets.run(
+        action_result = await self._resource_usage.search_user_usage_buckets.run(
             SearchUserUsageBucketsAction(
                 items=[
                     UserUsageBucketScopeItem(
@@ -408,7 +417,7 @@ class ResourceUsageAdapter(BaseAdapter):
             offset=offset,
         )
         resource_group_id = await self._resource_group_id(resource_group_name)
-        action_result = await self._processors.resource_usage.search_domain_usage_buckets.run(
+        action_result = await self._resource_usage.search_domain_usage_buckets.run(
             SearchDomainUsageBucketsAction(
                 items=[
                     DomainUsageBucketScopeItem(
@@ -459,7 +468,7 @@ class ResourceUsageAdapter(BaseAdapter):
             offset=offset,
         )
         resource_group_id = await self._resource_group_id(resource_group_name)
-        action_result = await self._processors.resource_usage.search_project_usage_buckets.run(
+        action_result = await self._resource_usage.search_project_usage_buckets.run(
             SearchProjectUsageBucketsAction(
                 items=[
                     ProjectUsageBucketScopeItem(
@@ -512,7 +521,7 @@ class ResourceUsageAdapter(BaseAdapter):
             offset=offset,
         )
         resource_group_id = await self._resource_group_id(resource_group_name)
-        action_result = await self._processors.resource_usage.search_user_usage_buckets.run(
+        action_result = await self._resource_usage.search_user_usage_buckets.run(
             SearchUserUsageBucketsAction(
                 items=[
                     UserUsageBucketScopeItem(
@@ -561,14 +570,12 @@ class ResourceUsageAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        action_result = (
-            await self._processors.resource_usage.global_search_domain_usage_buckets.run(
-                GlobalSearchDomainUsageBucketsAction(
-                    searcher=DomainUsageBucketSearcher(
-                        pagination=querier.pagination,
-                        conditions=querier.conditions,
-                        orders=querier.orders,
-                    )
+        action_result = await self._resource_usage.global_search_domain_usage_buckets.run(
+            GlobalSearchDomainUsageBucketsAction(
+                searcher=DomainUsageBucketSearcher(
+                    pagination=querier.pagination,
+                    conditions=querier.conditions,
+                    orders=querier.orders,
                 )
             )
         )
@@ -604,14 +611,12 @@ class ResourceUsageAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        action_result = (
-            await self._processors.resource_usage.global_search_project_usage_buckets.run(
-                GlobalSearchProjectUsageBucketsAction(
-                    searcher=ProjectUsageBucketSearcher(
-                        pagination=querier.pagination,
-                        conditions=querier.conditions,
-                        orders=querier.orders,
-                    )
+        action_result = await self._resource_usage.global_search_project_usage_buckets.run(
+            GlobalSearchProjectUsageBucketsAction(
+                searcher=ProjectUsageBucketSearcher(
+                    pagination=querier.pagination,
+                    conditions=querier.conditions,
+                    orders=querier.orders,
                 )
             )
         )
@@ -647,7 +652,7 @@ class ResourceUsageAdapter(BaseAdapter):
             limit=limit,
             offset=offset,
         )
-        action_result = await self._processors.resource_usage.global_search_user_usage_buckets.run(
+        action_result = await self._resource_usage.global_search_user_usage_buckets.run(
             GlobalSearchUserUsageBucketsAction(
                 searcher=UserUsageBucketSearcher(
                     pagination=querier.pagination,
@@ -690,14 +695,12 @@ class ResourceUsageAdapter(BaseAdapter):
             offset=offset,
             base_conditions=base_conditions,
         )
-        action_result = (
-            await self._processors.resource_usage.global_search_project_usage_buckets.run(
-                GlobalSearchProjectUsageBucketsAction(
-                    searcher=ProjectUsageBucketSearcher(
-                        pagination=querier.pagination,
-                        conditions=querier.conditions,
-                        orders=querier.orders,
-                    )
+        action_result = await self._resource_usage.global_search_project_usage_buckets.run(
+            GlobalSearchProjectUsageBucketsAction(
+                searcher=ProjectUsageBucketSearcher(
+                    pagination=querier.pagination,
+                    conditions=querier.conditions,
+                    orders=querier.orders,
                 )
             )
         )
@@ -735,7 +738,7 @@ class ResourceUsageAdapter(BaseAdapter):
             offset=offset,
             base_conditions=base_conditions,
         )
-        action_result = await self._processors.resource_usage.global_search_user_usage_buckets.run(
+        action_result = await self._resource_usage.global_search_user_usage_buckets.run(
             GlobalSearchUserUsageBucketsAction(
                 searcher=UserUsageBucketSearcher(
                     pagination=querier.pagination,
@@ -1094,7 +1097,7 @@ class ResourceUsageAdapter(BaseAdapter):
 
         The request names the group; a scope has to name its id.
         """
-        result = await self._processors.resource_group.lookup.run(
+        result = await self._resource_group.lookup.run(
             LookupResourceGroupAction(name=ResourceGroupName(name))
         )
         return result.entity_id()

--- a/src/ai/backend/manager/api/adapters/retention_policy/adapter.py
+++ b/src/ai/backend/manager/api/adapters/retention_policy/adapter.py
@@ -46,6 +46,7 @@ from ai.backend.manager.services.retention_policy.actions.search import (
 from ai.backend.manager.services.retention_policy.actions.update import (
     UpdateRetentionPolicyAction,
 )
+from ai.backend.manager.services.retention_policy.processors import RetentionPolicyProcessors
 from ai.backend.manager.types import OptionalState
 
 
@@ -60,6 +61,11 @@ def _retention_policy_pagination_spec() -> PaginationSpec:
 
 
 class RetentionPolicyAdapter(BaseAdapter):
+    _retention_policy: RetentionPolicyProcessors
+
+    def __init__(self, retention_policy: RetentionPolicyProcessors) -> None:
+        self._retention_policy = retention_policy
+
     async def search(
         self,
         input: SearchRetentionPoliciesInput,
@@ -78,7 +84,7 @@ class RetentionPolicyAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.retention_policy.global_search.run(
+        result = await self._retention_policy.global_search.run(
             SearchRetentionPoliciesAction(searcher=searcher)
         )
         return SearchRetentionPoliciesPayload(
@@ -89,9 +95,7 @@ class RetentionPolicyAdapter(BaseAdapter):
         )
 
     async def get(self, policy_id: RetentionPolicyID) -> RetentionPolicyNode:
-        result = await self._processors.retention_policy.get.run(
-            GetRetentionPolicyAction(policy_id=policy_id)
-        )
+        result = await self._retention_policy.get.run(GetRetentionPolicyAction(policy_id=policy_id))
         return self._data_to_node(result.data)
 
     async def create(
@@ -103,7 +107,7 @@ class RetentionPolicyAdapter(BaseAdapter):
             retention_period=timedelta(days=input.retention_period_days),
             enabled=input.enabled,
         )
-        result = await self._processors.retention_policy.global_create.run(
+        result = await self._retention_policy.global_create.run(
             CreateRetentionPolicyAction(creator=creator)
         )
         return CreateRetentionPolicyPayload(policy=self._data_to_node(result.data))
@@ -130,22 +134,18 @@ class RetentionPolicyAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.retention_policy.update.run(
+        result = await self._retention_policy.update.run(
             UpdateRetentionPolicyAction(updater=updater)
         )
         return UpdateRetentionPolicyPayload(policy=self._data_to_node(result.data))
 
     async def delete(self, policy_id: RetentionPolicyID) -> DeleteRetentionPolicyPayload:
-        result = await self._processors.retention_policy.delete.run(
-            DeleteRetentionPolicyAction(id=policy_id)
-        )
+        result = await self._retention_policy.delete.run(DeleteRetentionPolicyAction(id=policy_id))
         return DeleteRetentionPolicyPayload(id=result.data.id)
 
     async def purge(self, policy_id: RetentionPolicyID) -> PurgeRetentionPolicyPayload:
         purger = RetentionPolicyPurger(policy_id=policy_id)
-        result = await self._processors.retention_policy.purge.run(
-            PurgeRetentionPolicyAction(purger=purger)
-        )
+        result = await self._retention_policy.purge.run(PurgeRetentionPolicyAction(purger=purger))
         return PurgeRetentionPolicyPayload(id=result.data.id)
 
     def _convert_filter(self, filter_: RetentionPolicyFilter) -> list[QueryCondition]:

--- a/src/ai/backend/manager/api/adapters/role_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/role_preset/adapter.py
@@ -100,6 +100,7 @@ from ai.backend.manager.services.role_preset.actions.search_permission_presets i
     SearchRolePermissionPresetsAction,
 )
 from ai.backend.manager.services.role_preset.actions.update import UpdateRolePresetAction
+from ai.backend.manager.services.role_preset.processors import RolePresetProcessors
 from ai.backend.manager.types import OptionalState
 
 
@@ -126,6 +127,11 @@ def _role_permission_preset_pagination_spec() -> PaginationSpec:
 class RolePresetAdapter(BaseAdapter):
     """Adapter for role preset domain operations."""
 
+    _role_preset: RolePresetProcessors
+
+    def __init__(self, role_preset: RolePresetProcessors) -> None:
+        self._role_preset = role_preset
+
     async def create(self, input: CreateRolePresetInput) -> CreateRolePresetPayload:
         """Create a new role preset."""
         creator = RolePresetCreator(
@@ -140,7 +146,7 @@ class RolePresetAdapter(BaseAdapter):
             )
             for entry in input.permissions
         ]
-        result = await self._processors.role_preset.create.run(
+        result = await self._role_preset.create.run(
             CreateRolePresetAction(
                 creator=creator,
                 permission_creators=permission_creators,
@@ -150,9 +156,7 @@ class RolePresetAdapter(BaseAdapter):
 
     async def get(self, role_preset_id: RolePresetID) -> RolePresetNode:
         """Get a single role preset by ID."""
-        result = await self._processors.role_preset.get.run(
-            GetRolePresetAction(preset_id=role_preset_id)
-        )
+        result = await self._role_preset.get.run(GetRolePresetAction(preset_id=role_preset_id))
         return self._data_to_node(result.data)
 
     async def search(self, input: SearchRolePresetsInput) -> SearchRolePresetsPayload:
@@ -176,9 +180,7 @@ class RolePresetAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.role_preset.search.run(
-            SearchRolePresetsAction(searcher=searcher)
-        )
+        result = await self._role_preset.search.run(SearchRolePresetsAction(searcher=searcher))
         return SearchRolePresetsPayload(
             items=[self._data_to_node(d) for d in result.items],
             total_count=result.total_count,
@@ -199,9 +201,7 @@ class RolePresetAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        result = await self._processors.role_preset.update.run(
-            UpdateRolePresetAction(updater=updater)
-        )
+        result = await self._role_preset.update.run(UpdateRolePresetAction(updater=updater))
         return UpdateRolePresetPayload(role_preset=self._data_to_node(result.data))
 
     async def update_from_body(
@@ -222,7 +222,7 @@ class RolePresetAdapter(BaseAdapter):
 
     async def bulk_delete(self, input: BulkDeleteRolePresetsInput) -> BulkDeleteRolePresetsPayload:
         """Bulk-soft-delete role presets."""
-        result = await self._processors.role_preset.bulk_delete.run(
+        result = await self._role_preset.bulk_delete.run(
             BulkDeleteRolePresetsAction(ids=input.role_preset_ids)
         )
         return BulkDeleteRolePresetsPayload(
@@ -242,7 +242,7 @@ class RolePresetAdapter(BaseAdapter):
         self, input: BulkRestoreRolePresetsInput
     ) -> BulkRestoreRolePresetsPayload:
         """Bulk-restore soft-deleted role presets."""
-        result = await self._processors.role_preset.bulk_restore.run(
+        result = await self._role_preset.bulk_restore.run(
             BulkRestoreRolePresetsAction(ids=input.role_preset_ids)
         )
         return BulkRestoreRolePresetsPayload(
@@ -260,7 +260,7 @@ class RolePresetAdapter(BaseAdapter):
 
     async def bulk_purge(self, input: BulkPurgeRolePresetsInput) -> BulkPurgeRolePresetsPayload:
         """Bulk-hard-delete role presets."""
-        result = await self._processors.role_preset.bulk_purge.run(
+        result = await self._role_preset.bulk_purge.run(
             BulkPurgeRolePresetsAction(ids=input.role_preset_ids)
         )
         return BulkPurgeRolePresetsPayload(
@@ -300,7 +300,7 @@ class RolePresetAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.role_preset.search_permission_presets.run(
+        result = await self._role_preset.search_permission_presets.run(
             SearchRolePermissionPresetsAction(preset_id=role_preset_id, searcher=searcher)
         )
         return SearchRolePermissionPresetsPayload(
@@ -323,7 +323,7 @@ class RolePresetAdapter(BaseAdapter):
             )
             for entry in input.permissions
         ]
-        result = await self._processors.role_preset.bulk_add_permissions.run(
+        result = await self._role_preset.bulk_add_permissions.run(
             BulkAddRolePermissionPresetsAction(preset_id=role_preset_id, creators=creators)
         )
         # The write is atomic: every entry landed, or the run raised and nothing did.
@@ -336,7 +336,7 @@ class RolePresetAdapter(BaseAdapter):
         self, input: BulkRemoveRolePermissionPresetsInput
     ) -> BulkRemoveRolePermissionPresetsPayload:
         """Bulk-remove permission entries from a role preset."""
-        result = await self._processors.role_preset.bulk_remove_permissions.run(
+        result = await self._role_preset.bulk_remove_permissions.run(
             BulkRemoveRolePermissionPresetsAction(ids=input.permission_preset_ids)
         )
         return BulkRemoveRolePermissionPresetsPayload(

--- a/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant/adapter.py
@@ -45,6 +45,7 @@ from ai.backend.manager.services.runtime_variant.actions.lookup import (
 from ai.backend.manager.services.runtime_variant.actions.purge import PurgeRuntimeVariantAction
 from ai.backend.manager.services.runtime_variant.actions.search import SearchRuntimeVariantsAction
 from ai.backend.manager.services.runtime_variant.actions.update import UpdateRuntimeVariantAction
+from ai.backend.manager.services.runtime_variant.processors import RuntimeVariantProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -59,6 +60,11 @@ def _runtime_variant_pagination_spec() -> PaginationSpec:
 
 
 class RuntimeVariantAdapter(BaseAdapter):
+    _runtime_variant: RuntimeVariantProcessors
+
+    def __init__(self, runtime_variant: RuntimeVariantProcessors) -> None:
+        self._runtime_variant = runtime_variant
+
     async def batch_load_by_ids(
         self, ids: Sequence[UUID]
     ) -> list[RuntimeVariantNode | Exception | None]:
@@ -70,7 +76,7 @@ class RuntimeVariantAdapter(BaseAdapter):
         if not ids:
             return []
         entity_ids = [RuntimeVariantID(value) for value in ids]
-        result = await self._processors.runtime_variant.public_bulk_get.run(
+        result = await self._runtime_variant.public_bulk_get.run(
             PublicBulkGetRuntimeVariantsAction(ids=entity_ids)
         )
         return [
@@ -98,7 +104,7 @@ class RuntimeVariantAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.runtime_variant.public_search.run(
+        result = await self._runtime_variant.public_search.run(
             SearchRuntimeVariantsAction(searcher=searcher)
         )
         return SearchRuntimeVariantsPayload(
@@ -109,7 +115,7 @@ class RuntimeVariantAdapter(BaseAdapter):
         )
 
     async def get(self, variant_id: UUID) -> RuntimeVariantNode:
-        result = await self._processors.runtime_variant.public_get.run(
+        result = await self._runtime_variant.public_get.run(
             GetRuntimeVariantAction(variant_id=RuntimeVariantID(variant_id))
         )
         return self._data_to_node(result.data)
@@ -122,7 +128,7 @@ class RuntimeVariantAdapter(BaseAdapter):
             name=input.name,
             description=input.description,
         )
-        result = await self._processors.runtime_variant.global_create.run(
+        result = await self._runtime_variant.global_create.run(
             CreateRuntimeVariantAction(creator=creator)
         )
         return CreateRuntimeVariantPayload(
@@ -146,15 +152,13 @@ class RuntimeVariantAdapter(BaseAdapter):
                 else TriState.update(input.description)
             ),
         )
-        result = await self._processors.runtime_variant.update.run(
-            UpdateRuntimeVariantAction(updater=updater)
-        )
+        result = await self._runtime_variant.update.run(UpdateRuntimeVariantAction(updater=updater))
         return UpdateRuntimeVariantPayload(
             runtime_variant=self._data_to_node(result.data),
         )
 
     async def delete(self, variant_id: UUID) -> DeleteRuntimeVariantPayload:
-        result = await self._processors.runtime_variant.purge.run(
+        result = await self._runtime_variant.purge.run(
             PurgeRuntimeVariantAction(id=RuntimeVariantID(variant_id))
         )
         return DeleteRuntimeVariantPayload(id=result.data.id)
@@ -162,7 +166,7 @@ class RuntimeVariantAdapter(BaseAdapter):
     async def bulk_delete(self, input: DeleteRuntimeVariantsInput) -> DeleteRuntimeVariantsPayload:
         """Delete multiple runtime variants by ID."""
         for variant_id in input.ids:
-            await self._processors.runtime_variant.purge.run(
+            await self._runtime_variant.purge.run(
                 PurgeRuntimeVariantAction(id=RuntimeVariantID(variant_id))
             )
         return DeleteRuntimeVariantsPayload(deleted_count=len(input.ids))
@@ -175,7 +179,7 @@ class RuntimeVariantAdapter(BaseAdapter):
         not form part of the v2 surface — v2 clients pass the id
         directly.
         """
-        result = await self._processors.runtime_variant.public_lookup.run(
+        result = await self._runtime_variant.public_lookup.run(
             LookupRuntimeVariantAction(name=name)
         )
         return result.entity_id()

--- a/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/runtime_variant_preset/adapter.py
@@ -69,6 +69,9 @@ from ai.backend.manager.services.runtime_variant_preset.actions.search import (
 from ai.backend.manager.services.runtime_variant_preset.actions.update import (
     UpdateRuntimeVariantPresetAction,
 )
+from ai.backend.manager.services.runtime_variant_preset.processors import (
+    RuntimeVariantPresetProcessors,
+)
 from ai.backend.manager.types import OptionalState, TriState
 
 
@@ -101,6 +104,11 @@ def _convert_ui_option_data(opt: UIOptionData | None) -> UIOption | None:
 
 
 class RuntimeVariantPresetAdapter(BaseAdapter):
+    _runtime_variant_preset: RuntimeVariantPresetProcessors
+
+    def __init__(self, runtime_variant_preset: RuntimeVariantPresetProcessors) -> None:
+        self._runtime_variant_preset = runtime_variant_preset
+
     async def search(
         self,
         input: SearchRuntimeVariantPresetsInput,
@@ -119,7 +127,7 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.runtime_variant_preset.public_search.run(
+        result = await self._runtime_variant_preset.public_search.run(
             SearchRuntimeVariantPresetsAction(searcher=searcher)
         )
         return SearchRuntimeVariantPresetsPayload(
@@ -130,7 +138,7 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
         )
 
     async def get(self, preset_id: UUID) -> RuntimeVariantPresetNode:
-        result = await self._processors.runtime_variant_preset.public_get.run(
+        result = await self._runtime_variant_preset.public_get.run(
             GetRuntimeVariantPresetAction(preset_id=RuntimeVariantPresetID(preset_id))
         )
         return self._data_to_node(result.data)
@@ -143,7 +151,7 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[RuntimeVariantPresetConditions.by_ids(ids)],
         )
-        result = await self._processors.runtime_variant_preset.public_search.run(
+        result = await self._runtime_variant_preset.public_search.run(
             SearchRuntimeVariantPresetsAction(searcher=searcher)
         )
         node_map = {item.id: self._data_to_node(item) for item in result.items}
@@ -166,7 +174,7 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
             display_name=input.display_name,
             ui_option=input.ui_option,
         )
-        result = await self._processors.runtime_variant_preset.global_create.run(
+        result = await self._runtime_variant_preset.global_create.run(
             CreateRuntimeVariantPresetAction(creator=creator)
         )
         return CreateRuntimeVariantPresetPayload(preset=self._data_to_node(result.data))
@@ -235,13 +243,13 @@ class RuntimeVariantPresetAdapter(BaseAdapter):
                 else TriState.update(input.ui_option)
             ),
         )
-        result = await self._processors.runtime_variant_preset.update.run(
+        result = await self._runtime_variant_preset.update.run(
             UpdateRuntimeVariantPresetAction(updater=updater)
         )
         return UpdateRuntimeVariantPresetPayload(preset=self._data_to_node(result.preset))
 
     async def delete(self, preset_id: UUID) -> DeleteRuntimeVariantPresetPayload:
-        result = await self._processors.runtime_variant_preset.purge.run(
+        result = await self._runtime_variant_preset.purge.run(
             PurgeRuntimeVariantPresetAction(id=RuntimeVariantPresetID(preset_id))
         )
         return DeleteRuntimeVariantPresetPayload(id=result.data.id)

--- a/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
+++ b/src/ai/backend/manager/api/adapters/scheduling_history/adapter.py
@@ -105,6 +105,7 @@ from ai.backend.manager.repositories.base import BatchQuerier
 from ai.backend.manager.services.resource_slot.actions.lookup_kernel_owner import (
     LookupKernelOwnerAction,
 )
+from ai.backend.manager.services.resource_slot.processors import ResourceSlotProcessors
 from ai.backend.manager.services.scheduling_history.actions.bulk_get_deployment_histories import (
     BulkGetDeploymentHistoriesAction,
 )
@@ -149,6 +150,7 @@ from ai.backend.manager.services.scheduling_history.actions.search_session_histo
 from ai.backend.manager.services.scheduling_history.actions.search_session_scoped_history import (
     SearchSessionScopedHistoryAction,
 )
+from ai.backend.manager.services.scheduling_history.processors import SchedulingHistoryProcessors
 
 _SESSION_HISTORY_PAGINATION_SPEC = PaginationSpec(
     forward_order=SESSION_DEFAULT_FORWARD_ORDER,
@@ -194,6 +196,17 @@ _ROUTE_HISTORY_PAGINATION_SPEC = PaginationSpec(
 class SchedulingHistoryAdapter(BaseAdapter):
     """Adapter for scheduling history domain operations."""
 
+    _scheduling_history: SchedulingHistoryProcessors
+    _resource_slot: ResourceSlotProcessors
+
+    def __init__(
+        self,
+        scheduling_history: SchedulingHistoryProcessors,
+        resource_slot: ResourceSlotProcessors,
+    ) -> None:
+        self._scheduling_history = scheduling_history
+        self._resource_slot = resource_slot
+
     # ========== Batch Load (DataLoader) ==========
 
     async def batch_load_session_histories_by_ids(
@@ -204,7 +217,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
             return []
         history_ids = [SessionSchedulingHistoryID(history_id) for history_id in ids]
         return await self.batch_load_fields(
-            self._processors.scheduling_history.bulk_get_session_histories,
+            self._scheduling_history.bulk_get_session_histories,
             BulkGetSessionHistoriesAction(ids=history_ids),
             history_ids,
             self._session_data_to_dto,
@@ -217,7 +230,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
         if not ids:
             return []
         return await self.batch_load_fields(
-            self._processors.scheduling_history.bulk_get_kernel_histories,
+            self._scheduling_history.bulk_get_kernel_histories,
             BulkGetKernelHistoriesAction(ids=ids),
             ids,
             self._kernel_data_to_dto,
@@ -231,7 +244,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
             return []
         history_ids = [DeploymentHistoryID(history_id) for history_id in ids]
         return await self.batch_load_fields(
-            self._processors.scheduling_history.bulk_get_deployment_histories,
+            self._scheduling_history.bulk_get_deployment_histories,
             BulkGetDeploymentHistoriesAction(ids=history_ids),
             history_ids,
             self._deployment_data_to_dto,
@@ -245,7 +258,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
             return []
         history_ids = [RouteHistoryID(history_id) for history_id in ids]
         return await self.batch_load_fields(
-            self._processors.scheduling_history.bulk_get_route_histories,
+            self._scheduling_history.bulk_get_route_histories,
             BulkGetRouteHistoriesAction(ids=history_ids),
             history_ids,
             self._route_data_to_dto,
@@ -259,7 +272,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
     ) -> AdminSearchSessionHistoriesPayload:
         """Search session scheduling histories (admin, no scope)."""
         querier = self._build_session_querier(input)
-        action_result = await self._processors.scheduling_history.search_session_history.run(
+        action_result = await self._scheduling_history.search_session_history.run(
             SearchSessionHistoryAction(querier=querier)
         )
         return AdminSearchSessionHistoriesPayload(
@@ -277,7 +290,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
         """Search session scheduling histories scoped to a session."""
         scope = SessionSchedulingHistoryOperationScope(session_id=session_id)
         querier = self._build_session_querier(input)
-        action_result = await self._processors.scheduling_history.search_session_scoped_history.run(
+        action_result = await self._scheduling_history.search_session_scoped_history.run(
             SearchSessionScopedHistoryAction(
                 session_id=SessionID(session_id), scope=scope, querier=querier
             )
@@ -442,7 +455,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.scheduling_history.search_kernel_history.run(
+        action_result = await self._scheduling_history.search_kernel_history.run(
             SearchKernelHistoryAction(querier=querier)
         )
         return SearchKernelHistoriesPayload(
@@ -475,7 +488,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
         # owning session and narrowed back down with a kernel_id query condition.
         if kernel_items:
             kernel_id = KernelId(kernel_items[0].value)
-            owner = await self._processors.resource_slot.lookup_kernel_owner.run(
+            owner = await self._resource_slot.lookup_kernel_owner.run(
                 LookupKernelOwnerAction(kernel_id=KernelID(kernel_id))
             )
             session_id = SessionId(owner.entity_id())
@@ -497,7 +510,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.scheduling_history.search_kernel_scoped_history.run(
+        action_result = await self._scheduling_history.search_kernel_scoped_history.run(
             SearchKernelScopedHistoryAction(
                 target=SessionKernelHistoryTarget(session_id=session_id),
                 querier=querier,
@@ -644,7 +657,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
     ) -> AdminSearchDeploymentHistoriesPayload:
         """Search deployment histories (admin, no scope)."""
         querier = self._build_deployment_querier(input)
-        action_result = await self._processors.scheduling_history.search_deployment_history.run(
+        action_result = await self._scheduling_history.search_deployment_history.run(
             SearchDeploymentHistoryAction(querier=querier)
         )
         return AdminSearchDeploymentHistoriesPayload(
@@ -662,11 +675,9 @@ class SchedulingHistoryAdapter(BaseAdapter):
         """Search deployment histories scoped to a deployment."""
         scope = DeploymentHistoryOperationScope(deployment_id=deployment_id)
         querier = self._build_deployment_querier(input)
-        action_result = (
-            await self._processors.scheduling_history.search_deployment_scoped_history.run(
-                SearchDeploymentScopedHistoryAction(
-                    deployment_id=DeploymentID(deployment_id), scope=scope, querier=querier
-                )
+        action_result = await self._scheduling_history.search_deployment_scoped_history.run(
+            SearchDeploymentScopedHistoryAction(
+                deployment_id=DeploymentID(deployment_id), scope=scope, querier=querier
             )
         )
         return AdminSearchDeploymentHistoriesPayload(
@@ -825,10 +836,8 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = (
-            await self._processors.scheduling_history.global_search_replica_group_history.run(
-                GlobalSearchReplicaGroupHistoryAction(querier=querier)
-            )
+        action_result = await self._scheduling_history.global_search_replica_group_history.run(
+            GlobalSearchReplicaGroupHistoryAction(querier=querier)
         )
         return SearchReplicaGroupHistoriesPayload(
             items=[self._replica_group_data_to_dto(h) for h in action_result.items],
@@ -871,12 +880,10 @@ class SchedulingHistoryAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = (
-            await self._processors.scheduling_history.scoped_search_replica_group_history.run(
-                ScopedSearchReplicaGroupHistoryAction(
-                    target=DeploymentReplicaGroupHistoryTarget(deployment_id=deployment_id),
-                    querier=querier,
-                )
+        action_result = await self._scheduling_history.scoped_search_replica_group_history.run(
+            ScopedSearchReplicaGroupHistoryAction(
+                target=DeploymentReplicaGroupHistoryTarget(deployment_id=deployment_id),
+                querier=querier,
             )
         )
         return SearchReplicaGroupHistoriesPayload(
@@ -1012,7 +1019,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
     ) -> AdminSearchRouteHistoriesPayload:
         """Search route histories (admin, no scope)."""
         querier = self._build_route_querier(input)
-        action_result = await self._processors.scheduling_history.search_route_history.run(
+        action_result = await self._scheduling_history.search_route_history.run(
             SearchRouteHistoryAction(querier=querier)
         )
         return AdminSearchRouteHistoriesPayload(
@@ -1030,7 +1037,7 @@ class SchedulingHistoryAdapter(BaseAdapter):
         """Search route histories scoped to a route."""
         scope = RouteHistoryOperationScope(route_id=ReplicaID(route_id))
         querier = self._build_route_querier(input)
-        action_result = await self._processors.scheduling_history.search_route_scoped_history.run(
+        action_result = await self._scheduling_history.search_route_scoped_history.run(
             SearchRouteScopedHistoryAction(scope=scope, querier=querier)
         )
         return AdminSearchRouteHistoriesPayload(

--- a/src/ai/backend/manager/api/adapters/secret/adapter.py
+++ b/src/ai/backend/manager/api/adapters/secret/adapter.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from ai.backend.common.dto.manager.v2.secret.response import (
     AdminReencryptSecretsPayload,
     AdminSecretStatusPayload,
@@ -13,20 +11,20 @@ from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.secret.types import SecretStatus
 from ai.backend.manager.services.secret.actions.reencrypt import ReencryptSecretsAction
 from ai.backend.manager.services.secret.actions.status import GetSecretStatusAction
-
-if TYPE_CHECKING:
-    from ai.backend.manager.services.processors import Processors
+from ai.backend.manager.services.secret.processors import SecretProcessors
 
 
 class SecretAdapter(BaseAdapter):
     """Adapter for stored secret re-encryption."""
 
-    def __init__(self, processors: Processors) -> None:
-        super().__init__(processors)
+    _secret: SecretProcessors
+
+    def __init__(self, secret: SecretProcessors) -> None:
+        self._secret = secret
 
     async def admin_reencrypt_secrets(self) -> AdminReencryptSecretsPayload:
         """Encrypt every stored secret again through the configured write provider."""
-        result = await self._processors.secret.reencrypt.run(ReencryptSecretsAction())
+        result = await self._secret.reencrypt.run(ReencryptSecretsAction())
         progress = result.progress
         return AdminReencryptSecretsPayload(
             scanned=progress.scanned,
@@ -36,7 +34,7 @@ class SecretAdapter(BaseAdapter):
 
     async def admin_secret_status(self) -> AdminSecretStatusPayload:
         """Count the stored secrets of every encrypted column by the key holding them."""
-        result = await self._processors.secret.get_status.run(GetSecretStatusAction())
+        result = await self._secret.get_status.run(GetSecretStatusAction())
         return self._status_payload(result.status)
 
     def _status_payload(self, status: SecretStatus) -> AdminSecretStatusPayload:

--- a/src/ai/backend/manager/api/adapters/service_catalog/adapter.py
+++ b/src/ai/backend/manager/api/adapters/service_catalog/adapter.py
@@ -33,12 +33,18 @@ from ai.backend.manager.models.specs.pagination import OffsetPagination
 from ai.backend.manager.services.service_catalog.actions.search import (
     SearchServiceCatalogsAction,
 )
+from ai.backend.manager.services.service_catalog.processors import ServiceCatalogProcessors
 
 DEFAULT_PAGINATION_LIMIT = 10
 
 
 class ServiceCatalogAdapter(BaseAdapter):
     """Adapter for service catalog domain operations."""
+
+    _service_catalog: ServiceCatalogProcessors
+
+    def __init__(self, service_catalog: ServiceCatalogProcessors) -> None:
+        self._service_catalog = service_catalog
 
     async def admin_search(
         self,
@@ -54,7 +60,7 @@ class ServiceCatalogAdapter(BaseAdapter):
         """
         searcher = self.build_searcher(input)
 
-        action_result = await self._processors.service_catalog.global_search_service_catalogs.run(
+        action_result = await self._service_catalog.global_search_service_catalogs.run(
             SearchServiceCatalogsAction(searcher=searcher)
         )
 

--- a/src/ai/backend/manager/api/adapters/session/adapter.py
+++ b/src/ai/backend/manager/api/adapters/session/adapter.py
@@ -149,6 +149,7 @@ from ai.backend.manager.services.idle_checker.actions.exclude_sessions import (
 from ai.backend.manager.services.idle_checker.actions.include_sessions import (
     IncludeSessionIdleChecksAction,
 )
+from ai.backend.manager.services.idle_checker.processors import IdleCheckerProcessors
 from ai.backend.manager.services.session.actions.batch_get_kernel_resource_allocation import (
     BatchGetKernelResourceAllocationAction,
 )
@@ -181,6 +182,7 @@ from ai.backend.manager.services.session.actions.start_service import StartServi
 from ai.backend.manager.services.session.actions.terminate_sessions import (
     TerminateSessionsAction,
 )
+from ai.backend.manager.services.session.processors import SessionProcessors
 
 
 def _fold_kernel_status(status: KernelStatus) -> str:
@@ -231,6 +233,13 @@ _KERNEL_PAGINATION_SPEC = PaginationSpec(
 
 class SessionAdapter(BaseAdapter):
     """Adapter for session and kernel domain operations."""
+
+    _session: SessionProcessors
+    _idle_checker: IdleCheckerProcessors
+
+    def __init__(self, session: SessionProcessors, idle_checker: IdleCheckerProcessors) -> None:
+        self._session = session
+        self._idle_checker = idle_checker
 
     @staticmethod
     def _require_user_id() -> UUID:
@@ -364,7 +373,7 @@ class SessionAdapter(BaseAdapter):
             owner_id=input.owner_id,
         )
 
-        result = await self._processors.session.enqueue_session.run(action)
+        result = await self._session.enqueue_session.run(action)
         return EnqueueSessionPayload(
             session=(await self._session_data_to_nodes([result.session_data]))[0],
         )
@@ -409,7 +418,7 @@ class SessionAdapter(BaseAdapter):
                 else None
             ),
         )
-        result = await self._processors.session.compute_schedule.run(action)
+        result = await self._session.compute_schedule.run(action)
         return ComputeSchedulePayload(
             results=[
                 self._compute_schedule_kernel_result_to_info(kernel_result)
@@ -458,7 +467,7 @@ class SessionAdapter(BaseAdapter):
 
     async def get(self, session_id: SessionId) -> SessionNode:
         """Get a single session by ID with RBAC validation."""
-        action_result = await self._processors.session.get_session.run(
+        action_result = await self._session.get_session.run(
             GetSessionAction(session_id=SessionID(session_id))
         )
         return (await self._session_data_to_nodes([action_result.session_data]))[0]
@@ -478,7 +487,7 @@ class SessionAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[SessionConditions.by_ids(session_ids)],
         )
-        action_result = await self._processors.session.search_sessions.run(
+        action_result = await self._session.search_sessions.run(
             SearchSessionsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
         nodes = await self._session_data_to_nodes(action_result.data)
@@ -500,7 +509,7 @@ class SessionAdapter(BaseAdapter):
             pagination=NoPagination(),
             conditions=[KernelConditions.by_ids(kernel_ids)],
         )
-        action_result = await self._processors.session.search_kernels.run(
+        action_result = await self._session.search_kernels.run(
             SearchKernelsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
         nodes = await self._kernel_infos_to_nodes(action_result.data)
@@ -542,7 +551,7 @@ class SessionAdapter(BaseAdapter):
         """
         if not session_ids:
             return []
-        action_result = await self._processors.session.batch_get_session_resource_allocation.run(
+        action_result = await self._session.batch_get_session_resource_allocation.run(
             BatchGetSessionResourceAllocationAction(session_ids=list(session_ids))
         )
         return [self._aggregate_to_allocation_dto(item.value) for item in action_result.items]
@@ -556,7 +565,7 @@ class SessionAdapter(BaseAdapter):
         """
         if not kernel_ids:
             return []
-        action_result = await self._processors.session.batch_get_kernel_resource_allocation.run(
+        action_result = await self._session.batch_get_kernel_resource_allocation.run(
             BatchGetKernelResourceAllocationAction(
                 kernel_ids=[KernelID(kernel_id) for kernel_id in kernel_ids]
             )
@@ -608,7 +617,7 @@ class SessionAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        action_result = await self._processors.session.search_sessions.run(
+        action_result = await self._session.search_sessions.run(
             SearchSessionsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
 
@@ -641,7 +650,7 @@ class SessionAdapter(BaseAdapter):
             base_conditions=[scope_condition],
         )
 
-        action_result = await self._processors.session.search_sessions.run(
+        action_result = await self._session.search_sessions.run(
             SearchSessionsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
 
@@ -676,7 +685,7 @@ class SessionAdapter(BaseAdapter):
             offset=input.offset,
             base_conditions=[_by_user_uuid],
         )
-        action_result = await self._processors.session.search_sessions.run(
+        action_result = await self._session.search_sessions.run(
             SearchSessionsAction(querier=querier, user_id=UserID(user.user_id))
         )
         return AdminSearchSessionsPayload(
@@ -705,7 +714,7 @@ class SessionAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.session.search_sessions_in_project.run(
+        action_result = await self._session.search_sessions_in_project.run(
             SearchSessionsInProjectAction(scope=scope, querier=querier)
         )
         return AdminSearchSessionsPayload(
@@ -737,7 +746,7 @@ class SessionAdapter(BaseAdapter):
             offset=input.offset,
             base_conditions=[_by_project_id],
         )
-        action_result = await self._processors.session.search_sessions.run(
+        action_result = await self._session.search_sessions.run(
             SearchSessionsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
         return AdminSearchSessionsPayload(
@@ -872,7 +881,7 @@ class SessionAdapter(BaseAdapter):
             offset=input.offset,
         )
 
-        action_result = await self._processors.session.search_kernels.run(
+        action_result = await self._session.search_kernels.run(
             SearchKernelsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
 
@@ -905,7 +914,7 @@ class SessionAdapter(BaseAdapter):
             base_conditions=[scope_condition],
         )
 
-        action_result = await self._processors.session.search_kernels.run(
+        action_result = await self._session.search_kernels.run(
             SearchKernelsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
 
@@ -938,7 +947,7 @@ class SessionAdapter(BaseAdapter):
             base_conditions=[scope_condition],
         )
 
-        action_result = await self._processors.session.search_kernels.run(
+        action_result = await self._session.search_kernels.run(
             SearchKernelsAction(querier=querier, user_id=UserID(self._require_user_id()))
         )
 
@@ -1031,7 +1040,7 @@ class SessionAdapter(BaseAdapter):
             session_ids=[SessionId(sid) for sid in input.session_ids],
             forced=input.forced,
         )
-        result = await self._processors.session.terminate_sessions.run(action)
+        result = await self._session.terminate_sessions.run(action)
         by_state: dict[SessionTerminationStatus, list[SessionId]] = defaultdict(list)
         for item in result.items:
             if item.value is not None:
@@ -1047,7 +1056,7 @@ class SessionAdapter(BaseAdapter):
         self, input: ExcludeSessionIdleChecksInput
     ) -> ExcludeSessionIdleChecksPayload:
         """Exclude checker-session pairs from idle checks."""
-        result = await self._processors.idle_checker.exclude_sessions.run(
+        result = await self._idle_checker.exclude_sessions.run(
             ExcludeSessionIdleChecksAction(
                 targets=[
                     SessionIdleCheckPair(
@@ -1081,7 +1090,7 @@ class SessionAdapter(BaseAdapter):
         self, input: IncludeSessionIdleChecksInput
     ) -> IncludeSessionIdleChecksPayload:
         """Re-include previously excluded checker-session pairs into idle checks."""
-        result = await self._processors.idle_checker.include_sessions.run(
+        result = await self._idle_checker.include_sessions.run(
             IncludeSessionIdleChecksAction(
                 targets=[
                     SessionIdleCheckPair(
@@ -1129,7 +1138,7 @@ class SessionAdapter(BaseAdapter):
             arguments=json.dumps(input.arguments) if input.arguments else None,
             envs=json.dumps(input.envs) if input.envs else None,
         )
-        result = await self._processors.session.start_service.run(action)
+        result = await self._session.start_service.run(action)
         return StartSessionServicePayload(token=result.token, wsproxy_addr=result.wsproxy_addr)
 
     async def shutdown_service(
@@ -1145,7 +1154,7 @@ class SessionAdapter(BaseAdapter):
             owner_access_key=AccessKey(access_key),
             service_name=input.service,
         )
-        await self._processors.session.shutdown_service.run(action)
+        await self._session.shutdown_service.run(action)
 
     # -------------------------------------------------------------------------
     # Logs
@@ -1164,7 +1173,7 @@ class SessionAdapter(BaseAdapter):
             owner_access_key=AccessKey(access_key),
             kernel_id=KernelId(kernel_id) if kernel_id else None,
         )
-        result = await self._processors.session.get_container_logs.run(action)
+        result = await self._session.get_container_logs.run(action)
         logs_text = result.result.get("result", {}).get("logs", "")
         return SessionLogsPayload(logs=logs_text)
 
@@ -1186,7 +1195,7 @@ class SessionAdapter(BaseAdapter):
                 new_name=input.name,
                 owner_access_key=AccessKey(access_key),
             )
-            result = await self._processors.session.rename_session.run(action)
+            result = await self._session.rename_session.run(action)
             return UpdateSessionPayload(
                 session=(await self._session_data_to_nodes([result.session_data]))[0]
             )

--- a/src/ai/backend/manager/api/adapters/storage_host/adapter.py
+++ b/src/ai/backend/manager/api/adapters/storage_host/adapter.py
@@ -13,10 +13,16 @@ from ai.backend.manager.services.vfolder.actions.search_storage_host_permissions
     SearchStorageHostPermissionsAction,
     StorageHostPermissionEntry,
 )
+from ai.backend.manager.services.vfolder.processors import VFolderProcessors
 
 
 class StorageHostAdapter(BaseAdapter):
     """Adapter for storage host queries."""
+
+    _vfolder: VFolderProcessors
+
+    def __init__(self, vfolder: VFolderProcessors) -> None:
+        self._vfolder = vfolder
 
     async def my_storage_host_permissions(self) -> MyStorageHostPermissionsPayload:
         """Return storage hosts the current user is allowed to use.
@@ -27,7 +33,7 @@ class StorageHostAdapter(BaseAdapter):
         me = current_user()
         if me is None:
             raise UnreachableError("User context is not available")
-        result = await self._processors.vfolder.search_storage_host_permissions.run(
+        result = await self._vfolder.search_storage_host_permissions.run(
             SearchStorageHostPermissionsAction(
                 user_uuid=me.user_id,
                 domain_name=me.domain_name,

--- a/src/ai/backend/manager/api/adapters/storage_namespace/adapter.py
+++ b/src/ai/backend/manager/api/adapters/storage_namespace/adapter.py
@@ -36,6 +36,7 @@ from ai.backend.manager.services.storage_namespace.actions.search import (
 from ai.backend.manager.services.storage_namespace.actions.unregister import (
     UnregisterNamespaceAction,
 )
+from ai.backend.manager.services.storage_namespace.processors import StorageNamespaceProcessors
 
 DEFAULT_PAGINATION_LIMIT = 10
 
@@ -43,11 +44,16 @@ DEFAULT_PAGINATION_LIMIT = 10
 class StorageNamespaceAdapter(BaseAdapter):
     """Adapter for storage namespace domain operations."""
 
+    _storage_namespace: StorageNamespaceProcessors
+
+    def __init__(self, storage_namespace: StorageNamespaceProcessors) -> None:
+        self._storage_namespace = storage_namespace
+
     async def register(
         self, input: RegisterStorageNamespaceInput
     ) -> RegisterStorageNamespacePayload:
         """Register a new namespace within a storage."""
-        action_result = await self._processors.storage_namespace.global_register.run(
+        action_result = await self._storage_namespace.global_register.run(
             RegisterNamespaceAction(
                 creator=StorageNamespaceCreator(
                     storage_id=input.storage_id,
@@ -65,20 +71,20 @@ class StorageNamespaceAdapter(BaseAdapter):
         """Unregister a namespace from a storage."""
         # The API names a namespace by the pair it was registered under, so the id the
         # purge needs is resolved first rather than taught to the purge itself.
-        resolved = await self._processors.storage_namespace.lookup.run(
+        resolved = await self._storage_namespace.lookup.run(
             LookupStorageNamespaceAction(
                 storage_id=input.storage_id,
                 namespace=input.namespace,
             )
         )
-        action_result = await self._processors.storage_namespace.unregister.run(
+        action_result = await self._storage_namespace.unregister.run(
             UnregisterNamespaceAction(id=resolved.entity_id())
         )
         return UnregisterStorageNamespacePayload(id=action_result.data.storage_id)
 
     async def get_namespaces(self, storage_id: uuid.UUID) -> list[StorageNamespaceNode]:
         """Retrieve all namespaces for a given storage."""
-        action_result = await self._processors.storage_namespace.global_get_namespaces.run(
+        action_result = await self._storage_namespace.global_get_namespaces.run(
             GetNamespacesAction(storage_id)
         )
         return [self._storage_namespace_data_to_dto(item) for item in action_result.items]
@@ -94,7 +100,7 @@ class StorageNamespaceAdapter(BaseAdapter):
         if not ids:
             return []
         entity_ids = [StorageNamespaceID(value) for value in ids]
-        result = await self._processors.storage_namespace.bulk_get.run(
+        result = await self._storage_namespace.bulk_get.run(
             BulkGetStorageNamespacesAction(ids=entity_ids)
         )
         return [
@@ -113,7 +119,7 @@ class StorageNamespaceAdapter(BaseAdapter):
             offset=input.offset if input.offset is not None else 0,
         )
         searcher = StorageNamespaceSearcher(conditions=[], orders=[], pagination=pagination)
-        action_result = await self._processors.storage_namespace.global_search.run(
+        action_result = await self._storage_namespace.global_search.run(
             SearchStorageNamespacesAction(searcher=searcher)
         )
         return AdminSearchStorageNamespacesPayload(

--- a/src/ai/backend/manager/api/adapters/user/adapter.py
+++ b/src/ai/backend/manager/api/adapters/user/adapter.py
@@ -167,12 +167,13 @@ from ai.backend.manager.types import OptionalState, TriState
 
 if TYPE_CHECKING:
     from ai.backend.manager.config.unified import AuthConfig
-    from ai.backend.manager.services.processors import Processors
 
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.models.keypair.row import KEYPAIR_SECRET_KEY_CONTEXT
 from ai.backend.manager.secret.pool import KeyProviderPool
+from ai.backend.manager.services.domain.processors import DomainProcessors
+from ai.backend.manager.services.user.processors import UserProcessors
 
 _USER_PAGINATION_SPEC = PaginationSpec(
     forward_order=UserOrders.created_at(ascending=False),
@@ -194,21 +195,26 @@ _KEYPAIR_PAGINATION_SPEC = PaginationSpec(
 class UserAdapter(BaseAdapter):
     """Adapter for user domain operations."""
 
+    _user: UserProcessors
+    _domain: DomainProcessors
+    _auth_config: AuthConfig
+    _key_provider_pool: KeyProviderPool
+
     def __init__(
         self,
-        processors: Processors,
+        user: UserProcessors,
+        domain: DomainProcessors,
         auth_config: AuthConfig,
         key_provider_pool: KeyProviderPool,
     ) -> None:
-        super().__init__(processors)
+        self._user = user
+        self._domain = domain
         self._auth_config = auth_config
         self._key_provider_pool = key_provider_pool
 
     async def resolve_domain_id(self, domain_name: str) -> DomainID:
         """The domain's id, for callers that only hold its name."""
-        result = await self._processors.domain.lookup.run(
-            LookupDomainAction(name=DomainName(domain_name))
-        )
+        result = await self._domain.lookup.run(LookupDomainAction(name=DomainName(domain_name)))
         return result.entity_id()
 
     # ------------------------------------------------------------------ batch load (DataLoader)
@@ -226,9 +232,7 @@ class UserAdapter(BaseAdapter):
                 UserConditions.by_uuid_in(UUIDInMatchSpec(values=list(user_ids), negated=False))
             ],
         )
-        result = await self._processors.user.global_search.run(
-            GlobalSearchUsersAction(searcher=searcher)
-        )
+        result = await self._user.global_search.run(GlobalSearchUsersAction(searcher=searcher))
         nodes = await self._user_nodes(result.items)
         user_map = {user.uuid: node for user, node in zip(result.items, nodes, strict=True)}
         return [user_map.get(user_id) for user_id in user_ids]
@@ -254,9 +258,7 @@ class UserAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.user.global_search.run(
-            GlobalSearchUsersAction(searcher=searcher)
-        )
+        result = await self._user.global_search.run(GlobalSearchUsersAction(searcher=searcher))
         return AdminSearchUsersPayload(
             items=await self._user_nodes(result.items),
             total_count=result.total_count,
@@ -284,7 +286,7 @@ class UserAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.user.scoped_search.run(
+        result = await self._user.scoped_search.run(
             ScopedSearchUsersAction(
                 items=[DomainUserScopeItem(domain_id=await self.resolve_domain_id(domain_name))],
                 searcher=searcher,
@@ -317,7 +319,7 @@ class UserAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        result = await self._processors.user.scoped_search.run(
+        result = await self._user.scoped_search.run(
             ScopedSearchUsersAction(
                 items=[ProjectUserScopeItem(project_id=project_id)],
                 searcher=searcher,
@@ -338,9 +340,7 @@ class UserAdapter(BaseAdapter):
     ) -> SearchUsersPayload:
         """Search users with no scope restriction (admin only)."""
         searcher = self._build_search_searcher(input)
-        result = await self._processors.user.global_search.run(
-            GlobalSearchUsersAction(searcher=searcher)
-        )
+        result = await self._user.global_search.run(GlobalSearchUsersAction(searcher=searcher))
         return SearchUsersPayload(
             items=await self._user_nodes(result.items),
             pagination=PaginationInfo(
@@ -357,7 +357,7 @@ class UserAdapter(BaseAdapter):
     ) -> SearchUsersPayload:
         """Search users within a domain."""
         searcher = self._build_search_searcher(input)
-        result = await self._processors.user.scoped_search.run(
+        result = await self._user.scoped_search.run(
             ScopedSearchUsersAction(
                 items=[DomainUserScopeItem(domain_id=await self.resolve_domain_id(domain_name))],
                 searcher=searcher,
@@ -379,7 +379,7 @@ class UserAdapter(BaseAdapter):
     ) -> SearchUsersPayload:
         """Search users within a project."""
         searcher = self._build_search_searcher(input)
-        result = await self._processors.user.scoped_search.run(
+        result = await self._user.scoped_search.run(
             ScopedSearchUsersAction(
                 items=[ProjectUserScopeItem(project_id=ProjectID(project_id))],
                 searcher=searcher,
@@ -402,7 +402,7 @@ class UserAdapter(BaseAdapter):
         """Search users assigned to a role."""
         searcher = self._build_search_searcher(input)
         searcher.conditions = [*searcher.conditions, UserConditions.by_role_id(role_id)]
-        result = await self._processors.user.search_users_by_role.run(
+        result = await self._user.search_users_by_role.run(
             SearchUsersByRoleAction(role_id=role_id, searcher=searcher)
         )
         return SearchUsersPayload(
@@ -418,9 +418,7 @@ class UserAdapter(BaseAdapter):
 
     async def get(self, user_id: UUID) -> UserPayload:
         """Get a user by UUID."""
-        action_result = await self._processors.user.get_user.run(
-            GetUserAction(user_id=UserID(user_id))
-        )
+        action_result = await self._user.get_user.run(GetUserAction(user_id=UserID(user_id)))
         return UserPayload(user=await self._user_node(action_result.user))
 
     # ------------------------------------------------------------------ single CRUD
@@ -453,7 +451,7 @@ class UserAdapter(BaseAdapter):
             integration_name=input.integration_name,
         )
         group_ids = [str(gid) for gid in input.group_ids] if input.group_ids else None
-        result = await self._processors.user.create_user.run(
+        result = await self._user.create_user.run(
             CreateUserAction(creator=creator, group_ids=group_ids)
         )
         return CreateUserPayload(
@@ -557,28 +555,26 @@ class UserAdapter(BaseAdapter):
                 else OptionalState.update([str(gid) for gid in input.group_ids])
             ),
         )
-        result = await self._processors.user.update_user.run(UpdateUserAction(updater=updater))
+        result = await self._user.update_user.run(UpdateUserAction(updater=updater))
         if not isinstance(input.main_access_key, Sentinel) and input.main_access_key is not None:
             await self.switch_default_access_key(UserID(user_id), AccessKey(input.main_access_key))
         return UpdateUserPayload(user=await self._user_node(result.data))
 
     async def delete_user_by_id(self, input: DeleteUserInput) -> DeleteUserPayload:
         """Soft-delete a user by UUID."""
-        await self._processors.user.delete_user.run(DeleteUserAction(user_id=UserID(input.user_id)))
+        await self._user.delete_user.run(DeleteUserAction(user_id=UserID(input.user_id)))
         return DeleteUserPayload(success=True)
 
     async def restore_user_by_id(self, input: RestoreUserInput) -> RestoreUserPayload:
         """Restore a soft-deleted user by UUID."""
-        await self._processors.user.restore_user.run(
-            RestoreUserAction(user_id=UserID(input.user_id))
-        )
+        await self._user.restore_user.run(RestoreUserAction(user_id=UserID(input.user_id)))
         return RestoreUserPayload(success=True)
 
     async def purge_user_by_id(
         self, input: PurgeUserInput, admin_user_id: UUID
     ) -> PurgeUserPayload:
         """Permanently purge a user by UUID."""
-        await self._processors.user.purge_user.run(
+        await self._user.purge_user.run(
             PurgeUserAction(
                 user_id=UserID(input.user_id),
                 admin_user_id=admin_user_id,
@@ -604,7 +600,7 @@ class UserAdapter(BaseAdapter):
         Deprecated: the generated keypairs are not returned. Use
         :meth:`bulk_create_users_with_keypair` instead.
         """
-        result = await self._processors.user.bulk_create_users.run(action)
+        result = await self._user.bulk_create_users.run(action)
         created_users = await self._user_nodes([item.user for item in result.data.successes])
         failed = [
             BulkCreateUserV2Error(
@@ -624,7 +620,7 @@ class UserAdapter(BaseAdapter):
 
         The secret key of each keypair is only returned here at creation time.
         """
-        result = await self._processors.user.bulk_create_users.run(action)
+        result = await self._user.bulk_create_users.run(action)
         created_nodes = await self._user_nodes([item.user for item in result.data.successes])
         created = [
             CreateUserPayload(
@@ -654,7 +650,7 @@ class UserAdapter(BaseAdapter):
         A switch runs only for a user whose own update went through, and a switch that
         fails turns that user into a failure instead of aborting the whole batch.
         """
-        result = await self._processors.user.bulk_modify_users.run(action)
+        result = await self._user.bulk_modify_users.run(action)
         failed = [
             BulkUpdateUserV2Error(
                 user_id=action.items[error.index].user_id,
@@ -676,7 +672,7 @@ class UserAdapter(BaseAdapter):
 
     async def bulk_purge_users(self, action: BulkPurgeUserAction) -> BulkPurgeUsersPayload:
         """Bulk-purge users permanently."""
-        result = await self._processors.user.bulk_purge_users.run(action)
+        result = await self._user.bulk_purge_users.run(action)
         failed = [
             BulkPurgeUserV2Error(
                 user_id=error.user_id,
@@ -692,14 +688,14 @@ class UserAdapter(BaseAdapter):
 
     async def update_user(self, action: UpdateUserAction) -> UpdateMyAllowedClientIPPayload:
         """Modify a user. Caller is responsible for building the action."""
-        await self._processors.user.update_user.run(action)
+        await self._user.update_user.run(action)
         return UpdateMyAllowedClientIPPayload(success=True)
 
     # ------------------------------------------------------------------ keypair operations
 
     async def issue_my_keypair(self, user_id: UUID) -> IssueMyKeypairPayload:
         """Issue a new keypair for the current user."""
-        result = await self._processors.user.issue_my_keypair.run(
+        result = await self._user.issue_my_keypair.run(
             IssueMyKeypairAction(user_id=UserID(user_id))
         )
         return IssueMyKeypairPayload(
@@ -714,7 +710,7 @@ class UserAdapter(BaseAdapter):
 
     async def update_my_keypair(self, access_key: str, is_active: bool) -> UpdateMyKeypairPayload:
         """Update a keypair owned by the current user."""
-        result = await self._processors.user.update_keypair.run(
+        result = await self._user.update_keypair.run(
             UpdateKeypairAction(
                 keypair_id=await self._resolve_keypair(access_key),
                 is_active=OptionalState.update(is_active),
@@ -726,7 +722,7 @@ class UserAdapter(BaseAdapter):
         self, user_id: UserID, access_key: AccessKey
     ) -> SwitchMyMainAccessKeyPayload:
         """Move the ``is_default`` marker among the user's keypairs onto ``access_key``."""
-        result = await self._processors.user.switch_default_access_key.run(
+        result = await self._user.switch_default_access_key.run(
             SwitchDefaultAccessKeyAction(user_id=user_id, access_key=access_key)
         )
         return SwitchMyMainAccessKeyPayload(success=result.success)
@@ -758,7 +754,7 @@ class UserAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.user.search_my_keypairs.run(
+        action_result = await self._user.search_my_keypairs.run(
             SearchMyKeypairsAction(user_id=UserID(scope.user_uuid), querier=querier)
         )
         return SearchResult(
@@ -812,7 +808,7 @@ class UserAdapter(BaseAdapter):
             resource_policy=input.resource_policy,
             rate_limit=input.rate_limit,
         )
-        result = await self._processors.user.admin_create_keypair.run(
+        result = await self._user.admin_create_keypair.run(
             AdminCreateKeypairAction(user_id=UserID(input.user_id), creator=creator)
         )
         return AdminCreateKeypairPayload(
@@ -821,7 +817,7 @@ class UserAdapter(BaseAdapter):
         )
 
     async def _resolve_keypair_owner(self, access_key: str) -> UserID:
-        result = await self._processors.user.lookup_keypair_owner.run(
+        result = await self._user.lookup_keypair_owner.run(
             LookupKeypairOwnerByAccessKeyAction(access_key=AccessKey(access_key))
         )
         return UserID(result.entity_id())
@@ -829,13 +825,13 @@ class UserAdapter(BaseAdapter):
     async def _resolve_keypair(self, access_key: str) -> KeyPairID:
         """The id of the keypair an access key names, which every operation on that row
         is built from."""
-        result = await self._processors.user.lookup_keypair.run(
+        result = await self._user.lookup_keypair.run(
             LookupKeypairByAccessKeyAction(access_key=AccessKey(access_key))
         )
         return KeyPairID(result.field_id)
 
     async def _purge_keypair(self, access_key: str) -> str:
-        result = await self._processors.user.purge_keypair.run(
+        result = await self._user.purge_keypair.run(
             PurgeKeypairAction(keypair_id=await self._resolve_keypair(access_key))
         )
         return str(result.keypair.access_key)
@@ -844,7 +840,7 @@ class UserAdapter(BaseAdapter):
         self, input: AdminUpdateKeypairInput
     ) -> AdminUpdateKeypairPayload:
         """Admin updates any keypair."""
-        result = await self._processors.user.update_keypair.run(
+        result = await self._user.update_keypair.run(
             UpdateKeypairAction(
                 keypair_id=await self._resolve_keypair(input.access_key),
                 is_active=OptionalState.from_nullable(input.is_active),
@@ -861,7 +857,7 @@ class UserAdapter(BaseAdapter):
 
     async def admin_get_keypair(self, access_key: str) -> KeypairNode:
         """Admin retrieves a single keypair by access key."""
-        result = await self._processors.user.get_keypair.run(
+        result = await self._user.get_keypair.run(
             GetKeypairAction(keypair_id=await self._resolve_keypair(access_key))
         )
         return self._keypair_data_to_node(result.keypair)
@@ -870,7 +866,7 @@ class UserAdapter(BaseAdapter):
         self, input: AdminRegisterSSHKeypairInput
     ) -> AdminRegisterSSHKeypairPayload:
         """Admin registers (overwrites) a user's SSH keypair."""
-        result = await self._processors.user.admin_register_ssh_keypair.run(
+        result = await self._user.admin_register_ssh_keypair.run(
             AdminRegisterSSHKeypairAction(
                 user_id=await self._resolve_keypair_owner(input.access_key),
                 access_key=input.access_key,
@@ -882,7 +878,7 @@ class UserAdapter(BaseAdapter):
 
     async def admin_delete_ssh_keypair(self, access_key: str) -> AdminDeleteSSHKeypairPayload:
         """Admin clears a user's SSH keypair."""
-        result = await self._processors.user.admin_delete_ssh_keypair.run(
+        result = await self._user.admin_delete_ssh_keypair.run(
             AdminDeleteSSHKeypairAction(
                 user_id=await self._resolve_keypair_owner(access_key), access_key=access_key
             )
@@ -891,7 +887,7 @@ class UserAdapter(BaseAdapter):
 
     async def admin_get_ssh_keypair(self, access_key: str) -> AdminGetSSHKeypairPayload:
         """Admin retrieves a user's SSH public key (never the private key)."""
-        result = await self._processors.user.admin_get_ssh_keypair.run(
+        result = await self._user.admin_get_ssh_keypair.run(
             AdminGetSSHKeypairAction(
                 user_id=await self._resolve_keypair_owner(access_key), access_key=access_key
             )
@@ -921,7 +917,7 @@ class UserAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.user.admin_search_keypairs.run(
+        action_result = await self._user.admin_search_keypairs.run(
             AdminSearchKeypairsAction(querier=querier)
         )
         return AdminSearchKeypairsPayload(
@@ -963,7 +959,7 @@ class UserAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.user.admin_search_keypairs.run(
+        action_result = await self._user.admin_search_keypairs.run(
             AdminSearchKeypairsAction(querier=querier)
         )
         return SearchResult(
@@ -1575,7 +1571,7 @@ class UserAdapter(BaseAdapter):
         """The key each user authorizes with, read for every one of them in one go."""
         if not users:
             return {}
-        result = await self._processors.user.get_default_keypairs.run(
+        result = await self._user.get_default_keypairs.run(
             GetDefaultKeypairsAction(user_ids=[UserID(user.id) for user in users])
         )
         return {

--- a/src/ai/backend/manager/api/adapters/vfolder/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfolder/adapter.py
@@ -115,6 +115,7 @@ from ai.backend.manager.models.vfolder.scopes import (
     UserVFolderOperationScope,
 )
 from ai.backend.manager.services.deployment.actions.create_deployment import CreateDeploymentAction
+from ai.backend.manager.services.deployment.processors import DeploymentProcessors
 from ai.backend.manager.services.vfolder.actions.admin_search_vfolders import (
     GlobalSearchVFoldersAction,
 )
@@ -150,6 +151,8 @@ from ai.backend.manager.services.vfolder.actions.vfolder_v2 import (
     DeleteVFolderV2Action,
     PurgeVFolderV2Action,
 )
+from ai.backend.manager.services.vfolder.processors import VFolderFileProcessors, VFolderProcessors
+from ai.backend.manager.services.vfolder.processors.vfolder_admin import VFolderAdminProcessors
 
 _VFOLDER_PAGINATION_SPEC = PaginationSpec(
     forward_order=VFOLDER_DEFAULT_FORWARD_ORDER,
@@ -199,6 +202,23 @@ def _build_policy_from_strategy_input(
 class VFolderAdapter(BaseAdapter):
     """Adapter for VFolder domain operations."""
 
+    _vfolder: VFolderProcessors
+    _vfolder_file: VFolderFileProcessors
+    _vfolder_admin: VFolderAdminProcessors
+    _deployment: DeploymentProcessors
+
+    def __init__(
+        self,
+        vfolder: VFolderProcessors,
+        vfolder_file: VFolderFileProcessors,
+        vfolder_admin: VFolderAdminProcessors,
+        deployment: DeploymentProcessors,
+    ) -> None:
+        self._vfolder = vfolder
+        self._vfolder_file = vfolder_file
+        self._vfolder_admin = vfolder_admin
+        self._deployment = deployment
+
     @staticmethod
     def _vfolder_data_to_node(data: VFolderData) -> VFolderNode:
         """Convert VFolderData to VFolderNode DTO."""
@@ -247,7 +267,7 @@ class VFolderAdapter(BaseAdapter):
         """
         if not ids:
             return []
-        action_result = await self._processors.vfolder.batch_load_vfolders_by_ids.run(
+        action_result = await self._vfolder.batch_load_vfolders_by_ids.run(
             GlobalBatchLoadVFoldersAction(ids=list(ids))
         )
         return [
@@ -277,7 +297,7 @@ class VFolderAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.vfolder_admin.admin_search_vfolders.run(
+        action_result = await self._vfolder_admin.admin_search_vfolders.run(
             GlobalSearchVFoldersAction(querier=querier)
         )
         return SearchVFoldersPayload(
@@ -312,7 +332,7 @@ class VFolderAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.vfolder.search_user_vfolders.run(
+        action_result = await self._vfolder.search_user_vfolders.run(
             SearchUserVFoldersAction(scope=scope, querier=querier)
         )
         return SearchVFoldersPayload(
@@ -345,7 +365,7 @@ class VFolderAdapter(BaseAdapter):
             limit=input.limit,
             offset=input.offset,
         )
-        action_result = await self._processors.vfolder.search_vfolders_in_project.run(
+        action_result = await self._vfolder.search_vfolders_in_project.run(
             SearchVFoldersInProjectAction(scope=scope, querier=querier)
         )
         return SearchVFoldersPayload(
@@ -379,9 +399,7 @@ class VFolderAdapter(BaseAdapter):
         return await self._create(self._project_creator(me, ProjectID(project_id), input))
 
     async def _create(self, creator: VFolderBaseCreator) -> CreateVFolderPayload:
-        result = await self._processors.vfolder.create_vfolder.run(
-            CreateVFolderAction(creator=creator)
-        )
+        result = await self._vfolder.create_vfolder.run(CreateVFolderAction(creator=creator))
         return CreateVFolderPayload(vfolder=self._vfolder_data_to_node(result.vfolder))
 
     def _personal_creator(
@@ -433,12 +451,12 @@ class VFolderAdapter(BaseAdapter):
             path=input.path,
             size=input.size,
         )
-        result = await self._processors.vfolder.create_upload_session_v2.run(action)
+        result = await self._vfolder.create_upload_session_v2.run(action)
         return CreateUploadSessionPayload(token=result.token, url=result.url)
 
     async def get(self, vfolder_id: UUID) -> VFolderNode:
         """Get a single vfolder by ID with RBAC validation."""
-        result = await self._processors.vfolder.get_v2.run(
+        result = await self._vfolder.get_v2.run(
             GetVFolderV2Action(vfolder_uuid=VFolderUUID(vfolder_id))
         )
         return self._vfolder_data_to_node(result.vfolder)
@@ -451,7 +469,7 @@ class VFolderAdapter(BaseAdapter):
         walk on vfs). Returns ``None`` for unmanaged vfolders, which have no
         storage-proxy backing.
         """
-        result = await self._processors.vfolder.get_folder_usage.run(
+        result = await self._vfolder.get_folder_usage.run(
             GetVFolderUsageAction(vfolder_uuid=VFolderUUID(vfolder_id))
         )
         usage = result.usage
@@ -465,7 +483,7 @@ class VFolderAdapter(BaseAdapter):
     async def delete(self, vfolder_id: UUID) -> DeleteVFolderPayload:
         """Soft-delete a vfolder (move to trash). RBAC enforced."""
         action = DeleteVFolderV2Action(vfolder_uuid=VFolderUUID(vfolder_id))
-        await self._processors.vfolder.delete_v2.run(action)
+        await self._vfolder.delete_v2.run(action)
         return DeleteVFolderPayload(id=vfolder_id)
 
     async def restore(self, vfolder_id: UUID) -> RestoreVFolderPayload:
@@ -477,7 +495,7 @@ class VFolderAdapter(BaseAdapter):
             user_uuid=me.user_id,
             vfolder_uuid=VFolderUUID(vfolder_id),
         )
-        await self._processors.vfolder.restore_vfolder_from_trash.run(action)
+        await self._vfolder.restore_vfolder_from_trash.run(action)
         return RestoreVFolderPayload(id=vfolder_id)
 
     async def purge(self, vfolder_id: UUID, input: PurgeVFolderInput) -> PurgeVFolderPayload:
@@ -487,7 +505,7 @@ class VFolderAdapter(BaseAdapter):
             cascade_model_card=input.options.cascade_model_card,
             force=input.options.force,
         )
-        await self._processors.vfolder.purge_v2.run(action)
+        await self._vfolder.purge_v2.run(action)
         return PurgeVFolderPayload(id=vfolder_id)
 
     async def deploy(
@@ -508,7 +526,7 @@ class VFolderAdapter(BaseAdapter):
         if me is None:
             raise UnreachableError("User context is not available")
 
-        batch_result = await self._processors.vfolder.batch_load_vfolders_by_ids.run(
+        batch_result = await self._vfolder.batch_load_vfolders_by_ids.run(
             GlobalBatchLoadVFoldersAction(ids=[vfolder_id])
         )
         if not batch_result.data or batch_result.data[0] is None:
@@ -563,7 +581,7 @@ class VFolderAdapter(BaseAdapter):
             policy=policy,
         )
 
-        result = await self._processors.deployment.create_deployment.run(
+        result = await self._deployment.create_deployment.run(
             CreateDeploymentAction(
                 project_id=ProjectID(creator.metadata.project),
                 creator=creator,
@@ -587,7 +605,7 @@ class VFolderAdapter(BaseAdapter):
         for vfolder_id in input.ids:
             action = DeleteVFolderV2Action(vfolder_uuid=VFolderUUID(vfolder_id))
             try:
-                result = await self._processors.vfolder.delete_v2.run(action)
+                result = await self._vfolder.delete_v2.run(action)
             except BackendAIError as e:
                 failed.append(BulkDeleteVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
                 continue
@@ -613,7 +631,7 @@ class VFolderAdapter(BaseAdapter):
                 force=input.options.force,
             )
             try:
-                await self._processors.vfolder.purge_v2.run(action)
+                await self._vfolder.purge_v2.run(action)
             except BackendAIError as e:
                 failed.append(BulkPurgeVFolderV2Error(vfolder_id=vfolder_id, message=str(e)))
                 continue
@@ -632,7 +650,7 @@ class VFolderAdapter(BaseAdapter):
         action = ListFilesV2Action(
             user_id=me.user_id, vfolder_uuid=VFolderUUID(vfolder_id), path=input.path
         )
-        result = await self._processors.vfolder_file.list_files_v2.run(action)
+        result = await self._vfolder_file.list_files_v2.run(action)
         return ListFilesPayload(
             items=[
                 FileEntryNode(
@@ -659,7 +677,7 @@ class VFolderAdapter(BaseAdapter):
             parents=input.parents,
             exist_ok=input.exist_ok,
         )
-        await self._processors.vfolder_file.mkdir_v2.run(action)
+        await self._vfolder_file.mkdir_v2.run(action)
         paths = [input.path] if isinstance(input.path, str) else input.path
         return MkdirPayload(results=paths)
 
@@ -671,7 +689,7 @@ class VFolderAdapter(BaseAdapter):
         action = MoveFileV2Action(
             user_id=me.user_id, vfolder_uuid=VFolderUUID(vfolder_id), src=input.src, dst=input.dst
         )
-        await self._processors.vfolder_file.move_file_v2.run(action)
+        await self._vfolder_file.move_file_v2.run(action)
         return MoveFilePayload(src=input.src, dst=input.dst)
 
     async def delete_files(self, vfolder_id: UUID, input: DeleteFilesInput) -> DeleteFilesPayload:
@@ -685,7 +703,7 @@ class VFolderAdapter(BaseAdapter):
             files=input.files,
             recursive=input.recursive,
         )
-        result = await self._processors.vfolder_file.delete_files_v2.run(action)
+        result = await self._vfolder_file.delete_files_v2.run(action)
         return DeleteFilesPayload(bgtask_id=result.bgtask_id)
 
     async def create_download_session(
@@ -701,7 +719,7 @@ class VFolderAdapter(BaseAdapter):
             path=input.path,
             archive=input.archive,
         )
-        result = await self._processors.vfolder_file.download_file_v2.run(action)
+        result = await self._vfolder_file.download_file_v2.run(action)
         return CreateDownloadSessionPayload(token=result.token, url=result.url)
 
     async def clone(self, vfolder_id: UUID, input: CloneVFolderInput) -> CloneVFolderPayload:
@@ -715,7 +733,7 @@ class VFolderAdapter(BaseAdapter):
             target_name=input.name,
             target_host=input.host,
         )
-        result = await self._processors.vfolder.clone_v2.run(action)
+        result = await self._vfolder.clone_v2.run(action)
         # Fetch the newly created vfolder for the response
         cloned_vfolder = await self.get(result.new_vfolder_id)
         return CloneVFolderPayload(

--- a/src/ai/backend/manager/api/adapters/vfs_storage/adapter.py
+++ b/src/ai/backend/manager/api/adapters/vfs_storage/adapter.py
@@ -32,6 +32,7 @@ from ai.backend.manager.services.vfs_storage.actions.list import ListVFSStorageA
 from ai.backend.manager.services.vfs_storage.actions.purge import PurgeVFSStorageAction
 from ai.backend.manager.services.vfs_storage.actions.search import SearchVFSStoragesAction
 from ai.backend.manager.services.vfs_storage.actions.update import UpdateVFSStorageAction
+from ai.backend.manager.services.vfs_storage.processors import VFSStorageProcessors
 from ai.backend.manager.types import OptionalState
 
 DEFAULT_PAGINATION_LIMIT = 10
@@ -40,9 +41,14 @@ DEFAULT_PAGINATION_LIMIT = 10
 class VFSStorageAdapter(BaseAdapter):
     """Adapter for VFS storage domain operations."""
 
+    _vfs_storage: VFSStorageProcessors
+
+    def __init__(self, vfs_storage: VFSStorageProcessors) -> None:
+        self._vfs_storage = vfs_storage
+
     async def create(self, input: CreateVFSStorageInput) -> CreateVFSStoragePayload:
         """Create a new VFS storage."""
-        action_result = await self._processors.vfs_storage.global_create.run(
+        action_result = await self._vfs_storage.global_create.run(
             CreateVFSStorageAction(
                 creator=VFSStorageCreator(
                     name=input.name,
@@ -62,7 +68,7 @@ class VFSStorageAdapter(BaseAdapter):
             offset=input.offset if input.offset is not None else 0,
         )
         searcher = VFSStorageSearcher(pagination=pagination, conditions=[], orders=[])
-        action_result = await self._processors.vfs_storage.global_search_vfs_storages.run(
+        action_result = await self._vfs_storage.global_search_vfs_storages.run(
             SearchVFSStoragesAction(searcher=searcher)
         )
         return AdminSearchVFSStoragesPayload(
@@ -83,7 +89,7 @@ class VFSStorageAdapter(BaseAdapter):
             pagination=OffsetPagination(limit=len(ids)),
             conditions=[VFSStorageConditions.by_ids(ids)],
         )
-        action_result = await self._processors.vfs_storage.global_search_vfs_storages.run(
+        action_result = await self._vfs_storage.global_search_vfs_storages.run(
             SearchVFSStoragesAction(searcher=searcher)
         )
         storage_map = {item.id: self._vfs_storage_data_to_dto(item) for item in action_result.items}
@@ -91,14 +97,14 @@ class VFSStorageAdapter(BaseAdapter):
 
     async def get(self, storage_id: UUID) -> VFSStorageNode:
         """Retrieve a single VFS storage by ID."""
-        action_result = await self._processors.vfs_storage.get.run(
+        action_result = await self._vfs_storage.get.run(
             GetVFSStorageAction(storage_id=VFSStorageID(storage_id))
         )
         return self._vfs_storage_data_to_dto(action_result.data)
 
     async def list_all(self) -> list[VFSStorageNode]:
         """List all VFS storages without pagination."""
-        action_result = await self._processors.vfs_storage.global_list_storages.run(
+        action_result = await self._vfs_storage.global_list_storages.run(
             ListVFSStorageAction(searcher=VFSStorageSearcher(pagination=NoPagination()))
         )
         return [self._vfs_storage_data_to_dto(item) for item in action_result.items]
@@ -119,16 +125,14 @@ class VFSStorageAdapter(BaseAdapter):
                 else OptionalState.nop()
             ),
         )
-        action_result = await self._processors.vfs_storage.update.run(
-            UpdateVFSStorageAction(updater=updater)
-        )
+        action_result = await self._vfs_storage.update.run(UpdateVFSStorageAction(updater=updater))
         return UpdateVFSStoragePayload(
             vfs_storage=self._vfs_storage_data_to_dto(action_result.data)
         )
 
     async def delete(self, input: DeleteVFSStorageInput) -> DeleteVFSStoragePayload:
         """Delete a VFS storage."""
-        action_result = await self._processors.vfs_storage.purge.run(
+        action_result = await self._vfs_storage.purge.run(
             PurgeVFSStorageAction(storage_id=input.id)
         )
         return DeleteVFSStoragePayload(id=action_result.data.id)

--- a/src/ai/backend/manager/api/gql_legacy/container_registry_v2.py
+++ b/src/ai/backend/manager/api/gql_legacy/container_registry_v2.py
@@ -124,9 +124,9 @@ class CreateContainerRegistryNodeV2(graphene.Mutation):  # type: ignore[misc]
         )
         allowed_groups = props.to_allowed_groups()
         if allowed_groups is not None:
-            await ContainerRegistryAdapter(ctx.processors).apply_allowed_groups(
-                ContainerRegistryID(result.data.id), allowed_groups
-            )
+            await ContainerRegistryAdapter(
+                ctx.processors.container_registry, ctx.processors.rbac
+            ).apply_allowed_groups(ContainerRegistryID(result.data.id), allowed_groups)
 
         return cls(
             container_registry=ContainerRegistryNode.from_dataclass(result.data),
@@ -206,9 +206,9 @@ class ModifyContainerRegistryNodeV2(graphene.Mutation):  # type: ignore[misc]
 
         allowed_groups = props.to_allowed_groups()
         if allowed_groups is not None:
-            await ContainerRegistryAdapter(ctx.processors).apply_allowed_groups(
-                ContainerRegistryID(reg_id), allowed_groups
-            )
+            await ContainerRegistryAdapter(
+                ctx.processors.container_registry, ctx.processors.rbac
+            ).apply_allowed_groups(ContainerRegistryID(reg_id), allowed_groups)
         result = await ctx.processors.container_registry.update_container_registry.run(
             props.to_action(reg_id)
         )

--- a/tests/component/app_config/conftest.py
+++ b/tests/component/app_config/conftest.py
@@ -87,7 +87,7 @@ def app_config_adapter(app_config_processors: AppConfigProcessors) -> AppConfigA
     carrying the real processors on that attribute is enough."""
     processors = MagicMock()
     processors.app_config = app_config_processors
-    return AppConfigAdapter(processors)
+    return AppConfigAdapter(processors.app_config)
 
 
 @pytest.fixture()
@@ -96,7 +96,7 @@ def app_config_definition_adapter(
 ) -> AppConfigDefinitionAdapter:
     processors = MagicMock()
     processors.app_config = app_config_processors
-    return AppConfigDefinitionAdapter(processors)
+    return AppConfigDefinitionAdapter(processors.app_config)
 
 
 @pytest.fixture()
@@ -105,7 +105,7 @@ def app_config_allow_list_adapter(
 ) -> AppConfigAllowListAdapter:
     processors = MagicMock()
     processors.app_config = app_config_processors
-    return AppConfigAllowListAdapter(processors)
+    return AppConfigAllowListAdapter(processors.app_config)
 
 
 @pytest.fixture()

--- a/tests/component/client_ip_masking/conftest.py
+++ b/tests/component/client_ip_masking/conftest.py
@@ -49,7 +49,7 @@ def server_module_registries(
 ) -> list[RouteRegistry]:
     processors = MagicMock(spec=Processors)
     processors.client_ip_masking = client_ip_masking_processors
-    adapter = ClientIPMaskingAdapter(processors)
+    adapter = ClientIPMaskingAdapter(processors.client_ip_masking)
     handler = V2ClientIPMaskingHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_client_ip_masking_routes(handler, route_deps))

--- a/tests/component/container_registry/conftest.py
+++ b/tests/component/container_registry/conftest.py
@@ -90,7 +90,7 @@ def server_module_registries(
         register_container_registry_routes(
             ContainerRegistryHandler(
                 container_registry=container_registry_processors,
-                adapter=ContainerRegistryAdapter(processors),
+                adapter=ContainerRegistryAdapter(processors.container_registry, processors.rbac),
             ),
             route_deps,
         ),

--- a/tests/component/deployment/test_deployment.py
+++ b/tests/component/deployment/test_deployment.py
@@ -361,7 +361,7 @@ class TestDeploymentAdapterFilter:
     ) -> DeploymentAdapter:
         processors_mock = MagicMock(spec=Processors)
         processors_mock.deployment = deployment_processors
-        return DeploymentAdapter(processors_mock, deployment_coordinator=MagicMock())
+        return DeploymentAdapter(processors_mock.deployment, deployment_coordinator=MagicMock())
 
     @staticmethod
     def _admin_user_data(user_uuid: uuid.UUID, domain: str) -> UserData:

--- a/tests/component/deployment_revision_preset/conftest.py
+++ b/tests/component/deployment_revision_preset/conftest.py
@@ -82,7 +82,7 @@ def server_module_registries(
 ) -> list[RouteRegistry]:
     processors = MagicMock(spec=Processors)
     processors.deployment_revision_preset = deployment_revision_preset_processors
-    adapter = DeploymentRevisionPresetAdapter(processors)
+    adapter = DeploymentRevisionPresetAdapter(processors.deployment_revision_preset)
     handler = V2DeploymentRevisionPresetHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_deployment_revision_preset_routes(handler, route_deps))

--- a/tests/component/idle_checker_assignment/conftest.py
+++ b/tests/component/idle_checker_assignment/conftest.py
@@ -226,7 +226,9 @@ def server_module_registries(
     processors = MagicMock(spec=Processors)
     processors.idle_checker_assignment = idle_checker_assignment_processors
     processors.rbac = rbac_processors
-    handler = V2IdleCheckerAssignmentHandler(adapter=IdleCheckerAssignmentAdapter(processors))
+    handler = V2IdleCheckerAssignmentHandler(
+        adapter=IdleCheckerAssignmentAdapter(processors.idle_checker_assignment, processors.rbac)
+    )
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_idle_checker_assignment_routes(handler, route_deps))
     return [v2_reg]

--- a/tests/component/image/conftest.py
+++ b/tests/component/image/conftest.py
@@ -58,14 +58,7 @@ def image_processors(
 
 @pytest.fixture()
 def image_adapter(image_processors: ImageProcessors) -> ImageAdapter:
-    """Build an ImageAdapter wired only with image processors.
-
-    Other adapter call sites in ImageAdapter use ``self._processors.image`` exclusively,
-    so a MagicMock backing object with ``.image`` set to the real ImageProcessors is sufficient.
-    """
-    processors = MagicMock()
-    processors.image = image_processors
-    return ImageAdapter(processors)
+    return ImageAdapter(image_processors)
 
 
 @pytest.fixture()

--- a/tests/component/keypair/conftest.py
+++ b/tests/component/keypair/conftest.py
@@ -73,7 +73,8 @@ def server_module_registries(
     processors.user = user_processors
 
     adapter = UserAdapter(
-        processors,
+        processors.user,
+        MagicMock(),
         auth_config=MagicMock(),
         key_provider_pool=KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
     )

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -226,9 +226,13 @@ def server_module_registries(
     processors.rbac = rbac_processors
     processors.user = user_processors
 
-    mc_handler = V2ModelCardHandler(adapter=ModelCardAdapter(processors))
-    proj_handler = V2ProjectHandler(adapter=ProjectAdapter(processors))
-    rbac_handler = V2RBACHandler(adapter=RBACAdapter(processors))
+    mc_handler = V2ModelCardHandler(adapter=ModelCardAdapter(processors.model_card, MagicMock()))
+    proj_handler = V2ProjectHandler(
+        adapter=ProjectAdapter(processors.project, processors.rbac, MagicMock(), processors.user)
+    )
+    rbac_handler = V2RBACHandler(
+        adapter=RBACAdapter(processors.rbac, processors.permission_controller)
+    )
 
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_model_card_routes(mc_handler, route_deps))

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -258,15 +258,22 @@ def server_module_registries(
     processors.permission_controller = permission_controller_processors
     processors.rbac = rbac_processors
 
-    proj_handler = V2ProjectHandler(adapter=ProjectAdapter(processors))
+    proj_handler = V2ProjectHandler(
+        adapter=ProjectAdapter(
+            processors.project, processors.rbac, processors.domain, processors.user
+        )
+    )
     user_handler = V2UserHandler(
         adapter=UserAdapter(
-            processors,
+            processors.user,
+            processors.domain,
             config_provider.config.auth,
             KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
         )
     )
-    rbac_handler = V2RBACHandler(adapter=RBACAdapter(processors))
+    rbac_handler = V2RBACHandler(
+        adapter=RBACAdapter(processors.rbac, processors.permission_controller)
+    )
 
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_project_routes(proj_handler, route_deps))

--- a/tests/component/prometheus_query_preset/conftest.py
+++ b/tests/component/prometheus_query_preset/conftest.py
@@ -104,7 +104,7 @@ def server_module_registries(
 ) -> list[RouteRegistry]:
     processors = MagicMock(spec=Processors)
     processors.prometheus_query_preset = prometheus_query_preset_processors
-    adapter = PrometheusQueryPresetAdapter(processors)
+    adapter = PrometheusQueryPresetAdapter(processors.prometheus_query_preset)
     handler = V2PrometheusQueryPresetHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_prometheus_query_preset_routes(handler, route_deps))

--- a/tests/component/rbac/test_rbac_role_permissions_bulk_v2.py
+++ b/tests/component/rbac/test_rbac_role_permissions_bulk_v2.py
@@ -85,7 +85,7 @@ def server_module_registries(
     processors = MagicMock()
     processors.permission_controller = permission_controller_processors
     processors.rbac = rbac_processors
-    adapter = RBACAdapter(processors)
+    adapter = RBACAdapter(processors.rbac, processors.permission_controller)
     handler = V2RBACHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_rbac_routes(handler, route_deps))

--- a/tests/component/rbac/test_rbac_role_v2.py
+++ b/tests/component/rbac/test_rbac_role_v2.py
@@ -99,7 +99,7 @@ def server_module_registries(
     processors = MagicMock()
     processors.permission_controller = permission_controller_processors
     processors.rbac = rbac_processors
-    adapter = RBACAdapter(processors)
+    adapter = RBACAdapter(processors.rbac, processors.permission_controller)
     handler = V2RBACHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_rbac_routes(handler, route_deps))

--- a/tests/component/rbac/test_rbac_scope_validation.py
+++ b/tests/component/rbac/test_rbac_scope_validation.py
@@ -20,7 +20,7 @@ from ai.backend.manager.models.rbac.exceptions import InvalidScope
 
 @pytest.fixture()
 def adapter() -> RBACAdapter:
-    return RBACAdapter(MagicMock())
+    return RBACAdapter(MagicMock(), MagicMock())
 
 
 class TestValidateScopeId:

--- a/tests/component/rbac/test_rbac_scoped_role_search.py
+++ b/tests/component/rbac/test_rbac_scoped_role_search.py
@@ -101,7 +101,7 @@ def server_module_registries(
     processors = MagicMock()
     processors.permission_controller = permission_controller_processors
     processors.rbac = rbac_processors
-    adapter = RBACAdapter(processors)
+    adapter = RBACAdapter(processors.rbac, processors.permission_controller)
     handler = V2RBACHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_rbac_routes(handler, route_deps))

--- a/tests/component/resource_allocation/conftest.py
+++ b/tests/component/resource_allocation/conftest.py
@@ -149,7 +149,9 @@ def server_module_registries(
     processors.session.resource_allocation = resource_allocation_processors
 
     adapter = ResourceAllocationAdapter(
-        processors=processors,
+        processors.session,
+        processors.domain,
+        processors.user,
         config_provider=config_provider,
     )
     handler = V2ResourceAllocationHandler(adapter=adapter)

--- a/tests/component/resource_allocation/test_resource_allocation_visibility.py
+++ b/tests/component/resource_allocation/test_resource_allocation_visibility.py
@@ -115,7 +115,9 @@ def _build_registries(
     processors.session = MagicMock()
     processors.session.resource_allocation = ra_processors
     adapter = ResourceAllocationAdapter(
-        processors=processors,
+        processors.session,
+        MagicMock(),
+        MagicMock(),
         config_provider=config_provider,
     )
     handler = V2ResourceAllocationHandler(adapter=adapter)

--- a/tests/component/resource_group/conftest.py
+++ b/tests/component/resource_group/conftest.py
@@ -110,7 +110,9 @@ def server_module_registries(
     processors.rbac = rbac_processors
 
     adapter = ResourceGroupAdapter(
-        processors,
+        processors.resource_group,
+        processors.rbac,
+        processors.domain,
         deployment_coordinator=MagicMock(),
         schedule_coordinator=MagicMock(),
     )

--- a/tests/component/resource_policy/conftest.py
+++ b/tests/component/resource_policy/conftest.py
@@ -107,7 +107,11 @@ def server_module_registries(
     processors.user_resource_policy = up_proc
     processors.project_resource_policy = pp_proc
 
-    adapter = ResourcePolicyAdapter(processors)
+    adapter = ResourcePolicyAdapter(
+        processors.keypair_resource_policy,
+        processors.user_resource_policy,
+        processors.project_resource_policy,
+    )
     handler = V2ResourcePolicyHandler(adapter=adapter)
 
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)

--- a/tests/component/runtime_variant/conftest.py
+++ b/tests/component/runtime_variant/conftest.py
@@ -49,7 +49,7 @@ def server_module_registries(
     processors = MagicMock(spec=Processors)
     processors.runtime_variant = runtime_variant_processors
 
-    adapter = RuntimeVariantAdapter(processors)
+    adapter = RuntimeVariantAdapter(processors.runtime_variant)
 
     handler = V2RuntimeVariantHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)

--- a/tests/component/scheduling_history/conftest.py
+++ b/tests/component/scheduling_history/conftest.py
@@ -108,7 +108,7 @@ def scheduling_history_adapter(
     processors.resource_slot.lookup_kernel_owner = processor_registry.group(
         GroupMeta(SESSION_ENTITY_TYPE)
     ).key_owner_lookup_ops(LookupKernelOwnerAction)
-    return SchedulingHistoryAdapter(processors)
+    return SchedulingHistoryAdapter(processors.scheduling_history, processors.resource_slot)
 
 
 @pytest.fixture()

--- a/tests/component/secret/conftest.py
+++ b/tests/component/secret/conftest.py
@@ -57,7 +57,7 @@ def server_module_registries(
     processors = MagicMock(spec=Processors)
     processors.secret = secret_processors
 
-    handler = V2SecretHandler(adapter=SecretAdapter(processors))
+    handler = V2SecretHandler(adapter=SecretAdapter(processors.secret))
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_secret_routes(handler, route_deps))
     return [v2_reg]

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -189,7 +189,7 @@ def build_session_registries(
     """Build the v2 session route registries around the given processors."""
     processors = MagicMock(spec=Processors)
     processors.session = session_processors
-    adapter = SessionAdapter(processors)
+    adapter = SessionAdapter(processors.session, MagicMock())
     handler = V2SessionHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_session_routes(handler, route_deps))

--- a/tests/component/user/conftest.py
+++ b/tests/component/user/conftest.py
@@ -141,7 +141,8 @@ def server_module_registries(
     processors.user = user_processors
     v2_handler = V2UserHandler(
         adapter=UserAdapter(
-            processors,
+            processors.user,
+            MagicMock(),
             auth_config=MagicMock(),
             key_provider_pool=KeyProviderPool(
                 providers=[], write_provider_type=KeyProviderType.PLAIN

--- a/tests/component/user/test_keypair_ops.py
+++ b/tests/component/user/test_keypair_ops.py
@@ -138,7 +138,8 @@ def server_module_registries(
     mock_gql_deps.processors = mock_processors
     mock_gql_deps.config_provider = config_provider
     mock_gql_deps.adapters.user = UserAdapter(
-        processors=mock_processors,
+        mock_processors.user,
+        mock_processors.domain,
         auth_config=None,  # type: ignore[arg-type]
         key_provider_pool=KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
     )

--- a/tests/component/vfolder/test_vfolder_clone.py
+++ b/tests/component/vfolder/test_vfolder_clone.py
@@ -108,7 +108,7 @@ def server_module_registries(
     processors = MagicMock(spec=Processors)
     processors.vfolder = vfolder_processors
     processors.vfolder_admin = vfolder_admin_processors
-    adapter = VFolderAdapter(processors)
+    adapter = VFolderAdapter(processors.vfolder, MagicMock(), processors.vfolder_admin, MagicMock())
     handler = V2VFolderHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_vfolder_routes(handler, route_deps))

--- a/tests/component/vfolder/test_vfolder_project_search.py
+++ b/tests/component/vfolder/test_vfolder_project_search.py
@@ -39,7 +39,7 @@ def server_module_registries(
     processors = MagicMock(spec=Processors)
     processors.vfolder = vfolder_processors
 
-    adapter = VFolderAdapter(processors)
+    adapter = VFolderAdapter(processors.vfolder, MagicMock(), MagicMock(), MagicMock())
 
     handler = V2VFolderHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -123,7 +123,7 @@ def server_module_registries(
     """Register v2 vfolder routes for testing."""
     processors = MagicMock(spec=Processors)
     processors.vfolder = vfolder_processors
-    adapter = VFolderAdapter(processors)
+    adapter = VFolderAdapter(processors.vfolder, MagicMock(), MagicMock(), MagicMock())
     handler = V2VFolderHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_vfolder_routes(handler, route_deps))

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -137,7 +137,7 @@ def server_module_registries(
     """Register v2 vfolder REST routes with real RBAC."""
     processors = MagicMock(spec=Processors)
     processors.vfolder = vfolder_processors
-    adapter = VFolderAdapter(processors)
+    adapter = VFolderAdapter(processors.vfolder, MagicMock(), MagicMock(), MagicMock())
     handler = V2VFolderHandler(adapter=adapter)
     v2_reg = RouteRegistry.create("v2", route_deps.cors_options)
     v2_reg.add_subregistry(register_v2_vfolder_routes(handler, route_deps))

--- a/tests/unit/manager/api/adapters/test_agent_adapter.py
+++ b/tests/unit/manager/api/adapters/test_agent_adapter.py
@@ -112,7 +112,7 @@ def processors(readable: AgentData, denied: AgentData, denial: GenericForbidden)
 
 @pytest.fixture
 def adapter(processors: MagicMock) -> AgentAdapter:
-    return AgentAdapter(processors)
+    return AgentAdapter(processors.agent)
 
 
 async def test_batch_load_answers_per_name(

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -212,7 +212,7 @@ class TestDeploymentSearchGates:
         processors.deployment = DeploymentProcessors(
             registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
         )
-        return DeploymentAdapter(processors, MagicMock())
+        return DeploymentAdapter(processors.deployment, MagicMock())
 
     async def test_my_search_is_answered_for_the_user_scope(
         self,
@@ -279,7 +279,7 @@ class TestFieldBatchLoads:
                 errors={DENIED_TOKEN: denial},
             )
         )
-        return DeploymentAdapter(processors, MagicMock()), processors
+        return DeploymentAdapter(processors.deployment, MagicMock()), processors
 
     async def test_access_tokens_answer_per_id(
         self,
@@ -341,7 +341,7 @@ class TestFieldBatchLoads:
         processors.deployment.bulk_get_deployment_policies.run = AsyncMock(
             return_value=OwnedFieldsOpsResult(designated={deployment_id: policy})
         )
-        deployment_adapter = DeploymentAdapter(processors, MagicMock())
+        deployment_adapter = DeploymentAdapter(processors.deployment, MagicMock())
         without_policy = uuid4()
 
         nodes = await deployment_adapter.batch_load_policies_by_endpoint_ids([

--- a/tests/unit/manager/api/adapters/test_fair_share_adapter.py
+++ b/tests/unit/manager/api/adapters/test_fair_share_adapter.py
@@ -62,7 +62,7 @@ _USER_CASES: list[tuple[UserFairShareOrderField, InstrumentedAttribute[Any]]] = 
 
 @pytest.fixture
 def adapter() -> FairShareAdapter:
-    return FairShareAdapter(MagicMock())
+    return FairShareAdapter(MagicMock(), MagicMock())
 
 
 def _assert_sorts_on(

--- a/tests/unit/manager/api/adapters/test_idle_checker_adapter.py
+++ b/tests/unit/manager/api/adapters/test_idle_checker_adapter.py
@@ -80,7 +80,7 @@ class TestIdleCheckerAdapter:
 
     @pytest.fixture
     def adapter(self, mock_processors: MagicMock) -> IdleCheckerAdapter:
-        return IdleCheckerAdapter(mock_processors)
+        return IdleCheckerAdapter(mock_processors.idle_checker)
 
     def test_builds_session_lifetime_spec(
         self,

--- a/tests/unit/manager/api/adapters/test_scheduling_history_adapter.py
+++ b/tests/unit/manager/api/adapters/test_scheduling_history_adapter.py
@@ -61,7 +61,7 @@ def processors(readable: SessionSchedulingHistoryData, denial: GenericForbidden)
 
 @pytest.fixture
 def adapter(processors: MagicMock) -> SchedulingHistoryAdapter:
-    return SchedulingHistoryAdapter(processors)
+    return SchedulingHistoryAdapter(processors.scheduling_history, processors.resource_slot)
 
 
 async def test_session_histories_answer_per_id(
@@ -122,7 +122,7 @@ async def test_kernel_histories_keep_the_given_order(processors: MagicMock) -> N
     processors.scheduling_history.bulk_get_kernel_histories.run = AsyncMock(
         return_value=BulkFieldOpsResult(successes={second.id: second, first.id: first}, errors={})
     )
-    adapter = SchedulingHistoryAdapter(processors)
+    adapter = SchedulingHistoryAdapter(processors.scheduling_history, processors.resource_slot)
 
     nodes = await adapter.batch_load_kernel_histories_by_ids([first.id, second.id])
 

--- a/tests/unit/manager/api/adapters/test_session_adapter.py
+++ b/tests/unit/manager/api/adapters/test_session_adapter.py
@@ -212,7 +212,7 @@ class TestEnqueueActionBuilding:
 
     @pytest.fixture
     def adapter(self, mock_processors: MagicMock) -> SessionAdapter:
-        return SessionAdapter(mock_processors)
+        return SessionAdapter(mock_processors.session, mock_processors.idle_checker)
 
     async def test_enqueue_interactive(
         self,
@@ -370,7 +370,7 @@ class TestTerminateActionBuilding:
 
     @pytest.fixture
     def adapter(self, mock_processors: MagicMock) -> SessionAdapter:
-        return SessionAdapter(mock_processors)
+        return SessionAdapter(mock_processors.session, mock_processors.idle_checker)
 
     async def test_terminate_single(
         self,

--- a/tests/unit/manager/api/adapters/test_vfolder_adapter.py
+++ b/tests/unit/manager/api/adapters/test_vfolder_adapter.py
@@ -96,7 +96,12 @@ class TestVFolderAdapterMySearch:
 
     @pytest.fixture
     def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
-        return VFolderAdapter(mock_processors)
+        return VFolderAdapter(
+            mock_processors.vfolder,
+            mock_processors.vfolder_file,
+            mock_processors.vfolder_admin,
+            mock_processors.deployment,
+        )
 
     async def test_my_search_calls_processor_with_user_scope(
         self,
@@ -194,7 +199,12 @@ class TestVFolderAdapterProjectSearch:
 
     @pytest.fixture
     def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
-        return VFolderAdapter(mock_processors)
+        return VFolderAdapter(
+            mock_processors.vfolder,
+            mock_processors.vfolder_file,
+            mock_processors.vfolder_admin,
+            mock_processors.deployment,
+        )
 
     async def test_project_search_calls_processor_with_project_scope(
         self,
@@ -233,7 +243,7 @@ class TestVFolderAdapterConvertFilter:
 
     @pytest.fixture
     def adapter(self) -> VFolderAdapter:
-        return VFolderAdapter(MagicMock())
+        return VFolderAdapter(MagicMock(), MagicMock(), MagicMock(), MagicMock())
 
     @pytest.mark.parametrize("value", [True, False])
     def test_cloneable_filter_produces_condition(
@@ -268,7 +278,12 @@ class TestVFolderAdapterGetFolderUsage:
 
     @pytest.fixture
     def adapter(self, mock_processors: MagicMock) -> VFolderAdapter:
-        return VFolderAdapter(mock_processors)
+        return VFolderAdapter(
+            mock_processors.vfolder,
+            mock_processors.vfolder_file,
+            mock_processors.vfolder_admin,
+            mock_processors.deployment,
+        )
 
     async def test_maps_usage_data_to_dto(
         self,

--- a/tests/unit/manager/api/resource_group/test_adapter.py
+++ b/tests/unit/manager/api/resource_group/test_adapter.py
@@ -45,7 +45,9 @@ def _get_pagination_spec() -> PaginationSpec:
 def _make_adapter() -> ResourceGroupAdapter:
     """Create a ResourceGroupAdapter with a mock processors."""
     return ResourceGroupAdapter(
-        processors=MagicMock(),
+        resource_group=MagicMock(),
+        rbac=MagicMock(),
+        domain=MagicMock(),
         deployment_coordinator=MagicMock(),
         schedule_coordinator=MagicMock(),
     )


### PR DESCRIPTION
## Summary
- `BaseAdapter` no longer takes the `Processors` bundle. Each adapter under `api/adapters/` receives the processor objects it calls (e.g. `DomainAdapter(domain: DomainProcessors, resource_group: ResourceGroupProcessors)`), declared as typed fields.
- `api/adapters/registry.py` is the one module that still imports `services.processors` and injects each adapter's processors from the bundle. The legacy GQL container-registry mutation builds its adapter the same way.
- Behavior is unchanged. Tests only update adapter construction; a `MagicMock(spec=Processors)` bundle raises on annotation-only fields, so processors a test does not wire are passed as `MagicMock()`.

## Measurements
`pants dependencies --transitive <adapter> | grep -c '^src/ai/backend/manager/'` (3,943 manager files total):

| Adapter | Before | After |
|---|---|---|
| domain | 1,988 | 455 |
| rbac | 1,988 | 377 |
| user | 1,988 | 646 |
| session | 1,988 | 717 |
| vfolder | 1,988 | 725 |

## Test plan
- [x] `pants lint check --changed-since=HEAD~1` passes (ruff, visibility, mypy)
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=direct` passes (unit adapter tests, component tests for vfolder, session_v2, rbac, project, user, keypair, resource_group, resource_allocation, model_card, image, and others)
- [x] No module under `api/adapters/` other than `registry.py` imports `ai.backend.manager.services.processors`

Resolves BA-7777

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDeCUV9vgqKfzVJ8hro1dQ
