### PR TITLE
feat(BA-7731): carry the role's scope and the permission's bit in the responses

### DIFF
--- a/changes/14446.deprecation.md
+++ b/changes/14446.deprecation.md
@@ -1,0 +1,1 @@
+Deprecate the `operation` field of a permission response in favour of `permission`, which names the same bit as what is held rather than as an action.

--- a/changes/14446.feature.md
+++ b/changes/14446.feature.md
@@ -1,0 +1,1 @@
+Report the scope a role belongs to on every role response, and report the permission bit a permission row holds under the name that bit has.

--- a/docs/manager/graphql-reference/supergraph.graphql
+++ b/docs/manager/graphql-reference/supergraph.graphql
@@ -14375,8 +14375,13 @@ type Permission implements Node
   scopeType: RBACElementType!
   scopeId: String!
   entityType: RBACElementType!
-  operation: OperationType!
   createdAt: DateTime!
+
+  """Added in 26.9.0. The permission bit the row holds."""
+  permission: PermissionBit!
+
+  """Deprecated: use `permission`. The same bit named as an action."""
+  operation: OperationType! @deprecated(reason: "Deprecated since 26.9.0. Use `permission`.")
 
   """The role this permission belongs to."""
   role: Role
@@ -18924,6 +18929,12 @@ type Role implements Node
   Added in 26.4.4. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
   """
   autoAssign: Boolean!
+
+  """Added in 26.9.0. Type of the scope the role belongs to."""
+  scopeType: String!
+
+  """Added in 26.9.0. ID of the scope the role belongs to."""
+  scopeId: UUID!
 
   """Added in 26.3.0. Permissions associated with this role."""
   permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection

--- a/docs/manager/graphql-reference/v2-schema.graphql
+++ b/docs/manager/graphql-reference/v2-schema.graphql
@@ -9908,8 +9908,13 @@ type Permission implements Node {
   scopeType: RBACElementType!
   scopeId: String!
   entityType: RBACElementType!
-  operation: OperationType!
   createdAt: DateTime!
+
+  """Added in 26.9.0. The permission bit the row holds."""
+  permission: PermissionBit!
+
+  """Deprecated: use `permission`. The same bit named as an action."""
+  operation: OperationType! @deprecated(reason: "Deprecated since 26.9.0. Use `permission`.")
 
   """The role this permission belongs to."""
   role: Role
@@ -13438,6 +13443,12 @@ type Role implements Node {
   Added in 26.4.4. When true, the role is automatically granted to a user when the user is added to a scope this role is registered in.
   """
   autoAssign: Boolean!
+
+  """Added in 26.9.0. Type of the scope the role belongs to."""
+  scopeType: String!
+
+  """Added in 26.9.0. ID of the scope the role belongs to."""
+  scopeId: UUID!
 
   """Added in 26.3.0. Permissions associated with this role."""
   permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection

--- a/src/ai/backend/common/dto/manager/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/rbac/response.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.types import EntityID, EntityType
 from ai.backend.common.data.permission.types import ScopeType as LegacyScopeType
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.types import BackendAISchema
@@ -51,6 +51,8 @@ class RoleDTO(BackendAISchema):
 
     id: UUID = Field(description="Role ID")
     name: str = Field(description="Role name")
+    scope_type: EntityType = Field(description="Type of the scope the role belongs to")
+    scope_id: EntityID = Field(description="ID of the scope the role belongs to")
     source: RoleSource = Field(description="Role source")
     status: RoleStatus = Field(description="Role status")
     created_at: datetime = Field(description="Creation timestamp")

--- a/src/ai/backend/common/dto/manager/v2/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/response.py
@@ -10,9 +10,11 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
+from ai.backend.common.data.entity.types import EntityID, EntityType
 
 from .types import (
     OperationTypeDTO,
+    PermissionBitDTO,
     RBACElementTypeDTO,
     RoleSourceDTO,
     RoleStatusDTO,
@@ -69,6 +71,8 @@ class RoleNode(BaseResponseModel):
     created_at: datetime = Field(description="Creation timestamp")
     updated_at: datetime = Field(description="Last update timestamp")
     deleted_at: datetime | None = Field(default=None, description="Deletion timestamp")
+    scope_type: EntityType = Field(description="Type of the scope the role belongs to")
+    scope_id: EntityID = Field(description="ID of the scope the role belongs to")
 
 
 class CreateRolePayload(BaseResponseModel):
@@ -221,7 +225,11 @@ class PermissionNode(BaseResponseModel):
     scope_type: RBACElementTypeDTO = Field(description="Scope element type")
     scope_id: str = Field(description="Scope element ID")
     entity_type: RBACElementTypeDTO = Field(description="Entity element type")
-    operation: OperationTypeDTO = Field(description="Operation type")
+    permission: PermissionBitDTO = Field(description="The permission bit the row holds")
+    operation: OperationTypeDTO = Field(
+        description="Deprecated: use `permission`. The same bit named as an action.",
+        deprecated=True,
+    )
     created_at: datetime = Field(description="Creation timestamp")
 
 

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -138,6 +138,7 @@ from ai.backend.common.dto.manager.v2.rbac.request import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     OperationTypeDTO,
     OperationTypeFilter,
+    PermissionBitDTO,
     RBACElementTypeDTO,
     RBACElementTypeFilter,
     RoleSourceDTO,
@@ -1852,6 +1853,8 @@ class RBACAdapter(BaseAdapter):
             created_at=data.created_at,
             updated_at=data.updated_at,
             deleted_at=data.deleted_at,
+            scope_type=data.scope_type,
+            scope_id=data.scope_id,
         )
 
     @staticmethod
@@ -1866,6 +1869,8 @@ class RBACAdapter(BaseAdapter):
             created_at=data.created_at,
             updated_at=data.updated_at,
             deleted_at=data.deleted_at,
+            scope_type=data.scope_type,
+            scope_id=data.scope_id,
         )
 
     @staticmethod
@@ -1876,6 +1881,7 @@ class RBACAdapter(BaseAdapter):
             scope_type=RBACElementTypeDTO(data.scope_type),
             scope_id=data.scope_id,
             entity_type=RBACElementTypeDTO(data.entity_type),
+            permission=PermissionBitDTO[data.permission.to_operation().name],
             operation=OperationTypeDTO(data.permission.to_operation().value),
             created_at=data.created_at,
         )
@@ -1916,6 +1922,8 @@ class RBACAdapter(BaseAdapter):
         return RoleDTO(
             id=data.id,
             name=data.name,
+            scope_type=data.scope_type,
+            scope_id=data.scope_id,
             source=RoleSource(data.source.value),
             status=RoleStatus(data.status.value),
             created_at=data.created_at,

--- a/src/ai/backend/manager/api/gql/entity_share/types.py
+++ b/src/ai/backend/manager/api/gql/entity_share/types.py
@@ -37,7 +37,6 @@ from ai.backend.common.dto.manager.v2.entity_share.types import (
     EntityShareSideDTO,
     EntityShareStatusDTO,
 )
-from ai.backend.common.dto.manager.v2.rbac.types import PermissionBitDTO
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
@@ -50,7 +49,7 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
-from ai.backend.manager.api.gql.rbac.types.scope import UUIDScopeGQL
+from ai.backend.manager.api.gql.rbac.types.scope import PermissionBitGQL, UUIDScopeGQL
 
 EntityShareStatusGQL: type[EntityShareStatusDTO] = gql_enum(
     BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Where a share stands."),
@@ -65,15 +64,6 @@ EntityShareSideGQL: type[EntityShareSideDTO] = gql_enum(
     ),
     EntityShareSideDTO,
     name="EntityShareSide",
-)
-
-PermissionBitGQL: type[PermissionBitDTO] = gql_enum(
-    BackendAIGQLMeta(
-        added_version=NEXT_RELEASE_VERSION,
-        description="One bit of a permission mask; distinct from OperationType, which names an action.",
-    ),
-    PermissionBitDTO,
-    name="PermissionBit",
 )
 
 

--- a/src/ai/backend/manager/api/gql/rbac/types/permission.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/permission.py
@@ -79,11 +79,13 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     OperationTypeFilter as OperationTypeFilterDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.common.types import SessionId
 from ai.backend.manager.api.gql.base import DateTimeFilter, OrderDirection, StringFilter, UUIDFilter
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
+    gql_added_field,
     gql_connection_type,
     gql_enum,
     gql_field,
@@ -94,6 +96,7 @@ from ai.backend.manager.api.gql.decorators import (
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
 from ai.backend.manager.api.gql.rbac.types.entity_node import EntityNode
 from ai.backend.manager.api.gql.rbac.types.scope import (
+    PermissionBitGQL,
     RBACElementTypeFilterGQL,
     RBACElementTypeGQL,
 )
@@ -157,8 +160,17 @@ class PermissionGQL(PydanticNodeMixin[PermissionNodeDTO]):
     scope_type: RBACElementTypeGQL
     scope_id: str
     entity_type: RBACElementTypeGQL
-    operation: OperationTypeGQL
     created_at: datetime
+    permission: PermissionBitGQL = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="The permission bit the row holds.",
+        )
+    )
+    operation: OperationTypeGQL = gql_field(
+        description="Deprecated: use `permission`. The same bit named as an action.",
+        deprecation_reason=f"Deprecated since {NEXT_RELEASE_VERSION}. Use `permission`.",
+    )
 
     @classmethod
     @override

--- a/src/ai/backend/manager/api/gql/rbac/types/role.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/role.py
@@ -108,7 +108,10 @@ from ai.backend.manager.api.gql.decorators import (
     gql_pydantic_type,
 )
 from ai.backend.manager.api.gql.pydantic_compat import PydanticNodeMixin, PydanticOutputMixin
-from ai.backend.manager.api.gql.rbac.types.scope import RBACElementTypeFilterGQL, ScopeInputGQL
+from ai.backend.manager.api.gql.rbac.types.scope import (
+    RBACElementTypeFilterGQL,
+    ScopeInputGQL,
+)
 from ai.backend.manager.api.gql.types import GQLFilter, GQLOrderBy, StrawberryGQLContext
 
 if TYPE_CHECKING:
@@ -167,6 +170,18 @@ class RoleGQL(PydanticNodeMixin[Any]):
                 "When true, the role is automatically granted to a user when the user is added "
                 "to a scope this role is registered in."
             ),
+        )
+    )
+    scope_type: str = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="Type of the scope the role belongs to.",
+        )
+    )
+    scope_id: UUID = gql_added_field(
+        BackendAIGQLMeta(
+            added_version=NEXT_RELEASE_VERSION,
+            description="ID of the scope the role belongs to.",
         )
     )
 

--- a/src/ai/backend/manager/api/gql/rbac/types/scope.py
+++ b/src/ai/backend/manager/api/gql/rbac/types/scope.py
@@ -11,6 +11,7 @@ from uuid import UUID
 
 from ai.backend.common.dto.manager.v2.rbac.types import (
     EntityTypeScope,
+    PermissionBitDTO,
     RBACElementTypeDTO,
     ScopeInputDTO,
     UUIDScope,
@@ -18,6 +19,7 @@ from ai.backend.common.dto.manager.v2.rbac.types import (
 from ai.backend.common.dto.manager.v2.rbac.types import (
     RBACElementTypeFilter as RBACElementTypeFilterDTO,
 )
+from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
 from ai.backend.manager.api.gql.decorators import (
     BackendAIGQLMeta,
     PydanticInputMixin,
@@ -115,3 +117,13 @@ class RBACElementTypeFilterGQL(PydanticInputMixin[RBACElementTypeFilterDTO]):
     not_in: list[RBACElementTypeGQL] | None = gql_field(
         description="Excludes rows whose element type is in this list.", default=None
     )
+
+
+PermissionBitGQL: type[PermissionBitDTO] = gql_enum(
+    BackendAIGQLMeta(
+        added_version=NEXT_RELEASE_VERSION,
+        description="One bit of a permission mask; distinct from OperationType, which names an action.",
+    ),
+    PermissionBitDTO,
+    name="PermissionBit",
+)

--- a/src/ai/backend/manager/api/rest/rbac/role_adapter.py
+++ b/src/ai/backend/manager/api/rest/rbac/role_adapter.py
@@ -40,6 +40,8 @@ class RoleAdapter(BaseFilterAdapter):
         return RoleDTO(
             id=data.id,
             name=data.name,
+            scope_type=data.scope_type,
+            scope_id=data.scope_id,
             source=data.source,
             status=data.status,
             created_at=data.created_at,

--- a/tests/unit/client_v2/test_rbac.py
+++ b/tests/unit/client_v2/test_rbac.py
@@ -47,6 +47,7 @@ from .conftest import MockAuth
 _DEFAULT_CONFIG = ClientConfig(endpoint=URL("https://api.example.com"))
 
 _SAMPLE_ROLE_ID = str(uuid.uuid4())
+_SAMPLE_SCOPE_ID = str(uuid.uuid4())
 _SAMPLE_USER_ID = str(uuid.uuid4())
 _NOW_ISO = "2025-01-01T00:00:00+00:00"
 
@@ -84,6 +85,8 @@ def _sample_role_dict(role_id: str = _SAMPLE_ROLE_ID) -> dict[str, Any]:
     return {
         "id": role_id,
         "name": "test-role",
+        "scope_type": "project",
+        "scope_id": _SAMPLE_SCOPE_ID,
         "source": RoleSource.CUSTOM.value,
         "status": RoleStatus.ACTIVE.value,
         "created_at": _NOW_ISO,

--- a/tests/unit/client_v2/test_rbac_client.py
+++ b/tests/unit/client_v2/test_rbac_client.py
@@ -40,12 +40,15 @@ from .conftest import MockAuth
 _DEFAULT_CONFIG = ClientConfig(endpoint=URL("https://api.example.com"))
 
 _ROLE_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_SCOPE_ID = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
 _USER_ID = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
 _GRANTED_BY = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
 
 _ROLE_PAYLOAD = {
     "id": str(_ROLE_ID),
     "name": "admin",
+    "scope_type": "project",
+    "scope_id": str(_SCOPE_ID),
     "source": "custom",
     "status": "active",
     "created_at": "2025-01-01T00:00:00+00:00",

--- a/tests/unit/common/dto/manager/v2/rbac/test_response.py
+++ b/tests/unit/common/dto/manager/v2/rbac/test_response.py
@@ -5,17 +5,27 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 
+import pytest
+
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.dto.manager.v2.rbac.response import (
     CreateRolePayload,
     DeleteRolePayload,
+    PermissionNode,
     PurgeRolePayload,
     RoleNode,
     UpdateRolePayload,
 )
 from ai.backend.common.dto.manager.v2.rbac.types import (
+    OperationTypeDTO,
+    PermissionBitDTO,
+    RBACElementTypeDTO,
     RoleSourceDTO,
     RoleStatusDTO,
 )
+from ai.backend.common.exception import BackendAISchemaValidationFailed
+
+_SCOPE_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
 
 class TestRoleNodeCreation:
@@ -32,6 +42,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
             deleted_at=None,
         )
         assert node.id == role_id
@@ -53,6 +65,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         assert node.id == role_id
         assert node.description is None
@@ -68,6 +82,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         assert node.description is None
 
@@ -82,6 +98,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         assert node.description is None
 
@@ -95,6 +113,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.DELETED,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
             deleted_at=now,
         )
         assert node.deleted_at == now
@@ -110,6 +130,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         assert node.source == RoleSourceDTO.SYSTEM
 
@@ -123,6 +145,8 @@ class TestRoleNodeCreation:
             status=RoleStatusDTO.INACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         assert node.status == RoleStatusDTO.INACTIVE
 
@@ -140,6 +164,8 @@ class TestCreateRolePayload:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         payload = CreateRolePayload(role=role_node)
         assert payload.role.name == "Admin"
@@ -156,6 +182,8 @@ class TestCreateRolePayload:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         payload = CreateRolePayload(role=role_node)
         assert payload.role.name == "Admin"
@@ -171,6 +199,8 @@ class TestCreateRolePayload:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         payload = CreateRolePayload(role=role_node)
         json_str = payload.model_dump_json()
@@ -193,6 +223,8 @@ class TestUpdateRolePayload:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         payload = UpdateRolePayload(role=role_node)
         assert payload.role.name == "UpdatedAdmin"
@@ -209,6 +241,8 @@ class TestUpdateRolePayload:
             status=RoleStatusDTO.INACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         payload = UpdateRolePayload(role=role_node)
         json_str = payload.model_dump_json()
@@ -290,6 +324,8 @@ class TestRoleNodeRoundTrip:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
             deleted_at=None,
         )
         json_str = node.model_dump_json()
@@ -311,6 +347,8 @@ class TestRoleNodeRoundTrip:
             status=RoleStatusDTO.DELETED,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
             deleted_at=now,
         )
         json_str = node.model_dump_json()
@@ -329,8 +367,80 @@ class TestRoleNodeRoundTrip:
             status=RoleStatusDTO.ACTIVE,
             created_at=now,
             updated_at=now,
+            scope_type=EntityType("project"),
+            scope_id=_SCOPE_ID,
         )
         json_str = node.model_dump_json()
         restored = RoleNode.model_validate_json(json_str)
         assert restored.id == role_id
         assert restored.name == "BasicRole"
+
+
+class TestRoleNodeScope:
+    """The role names the one scope it belongs to."""
+
+    def test_the_scope_is_required(self) -> None:
+        now = datetime.now(tz=UTC).isoformat()
+        with pytest.raises(BackendAISchemaValidationFailed):
+            RoleNode.model_validate({
+                "id": str(uuid.uuid4()),
+                "name": "Scopeless",
+                "source": RoleSourceDTO.CUSTOM.value,
+                "status": RoleStatusDTO.ACTIVE.value,
+                "created_at": now,
+                "updated_at": now,
+            })
+
+    def test_the_scope_survives_a_round_trip(self) -> None:
+        now = datetime.now(tz=UTC)
+        node = RoleNode(
+            id=uuid.uuid4(),
+            name="Scoped",
+            source=RoleSourceDTO.CUSTOM,
+            status=RoleStatusDTO.ACTIVE,
+            created_at=now,
+            updated_at=now,
+            scope_type=EntityType("domain"),
+            scope_id=_SCOPE_ID,
+        )
+
+        restored = RoleNode.model_validate_json(node.model_dump_json())
+
+        assert restored.scope_type == "domain"
+        assert restored.scope_id == _SCOPE_ID
+
+
+class TestPermissionNodeBit:
+    """A permission row names the bit it holds, and keeps the deprecated action name."""
+
+    def _node(self, permission: PermissionBitDTO, operation: OperationTypeDTO) -> PermissionNode:
+        return PermissionNode(
+            id=uuid.uuid4(),
+            role_id=uuid.uuid4(),
+            scope_type=RBACElementTypeDTO.PROJECT,
+            scope_id=str(_SCOPE_ID),
+            entity_type=RBACElementTypeDTO.VFOLDER,
+            permission=permission,
+            operation=operation,
+            created_at=datetime.now(tz=UTC),
+        )
+
+    def test_both_names_of_the_same_bit_are_carried(self) -> None:
+        node = self._node(PermissionBitDTO.SOFT_DELETE, OperationTypeDTO.SOFT_DELETE)
+
+        assert node.permission == PermissionBitDTO.SOFT_DELETE
+        assert node.operation == OperationTypeDTO.SOFT_DELETE
+        assert node.permission.value == "soft_delete"
+        assert node.operation.value == "soft-delete"
+
+    def test_the_bit_is_required(self) -> None:
+        with pytest.raises(BackendAISchemaValidationFailed):
+            PermissionNode.model_validate({
+                "id": str(uuid.uuid4()),
+                "role_id": str(uuid.uuid4()),
+                "scope_type": RBACElementTypeDTO.PROJECT.value,
+                "scope_id": str(_SCOPE_ID),
+                "entity_type": RBACElementTypeDTO.VFOLDER.value,
+                "operation": OperationTypeDTO.READ.value,
+                "created_at": datetime.now(tz=UTC).isoformat(),
+            })

--- a/tests/unit/manager/api/gql/rbac/test_permission_mutations.py
+++ b/tests/unit/manager/api/gql/rbac/test_permission_mutations.py
@@ -12,7 +12,11 @@ import pytest
 from aiohttp.web_exceptions import HTTPForbidden
 
 from ai.backend.common.dto.manager.v2.rbac.response import PermissionNode
-from ai.backend.common.dto.manager.v2.rbac.types import OperationTypeDTO, RBACElementTypeDTO
+from ai.backend.common.dto.manager.v2.rbac.types import (
+    OperationTypeDTO,
+    PermissionBitDTO,
+    RBACElementTypeDTO,
+)
 from ai.backend.manager.api.gql.rbac.resolver import permission as permission_resolver
 from ai.backend.manager.api.gql.rbac.types import PermissionGQL, UpdatePermissionInput
 from ai.backend.manager.api.gql.rbac.types.permission import OperationTypeGQL
@@ -34,6 +38,7 @@ def _make_permission_node(
         scope_type=scope_type,
         scope_id=scope_id,
         entity_type=entity_type,
+        permission=PermissionBitDTO[operation.name],
         operation=operation,
         created_at=datetime.now(UTC),
     )


### PR DESCRIPTION
## Summary

- A role belongs to one scope since BA-7730, but nothing said which one on the way out. `RoleNode`, `RoleGQL` and the v1 `RoleDTO` now carry `scope_type` and `scope_id`, read off the row as an `EntityType` and an `EntityID` — no element enum stands between the column and the wire.
- A permission row answers with `permission`, the bit it actually holds. `operation` stays, carrying the same bit named as an action, and is deprecated.
- `PermissionBitGQL` moves from `entity_share` to the shared rbac scope module. `entity_share` imports rbac, so reading the enum back from rbac closed a circle. The enum is unreleased, so the move leaves the schema unchanged.

## Schema changes

Every change is additive; the graphql-inspector check reports no breaking change.

```
+ permission: PermissionBit!   (Added in 26.9.0)
+ operation  @deprecated       (Deprecated since 26.9.0. Use `permission`.)
+ scopeType: String!           (Added in 26.9.0)
+ scopeId: UUID!               (Added in 26.9.0)
```

## Not in scope

The v1 REST `PermissionDTO` and `ObjectPermissionDTO` keep `operation` alone. The v1 types module has no bit enum, and mirroring the deprecation there would make v1 depend on v2. Dropping the scope from the permission rows themselves is BA-7732.

## Test plan

- [x] `pants lint` and `pants check --changed-dependents=transitive` over the change set
- [x] `pants test --changed-since --changed-dependents=direct` (11 targets)
- [ ] CI

Resolves BA-7731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013UiMJNt9dasPDtpBP7sSsC


<!-- readthedocs-preview sorna start -->
----
📚 Documentation preview 📚: https://sorna--14446.org.readthedocs.build/en/14446/

<!-- readthedocs-preview sorna end -->

<!-- readthedocs-preview sorna-ko start -->
----
📚 Documentation preview 📚: https://sorna-ko--14446.org.readthedocs.build/ko/14446/

<!-- readthedocs-preview sorna-ko end -->