### PR TITLE
refactor(BA-7778): build the action validator bundles in one function

### DIFF
--- a/changes/14443.misc.md
+++ b/changes/14443.misc.md
@@ -1,0 +1,1 @@
+Build the manager's action validator bundles in one function instead of inline in the processing composer.

--- a/src/ai/backend/manager/actions/validators/build.py
+++ b/src/ai/backend/manager/actions/validators/build.py
@@ -1,0 +1,67 @@
+from ai.backend.manager.actions.v2.bulk.validator.rbac import (
+    VirtualEntityAtomicBulkActionRBACValidator,
+    VirtualEntityPartialBulkActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.relation.validator.rbac import (
+    VirtualEntityRelationActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.scope.validator.rbac import (
+    VirtualEntityScopeActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.single_entity.validator.rbac import (
+    VirtualEntitySingleEntityActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.validators import ActionValidators as V2ActionValidators
+from ai.backend.manager.actions.validators import ActionValidators
+from ai.backend.manager.actions.validators.rbac import (
+    LegacyRBACValidators,
+    RBACValidators,
+    VirtualEntityRBACValidators,
+)
+from ai.backend.manager.actions.validators.rbac.legacy import (
+    LegacyScopeActionRBACValidator,
+    LegacySingleEntityActionRBACValidator,
+)
+from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+
+def build_action_validators(
+    permission_controller_repository: PermissionControllerRepository,
+    config_provider: ManagerConfigProvider,
+) -> tuple[ActionValidators, V2ActionValidators]:
+    rbac_validators = RBACValidators(
+        scope=ScopeActionRBACValidator(permission_controller_repository, config_provider),
+    )
+    legacy_rbac_validators = LegacyRBACValidators(
+        scope=LegacyScopeActionRBACValidator(permission_controller_repository),
+        single_entity=LegacySingleEntityActionRBACValidator(permission_controller_repository),
+    )
+    virtual_entity_rbac_validators = VirtualEntityRBACValidators(
+        scope=VirtualEntityScopeActionRBACValidator(
+            permission_controller_repository, config_provider
+        ),
+        single_entity=VirtualEntitySingleEntityActionRBACValidator(
+            permission_controller_repository, config_provider
+        ),
+        partial_bulk=VirtualEntityPartialBulkActionRBACValidator(
+            permission_controller_repository, config_provider
+        ),
+        atomic_bulk=VirtualEntityAtomicBulkActionRBACValidator(
+            permission_controller_repository, config_provider
+        ),
+        relation=VirtualEntityRelationActionRBACValidator(
+            permission_controller_repository, config_provider
+        ),
+    )
+    return (
+        ActionValidators(
+            rbac=rbac_validators,
+            legacy_rbac=legacy_rbac_validators,
+            virtual_entity_rbac=virtual_entity_rbac_validators,
+        ),
+        virtual_entity_rbac_validators.to_action_validators(),
+    )

--- a/src/ai/backend/manager/dependencies/processing/composer.py
+++ b/src/ai/backend/manager/dependencies/processing/composer.py
@@ -34,10 +34,6 @@ from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.v2.bulk.monitor.audit_log import BulkActionAuditLogMonitor
 from ai.backend.manager.actions.v2.bulk.monitor.prometheus import BulkActionPrometheusMonitor
 from ai.backend.manager.actions.v2.bulk.monitor.reporter import BulkActionReporterMonitor
-from ai.backend.manager.actions.v2.bulk.validator.rbac import (
-    VirtualEntityAtomicBulkActionRBACValidator,
-    VirtualEntityPartialBulkActionRBACValidator,
-)
 from ai.backend.manager.actions.v2.global_scope.monitor.audit_log import (
     GlobalActionAuditLogMonitor,
 )
@@ -63,15 +59,9 @@ from ai.backend.manager.actions.v2.relation.monitor.prometheus import (
 from ai.backend.manager.actions.v2.relation.monitor.reporter import (
     RelationActionReporterMonitor,
 )
-from ai.backend.manager.actions.v2.relation.validator.rbac import (
-    VirtualEntityRelationActionRBACValidator,
-)
 from ai.backend.manager.actions.v2.scope.monitor.audit_log import ScopeActionAuditLogMonitor
 from ai.backend.manager.actions.v2.scope.monitor.prometheus import ScopeActionPrometheusMonitor
 from ai.backend.manager.actions.v2.scope.monitor.reporter import ScopeActionReporterMonitor
-from ai.backend.manager.actions.v2.scope.validator.rbac import (
-    VirtualEntityScopeActionRBACValidator,
-)
 from ai.backend.manager.actions.v2.single_entity.monitor.audit_log import (
     SingleEntityActionAuditLogMonitor,
 )
@@ -81,20 +71,7 @@ from ai.backend.manager.actions.v2.single_entity.monitor.prometheus import (
 from ai.backend.manager.actions.v2.single_entity.monitor.reporter import (
     SingleEntityActionReporterMonitor,
 )
-from ai.backend.manager.actions.v2.single_entity.validator.rbac import (
-    VirtualEntitySingleEntityActionRBACValidator,
-)
-from ai.backend.manager.actions.validators import ActionValidators
-from ai.backend.manager.actions.validators.rbac import (
-    LegacyRBACValidators,
-    RBACValidators,
-    VirtualEntityRBACValidators,
-)
-from ai.backend.manager.actions.validators.rbac.legacy import (
-    LegacyScopeActionRBACValidator,
-    LegacySingleEntityActionRBACValidator,
-)
-from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
+from ai.backend.manager.actions.validators.build import build_action_validators
 from ai.backend.manager.agent_cache import AgentRPCCache
 from ai.backend.manager.clients.agent.pool import AgentClientPool
 from ai.backend.manager.clients.appproxy.client import AppProxyClientPool
@@ -391,31 +368,9 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
             registry_quota_service=setup_input.registry_quota_service,
         )
 
-        permission_controller_repository = setup_input.repositories.permission_controller.repository
-        config_provider = setup_input.config_provider
-        rbac_validators = RBACValidators(
-            scope=ScopeActionRBACValidator(permission_controller_repository, config_provider),
-        )
-        legacy_rbac_validators = LegacyRBACValidators(
-            scope=LegacyScopeActionRBACValidator(permission_controller_repository),
-            single_entity=LegacySingleEntityActionRBACValidator(permission_controller_repository),
-        )
-        virtual_entity_rbac_validators = VirtualEntityRBACValidators(
-            scope=VirtualEntityScopeActionRBACValidator(
-                permission_controller_repository, config_provider
-            ),
-            single_entity=VirtualEntitySingleEntityActionRBACValidator(
-                permission_controller_repository, config_provider
-            ),
-            partial_bulk=VirtualEntityPartialBulkActionRBACValidator(
-                permission_controller_repository, config_provider
-            ),
-            atomic_bulk=VirtualEntityAtomicBulkActionRBACValidator(
-                permission_controller_repository, config_provider
-            ),
-            relation=VirtualEntityRelationActionRBACValidator(
-                permission_controller_repository, config_provider
-            ),
+        validators, v2_validators = build_action_validators(
+            setup_input.repositories.permission_controller.repository,
+            setup_input.config_provider,
         )
 
         processor_bundle = await stack.enter_dependency(
@@ -425,12 +380,8 @@ class ProcessingComposer(DependencyComposer[ProcessingInput, ProcessingResources
                 action_monitors=action_monitors,
                 event_hub=setup_input.event_hub,
                 event_fetcher=setup_input.event_fetcher,
-                validators=ActionValidators(
-                    rbac=rbac_validators,
-                    legacy_rbac=legacy_rbac_validators,
-                    virtual_entity_rbac=virtual_entity_rbac_validators,
-                ),
-                v2_validators=virtual_entity_rbac_validators.to_action_validators(),
+                validators=validators,
+                v2_validators=v2_validators,
             ),
         )
         processors = processor_bundle.processors

--- a/tests/unit/manager/actions/validators/test_build_action_validators.py
+++ b/tests/unit/manager/actions/validators/test_build_action_validators.py
@@ -1,0 +1,63 @@
+"""build_action_validators fills every v2 slot and every ActionValidators bundle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ai.backend.manager.actions.v2.bulk.validator.rbac import (
+    VirtualEntityAtomicBulkActionRBACValidator,
+    VirtualEntityPartialBulkActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.relation.validator.rbac import (
+    VirtualEntityRelationActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.scope.validator.rbac import (
+    VirtualEntityScopeActionRBACValidator,
+)
+from ai.backend.manager.actions.v2.single_entity.validator.rbac import (
+    VirtualEntitySingleEntityActionRBACValidator,
+)
+from ai.backend.manager.actions.validators.build import build_action_validators
+from ai.backend.manager.actions.validators.rbac import (
+    LegacyRBACValidators,
+    RBACValidators,
+    VirtualEntityRBACValidators,
+)
+from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.repositories.permission_controller.repository import (
+    PermissionControllerRepository,
+)
+
+
+class TestBuildActionValidators:
+    def test_every_v2_slot_holds_its_validator(self) -> None:
+        _, v2_validators = build_action_validators(
+            MagicMock(spec=PermissionControllerRepository),
+            MagicMock(spec=ManagerConfigProvider),
+        )
+
+        assert len(v2_validators.single_entity) == 1
+        assert isinstance(
+            v2_validators.single_entity[0], VirtualEntitySingleEntityActionRBACValidator
+        )
+        assert len(v2_validators.partial_bulk) == 1
+        assert isinstance(
+            v2_validators.partial_bulk[0], VirtualEntityPartialBulkActionRBACValidator
+        )
+        assert len(v2_validators.atomic_bulk) == 1
+        assert isinstance(v2_validators.atomic_bulk[0], VirtualEntityAtomicBulkActionRBACValidator)
+        assert len(v2_validators.scope) == 1
+        assert isinstance(v2_validators.scope[0], VirtualEntityScopeActionRBACValidator)
+        assert len(v2_validators.relation) == 1
+        assert isinstance(v2_validators.relation[0], VirtualEntityRelationActionRBACValidator)
+
+    def test_action_validators_holds_three_bundles(self) -> None:
+        validators, v2_validators = build_action_validators(
+            MagicMock(spec=PermissionControllerRepository),
+            MagicMock(spec=ManagerConfigProvider),
+        )
+
+        assert isinstance(validators.rbac, RBACValidators)
+        assert isinstance(validators.legacy_rbac, LegacyRBACValidators)
+        assert isinstance(validators.virtual_entity_rbac, VirtualEntityRBACValidators)
+        assert v2_validators.scope == [validators.virtual_entity_rbac.scope]


### PR DESCRIPTION
## Summary
- Move the RBAC validator assembly out of `dependencies/processing/composer.py` into `actions/validators/build.py` as `build_action_validators()`, returning the `ActionValidators` bundles and the v2 `ActionValidators` slots together.
- Pure move, no behavior change; the composer now calls the function.
- Add a unit test asserting every v2 slot (single_entity, partial_bulk, atomic_bulk, scope, relation) holds its RBAC validator and `ActionValidators` carries all three bundles.

## Test plan
- [x] `pants check` (mypy) passes
- [x] `tests/unit/manager/actions/validators/test_build_action_validators.py` passes
- [x] `tests/unit/manager/dependencies/processing/test_composer.py` passes

Resolves BA-7778

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRB9aMEaqXusz1TLfpiHFj