### PR TITLE
refactor(BA-7775): declare entity and field types as per-kind classes

### DIFF
--- a/changes/14447.enhance.md
+++ b/changes/14447.enhance.md
@@ -1,0 +1,1 @@
+Declare each entity and field type as its own class that answers its name, description and owning entity kind, replacing the module-level type constants.

--- a/src/ai/backend/common/data/app_config/types.py
+++ b/src/ai/backend/common/data/app_config/types.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import enum
 
 from ai.backend.common.data.entity.app_config import AppConfigScopeID
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.types import EntityIdentifier
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.permission.types import RBACElementType, ScopeType
 from ai.backend.common.exception import UnreachableError
 
@@ -34,9 +34,9 @@ class AppConfigScopeType(enum.StrEnum):
         match owner:
             case None:
                 return cls.PUBLIC
-            case _ if owner.entity_type() == DOMAIN_ENTITY_TYPE:
+            case _ if owner.entity_type() == DomainEntityType():
                 return cls.DOMAIN
-            case _ if owner.entity_type() == USER_ENTITY_TYPE:
+            case _ if owner.entity_type() == UserEntityType():
                 return cls.USER
             case _:
                 raise UnreachableError(f"No app config scope owns a {owner.entity_type()}")

--- a/src/ai/backend/common/data/entity/KNOWLEDGE.md
+++ b/src/ai/backend/common/data/entity/KNOWLEDGE.md
@@ -3,7 +3,7 @@ name: entity-type-catalog
 type: reference
 description: entity classification (Entity/Public entity/Global/Field/Virtual), ownership and reference relations, the foreign-key rule for assignments
 scope: src/ai/backend/common/data/entity
-keywords: [EntityType, ENTITY_TYPE, EntityCreator, GlobalEntityCreator, FieldEntityCreator, member_of, virtual entity, ownership, entity relation]
+keywords: [EntityType, FieldType, DanglingFieldType, EntityCreator, GlobalEntityCreator, FieldEntityCreator, member_of, virtual entity, ownership, entity relation]
 sources:
   - src/ai/backend/common/data/entity
   - src/ai/backend/manager/models
@@ -15,13 +15,26 @@ status: draft
 
 # Entity catalog
 
-This package declares one type constant per entity. A constant carries only a name, so
-what the entity is, what it owns and what it is tied to is recorded here. Everything is
-stated at the conceptual level; which table holds it belongs to the `models` documents.
+이 패키지는 종류마다 `EntityType` 또는 `FieldType` 서브클래스를 하나 둔다. 클래스는
+`name()`과 `description()`을 답하고, 필드 종류는 행을 소유하는 엔티티 종류를
+`owner_type()`으로 답한다. 소유자가 행의 값이라 고정되지 않는 필드 종류(audit_log,
+audit_log_scope, label)는 `DanglingFieldType`을 상속해 `None`을 답한다. 무엇을 소유하고
+무엇에 묶이는지는 이 문서에 적는다. 전부 개념 수준이며, 어느 테이블이 담는지는 `models`
+문서가 맡는다.
 
-A tree states ownership; a table states fields and references. A field is authorized
-through the entity that owns it, while a reference is not ownership and therefore never
-becomes an authorization path.
+## 타입 값 규칙
+
+- 값은 사용처에서 `AgentEntityType()`처럼 인자 없이 만든다. 모듈 인스턴스 상수를 두지
+  않는다.
+- 필드 종류는 `owner_type()`으로 행을 소유하는 엔티티 종류를 답한다. 소유자가 행의
+  값이라 고정되지 않으면 `DanglingFieldType`을 상속해 `None`을 답한다.
+- `EntityType(value)`는 base 인스턴스를 만들며 `name()`과 `description()`을 답하지
+  않는다. 문자열을 읽는 경계(행 컬럼, legacy 액션, RBAC 요소)에서만 쓰고 그 밖에서는
+  만들지 않는다.
+- pydantic은 base로 선언한 필드면 문자열을 그대로 받고, 종류로 선언한 필드면 그 이름만
+  받는다. 행에는 `name()` 문자열이 저장된다.
+- secret과 fair share 계열은 dangling field로 옮겨야 하나 아직 엔티티로 선언되고
+  배선되어 있다. 옮기려면 `FieldGroup`에 서비스 기반 배선이 필요하다.
 
 ## Entity
 
@@ -258,8 +271,8 @@ Ownership relations with no foreign key declared.
 ## Direction: fold identifiers onto the entity axis
 
 Most id types identify an entity or a field, so they are declared in the same file as the
-entity type constant. Adding only one of the two then shows up simply by opening the file,
-and a file with no type constant becomes a signal in itself — either a field, or not yet
+type class. Adding only one of the two then shows up simply by opening the file,
+and a file with no type class becomes a signal in itself — either a field, or not yet
 classified.
 
 - A scope identifier is an alias of an entity identifier, so it belongs on this axis.

--- a/src/ai/backend/common/data/entity/agent.py
+++ b/src/ai/backend/common/data/entity/agent.py
@@ -3,12 +3,21 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "AGENT_ENTITY_TYPE",
+    "AgentEntityType",
     "AgentUUID",
 )
 
 
-AGENT_ENTITY_TYPE = EntityType("agent")
+class AgentEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "agent"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A compute node that runs kernels and reports its resources."
 
 
 class AgentUUID(EntityIdentifier):
@@ -20,4 +29,4 @@ class AgentUUID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()

--- a/src/ai/backend/common/data/entity/agent_resource.py
+++ b/src/ai/backend/common/data/entity/agent_resource.py
@@ -1,11 +1,30 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.agent import AgentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("AgentResourceID",)
 
 
-AGENT_RESOURCE_FIELD_TYPE = FieldType("agent_resource")
+class AgentResourceFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "agent_resource"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One slot of a resource an agent offers."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return AgentEntityType
 
 
 class AgentResourceID(FieldIdentifier):
@@ -14,4 +33,4 @@ class AgentResourceID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return AGENT_RESOURCE_FIELD_TYPE
+        return AgentResourceFieldType()

--- a/src/ai/backend/common/data/entity/app_config.py
+++ b/src/ai/backend/common/data/entity/app_config.py
@@ -1,24 +1,52 @@
-from typing import NewType
+from typing import NewType, override
 from uuid import UUID
 
 from ai.backend.common.data.entity.types import EntityType
 
 __all__ = (
-    "APP_CONFIG_ALLOW_LIST_ENTITY_TYPE",
-    "APP_CONFIG_ENTITY_TYPE",
-    "APP_CONFIG_FRAGMENT_ENTITY_TYPE",
+    "AppConfigAllowListEntityType",
+    "AppConfigEntityType",
+    "AppConfigFragmentEntityType",
     "AppConfigScopeID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.APP_CONFIG_ALLOW_LIST value.
-APP_CONFIG_ALLOW_LIST_ENTITY_TYPE = EntityType("app_config_allow_list")
+class AppConfigAllowListEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "app_config_allow_list"
 
-# Raw string mirroring the RBAC-managed EntityType.APP_CONFIG_FRAGMENT value.
-APP_CONFIG_FRAGMENT_ENTITY_TYPE = EntityType("app_config_fragment")
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The set of app config keys a scope may set."
+
+
+class AppConfigFragmentEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "app_config_fragment"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One key and value of an app config, set in one scope."
+
 
 # The merged config a caller reads; the fragments it is merged from are their own type.
-APP_CONFIG_ENTITY_TYPE = EntityType("app_config")
+class AppConfigEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "app_config"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The app config read from a scope, built from its fragments."
+
 
 # Who an app config fragment belongs to. Polymorphic across scope kinds (domain/user); the
 # concrete kind is discriminated by the accompanying ``AppConfigScopeType``, and ``public``

--- a/src/ai/backend/common/data/entity/app_config_allow_list.py
+++ b/src/ai/backend/common/data/entity/app_config_allow_list.py
@@ -1,6 +1,6 @@
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_ALLOW_LIST_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = ("AppConfigAllowListID",)
@@ -9,4 +9,4 @@ __all__ = ("AppConfigAllowListID",)
 class AppConfigAllowListID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return APP_CONFIG_ALLOW_LIST_ENTITY_TYPE
+        return AppConfigAllowListEntityType()

--- a/src/ai/backend/common/data/entity/app_config_definition.py
+++ b/src/ai/backend/common/data/entity/app_config_definition.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "APP_CONFIG_DEFINITION_ENTITY_TYPE",
+    "AppConfigDefinitionEntityType",
     "AppConfigDefinitionID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.APP_CONFIG_DEFINITION value.
-APP_CONFIG_DEFINITION_ENTITY_TYPE = EntityType("app_config_definition")
+class AppConfigDefinitionEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "app_config_definition"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The declaration of an app config key and its value type."
 
 
 class AppConfigDefinitionID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return APP_CONFIG_DEFINITION_ENTITY_TYPE
+        return AppConfigDefinitionEntityType()

--- a/src/ai/backend/common/data/entity/app_config_fragment.py
+++ b/src/ai/backend/common/data/entity/app_config_fragment.py
@@ -1,6 +1,6 @@
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_FRAGMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = ("AppConfigFragmentID",)
@@ -9,4 +9,4 @@ __all__ = ("AppConfigFragmentID",)
 class AppConfigFragmentID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return APP_CONFIG_FRAGMENT_ENTITY_TYPE
+        return AppConfigFragmentEntityType()

--- a/src/ai/backend/common/data/entity/artifact.py
+++ b/src/ai/backend/common/data/entity/artifact.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("ARTIFACT_ENTITY_TYPE", "ArtifactID")
+__all__ = ("ArtifactEntityType", "ArtifactID")
 
-ARTIFACT_ENTITY_TYPE = EntityType("artifact")
+
+class ArtifactEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "artifact"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A model or dataset pulled from an artifact registry."
 
 
 class ArtifactID(EntityIdentifier):
@@ -14,4 +24,4 @@ class ArtifactID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return ARTIFACT_ENTITY_TYPE
+        return ArtifactEntityType()

--- a/src/ai/backend/common/data/entity/artifact_registry.py
+++ b/src/ai/backend/common/data/entity/artifact_registry.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("ARTIFACT_REGISTRY_ENTITY_TYPE", "ArtifactRegistryID")
+__all__ = ("ArtifactRegistryEntityType", "ArtifactRegistryID")
 
-ARTIFACT_REGISTRY_ENTITY_TYPE = EntityType("artifact_registry")
+
+class ArtifactRegistryEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "artifact_registry"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A source artifacts are pulled from."
 
 
 class ArtifactRegistryID(EntityIdentifier):
@@ -14,4 +24,4 @@ class ArtifactRegistryID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return ARTIFACT_REGISTRY_ENTITY_TYPE
+        return ArtifactRegistryEntityType()

--- a/src/ai/backend/common/data/entity/artifact_revision.py
+++ b/src/ai/backend/common/data/entity/artifact_revision.py
@@ -1,18 +1,37 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = (
-    "ARTIFACT_REVISION_FIELD_TYPE",
+    "ArtifactRevisionFieldType",
     "ArtifactRevisionID",
 )
 
 
-ARTIFACT_REVISION_FIELD_TYPE = FieldType("artifact_revision")
+class ArtifactRevisionFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "artifact_revision"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One version of an artifact."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return ArtifactEntityType
 
 
 class ArtifactRevisionID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return ARTIFACT_REVISION_FIELD_TYPE
+        return ArtifactRevisionFieldType()

--- a/src/ai/backend/common/data/entity/audit_log.py
+++ b/src/ai/backend/common/data/entity/audit_log.py
@@ -1,17 +1,37 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import DanglingFieldType, FieldIdentifier, FieldType
 
 __all__ = (
-    "AUDIT_LOG_FIELD_TYPE",
-    "AUDIT_LOG_SCOPE_FIELD_TYPE",
+    "AuditLogFieldType",
+    "AuditLogScopeFieldType",
     "AuditLogID",
     "AuditLogScopeID",
 )
 
 
-AUDIT_LOG_FIELD_TYPE = FieldType("audit_log")
-AUDIT_LOG_SCOPE_FIELD_TYPE = FieldType("audit_log_scope")
+class AuditLogFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "audit_log"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One record of an action, owned by whatever entity the action was about."
+
+
+class AuditLogScopeFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "audit_log_scope"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One scope an audit record sits in."
 
 
 class AuditLogID(FieldIdentifier):
@@ -25,7 +45,7 @@ class AuditLogID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return AUDIT_LOG_FIELD_TYPE
+        return AuditLogFieldType()
 
 
 class AuditLogScopeID(FieldIdentifier):
@@ -34,4 +54,4 @@ class AuditLogScopeID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return AUDIT_LOG_SCOPE_FIELD_TYPE
+        return AuditLogScopeFieldType()

--- a/src/ai/backend/common/data/entity/auth.py
+++ b/src/ai/backend/common/data/entity/auth.py
@@ -1,8 +1,17 @@
+from typing import override
+
 from ai.backend.common.data.entity.types import EntityType
 
-__all__ = ("AUTH_ENTITY_TYPE",)
+__all__ = ("AuthEntityType",)
 
 
-# Raw string mirroring the RBAC-managed EntityType.AUTH value. It names the credential
-# and login-session state that answers for no other entity.
-AUTH_ENTITY_TYPE = EntityType("auth")
+class AuthEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "auth"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The authentication operations, which name no row."

--- a/src/ai/backend/common/data/entity/client_ip_masking.py
+++ b/src/ai/backend/common/data/entity/client_ip_masking.py
@@ -3,17 +3,26 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "CLIENT_IP_MASKING_POLICY_ENTITY_TYPE",
+    "ClientIPMaskingPolicyEntityType",
     "ClientIPMaskingPolicyID",
 )
 
 
 # One policy row per masking target. Named on its own rather than under the record it
 # governs: the same policy answers for login history, login sessions and audit logs.
-CLIENT_IP_MASKING_POLICY_ENTITY_TYPE = EntityType("client_ip_masking_policy")
+class ClientIPMaskingPolicyEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "client_ip_masking_policy"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A rule masking client addresses in recorded logs."
 
 
 class ClientIPMaskingPolicyID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+        return ClientIPMaskingPolicyEntityType()

--- a/src/ai/backend/common/data/entity/container_registry.py
+++ b/src/ai/backend/common/data/entity/container_registry.py
@@ -3,18 +3,28 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
 
 __all__ = (
-    "CONTAINER_REGISTRY_ENTITY_TYPE",
+    "ContainerRegistryEntityType",
     "CONTAINER_REGISTRY_SCOPE_TYPE",
     "ContainerRegistryID",
 )
 
 
-# Raw strings mirroring the RBAC-managed RBACElementType.CONTAINER_REGISTRY value.
-CONTAINER_REGISTRY_ENTITY_TYPE = EntityType("container_registry")
-CONTAINER_REGISTRY_SCOPE_TYPE = ScopeType(CONTAINER_REGISTRY_ENTITY_TYPE)
+class ContainerRegistryEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "container_registry"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A registry images are pulled from."
+
+
+CONTAINER_REGISTRY_SCOPE_TYPE = ScopeType(ContainerRegistryEntityType())
 
 
 class ContainerRegistryID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return CONTAINER_REGISTRY_ENTITY_TYPE
+        return ContainerRegistryEntityType()

--- a/src/ai/backend/common/data/entity/deployment.py
+++ b/src/ai/backend/common/data/entity/deployment.py
@@ -4,10 +4,22 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
 
-__all__ = ("DEPLOYMENT_ENTITY_TYPE", "DEPLOYMENT_SCOPE_TYPE", "DeploymentID")
+__all__ = ("DeploymentEntityType", "DEPLOYMENT_SCOPE_TYPE", "DeploymentID")
 
-DEPLOYMENT_ENTITY_TYPE = EntityType("deployment")
-DEPLOYMENT_SCOPE_TYPE = ScopeType(DEPLOYMENT_ENTITY_TYPE)
+
+class DeploymentEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A served model with its replicas and revisions."
+
+
+DEPLOYMENT_SCOPE_TYPE = ScopeType(DeploymentEntityType())
 
 
 class DeploymentID(EntityIdentifier):
@@ -15,4 +27,4 @@ class DeploymentID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()

--- a/src/ai/backend/common/data/entity/deployment_history.py
+++ b/src/ai/backend/common/data/entity/deployment_history.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("DEPLOYMENT_HISTORY_FIELD_TYPE", "DeploymentHistoryID")
+__all__ = ("DeploymentHistoryFieldType", "DeploymentHistoryID")
 
-DEPLOYMENT_HISTORY_FIELD_TYPE = FieldType("deployment_history")
+
+class DeploymentHistoryFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_history"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One state change of a deployment."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class DeploymentHistoryID(FieldIdentifier):
@@ -15,4 +35,4 @@ class DeploymentHistoryID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return DEPLOYMENT_HISTORY_FIELD_TYPE
+        return DeploymentHistoryFieldType()

--- a/src/ai/backend/common/data/entity/deployment_policy.py
+++ b/src/ai/backend/common/data/entity/deployment_policy.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("DEPLOYMENT_POLICY_FIELD_TYPE", "DeploymentPolicyID")
+__all__ = ("DeploymentPolicyFieldType", "DeploymentPolicyID")
 
-DEPLOYMENT_POLICY_FIELD_TYPE = FieldType("deployment_policy")
+
+class DeploymentPolicyFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_policy"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The scaling and routing policy of a deployment."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class DeploymentPolicyID(FieldIdentifier):
@@ -19,4 +39,4 @@ class DeploymentPolicyID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return DEPLOYMENT_POLICY_FIELD_TYPE
+        return DeploymentPolicyFieldType()

--- a/src/ai/backend/common/data/entity/deployment_preset.py
+++ b/src/ai/backend/common/data/entity/deployment_preset.py
@@ -3,16 +3,25 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "DEPLOYMENT_PRESET_ENTITY_TYPE",
+    "DeploymentPresetEntityType",
     "DeploymentPresetID",
 )
 
 
-DEPLOYMENT_PRESET_ENTITY_TYPE = EntityType("deployment_preset")
+class DeploymentPresetEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A reusable revision setting a deployment can start from."
 
 
 class DeploymentPresetID(EntityIdentifier):
     @classmethod
     @override
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_PRESET_ENTITY_TYPE
+        return DeploymentPresetEntityType()

--- a/src/ai/backend/common/data/entity/deployment_revision.py
+++ b/src/ai/backend/common/data/entity/deployment_revision.py
@@ -1,18 +1,37 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = (
-    "DEPLOYMENT_REVISION_FIELD_TYPE",
+    "DeploymentRevisionFieldType",
     "DeploymentRevisionID",
 )
 
 
-DEPLOYMENT_REVISION_FIELD_TYPE = FieldType("deployment_revision")
+class DeploymentRevisionFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_revision"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One configuration a deployment has run with."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class DeploymentRevisionID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return DEPLOYMENT_REVISION_FIELD_TYPE
+        return DeploymentRevisionFieldType()

--- a/src/ai/backend/common/data/entity/deployment_revision_resource_slot.py
+++ b/src/ai/backend/common/data/entity/deployment_revision_resource_slot.py
@@ -1,11 +1,30 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("DeploymentRevisionResourceSlotID",)
 
 
-DEPLOYMENT_REVISION_RESOURCE_SLOT_FIELD_TYPE = FieldType("deployment_revision_resource_slot")
+class DeploymentRevisionResourceSlotFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_revision_resource_slot"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One slot's amount a deployment revision declares."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class DeploymentRevisionResourceSlotID(FieldIdentifier):
@@ -14,4 +33,4 @@ class DeploymentRevisionResourceSlotID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return DEPLOYMENT_REVISION_RESOURCE_SLOT_FIELD_TYPE
+        return DeploymentRevisionResourceSlotFieldType()

--- a/src/ai/backend/common/data/entity/deployment_token.py
+++ b/src/ai/backend/common/data/entity/deployment_token.py
@@ -2,12 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("DEPLOYMENT_TOKEN_FIELD_TYPE", "DeploymentTokenID")
+__all__ = ("DeploymentTokenFieldType", "DeploymentTokenID")
 
 
-DEPLOYMENT_TOKEN_FIELD_TYPE = FieldType("deployment_token")
+class DeploymentTokenFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_token"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An access token issued for a deployment."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class DeploymentTokenID(FieldIdentifier):
@@ -20,4 +39,4 @@ class DeploymentTokenID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return DEPLOYMENT_TOKEN_FIELD_TYPE
+        return DeploymentTokenFieldType()

--- a/src/ai/backend/common/data/entity/domain.py
+++ b/src/ai/backend/common/data/entity/domain.py
@@ -8,22 +8,32 @@ from ai.backend.common.data.entity.types import (
 )
 
 __all__ = (
-    "DOMAIN_ENTITY_TYPE",
+    "DomainEntityType",
     "DOMAIN_SCOPE_TYPE",
     "DomainID",
     "DomainName",
 )
 
 
-# Raw string mirroring the RBAC-managed RBACElementType.DOMAIN value.
-DOMAIN_ENTITY_TYPE = EntityType("domain")
-DOMAIN_SCOPE_TYPE = ScopeType(DOMAIN_ENTITY_TYPE)
+class DomainEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "domain"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The top-level tenant holding projects and users."
+
+
+DOMAIN_SCOPE_TYPE = ScopeType(DomainEntityType())
 
 
 class DomainID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
 
 class DomainName(NaturalKey):

--- a/src/ai/backend/common/data/entity/entity_label.py
+++ b/src/ai/backend/common/data/entity/entity_label.py
@@ -1,10 +1,21 @@
 from typing import NewType, override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import DanglingFieldType, FieldIdentifier, FieldType
 
 __all__ = ("EntityLabelID", "EntityLabelKey")
 
-ENTITY_LABEL_FIELD_TYPE = FieldType("label")
+
+class EntityLabelFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "label"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One key and value label put on an entity of any kind."
+
 
 EntityLabelKey = NewType("EntityLabelKey", str)
 """The key half of a ``key=value`` label. Names no entity: which rows carry it is what
@@ -17,4 +28,4 @@ class EntityLabelID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return ENTITY_LABEL_FIELD_TYPE
+        return EntityLabelFieldType()

--- a/src/ai/backend/common/data/entity/entity_share.py
+++ b/src/ai/backend/common/data/entity/entity_share.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("ENTITY_SHARE_ENTITY_TYPE", "EntityShareID")
+__all__ = ("EntityShareEntityType", "EntityShareID")
 
-ENTITY_SHARE_ENTITY_TYPE = EntityType("entity_share")
+
+class EntityShareEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "entity_share"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A grant of one entity to another user or project."
 
 
 class EntityShareID(EntityIdentifier):
@@ -18,4 +28,4 @@ class EntityShareID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return ENTITY_SHARE_ENTITY_TYPE
+        return EntityShareEntityType()

--- a/src/ai/backend/common/data/entity/error_log.py
+++ b/src/ai/backend/common/data/entity/error_log.py
@@ -2,15 +2,34 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
+from ai.backend.common.data.entity.user import UserEntityType
 
 __all__ = (
-    "ERROR_LOG_FIELD_TYPE",
+    "ErrorLogFieldType",
     "ErrorLogID",
 )
 
 
-ERROR_LOG_FIELD_TYPE = FieldType("error_log")
+class ErrorLogFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "error_log"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One error recorded for a user."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return UserEntityType
 
 
 class ErrorLogID(FieldIdentifier):
@@ -23,4 +42,4 @@ class ErrorLogID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return ERROR_LOG_FIELD_TYPE
+        return ErrorLogFieldType()

--- a/src/ai/backend/common/data/entity/etcd_config.py
+++ b/src/ai/backend/common/data/entity/etcd_config.py
@@ -1,7 +1,17 @@
+from typing import override
+
 from ai.backend.common.data.entity.types import EntityType
 
-__all__ = ("ETCD_CONFIG_ENTITY_TYPE",)
+__all__ = ("EtcdConfigEntityType",)
 
 
-# Raw string mirroring the RBAC-managed EntityType.ETCD_CONFIG value.
-ETCD_CONFIG_ENTITY_TYPE = EntityType("etcd_config")
+class EtcdConfigEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "etcd_config"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The cluster configuration kept in etcd."

--- a/src/ai/backend/common/data/entity/export.py
+++ b/src/ai/backend/common/data/entity/export.py
@@ -1,7 +1,19 @@
 """Entity type of the export reports."""
 
+from typing import override
+
 from ai.backend.common.data.entity.types import EntityType
 
-__all__ = ("EXPORT_ENTITY_TYPE",)
+__all__ = ("ExportEntityType",)
 
-EXPORT_ENTITY_TYPE = EntityType("export")
+
+class ExportEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "export"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A data export operation, which names no row."

--- a/src/ai/backend/common/data/entity/fair_share.py
+++ b/src/ai/backend/common/data/entity/fair_share.py
@@ -1,13 +1,47 @@
 """Entity types of the fair share tables."""
 
+from typing import override
+
 from ai.backend.common.data.entity.types import EntityType
 
 __all__ = (
-    "DOMAIN_FAIR_SHARE_ENTITY_TYPE",
-    "PROJECT_FAIR_SHARE_ENTITY_TYPE",
-    "USER_FAIR_SHARE_ENTITY_TYPE",
+    "DomainFairShareEntityType",
+    "ProjectFairShareEntityType",
+    "UserFairShareEntityType",
 )
 
-DOMAIN_FAIR_SHARE_ENTITY_TYPE = EntityType("domain_fair_share")
-PROJECT_FAIR_SHARE_ENTITY_TYPE = EntityType("project_fair_share")
-USER_FAIR_SHARE_ENTITY_TYPE = EntityType("user_fair_share")
+
+class DomainFairShareEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "domain_fair_share"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A domain's fair-share weight in a resource group."
+
+
+class ProjectFairShareEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "project_fair_share"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A project's fair-share weight in a resource group."
+
+
+class UserFairShareEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "user_fair_share"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A user's fair-share weight in a resource group."

--- a/src/ai/backend/common/data/entity/idle_checker.py
+++ b/src/ai/backend/common/data/entity/idle_checker.py
@@ -4,20 +4,28 @@ from uuid import UUID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "IDLE_CHECKER_ENTITY_TYPE",
+    "IdleCheckerEntityType",
     "IdleCheckerAssignmentID",
     "IdleCheckerID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.IDLE_CHECKER value.
-IDLE_CHECKER_ENTITY_TYPE = EntityType("idle_checker")
+class IdleCheckerEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "idle_checker"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A rule that ends idle sessions, assigned to scopes."
 
 
 class IdleCheckerID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
 
 IdleCheckerAssignmentID = NewType("IdleCheckerAssignmentID", UUID)

--- a/src/ai/backend/common/data/entity/image.py
+++ b/src/ai/backend/common/data/entity/image.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("IMAGE_ENTITY_TYPE", "ImageID")
+__all__ = ("ImageEntityType", "ImageID")
 
-IMAGE_ENTITY_TYPE = EntityType("image")
+
+class ImageEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "image"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A container image known to a container registry."
 
 
 class ImageID(EntityIdentifier):
@@ -14,4 +24,4 @@ class ImageID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return IMAGE_ENTITY_TYPE
+        return ImageEntityType()

--- a/src/ai/backend/common/data/entity/image_alias.py
+++ b/src/ai/backend/common/data/entity/image_alias.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.image import ImageEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("IMAGE_ALIAS_FIELD_TYPE", "ImageAliasID")
+__all__ = ("ImageAliasFieldType", "ImageAliasID")
 
-IMAGE_ALIAS_FIELD_TYPE = FieldType("image_alias")
+
+class ImageAliasFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "image_alias"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An alternate name of an image."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return ImageEntityType
 
 
 class ImageAliasID(FieldIdentifier):
@@ -15,4 +35,4 @@ class ImageAliasID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return IMAGE_ALIAS_FIELD_TYPE
+        return ImageAliasFieldType()

--- a/src/ai/backend/common/data/entity/kernel.py
+++ b/src/ai/backend/common/data/entity/kernel.py
@@ -6,12 +6,31 @@ field identifier: what a kernel belongs to is knowable only through that session
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("KernelID",)
 
 
-KERNEL_FIELD_TYPE = FieldType("kernel")
+class KernelFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "kernel"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One container of a session, placed on one agent."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return SessionEntityType
 
 
 class KernelID(FieldIdentifier):
@@ -20,4 +39,4 @@ class KernelID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return KERNEL_FIELD_TYPE
+        return KernelFieldType()

--- a/src/ai/backend/common/data/entity/kernel_scheduling_history.py
+++ b/src/ai/backend/common/data/entity/kernel_scheduling_history.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("KERNEL_SCHEDULING_HISTORY_FIELD_TYPE", "KernelSchedulingHistoryID")
+__all__ = ("KernelSchedulingHistoryFieldType", "KernelSchedulingHistoryID")
 
-KERNEL_SCHEDULING_HISTORY_FIELD_TYPE = FieldType("kernel_scheduling_history")
+
+class KernelSchedulingHistoryFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "kernel_scheduling_history"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One scheduling step recorded for a kernel."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return SessionEntityType
 
 
 class KernelSchedulingHistoryID(FieldIdentifier):
@@ -15,4 +35,4 @@ class KernelSchedulingHistoryID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return KERNEL_SCHEDULING_HISTORY_FIELD_TYPE
+        return KernelSchedulingHistoryFieldType()

--- a/src/ai/backend/common/data/entity/keypair.py
+++ b/src/ai/backend/common/data/entity/keypair.py
@@ -1,21 +1,37 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
+from ai.backend.common.data.entity.user import UserEntityType
 
 __all__ = (
-    "KEYPAIR_FIELD_TYPE",
+    "KeyPairFieldType",
     "KeyPairID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.KEYPAIR value. It names what the row
+class KeyPairFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "keypair"
 
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An access key and secret key pair of a user."
 
-KEYPAIR_FIELD_TYPE = FieldType("keypair")
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return UserEntityType
 
 
 class KeyPairID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return KEYPAIR_FIELD_TYPE
+        return KeyPairFieldType()

--- a/src/ai/backend/common/data/entity/login_client_type.py
+++ b/src/ai/backend/common/data/entity/login_client_type.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "LOGIN_CLIENT_TYPE_ENTITY_TYPE",
+    "LoginClientTypeEntityType",
     "LoginClientTypeID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.LOGIN_CLIENT_TYPE value.
-LOGIN_CLIENT_TYPE_ENTITY_TYPE = EntityType("login_client_type")
+class LoginClientTypeEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "login_client_type"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A kind of client a login session is opened from."
 
 
 class LoginClientTypeID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return LOGIN_CLIENT_TYPE_ENTITY_TYPE
+        return LoginClientTypeEntityType()

--- a/src/ai/backend/common/data/entity/login_history.py
+++ b/src/ai/backend/common/data/entity/login_history.py
@@ -2,15 +2,34 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
+from ai.backend.common.data.entity.user import UserEntityType
 
 __all__ = (
-    "LOGIN_HISTORY_FIELD_TYPE",
+    "LoginHistoryFieldType",
     "LoginHistoryID",
 )
 
 
-LOGIN_HISTORY_FIELD_TYPE = FieldType("login_history")
+class LoginHistoryFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "login_history"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One login attempt recorded for a user."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return UserEntityType
 
 
 class LoginHistoryID(FieldIdentifier):
@@ -23,4 +42,4 @@ class LoginHistoryID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return LOGIN_HISTORY_FIELD_TYPE
+        return LoginHistoryFieldType()

--- a/src/ai/backend/common/data/entity/login_session.py
+++ b/src/ai/backend/common/data/entity/login_session.py
@@ -2,15 +2,34 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
+from ai.backend.common.data.entity.user import UserEntityType
 
 __all__ = (
-    "LOGIN_SESSION_FIELD_TYPE",
+    "LoginSessionFieldType",
     "LoginSessionID",
 )
 
 
-LOGIN_SESSION_FIELD_TYPE = FieldType("login_session")
+class LoginSessionFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "login_session"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One live login of a user."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return UserEntityType
 
 
 class LoginSessionID(FieldIdentifier):
@@ -23,4 +42,4 @@ class LoginSessionID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return LOGIN_SESSION_FIELD_TYPE
+        return LoginSessionFieldType()

--- a/src/ai/backend/common/data/entity/manager_admin.py
+++ b/src/ai/backend/common/data/entity/manager_admin.py
@@ -1,7 +1,17 @@
+from typing import override
+
 from ai.backend.common.data.entity.types import EntityType
 
-__all__ = ("MANAGER_ADMIN_ENTITY_TYPE",)
+__all__ = ("ManagerAdminEntityType",)
 
 
-# Raw string mirroring the RBAC-managed EntityType.MANAGER_ADMIN value.
-MANAGER_ADMIN_ENTITY_TYPE = EntityType("manager_admin")
+class ManagerAdminEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "manager_admin"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The manager administration operations, which name no row."

--- a/src/ai/backend/common/data/entity/model_card.py
+++ b/src/ai/backend/common/data/entity/model_card.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "MODEL_CARD_ENTITY_TYPE",
+    "ModelCardEntityType",
     "ModelCardID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.MODEL_CARD value.
-MODEL_CARD_ENTITY_TYPE = EntityType("model_card")
+class ModelCardEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "model_card"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A description of a model kept in a vfolder."
 
 
 class ModelCardID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()

--- a/src/ai/backend/common/data/entity/model_card_resource_requirement.py
+++ b/src/ai/backend/common/data/entity/model_card_resource_requirement.py
@@ -1,11 +1,30 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("ModelCardResourceRequirementID",)
 
 
-MODEL_CARD_RESOURCE_REQUIREMENT_FIELD_TYPE = FieldType("model_card_resource_requirement")
+class ModelCardResourceRequirementFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "model_card_resource_requirement"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One resource requirement a model card declares."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return ModelCardEntityType
 
 
 class ModelCardResourceRequirementID(FieldIdentifier):
@@ -14,4 +33,4 @@ class ModelCardResourceRequirementID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return MODEL_CARD_RESOURCE_REQUIREMENT_FIELD_TYPE
+        return ModelCardResourceRequirementFieldType()

--- a/src/ai/backend/common/data/entity/network.py
+++ b/src/ai/backend/common/data/entity/network.py
@@ -3,15 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "NETWORK_ENTITY_TYPE",
+    "NetworkEntityType",
     "NetworkID",
 )
 
 
-NETWORK_ENTITY_TYPE = EntityType("network")
+class NetworkEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "network"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An overlay network sessions of a project attach to."
 
 
 class NetworkID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return NETWORK_ENTITY_TYPE
+        return NetworkEntityType()

--- a/src/ai/backend/common/data/entity/notification.py
+++ b/src/ai/backend/common/data/entity/notification.py
@@ -3,25 +3,44 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "NOTIFICATION_CHANNEL_ENTITY_TYPE",
-    "NOTIFICATION_RULE_ENTITY_TYPE",
+    "NotificationChannelEntityType",
+    "NotificationRuleEntityType",
     "NotificationChannelID",
     "NotificationRuleID",
 )
 
 
-# Raw strings mirroring the RBAC-managed EntityType values.
-NOTIFICATION_CHANNEL_ENTITY_TYPE = EntityType("notification_channel")
-NOTIFICATION_RULE_ENTITY_TYPE = EntityType("notification_rule")
+class NotificationChannelEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "notification_channel"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A destination notifications are sent to."
+
+
+class NotificationRuleEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "notification_rule"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A rule choosing which events reach a notification channel."
 
 
 class NotificationChannelID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return NOTIFICATION_CHANNEL_ENTITY_TYPE
+        return NotificationChannelEntityType()
 
 
 class NotificationRuleID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return NOTIFICATION_RULE_ENTITY_TYPE
+        return NotificationRuleEntityType()

--- a/src/ai/backend/common/data/entity/object_storage.py
+++ b/src/ai/backend/common/data/entity/object_storage.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "OBJECT_STORAGE_ENTITY_TYPE",
+    "ObjectStorageEntityType",
     "ObjectStorageID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.OBJECT_STORAGE value.
-OBJECT_STORAGE_ENTITY_TYPE = EntityType("object_storage")
+class ObjectStorageEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "object_storage"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An object storage backend behind a storage namespace."
 
 
 class ObjectStorageID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return OBJECT_STORAGE_ENTITY_TYPE
+        return ObjectStorageEntityType()

--- a/src/ai/backend/common/data/entity/permission.py
+++ b/src/ai/backend/common/data/entity/permission.py
@@ -1,14 +1,33 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = (
-    "PERMISSION_FIELD_TYPE",
+    "PermissionFieldType",
     "PermissionID",
 )
 
 
-PERMISSION_FIELD_TYPE = FieldType("permission")
+class PermissionFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "permission"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One permission a role grants."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return RoleEntityType
 
 
 class PermissionID(FieldIdentifier):
@@ -17,4 +36,4 @@ class PermissionID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return PERMISSION_FIELD_TYPE
+        return PermissionFieldType()

--- a/src/ai/backend/common/data/entity/preset_resource_slot.py
+++ b/src/ai/backend/common/data/entity/preset_resource_slot.py
@@ -1,11 +1,30 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("PresetResourceSlotID",)
 
 
-DEPLOYMENT_PRESET_RESOURCE_SLOT_FIELD_TYPE = FieldType("deployment_preset_resource_slot")
+class DeploymentPresetResourceSlotFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "deployment_preset_resource_slot"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One slot's amount a deployment preset declares."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentPresetEntityType
 
 
 class PresetResourceSlotID(FieldIdentifier):
@@ -14,4 +33,4 @@ class PresetResourceSlotID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return DEPLOYMENT_PRESET_RESOURCE_SLOT_FIELD_TYPE
+        return DeploymentPresetResourceSlotFieldType()

--- a/src/ai/backend/common/data/entity/project.py
+++ b/src/ai/backend/common/data/entity/project.py
@@ -3,18 +3,28 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
 
 __all__ = (
-    "PROJECT_ENTITY_TYPE",
+    "ProjectEntityType",
     "PROJECT_SCOPE_TYPE",
     "ProjectID",
 )
 
 
-# Raw strings mirroring the RBAC-managed RBACElementType.PROJECT value.
-PROJECT_ENTITY_TYPE = EntityType("project")
-PROJECT_SCOPE_TYPE = ScopeType(PROJECT_ENTITY_TYPE)
+class ProjectEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "project"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A group of users inside a domain that owns sessions and vfolders."
+
+
+PROJECT_SCOPE_TYPE = ScopeType(ProjectEntityType())
 
 
 class ProjectID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()

--- a/src/ai/backend/common/data/entity/prometheus_query_preset.py
+++ b/src/ai/backend/common/data/entity/prometheus_query_preset.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "PROMETHEUS_QUERY_PRESET_ENTITY_TYPE",
+    "PrometheusQueryPresetEntityType",
     "PrometheusQueryPresetID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.PROMETHEUS_QUERY_PRESET value.
-PROMETHEUS_QUERY_PRESET_ENTITY_TYPE = EntityType("prometheus_query_preset")
+class PrometheusQueryPresetEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "prometheus_query_preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A saved Prometheus query."
 
 
 class PrometheusQueryPresetID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_ENTITY_TYPE
+        return PrometheusQueryPresetEntityType()

--- a/src/ai/backend/common/data/entity/prometheus_query_preset_category.py
+++ b/src/ai/backend/common/data/entity/prometheus_query_preset_category.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE",
+    "PrometheusQueryPresetCategoryEntityType",
     "PrometheusQueryPresetCategoryID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.PROMETHEUS_QUERY_PRESET_CATEGORY value.
-PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE = EntityType("prometheus_query_preset_category")
+class PrometheusQueryPresetCategoryEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "prometheus_query_preset_category"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A grouping of Prometheus query presets."
 
 
 class PrometheusQueryPresetCategoryID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE
+        return PrometheusQueryPresetCategoryEntityType()

--- a/src/ai/backend/common/data/entity/replica.py
+++ b/src/ai/backend/common/data/entity/replica.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("REPLICA_FIELD_TYPE", "ReplicaID")
+__all__ = ("ReplicaFieldType", "ReplicaID")
 
-REPLICA_FIELD_TYPE = FieldType("replica")
+
+class ReplicaFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "replica"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One running copy of a deployment."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class ReplicaID(FieldIdentifier):
@@ -19,4 +39,4 @@ class ReplicaID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return REPLICA_FIELD_TYPE
+        return ReplicaFieldType()

--- a/src/ai/backend/common/data/entity/replica_group.py
+++ b/src/ai/backend/common/data/entity/replica_group.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("REPLICA_GROUP_FIELD_TYPE", "ReplicaGroupID")
+__all__ = ("ReplicaGroupFieldType", "ReplicaGroupID")
 
-REPLICA_GROUP_FIELD_TYPE = FieldType("replica_group")
+
+class ReplicaGroupFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "replica_group"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A set of replicas of a deployment that share a revision."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class ReplicaGroupID(FieldIdentifier):
@@ -19,4 +39,4 @@ class ReplicaGroupID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return REPLICA_GROUP_FIELD_TYPE
+        return ReplicaGroupFieldType()

--- a/src/ai/backend/common/data/entity/replica_group_history.py
+++ b/src/ai/backend/common/data/entity/replica_group_history.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("REPLICA_GROUP_HISTORY_FIELD_TYPE", "ReplicaGroupHistoryID")
+__all__ = ("ReplicaGroupHistoryFieldType", "ReplicaGroupHistoryID")
 
-REPLICA_GROUP_HISTORY_FIELD_TYPE = FieldType("replica_group_history")
+
+class ReplicaGroupHistoryFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "replica_group_history"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One state change of a replica group."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class ReplicaGroupHistoryID(FieldIdentifier):
@@ -15,4 +35,4 @@ class ReplicaGroupHistoryID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return REPLICA_GROUP_HISTORY_FIELD_TYPE
+        return ReplicaGroupHistoryFieldType()

--- a/src/ai/backend/common/data/entity/resource_allocation.py
+++ b/src/ai/backend/common/data/entity/resource_allocation.py
@@ -1,11 +1,30 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("ResourceAllocationID",)
 
 
-RESOURCE_ALLOCATION_FIELD_TYPE = FieldType("resource_allocation")
+class ResourceAllocationFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "resource_allocation"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One slot's amount allocated to one kernel of a session."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return SessionEntityType
 
 
 class ResourceAllocationID(FieldIdentifier):
@@ -17,4 +36,4 @@ class ResourceAllocationID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return RESOURCE_ALLOCATION_FIELD_TYPE
+        return ResourceAllocationFieldType()

--- a/src/ai/backend/common/data/entity/resource_group.py
+++ b/src/ai/backend/common/data/entity/resource_group.py
@@ -3,22 +3,32 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, NaturalKey, ScopeType
 
 __all__ = (
-    "RESOURCE_GROUP_ENTITY_TYPE",
+    "ResourceGroupEntityType",
     "RESOURCE_GROUP_SCOPE_TYPE",
     "ResourceGroupID",
     "ResourceGroupName",
 )
 
 
-# Raw strings mirroring the RBAC-managed RBACElementType.RESOURCE_GROUP value.
-RESOURCE_GROUP_ENTITY_TYPE = EntityType("resource_group")
-RESOURCE_GROUP_SCOPE_TYPE = ScopeType(RESOURCE_GROUP_ENTITY_TYPE)
+class ResourceGroupEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "resource_group"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A pool of agents sessions are scheduled onto."
+
+
+RESOURCE_GROUP_SCOPE_TYPE = ScopeType(ResourceGroupEntityType())
 
 
 class ResourceGroupID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return RESOURCE_GROUP_ENTITY_TYPE
+        return ResourceGroupEntityType()
 
 
 class ResourceGroupName(NaturalKey):

--- a/src/ai/backend/common/data/entity/resource_policy.py
+++ b/src/ai/backend/common/data/entity/resource_policy.py
@@ -3,34 +3,64 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE",
+    "KeyPairResourcePolicyEntityType",
     "KeyPairResourcePolicyUUID",
-    "PROJECT_RESOURCE_POLICY_ENTITY_TYPE",
+    "ProjectResourcePolicyEntityType",
     "ProjectResourcePolicyUUID",
-    "USER_RESOURCE_POLICY_ENTITY_TYPE",
+    "UserResourcePolicyEntityType",
     "UserResourcePolicyUUID",
 )
 
 
-# Raw strings mirroring the RBAC-managed EntityType.*_RESOURCE_POLICY values.
-KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE = EntityType("keypair_resource_policy")
-USER_RESOURCE_POLICY_ENTITY_TYPE = EntityType("user_resource_policy")
-PROJECT_RESOURCE_POLICY_ENTITY_TYPE = EntityType("project_resource_policy")
+class KeyPairResourcePolicyEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "keypair_resource_policy"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "Resource limits applied per keypair."
+
+
+class UserResourcePolicyEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "user_resource_policy"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "Resource limits applied per user."
+
+
+class ProjectResourcePolicyEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "project_resource_policy"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "Resource limits applied per project."
 
 
 class KeyPairResourcePolicyUUID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE
+        return KeyPairResourcePolicyEntityType()
 
 
 class UserResourcePolicyUUID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return USER_RESOURCE_POLICY_ENTITY_TYPE
+        return UserResourcePolicyEntityType()
 
 
 class ProjectResourcePolicyUUID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return PROJECT_RESOURCE_POLICY_ENTITY_TYPE
+        return ProjectResourcePolicyEntityType()

--- a/src/ai/backend/common/data/entity/resource_preset.py
+++ b/src/ai/backend/common/data/entity/resource_preset.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("RESOURCE_PRESET_ENTITY_TYPE", "ResourcePresetID")
+__all__ = ("ResourcePresetEntityType", "ResourcePresetID")
 
-RESOURCE_PRESET_ENTITY_TYPE = EntityType("resource_preset")
+
+class ResourcePresetEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "resource_preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A named set of resource amounts a session can request."
 
 
 class ResourcePresetID(EntityIdentifier):
@@ -14,4 +24,4 @@ class ResourcePresetID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return RESOURCE_PRESET_ENTITY_TYPE
+        return ResourcePresetEntityType()

--- a/src/ai/backend/common/data/entity/resource_slot.py
+++ b/src/ai/backend/common/data/entity/resource_slot.py
@@ -3,14 +3,22 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, NaturalKey
 
 __all__ = (
-    "RESOURCE_SLOT_TYPE_ENTITY_TYPE",
+    "ResourceSlotTypeEntityType",
     "ResourceSlotName",
     "ResourceSlotTypeUUID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.RESOURCE_SLOT_TYPE value.
-RESOURCE_SLOT_TYPE_ENTITY_TYPE = EntityType("resource_slot_type")
+class ResourceSlotTypeEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "resource_slot_type"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A kind of resource an agent can offer."
 
 
 class ResourceSlotName(NaturalKey):
@@ -23,4 +31,4 @@ class ResourceSlotName(NaturalKey):
 class ResourceSlotTypeUUID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
+        return ResourceSlotTypeEntityType()

--- a/src/ai/backend/common/data/entity/retention_policy.py
+++ b/src/ai/backend/common/data/entity/retention_policy.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "RETENTION_POLICY_ENTITY_TYPE",
+    "RetentionPolicyEntityType",
     "RetentionPolicyID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.RETENTION_POLICY value.
-RETENTION_POLICY_ENTITY_TYPE = EntityType("retention_policy")
+class RetentionPolicyEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "retention_policy"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A rule purging records older than a retention period."
 
 
 class RetentionPolicyID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return RETENTION_POLICY_ENTITY_TYPE
+        return RetentionPolicyEntityType()

--- a/src/ai/backend/common/data/entity/role.py
+++ b/src/ai/backend/common/data/entity/role.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "ROLE_ENTITY_TYPE",
+    "RoleEntityType",
     "RoleID",
 )
 
 
-# Raw string mirroring the RBAC-managed role element value.
-ROLE_ENTITY_TYPE = EntityType("role")
+class RoleEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "role"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A named set of permissions granted in a scope."
 
 
 class RoleID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return ROLE_ENTITY_TYPE
+        return RoleEntityType()

--- a/src/ai/backend/common/data/entity/role_permission_preset.py
+++ b/src/ai/backend/common/data/entity/role_permission_preset.py
@@ -1,15 +1,34 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
 __all__ = ("RolePermissionPresetID",)
 
 
-ROLE_PERMISSION_PRESET_FIELD_TYPE = FieldType("role_permission_preset")
+class RolePermissionPresetFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "role_permission_preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One permission a role preset grants."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return RolePresetEntityType
 
 
 class RolePermissionPresetID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return ROLE_PERMISSION_PRESET_FIELD_TYPE
+        return RolePermissionPresetFieldType()

--- a/src/ai/backend/common/data/entity/role_preset.py
+++ b/src/ai/backend/common/data/entity/role_preset.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "ROLE_PRESET_ENTITY_TYPE",
+    "RolePresetEntityType",
     "RolePresetID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType a role preset is recorded under.
-ROLE_PRESET_ENTITY_TYPE = EntityType("role_preset")
+class RolePresetEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "role_preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A template roles are created from."
 
 
 class RolePresetID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return ROLE_PRESET_ENTITY_TYPE
+        return RolePresetEntityType()

--- a/src/ai/backend/common/data/entity/route_history.py
+++ b/src/ai/backend/common/data/entity/route_history.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("ROUTE_HISTORY_FIELD_TYPE", "RouteHistoryID")
+__all__ = ("RouteHistoryFieldType", "RouteHistoryID")
 
-ROUTE_HISTORY_FIELD_TYPE = FieldType("route_history")
+
+class RouteHistoryFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "route_history"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One routing change recorded for a deployment."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
 
 
 class RouteHistoryID(FieldIdentifier):
@@ -15,4 +35,4 @@ class RouteHistoryID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return ROUTE_HISTORY_FIELD_TYPE
+        return RouteHistoryFieldType()

--- a/src/ai/backend/common/data/entity/runtime_variant.py
+++ b/src/ai/backend/common/data/entity/runtime_variant.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "RUNTIME_VARIANT_ENTITY_TYPE",
+    "RuntimeVariantEntityType",
     "RuntimeVariantID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.RUNTIME_VARIANT value.
-RUNTIME_VARIANT_ENTITY_TYPE = EntityType("runtime_variant")
+class RuntimeVariantEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "runtime_variant"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A model serving runtime a deployment revision runs on."
 
 
 class RuntimeVariantID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return RUNTIME_VARIANT_ENTITY_TYPE
+        return RuntimeVariantEntityType()

--- a/src/ai/backend/common/data/entity/runtime_variant_preset.py
+++ b/src/ai/backend/common/data/entity/runtime_variant_preset.py
@@ -3,17 +3,26 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "RUNTIME_VARIANT_PRESET_ENTITY_TYPE",
+    "RuntimeVariantPresetEntityType",
     "RuntimeVariantPresetID",
 )
 
 
 # The presets of a runtime variant are their own catalog: the actions name this rather
 # than the variant's type so audit rows and permission lookups do not conflate the two.
-RUNTIME_VARIANT_PRESET_ENTITY_TYPE = EntityType("runtime_variant_preset")
+class RuntimeVariantPresetEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "runtime_variant_preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A saved setting of a runtime variant."
 
 
 class RuntimeVariantPresetID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return RUNTIME_VARIANT_PRESET_ENTITY_TYPE
+        return RuntimeVariantPresetEntityType()

--- a/src/ai/backend/common/data/entity/secret.py
+++ b/src/ai/backend/common/data/entity/secret.py
@@ -1,8 +1,19 @@
+from typing import override
+
 from ai.backend.common.data.entity.types import EntityType
 
-__all__ = ("SECRET_ENTITY_TYPE",)
+__all__ = ("SecretEntityType",)
 
 
 # The stored secrets of every encrypted column. Named on its own rather than under one
 # of the entities holding them: the same operation covers all of those columns.
-SECRET_ENTITY_TYPE = EntityType("secret")
+class SecretEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "secret"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A named secret value."

--- a/src/ai/backend/common/data/entity/service_catalog.py
+++ b/src/ai/backend/common/data/entity/service_catalog.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "SERVICE_CATALOG_ENTITY_TYPE",
+    "ServiceCatalogEntityType",
     "ServiceCatalogID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.SERVICE_CATALOG value.
-SERVICE_CATALOG_ENTITY_TYPE = EntityType("service_catalog")
+class ServiceCatalogEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "service_catalog"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A registered service and its endpoint."
 
 
 class ServiceCatalogID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return SERVICE_CATALOG_ENTITY_TYPE
+        return ServiceCatalogEntityType()

--- a/src/ai/backend/common/data/entity/session.py
+++ b/src/ai/backend/common/data/entity/session.py
@@ -3,18 +3,28 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
 
 __all__ = (
-    "SESSION_ENTITY_TYPE",
+    "SessionEntityType",
     "SESSION_SCOPE_TYPE",
     "SessionID",
 )
 
 
-# Raw strings mirroring the RBAC-managed RBACElementType.SESSION value.
-SESSION_ENTITY_TYPE = EntityType("session")
-SESSION_SCOPE_TYPE = ScopeType(SESSION_ENTITY_TYPE)
+class SessionEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "session"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A compute session made of one or more kernels."
+
+
+SESSION_SCOPE_TYPE = ScopeType(SessionEntityType())
 
 
 class SessionID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()

--- a/src/ai/backend/common/data/entity/session_dependency.py
+++ b/src/ai/backend/common/data/entity/session_dependency.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("SESSION_DEPENDENCY_FIELD_TYPE", "SessionDependencyID")
+__all__ = ("SessionDependencyFieldType", "SessionDependencyID")
 
-SESSION_DEPENDENCY_FIELD_TYPE = FieldType("session_dependency")
+
+class SessionDependencyFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "session_dependency"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One session another session waits on."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return SessionEntityType
 
 
 class SessionDependencyID(FieldIdentifier):
@@ -15,4 +35,4 @@ class SessionDependencyID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return SESSION_DEPENDENCY_FIELD_TYPE
+        return SessionDependencyFieldType()

--- a/src/ai/backend/common/data/entity/session_group.py
+++ b/src/ai/backend/common/data/entity/session_group.py
@@ -3,15 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "SESSION_GROUP_ENTITY_TYPE",
+    "SessionGroupEntityType",
     "SessionGroupID",
 )
 
 
-SESSION_GROUP_ENTITY_TYPE = EntityType("session_group")
+class SessionGroupEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "session_group"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A set of sessions placed together or apart."
 
 
 class SessionGroupID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return SESSION_GROUP_ENTITY_TYPE
+        return SessionGroupEntityType()

--- a/src/ai/backend/common/data/entity/session_scheduling_history.py
+++ b/src/ai/backend/common/data/entity/session_scheduling_history.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
 
-__all__ = ("SESSION_SCHEDULING_HISTORY_FIELD_TYPE", "SessionSchedulingHistoryID")
+__all__ = ("SessionSchedulingHistoryFieldType", "SessionSchedulingHistoryID")
 
-SESSION_SCHEDULING_HISTORY_FIELD_TYPE = FieldType("session_scheduling_history")
+
+class SessionSchedulingHistoryFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "session_scheduling_history"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One scheduling step recorded for a session."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return SessionEntityType
 
 
 class SessionSchedulingHistoryID(FieldIdentifier):
@@ -15,4 +35,4 @@ class SessionSchedulingHistoryID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return SESSION_SCHEDULING_HISTORY_FIELD_TYPE
+        return SessionSchedulingHistoryFieldType()

--- a/src/ai/backend/common/data/entity/session_template.py
+++ b/src/ai/backend/common/data/entity/session_template.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("SESSION_TEMPLATE_ENTITY_TYPE", "SessionTemplateID")
+__all__ = ("SessionTemplateEntityType", "SessionTemplateID")
 
-SESSION_TEMPLATE_ENTITY_TYPE = EntityType("session_template")
+
+class SessionTemplateEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "session_template"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A saved setting a session can be created from."
 
 
 class SessionTemplateID(EntityIdentifier):
@@ -14,4 +24,4 @@ class SessionTemplateID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return SESSION_TEMPLATE_ENTITY_TYPE
+        return SessionTemplateEntityType()

--- a/src/ai/backend/common/data/entity/storage_namespace.py
+++ b/src/ai/backend/common/data/entity/storage_namespace.py
@@ -3,16 +3,24 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
-    "STORAGE_NAMESPACE_ENTITY_TYPE",
+    "StorageNamespaceEntityType",
     "StorageNamespaceID",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.STORAGE_NAMESPACE value.
-STORAGE_NAMESPACE_ENTITY_TYPE = EntityType("storage_namespace")
+class StorageNamespaceEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "storage_namespace"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A named space in a storage backend that holds artifacts."
 
 
 class StorageNamespaceID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return STORAGE_NAMESPACE_ENTITY_TYPE
+        return StorageNamespaceEntityType()

--- a/src/ai/backend/common/data/entity/types.py
+++ b/src/ai/backend/common/data/entity/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, NewType, override
+from typing import Any, NewType, Self, override
 from uuid import UUID
 
 from pydantic import GetCoreSchemaHandler
@@ -22,22 +22,63 @@ class EntityType(str):
 
     A class rather than a `NewType` so a `NaturalKey` cannot be passed where this is
     expected: two `NewType`s over `str` are mutually assignable.
+
+    One subclass per kind, built with no argument: ``AgentEntityType()``. Do not
+    declare a module-level instance of one.
+
+    ``EntityType(value)`` rebuilds the bare base from a string and answers no `name()`
+    or `description()`. Reserved for a boundary that reads one -- a row column, a
+    legacy action, an RBAC element -- and written nowhere else.
     """
+
+    def __new__(cls, value: str | None = None) -> Self:
+        """A kind is built with no argument. Passing a value rebuilds the bare base from
+        a string, which the rules below reserve for a boundary reading one."""
+        return super().__new__(cls, cls.name() if value is None else value)
+
+    @override
+    def __reduce__(self) -> tuple[type[Any], tuple[Any, ...]]:
+        if type(self) is EntityType:
+            return (EntityType, (str(self),))
+        return (type(self), ())
+
+    @classmethod
+    def name(cls) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    def description(cls) -> str:
+        raise NotImplementedError
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
         """Validated as the string it is; pydantic builds no schema for a `str`
-        subclass on its own."""
-        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())
+        subclass on its own. A kind accepts its own name alone."""
+        if cls is EntityType:
+            return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())
+        return core_schema.no_info_after_validator_function(
+            lambda _: cls(), core_schema.literal_schema([cls.name()])
+        )
 
 
 # Every entity doubles as a scope, so a scope type IS an entity type; the
 # reverse direction stays an explicit declaration (`ScopeType(<entity type>)`).
 ScopeType = NewType("ScopeType", EntityType)
 
-# The system itself, for a global operation that names nothing else. Wiring
-# only — see `manager/actions/AGENTS.md`.
-GLOBAL_ENTITY_TYPE = EntityType("global")
+
+class GlobalEntityType(EntityType):
+    """The system itself, for a global operation that names nothing else. Wiring
+    only — see `manager/actions/AGENTS.md`."""
+
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "global"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The system itself, recorded by a global operation that names no entity."
 
 
 class FieldType(str):
@@ -45,13 +86,55 @@ class FieldType(str):
 
     Kept apart from `EntityType` for the same reason that one is a class rather than a
     `NewType`: a field row is not an entity, and the two must not be interchangeable.
+
+    Subclassed per kind the same way `EntityType` is, with the same rule for a value
+    rebuilt from a string. A kind answers the entity kind owning its rows; a kind whose
+    owner is a value on the row is a :class:`DanglingFieldType`.
     """
+
+    def __new__(cls, value: str | None = None) -> Self:
+        """A kind is built with no argument. Passing a value rebuilds the bare base from
+        a string, which the rules below reserve for a boundary reading one."""
+        return super().__new__(cls, cls.name() if value is None else value)
+
+    @override
+    def __reduce__(self) -> tuple[type[Any], tuple[Any, ...]]:
+        if type(self) is FieldType:
+            return (FieldType, (str(self),))
+        return (type(self), ())
+
+    @classmethod
+    def name(cls) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    def description(cls) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    def owner_type(cls) -> type[EntityType] | None:
+        """The entity kind owning this kind's rows, or ``None`` when the owner is a
+        value on the row rather than one fixed kind."""
+        raise NotImplementedError
 
     @classmethod
     def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
         """Validated as the string it is; pydantic builds no schema for a `str`
-        subclass on its own."""
-        return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())
+        subclass on its own. A kind accepts its own name alone."""
+        if cls is FieldType:
+            return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())
+        return core_schema.no_info_after_validator_function(
+            lambda _: cls(), core_schema.literal_schema([cls.name()])
+        )
+
+
+class DanglingFieldType(FieldType):
+    """A field kind whose owner is a value on the row, not one fixed entity kind."""
+
+    @override
+    @classmethod
+    def owner_type(cls) -> None:
+        return None
 
 
 class NaturalKey(str):

--- a/src/ai/backend/common/data/entity/usage_bucket.py
+++ b/src/ai/backend/common/data/entity/usage_bucket.py
@@ -1,15 +1,47 @@
-from ai.backend.common.data.entity.types import FieldType
+from typing import override
+
+from ai.backend.common.data.entity.types import DanglingFieldType
 
 __all__ = (
-    "DOMAIN_USAGE_BUCKET_FIELD_TYPE",
-    "PROJECT_USAGE_BUCKET_FIELD_TYPE",
-    "USER_USAGE_BUCKET_FIELD_TYPE",
+    "DomainUsageBucketFieldType",
+    "ProjectUsageBucketFieldType",
+    "UserUsageBucketFieldType",
 )
 
 
-# A bucket is one owner's usage over one window, so the owner's kind is part of what the
-# row is. The legacy RBAC `EntityType` spells the same pair with a `:`; a field type is
-# one name.
-DOMAIN_USAGE_BUCKET_FIELD_TYPE = FieldType("domain_usage_bucket")
-PROJECT_USAGE_BUCKET_FIELD_TYPE = FieldType("project_usage_bucket")
-USER_USAGE_BUCKET_FIELD_TYPE = FieldType("user_usage_bucket")
+# A bucket is one scope's usage in one resource group over one window, so neither side
+# alone owns the row and the wiring fixes no entity type for it.
+class DomainUsageBucketFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "domain_usage_bucket"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One period's resource usage of a domain."
+
+
+class ProjectUsageBucketFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "project_usage_bucket"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One period's resource usage of a project."
+
+
+class UserUsageBucketFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "user_usage_bucket"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One period's resource usage of a user."

--- a/src/ai/backend/common/data/entity/user.py
+++ b/src/ai/backend/common/data/entity/user.py
@@ -3,18 +3,28 @@ from typing import override
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
 
 __all__ = (
-    "USER_ENTITY_TYPE",
+    "UserEntityType",
     "USER_SCOPE_TYPE",
     "UserID",
 )
 
 
-# Raw strings mirroring the RBAC-managed RBACElementType.USER value.
-USER_ENTITY_TYPE = EntityType("user")
-USER_SCOPE_TYPE = ScopeType(USER_ENTITY_TYPE)
+class UserEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "user"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An account inside a domain."
+
+
+USER_SCOPE_TYPE = ScopeType(UserEntityType())
 
 
 class UserID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()

--- a/src/ai/backend/common/data/entity/vfolder.py
+++ b/src/ai/backend/common/data/entity/vfolder.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("VFOLDER_ENTITY_TYPE", "VFolderUUID")
+__all__ = ("VFolderEntityType", "VFolderUUID")
 
-VFOLDER_ENTITY_TYPE = EntityType("vfolder")
+
+class VFolderEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "vfolder"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A virtual folder owned by a user or a project."
 
 
 class VFolderUUID(EntityIdentifier):
@@ -18,4 +28,4 @@ class VFolderUUID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return VFOLDER_ENTITY_TYPE
+        return VFolderEntityType()

--- a/src/ai/backend/common/data/entity/vfolder_invitation.py
+++ b/src/ai/backend/common/data/entity/vfolder_invitation.py
@@ -4,9 +4,19 @@ from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("VFOLDER_INVITATION_ENTITY_TYPE", "VFolderInvitationID")
+__all__ = ("VFolderInvitationEntityType", "VFolderInvitationID")
 
-VFOLDER_INVITATION_ENTITY_TYPE = EntityType("vfolder_invitation")
+
+class VFolderInvitationEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "vfolder_invitation"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "An invitation to share a vfolder with a user."
 
 
 class VFolderInvitationID(EntityIdentifier):
@@ -18,4 +28,4 @@ class VFolderInvitationID(EntityIdentifier):
 
     @override
     def entity_type(self) -> EntityType:
-        return VFOLDER_INVITATION_ENTITY_TYPE
+        return VFolderInvitationEntityType()

--- a/src/ai/backend/common/data/entity/vfolder_permission.py
+++ b/src/ai/backend/common/data/entity/vfolder_permission.py
@@ -2,11 +2,31 @@
 
 from typing import override
 
-from ai.backend.common.data.entity.types import FieldIdentifier, FieldType
+from ai.backend.common.data.entity.types import (
+    EntityType,
+    FieldIdentifier,
+    FieldType,
+)
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 
-__all__ = ("VFOLDER_PERMISSION_FIELD_TYPE", "VFolderPermissionID")
+__all__ = ("VFolderPermissionFieldType", "VFolderPermissionID")
 
-VFOLDER_PERMISSION_FIELD_TYPE = FieldType("vfolder_permission")
+
+class VFolderPermissionFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "vfolder_permission"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One user's permission on a vfolder."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return VFolderEntityType
 
 
 class VFolderPermissionID(FieldIdentifier):
@@ -15,4 +35,4 @@ class VFolderPermissionID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return VFOLDER_PERMISSION_FIELD_TYPE
+        return VFolderPermissionFieldType()

--- a/src/ai/backend/common/data/entity/vfs_storage.py
+++ b/src/ai/backend/common/data/entity/vfs_storage.py
@@ -4,15 +4,23 @@ from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
     "VFSStorageID",
-    "VFS_STORAGE_ENTITY_TYPE",
+    "VFSStorageEntityType",
 )
 
 
-# Raw string mirroring the RBAC-managed EntityType.VFS_STORAGE value.
-VFS_STORAGE_ENTITY_TYPE = EntityType("vfs_storage")
+class VFSStorageEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "vfs_storage"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A filesystem backend behind a storage namespace."
 
 
 class VFSStorageID(EntityIdentifier):
     @override
     def entity_type(self) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()

--- a/src/ai/backend/manager/actions/AGENTS.md
+++ b/src/ai/backend/manager/actions/AGENTS.md
@@ -34,7 +34,7 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
   named scope itself and every one of them has to permit the run.
 - Its audit row names no entity and no kind; the scopes go to `audit_log_scopes`, which
   is why `audit_logs.entity_type` is nullable. The catalog records the wiring with no
-  entity type at all, which `GLOBAL_ENTITY_TYPE` does not stand for — that names an
+  entity type at all, which `GlobalEntityType` does not stand for — that names an
   operation over every entity, and a relation targets none.
 - It is wired through `ConcernGroups.relation_group()`, not through an entity group:
   a group is answered for by an entity type and a relation is answered for by none.
@@ -203,7 +203,7 @@ decides the shape. Do not create new subclasses of the legacy `BaseAction` bases
   different permission from the write that follows — the lookup asks for read, the
   write for write.
 - `BaseGlobalAction` declares no `entity_id()`.
-- `GLOBAL_ENTITY_TYPE` is what a global operation records when it names no other
+- `GlobalEntityType` is what a global operation records when it names no other
   entity. Wiring only — service and domain code never reference it.
 
 ## Monitors

--- a/src/ai/backend/manager/actions/registry/registry.py
+++ b/src/ai/backend/manager/actions/registry/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityData, FieldData
+from ai.backend.common.data.entity.types import EntityData, FieldData, GlobalEntityType
 from ai.backend.manager.actions.registry.field import FieldGroup, LookupFieldGroup
 from ai.backend.manager.actions.registry.group import (
     ProcessorGroup,
@@ -61,7 +61,7 @@ class ConcernGroups[TData: EntityData]:
     def dangling_field_group[TFieldData: FieldData](
         self, meta: FieldGroupMeta, data_cls: type[TFieldData]
     ) -> FieldGroup[TFieldData]:
-        return FieldGroup(self._deps, self._records, self._concern, meta, GLOBAL_ENTITY_TYPE)
+        return FieldGroup(self._deps, self._records, self._concern, meta, GlobalEntityType())
 
 
 class ProcessorRegistry[TData: EntityData]:
@@ -89,7 +89,7 @@ class ProcessorRegistry[TData: EntityData]:
         :meth:`ProcessorGroup.field_group`: the owner's type is a value on the row, and
         some rows have no owner at all.
         """
-        return FieldGroup(self._deps, self._records, meta.field_type, meta, GLOBAL_ENTITY_TYPE)
+        return FieldGroup(self._deps, self._records, meta.field_type, meta, GlobalEntityType())
 
     def dangling_lookup_field_group[TFieldData: FieldData](
         self,
@@ -127,7 +127,7 @@ class ProcessorRegistry[TData: EntityData]:
             self._records,
             meta.field_type,
             meta,
-            GLOBAL_ENTITY_TYPE,
+            GlobalEntityType(),
             owner_lookup,
             bulk_owner_lookup,
             partial_bulk_owner_lookup,
@@ -138,7 +138,7 @@ class ProcessorRegistry[TData: EntityData]:
         self._records.append(
             WiredProcessor(
                 concern=meta.field_type,
-                entity_type=GLOBAL_ENTITY_TYPE,
+                entity_type=GlobalEntityType(),
                 field_type=meta.field_type,
                 action_cls=action_cls,
                 kind=ActionKind.LOOKUP,

--- a/src/ai/backend/manager/actions/registry/types.py
+++ b/src/ai/backend/manager/actions/registry/types.py
@@ -119,7 +119,7 @@ class WiredProcessor:
 
     concern: str
     # ``None`` when the operation targets no entity at all, which only a relation does.
-    # Distinct from ``GLOBAL_ENTITY_TYPE``, which names an operation over every entity.
+    # Distinct from ``GlobalEntityType()``, which names an operation over every entity.
     entity_type: EntityType | None
     # Set when the operation is over a field row, whose owner ``entity_type`` names.
     field_type: FieldType | None

--- a/src/ai/backend/manager/actions/v2/global_scope/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/global_scope/monitor/audit_log.py
@@ -5,7 +5,7 @@ from typing import override
 from ai.backend.common.contexts.client_ip import current_client_ip
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE
+from ai.backend.common.data.entity.types import GlobalEntityType
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.audit_policy import AuditLogPolicy
 from ai.backend.manager.actions.types import BLANK_ID
@@ -59,7 +59,7 @@ class GlobalActionAuditLogMonitor(GlobalActionMonitor):
             ClientIPMaskingTarget.AUDIT_LOGS, current_client_ip()
         )
         creator = GlobalAuditLogCreator(
-            entity_type=GLOBAL_ENTITY_TYPE,
+            entity_type=GlobalEntityType(),
             action_id=meta.action_id,
             operation=action.operation_type(),
             action_name=action.action_name(),

--- a/src/ai/backend/manager/api/adapters/entity/types.py
+++ b/src/ai/backend/manager/api/adapters/entity/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.errors.api import InvalidAPIParameters
 
@@ -25,7 +25,7 @@ class WiredEntityTypes:
         self._types = frozenset(
             wiring.entity_type
             for wiring in registry.wired_processors()
-            if wiring.entity_type is not None and wiring.entity_type != GLOBAL_ENTITY_TYPE
+            if wiring.entity_type is not None and wiring.entity_type != GlobalEntityType()
         )
         self._sorted = tuple(sorted(self._types))
 

--- a/src/ai/backend/manager/api/gql/agent/types.py
+++ b/src/ai/backend/manager/api/gql/agent/types.py
@@ -11,7 +11,7 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID
 from strawberry.scalars import JSON
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import RuntimeEntityID
 from ai.backend.common.dto.manager.v2.agent.request import (
     AgentFilter,
@@ -409,7 +409,7 @@ class AgentV2GQL(PydanticNodeMixin[AgentNode]):
     ) -> EntityLabelConnection | None:
         return await resolve_entity_labels(
             info,
-            RuntimeEntityID(AGENT_ENTITY_TYPE, self.uuid),
+            RuntimeEntityID(AgentEntityType(), self.uuid),
             filter=filter,
             order_by=order_by,
             before=before,

--- a/src/ai/backend/manager/api/gql/deployment/types/deployment.py
+++ b/src/ai/backend/manager/api/gql/deployment/types/deployment.py
@@ -12,7 +12,7 @@ from strawberry import ID, UNSET, Info
 from strawberry.relay import Connection, Edge, NodeID, PageInfo
 
 from ai.backend.common.data.endpoint.types import ScalingState
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import RuntimeEntityID
 from ai.backend.common.data.model_deployment.types import (
     ModelDeploymentStatus,
@@ -701,7 +701,7 @@ class ModelDeployment(PydanticNodeMixin[DeploymentNodeDTO]):
     ) -> EntityLabelConnection | None:
         return await resolve_entity_labels(
             info,
-            RuntimeEntityID(DEPLOYMENT_ENTITY_TYPE, UUID(str(self.id))),
+            RuntimeEntityID(DeploymentEntityType(), UUID(str(self.id))),
             filter=filter,
             order_by=order_by,
             before=before,

--- a/src/ai/backend/manager/api/gql/session/types.py
+++ b/src/ai/backend/manager/api/gql/session/types.py
@@ -13,7 +13,7 @@ from strawberry import ID, Info
 from strawberry.relay import Connection, Edge, NodeID
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import RuntimeEntityID
 from ai.backend.common.dto.manager.v2.common import (
     ResourceSlotEntryInput as ResourceSlotEntryInputDTO,
@@ -561,7 +561,7 @@ class SessionV2GQL(PydanticNodeMixin[SessionNode]):
     ) -> EntityLabelConnection | None:
         return await resolve_entity_labels(
             info,
-            RuntimeEntityID(SESSION_ENTITY_TYPE, UUID(str(self.id))),
+            RuntimeEntityID(SessionEntityType(), UUID(str(self.id))),
             filter=filter,
             order_by=order_by,
             before=before,

--- a/src/ai/backend/manager/api/gql/vfolder_v2/types/node.py
+++ b/src/ai/backend/manager/api/gql/vfolder_v2/types/node.py
@@ -10,7 +10,7 @@ from strawberry import Info
 from strawberry.relay import Connection, Edge, NodeID, PageInfo
 
 from ai.backend.common.data.entity.types import RuntimeEntityID
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.dto.manager.v2.model_card.request import SearchModelCardsInput
 from ai.backend.common.dto.manager.v2.vfolder.response import VFolderNode
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
@@ -186,7 +186,7 @@ class VFolderGQL(PydanticNodeMixin[VFolderNode]):
     ) -> EntityLabelConnection | None:
         return await resolve_entity_labels(
             info,
-            RuntimeEntityID(VFOLDER_ENTITY_TYPE, UUID(self.id)),
+            RuntimeEntityID(VFolderEntityType(), UUID(self.id)),
             filter=filter,
             order_by=order_by,
             before=before,

--- a/src/ai/backend/manager/cli/ops.py
+++ b/src/ai/backend/manager/cli/ops.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import importlib
 import inspect
 import json
+import pkgutil
 import textwrap
+import uuid
 from collections.abc import Sequence
 from itertools import groupby
 from typing import Any, Final
@@ -12,6 +15,14 @@ from typing import Any, Final
 import click
 from tabulate import tabulate
 
+import ai.backend.common.data.entity as entity_package
+from ai.backend.common.data.entity.types import (
+    DanglingFieldType,
+    EntityIdentifier,
+    EntityType,
+    FieldType,
+    RuntimeEntityID,
+)
 from ai.backend.manager.actions.registry.types import Concern, WiredProcessor
 from ai.backend.manager.actions.types import (
     ActionBacking,
@@ -45,6 +56,7 @@ _FIELD_BLOCK_COLUMNS: Final[tuple[str, ...]] = tuple(
     column for column in _ENTITY_BLOCK_COLUMNS if column != "entity_type"
 )
 _ENTITY_COLUMNS: Final[tuple[str, ...]] = ("concern", "entity_type", "field_type", "operations")
+_TYPE_COLUMNS: Final[tuple[str, ...]] = ("classification", "entity_type", "field_type")
 # Stands for a column a wiring leaves unset, so every line has the same shape.
 _ABSENT: Final[str] = "-"
 # An operation targeting no entity at all, which only a relation does. Distinct from
@@ -127,6 +139,63 @@ class EntityFields:
             (self.concern, self.entity_type, field, str(count)) for field, count in self.fields
         )
         return rows
+
+
+@dataclasses.dataclass(frozen=True)
+class TypeCatalog:
+    """Every declared entity and field type, grouped by the ownership they declare.
+
+    Read off the type classes rather than the wiring, so a kind no operation reaches
+    yet is listed too. Rationale: `common/data/entity/KNOWLEDGE.md`.
+    """
+
+    owners: tuple[tuple[str, tuple[str, ...]], ...]
+    dangling: tuple[str, ...]
+    unclassified: tuple[str, ...]
+
+    def rows(self) -> list[tuple[str, ...]]:
+        rows: list[tuple[str, ...]] = []
+        for owner, fields in self.owners:
+            rows.append(("entity", owner, _ABSENT))
+            rows.extend(("field", owner, field) for field in fields)
+        rows.extend(("dangling_field", _ABSENT, field) for field in self.dangling)
+        rows.extend(("unclassified", name, _ABSENT) for name in self.unclassified)
+        return rows
+
+
+def _subclasses[T: type](base: T) -> list[T]:
+    found: list[T] = []
+    for sub in base.__subclasses__():
+        found.append(sub)
+        found.extend(_subclasses(sub))
+    return found
+
+
+def _load_type_catalog() -> TypeCatalog:
+    for module in pkgutil.iter_modules(entity_package.__path__):
+        importlib.import_module(f"{entity_package.__name__}.{module.name}")
+    entity_kinds = {kind.name(): kind for kind in _subclasses(EntityType)}
+    field_kinds = [kind for kind in _subclasses(FieldType) if kind is not DanglingFieldType]
+    # An id is what says a kind has a row of its own, and it answers from the value, so
+    # a nil uuid stands in for the row this catalog never reads. RuntimeEntityID names
+    # no fixed kind, carrying it as a value instead, so it declares nothing here.
+    id_classes: list[Any] = list(_subclasses(EntityIdentifier))
+    named = {
+        type(id_cls(uuid.UUID(int=0)).entity_type()).name()
+        for id_cls in id_classes
+        if id_cls is not RuntimeEntityID and "entity_type" in id_cls.__dict__
+    }
+    owned: dict[str, list[str]] = {name: [] for name in entity_kinds}
+    dangling: list[str] = []
+    for kind in field_kinds:
+        owner = kind.owner_type()
+        if owner is None:
+            dangling.append(kind.name())
+        else:
+            owned[owner.name()].append(kind.name())
+    owners = tuple((name, tuple(sorted(owned[name]))) for name in sorted(owned) if name in named)
+    unclassified = tuple(sorted(name for name in entity_kinds if name not in named))
+    return TypeCatalog(owners, tuple(sorted(dangling)), unclassified)
 
 
 def _type_name(annotation: Any) -> str:
@@ -408,3 +477,62 @@ def describe_operation(entity_type: str, action_name: str) -> None:
             print("input_fields")
             print(textwrap.indent(tabulate(fields, tablefmt="plain"), "  "))
         print()
+
+
+@cli.command(name="types")
+@click.option(
+    "-o",
+    "--output",
+    default="table",
+    type=click.Choice(["table", "json", "tsv"]),
+    help="Set the output style of the command results.",
+)
+def list_types(output: str) -> None:
+    """
+    List every declared entity and field type by the ownership it declares.
+
+    Read off the type classes, not the wiring, so a kind no operation reaches yet is
+    listed too. A field type whose owner is a value on the row is dangling; an entity
+    type no id class names has no row of its own and is left unclassified.
+
+    Examples:
+
+        $ backend.ai mgr ops types
+    """
+    catalog = _load_type_catalog()
+    match output:
+        case "json":
+            print(
+                json.dumps(
+                    [dict(zip(_TYPE_COLUMNS, row, strict=True)) for row in catalog.rows()],
+                    indent=2,
+                )
+            )
+        case "tsv":
+            print("\t".join(_TYPE_COLUMNS))
+            for row in catalog.rows():
+                print("\t".join(row))
+        case _:
+            print(
+                tabulate(
+                    [
+                        (owner, ", ".join(fields) if fields else _ABSENT)
+                        for owner, fields in catalog.owners
+                    ],
+                    headers=("entity type", "field types it owns"),
+                    tablefmt="plain",
+                )
+            )
+            print()
+            print("dangling field types (owner is a value on the row)")
+            print(textwrap.indent("\n".join(catalog.dangling), "  "))
+            print()
+            print("unclassified entity types (no id class names a row)")
+            print(textwrap.indent("\n".join(catalog.unclassified), "  "))
+            print()
+            owned_fields = sum(len(fields) for _, fields in catalog.owners)
+            print(
+                f"{len(catalog.owners)} entity types, "
+                f"{owned_fields + len(catalog.dangling)} field types, "
+                f"{len(catalog.unclassified)} unclassified"
+            )

--- a/src/ai/backend/manager/models/agent/conditions.py
+++ b/src/ai/backend/manager/models/agent/conditions.py
@@ -6,7 +6,7 @@ from collections.abc import Collection
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.agent.types import AgentStatus
 from ai.backend.manager.models.clauses import QueryCondition
@@ -21,7 +21,7 @@ from .row import AgentRow
 class AgentConditions:
     """Query condition factories for filtering agent rows."""
 
-    labels = make_entity_label_nested_conditions(AgentRow, AgentRow.uuid, AGENT_ENTITY_TYPE)
+    labels = make_entity_label_nested_conditions(AgentRow, AgentRow.uuid, AgentEntityType())
     """The `labels` nested filter: some / every / none over the labels on a agent."""
 
     @staticmethod

--- a/src/ai/backend/manager/models/endpoint/conditions.py
+++ b/src/ai/backend/manager/models/endpoint/conditions.py
@@ -9,7 +9,7 @@ from datetime import datetime
 import sqlalchemy as sa
 
 from ai.backend.common.data.endpoint.types import EndpointLifecycle, ScalingState
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.filter_specs import (
     StringMatchSpec,
     UUIDEqualMatchSpec,
@@ -33,7 +33,7 @@ class DeploymentConditions:
     """Query conditions for deployments."""
 
     labels = make_entity_label_nested_conditions(
-        EndpointRow, EndpointRow.id, DEPLOYMENT_ENTITY_TYPE
+        EndpointRow, EndpointRow.id, DeploymentEntityType()
     )
     """The `labels` nested filter: some / every / none over the labels on a endpoint."""
 

--- a/src/ai/backend/manager/models/entity_share/scopes.py
+++ b/src/ai/backend/manager/models/entity_share/scopes.py
@@ -8,9 +8,9 @@ from typing import Any, override
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.entity_share.row import EntityShareRow
 from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
@@ -49,7 +49,7 @@ class EntityShareRecipientScope(OperationScope):
                     .scalar_subquery()
                 ),
                 sa.and_(
-                    EntityShareRow.recipient_entity_type == USER_ENTITY_TYPE,
+                    EntityShareRow.recipient_entity_type == UserEntityType(),
                     EntityShareRow.recipient_entity_id == recipient_user_id,
                 ),
             )
@@ -75,7 +75,7 @@ class EntityShareRecipientProjectScope(OperationScope):
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return sa.and_(
-                EntityShareRow.recipient_entity_type == PROJECT_ENTITY_TYPE,
+                EntityShareRow.recipient_entity_type == ProjectEntityType(),
                 EntityShareRow.recipient_entity_id == project_id,
             )
 

--- a/src/ai/backend/manager/models/entity_share/updaters.py
+++ b/src/ai/backend/manager/models/entity_share/updaters.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.entity.entity_share import EntityShareID
 from ai.backend.common.data.entity.types import EntityIdentifier
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.data.entity_share.types import (
     EntityShareData,
     EntityShareStatus,
@@ -81,7 +81,7 @@ class _RecipientInvitationUpdater(GuardedDataUpdater[EntityShareRow, EntityShare
                 EntityShareRow.recipient_entity_type == scope.entity_type(),
                 EntityShareRow.recipient_entity_id == scope,
             )
-            if scope.entity_type() != USER_ENTITY_TYPE:
+            if scope.entity_type() != UserEntityType():
                 return named
             return sa.or_(
                 named,

--- a/src/ai/backend/manager/models/idle_checker/creators.py
+++ b/src/ai/backend/manager/models/idle_checker/creators.py
@@ -7,12 +7,12 @@ from typing import Any, override
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.idle_checker import IdleCheckerID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.idle_checker.types import IdleCheckerSpec
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckerData
@@ -84,10 +84,10 @@ class IdleCheckerAssignmentCreator(
         """The scope row must be there: its side carries no foreign key. A scope type
         outside the four the table takes is refused the same way."""
         columns: dict[EntityType, InstrumentedAttribute[Any]] = {
-            DOMAIN_ENTITY_TYPE: DomainRow.id,
-            PROJECT_ENTITY_TYPE: ProjectRow.id,
-            RESOURCE_GROUP_ENTITY_TYPE: ResourceGroupRow.id,
-            USER_ENTITY_TYPE: UserRow.uuid,
+            DomainEntityType(): DomainRow.id,
+            ProjectEntityType(): ProjectRow.id,
+            ResourceGroupEntityType(): ResourceGroupRow.id,
+            UserEntityType(): UserRow.uuid,
         }
         column = columns.get(scope.entity_type())
         finder = sa.select(sa.literal(True))

--- a/src/ai/backend/manager/models/session/conditions.py
+++ b/src/ai/backend/manager/models/session/conditions.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.manager.models.entity_label.conditions import (
     make_entity_label_nested_conditions,
 )
@@ -36,7 +36,7 @@ from .row import SessionRow
 class SessionConditions:
     """Query conditions for sessions."""
 
-    labels = make_entity_label_nested_conditions(SessionRow, SessionRow.id, SESSION_ENTITY_TYPE)
+    labels = make_entity_label_nested_conditions(SessionRow, SessionRow.id, SessionEntityType())
     """The `labels` nested filter: some / every / none over the labels on a session."""
 
     @staticmethod

--- a/src/ai/backend/manager/models/vfolder/conditions.py
+++ b/src/ai/backend/manager/models/vfolder/conditions.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.manager.models.entity_label.conditions import (
     make_entity_label_nested_conditions,
 )
@@ -29,7 +29,7 @@ from .row import VFolderRow
 class VFolderConditions:
     """Query conditions for vfolders."""
 
-    labels = make_entity_label_nested_conditions(VFolderRow, VFolderRow.id, VFOLDER_ENTITY_TYPE)
+    labels = make_entity_label_nested_conditions(VFolderRow, VFolderRow.id, VFolderEntityType())
     """The `labels` nested filter: some / every / none over the labels on a vfolder."""
 
     @staticmethod

--- a/src/ai/backend/manager/models/virtual_entity/queries.py
+++ b/src/ai/backend/manager/models/virtual_entity/queries.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
 from ai.backend.common.data.entity.types import EntityID, ScopeID, ScopeType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
 
@@ -44,7 +44,7 @@ def user_scope_membership_query(
         .join(member, EntityMembershipRow.member_entity_id == member.id)
         .where(
             VirtualEntityRow.entity_type == scope_type,
-            member.entity_type == USER_ENTITY_TYPE,
+            member.entity_type == UserEntityType(),
         )
     )
     if user_id is not None:
@@ -72,7 +72,7 @@ def user_scope_membership_exists(
         .where(
             VirtualEntityRow.entity_type == scope_type,
             VirtualEntityRow.entity_id == scope_id,
-            member.entity_type == USER_ENTITY_TYPE,
+            member.entity_type == UserEntityType(),
             member.entity_id == user_id,
         )
     )

--- a/src/ai/backend/manager/repositories/ops/v2/share/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/share/write.py
@@ -15,7 +15,7 @@ from collections.abc import Collection, Mapping, Sequence
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.types import EntityIdentifier
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.permission.id import FieldPath
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.data.entity_share.types import EntityShareData, EntityShareStatus
@@ -249,7 +249,7 @@ class V2ShareWriteOps(V2WriteOps, V2CapOps):
         A project takes it itself. A person takes it into the project that is theirs
         alone, which every account has.
         """
-        if answering_scope.entity_type() != USER_ENTITY_TYPE:
+        if answering_scope.entity_type() != UserEntityType():
             return answering_scope
         personal = await self.lookup_entity_id(
             PersonalProjectOfUserLookup(user_id=UserID(answering_scope))

--- a/src/ai/backend/manager/services/agent/actions/bulk_lookup.py
+++ b/src/ai/backend/manager/services/agent/actions/bulk_lookup.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE, AgentUUID
+from ai.backend.common.data.entity.agent import AgentEntityType, AgentUUID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.v2.ops.base import BulkLookupEntityOpsAction
@@ -25,7 +25,7 @@ class BulkLookupAgentsAction(BulkLookupEntityOpsAction[AgentId, AgentUUID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/get_total_resources.py
+++ b/src/ai/backend/manager/services/agent/actions/get_total_resources.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.resource.types import TotalResourceData
 from ai.backend.manager.actions.types import ActionOperationType
@@ -20,7 +20,7 @@ class GetTotalResourcesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/get_watcher_status.py
+++ b/src/ai/backend/manager/services/agent/actions/get_watcher_status.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -15,7 +15,7 @@ class GetWatcherStatusAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/load_container_counts.py
+++ b/src/ai/backend/manager/services/agent/actions/load_container_counts.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -24,7 +24,7 @@ class LoadContainerCountsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/lookup.py
+++ b/src/ai/backend/manager/services/agent/actions/lookup.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE, AgentUUID
+from ai.backend.common.data.entity.agent import AgentEntityType, AgentUUID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -41,7 +41,7 @@ class LookupAgentAction(LookupEntityOpsAction[AgentRow, AgentUUID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/lookup_resource_owner.py
+++ b/src/ai/backend/manager/services/agent/actions/lookup_resource_owner.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE, AgentUUID
+from ai.backend.common.data.entity.agent import AgentEntityType, AgentUUID
 from ai.backend.common.data.entity.agent_resource import AgentResourceID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
@@ -37,7 +37,7 @@ class LookupAgentResourceOwnerAction(LookupFieldOwnerOpsAction[AgentResourceID, 
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod
@@ -66,7 +66,7 @@ class LookupBulkAgentResourceOwnerAction(LookupBulkFieldOwnerOpsAction[AgentReso
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/recalculate_usage.py
+++ b/src/ai/backend/manager/services/agent/actions/recalculate_usage.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -14,7 +14,7 @@ class RecalculateUsageAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/search_agents.py
+++ b/src/ai/backend/manager/services/agent/actions/search_agents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -24,7 +24,7 @@ class SearchAgentsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/sync_agent_registry.py
+++ b/src/ai/backend/manager/services/agent/actions/sync_agent_registry.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -16,7 +16,7 @@ class SyncAgentRegistryAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/update_resource_group.py
+++ b/src/ai/backend/manager/services/agent/actions/update_resource_group.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId, SessionId
@@ -22,7 +22,7 @@ class UpdateAgentResourceGroupAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/watcher_agent_restart.py
+++ b/src/ai/backend/manager/services/agent/actions/watcher_agent_restart.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -15,7 +15,7 @@ class WatcherAgentRestartAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/watcher_agent_start.py
+++ b/src/ai/backend/manager/services/agent/actions/watcher_agent_start.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -15,7 +15,7 @@ class WatcherAgentStartAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/actions/watcher_agent_stop.py
+++ b/src/ai/backend/manager/services/agent/actions/watcher_agent_stop.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -15,7 +15,7 @@ class WatcherAgentStopAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/agent/processors.py
+++ b/src/ai/backend/manager/services/agent/processors.py
@@ -1,5 +1,5 @@
 from ai.backend.common.data.entity.agent import AgentUUID
-from ai.backend.common.data.entity.agent_resource import AGENT_RESOURCE_FIELD_TYPE
+from ai.backend.common.data.entity.agent_resource import AgentResourceFieldType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
@@ -129,7 +129,7 @@ class AgentProcessors:
             BulkLoadAgentPermissionsAction, service.bulk_load_permissions
         )
         resources: LookupFieldGroup[AgentResourceData] = group.field_group(
-            FieldGroupMeta(AGENT_RESOURCE_FIELD_TYPE),
+            FieldGroupMeta(AgentResourceFieldType()),
             AgentResourceData,
             LookupAgentResourceOwnerAction,
             LookupBulkAgentResourceOwnerAction,

--- a/src/ai/backend/manager/services/app_config/actions/allow_list/admin_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/allow_list/admin_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_ALLOW_LIST_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigAllowListData
@@ -24,7 +24,7 @@ class AdminSearchAppConfigAllowListAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_ALLOW_LIST_ENTITY_TYPE
+        return AppConfigAllowListEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/allow_list/create.py
+++ b/src/ai/backend/manager/services/app_config/actions/allow_list/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_ALLOW_LIST_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigAllowListData
@@ -24,7 +24,7 @@ class CreateAppConfigAllowListAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_ALLOW_LIST_ENTITY_TYPE
+        return AppConfigAllowListEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/definition/admin_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/definition/admin_search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.app_config_definition import (
-    APP_CONFIG_DEFINITION_ENTITY_TYPE,
+    AppConfigDefinitionEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -26,7 +26,7 @@ class AdminSearchAppConfigDefinitionsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_DEFINITION_ENTITY_TYPE
+        return AppConfigDefinitionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/definition/create.py
+++ b/src/ai/backend/manager/services/app_config/actions/definition/create.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.app_config_definition import (
-    APP_CONFIG_DEFINITION_ENTITY_TYPE,
+    AppConfigDefinitionEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -28,7 +28,7 @@ class CreateAppConfigDefinitionAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_DEFINITION_ENTITY_TYPE
+        return AppConfigDefinitionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/fragment/admin_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/admin_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_FRAGMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData
@@ -24,7 +24,7 @@ class AdminSearchAppConfigFragmentAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_FRAGMENT_ENTITY_TYPE
+        return AppConfigFragmentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/fragment/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/bulk_upsert.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_FRAGMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
     EntityType,
@@ -33,7 +33,7 @@ class BulkUpsertAppConfigFragmentsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_FRAGMENT_ENTITY_TYPE
+        return AppConfigFragmentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/fragment/global_bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/global_bulk_upsert.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_FRAGMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import AtomicUpsertGlobalEntityOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData
@@ -29,7 +29,7 @@ class GlobalBulkUpsertAppConfigFragmentsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_FRAGMENT_ENTITY_TYPE
+        return AppConfigFragmentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/fragment/scoped_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/scoped_search.py
@@ -6,7 +6,7 @@ from typing import override
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.entity.app_config import (
-    APP_CONFIG_FRAGMENT_ENTITY_TYPE,
+    AppConfigFragmentEntityType,
     AppConfigScopeID,
 )
 from ai.backend.common.data.entity.types import (
@@ -41,7 +41,7 @@ class ScopedSearchAppConfigFragmentAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_FRAGMENT_ENTITY_TYPE
+        return AppConfigFragmentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/search.py
+++ b/src/ai/backend/manager/services/app_config/actions/search.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import APP_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config import AppConfigEntityType
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
@@ -42,7 +42,7 @@ class SearchAppConfigsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_ENTITY_TYPE
+        return AppConfigEntityType()
 
     @override
     @classmethod
@@ -82,7 +82,7 @@ class AnonymousSearchAppConfigsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return APP_CONFIG_ENTITY_TYPE
+        return AppConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/artifact/actions/base.py
+++ b/src/ai/backend/manager/services/artifact/actions/base.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE, ArtifactID
+from ai.backend.common.data.entity.artifact import ArtifactEntityType, ArtifactID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -14,7 +14,7 @@ class ArtifactAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ARTIFACT_ENTITY_TYPE
+        return ArtifactEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/artifact/actions/get_revisions.py
+++ b/src/ai/backend/manager/services/artifact/actions/get_revisions.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE, ArtifactID
+from ai.backend.common.data.entity.artifact import ArtifactEntityType, ArtifactID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.artifact.types import ArtifactRevisionData
@@ -29,7 +29,7 @@ class GetArtifactRevisionsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ARTIFACT_ENTITY_TYPE
+        return ArtifactEntityType()
 
     @override
     @classmethod
@@ -38,7 +38,7 @@ class GetArtifactRevisionsAction(
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=ScopeType(ARTIFACT_ENTITY_TYPE), scope_id=self.artifact_id),)
+        return (ScopeRef(scope_type=ScopeType(ArtifactEntityType()), scope_id=self.artifact_id),)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/artifact/revision/actions/base.py
+++ b/src/ai/backend/manager/services/artifact/revision/actions/base.py
@@ -3,7 +3,7 @@ from typing import override
 
 from ai.backend.common.data.entity.artifact import ArtifactID
 from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionID
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.services.artifact.revision.actions.lookup_owner import (
@@ -18,7 +18,7 @@ class ArtifactRevisionAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/artifact/revision/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/artifact/revision/actions/lookup_owner.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE, ArtifactID
+from ai.backend.common.data.entity.artifact import ArtifactEntityType, ArtifactID
 from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
@@ -37,7 +37,7 @@ class LookupArtifactRevisionOwnerAction(LookupFieldOwnerOpsAction[ArtifactRevisi
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ARTIFACT_ENTITY_TYPE
+        return ArtifactEntityType()
 
     @override
     @classmethod
@@ -68,7 +68,7 @@ class LookupBulkArtifactRevisionOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ARTIFACT_ENTITY_TYPE
+        return ArtifactEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/artifact_registry/actions/base.py
+++ b/src/ai/backend/manager/services/artifact_registry/actions/base.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.artifact_registry import (
-    ARTIFACT_REGISTRY_ENTITY_TYPE,
+    ArtifactRegistryEntityType,
     ArtifactRegistryID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
@@ -17,7 +17,7 @@ class ArtifactRegistryAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ARTIFACT_REGISTRY_ENTITY_TYPE
+        return ArtifactRegistryEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/artifact_registry/actions/lookup.py
+++ b/src/ai/backend/manager/services/artifact_registry/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.artifact_registry import (
-    ARTIFACT_REGISTRY_ENTITY_TYPE,
+    ArtifactRegistryEntityType,
     ArtifactRegistryID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -38,7 +38,7 @@ class LookupArtifactRegistryAction(LookupEntityOpsAction[ArtifactRegistryRow, Ar
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ARTIFACT_REGISTRY_ENTITY_TYPE
+        return ArtifactRegistryEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/audit_log/actions/search.py
+++ b/src/ai/backend/manager/services/audit_log/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.audit_log.types import AuditLogData
 from ai.backend.manager.models.audit_log.row import AuditLogRow
@@ -19,7 +19,7 @@ class SearchAuditLogsAction(SearchGlobalOpsAction[AuditLogRow, AuditLogData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/auth/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/auth/KNOWLEDGE.md
@@ -5,7 +5,7 @@ description: 인증 도메인의 액션이 왜 auth 와 user 두 그룹으로 �
 scope: src/ai/backend/manager/services/auth
 keywords:
   - AuthProcessors
-  - AUTH_ENTITY_TYPE
+  - AuthEntityType
   - anonymous_global
   - PublicActionProcessor
   - RevokeLoginSessionAction

--- a/src/ai/backend/manager/services/auth/actions/base.py
+++ b/src/ai/backend/manager/services/auth/actions/base.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
+from ai.backend.common.data.entity.auth import AuthEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
 
@@ -18,7 +18,7 @@ class AuthGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AUTH_ENTITY_TYPE
+        return AuthEntityType()
 
 
 class UserGlobalAction(BaseGlobalAction):
@@ -27,7 +27,7 @@ class UserGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/auth/actions/lookup_login_history_owner.py
+++ b/src/ai/backend/manager/services/auth/actions/lookup_login_history_owner.py
@@ -6,7 +6,7 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.login_history import LoginHistoryID
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -37,7 +37,7 @@ class LookupLoginHistoryOwnerAction(LookupFieldOwnerOpsAction[LoginHistoryID, Us
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -66,7 +66,7 @@ class LookupBulkLoginHistoryOwnerAction(LookupBulkFieldOwnerOpsAction[LoginHisto
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/auth/actions/lookup_login_session_owner.py
+++ b/src/ai/backend/manager/services/auth/actions/lookup_login_session_owner.py
@@ -6,7 +6,7 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.login_session import LoginSessionID
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -37,7 +37,7 @@ class LookupLoginSessionOwnerAction(LookupFieldOwnerOpsAction[LoginSessionID, Us
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -66,7 +66,7 @@ class LookupBulkLoginSessionOwnerAction(LookupBulkFieldOwnerOpsAction[LoginSessi
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/auth/actions/search_login_history.py
+++ b/src/ai/backend/manager/services/auth/actions/search_login_history.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
 from ai.backend.manager.actions.v2.ops.base import (
     OperationScopeOpsAction,
     SearchGlobalOpsAction,
@@ -24,7 +24,7 @@ class GlobalSearchLoginHistoryAction(SearchGlobalOpsAction[LoginHistoryRow, Logi
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -46,7 +46,7 @@ class SearchLoginHistoryAction(OperationScopeOpsAction[LoginHistoryRow, LoginHis
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/auth/actions/search_login_sessions.py
+++ b/src/ai/backend/manager/services/auth/actions/search_login_sessions.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
 from ai.backend.manager.actions.v2.ops.base import (
     OperationScopeOpsAction,
     SearchGlobalOpsAction,
@@ -24,7 +24,7 @@ class GlobalSearchLoginSessionsAction(SearchGlobalOpsAction[LoginSessionRow, Log
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -46,7 +46,7 @@ class SearchLoginSessionsAction(OperationScopeOpsAction[LoginSessionRow, LoginSe
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/auth/processors.py
+++ b/src/ai/backend/manager/services/auth/processors.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-from ai.backend.common.data.entity.login_history import LOGIN_HISTORY_FIELD_TYPE
-from ai.backend.common.data.entity.login_session import LOGIN_SESSION_FIELD_TYPE
+from ai.backend.common.data.entity.login_history import LoginHistoryFieldType
+from ai.backend.common.data.entity.login_session import LoginSessionFieldType
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.registry.types import FieldGroupMeta
@@ -194,13 +194,13 @@ class AuthProcessors:
             UploadSSHKeypairAction, service.upload_ssh_keypair
         )
         self.login_sessions = user_group.field_group(
-            FieldGroupMeta(LOGIN_SESSION_FIELD_TYPE),
+            FieldGroupMeta(LoginSessionFieldType()),
             LoginSessionData,
             LookupLoginSessionOwnerAction,
             LookupBulkLoginSessionOwnerAction,
         )
         self.login_history = user_group.field_group(
-            FieldGroupMeta(LOGIN_HISTORY_FIELD_TYPE),
+            FieldGroupMeta(LoginHistoryFieldType()),
             LoginHistoryData,
             LookupLoginHistoryOwnerAction,
             LookupBulkLoginHistoryOwnerAction,

--- a/src/ai/backend/manager/services/client_ip_masking/actions/search.py
+++ b/src/ai/backend/manager/services/client_ip_masking/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.client_ip.types import ClientIPMaskingPolicyData
@@ -22,7 +22,7 @@ class SearchClientIPMaskingPoliciesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+        return ClientIPMaskingPolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/client_ip_masking/actions/upsert.py
+++ b/src/ai/backend/manager/services/client_ip_masking/actions/upsert.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import UpsertGlobalOpsAction
 from ai.backend.manager.data.client_ip.masking import ClientIPMaskingMode, ClientIPMaskingTarget
@@ -30,7 +30,7 @@ class UpsertClientIPMaskingPolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+        return ClientIPMaskingPolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/container_registry/actions/base.py
+++ b/src/ai/backend/manager/services/container_registry/actions/base.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.container_registry import (
-    CONTAINER_REGISTRY_ENTITY_TYPE,
+    ContainerRegistryEntityType,
     ContainerRegistryID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
@@ -17,7 +17,7 @@ class ContainerRegistryAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return CONTAINER_REGISTRY_ENTITY_TYPE
+        return ContainerRegistryEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/deployment/actions/access_token/global_search_access_tokens.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/global_search_access_tokens.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
@@ -22,7 +22,7 @@ class GlobalSearchAccessTokensAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment/actions/access_token/search_access_tokens.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/search_access_tokens.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
@@ -30,7 +30,7 @@ class SearchAccessTokensAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -40,7 +40,7 @@ class SearchAccessTokensAction(
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
         return (
-            ScopeRef(scope_type=ScopeType(DEPLOYMENT_ENTITY_TYPE), scope_id=self.deployment_id),
+            ScopeRef(scope_type=ScopeType(DeploymentEntityType()), scope_id=self.deployment_id),
         )
 
     @override

--- a/src/ai/backend/manager/services/deployment/actions/base.py
+++ b/src/ai/backend/manager/services/deployment/actions/base.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -38,7 +38,7 @@ class DeploymentGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
 
 @dataclass
@@ -48,7 +48,7 @@ class DeploymentScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/deployment/actions/global_search_replicas.py
+++ b/src/ai/backend/manager/services/deployment/actions/global_search_replicas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment.types import ModelReplicaData
@@ -20,7 +20,7 @@ class GlobalSearchReplicasAction(SearchGlobalOpsAction[RoutingRow, ModelReplicaD
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/deployment/actions/lookup_owner.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, override
 from uuid import UUID
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
@@ -52,7 +52,7 @@ class LookupAutoScalingRuleDeploymentAction(LookupFieldOwnerByKeyOpsAction[Deplo
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -94,7 +94,7 @@ class LookupDeploymentRevisionOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -125,7 +125,7 @@ class LookupBulkDeploymentRevisionOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -169,7 +169,7 @@ class LookupReplicaOwnerAction(LookupFieldOwnerOpsAction[ReplicaID, DeploymentID
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -198,7 +198,7 @@ class LookupBulkReplicaOwnerAction(LookupBulkFieldOwnerOpsAction[ReplicaID, Depl
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -244,7 +244,7 @@ class LookupDeploymentAccessTokenOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -275,7 +275,7 @@ class LookupBulkDeploymentAccessTokenOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -321,7 +321,7 @@ class LookupDeploymentPolicyOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -352,7 +352,7 @@ class LookupBulkDeploymentPolicyOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/global_search_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/global_search_revisions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment.types import ModelRevisionData
@@ -20,7 +20,7 @@ class GlobalSearchRevisionsAction(SearchGlobalOpsAction[DeploymentRevisionRow, M
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/search_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/search_revisions.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelRevisionData
@@ -30,7 +30,7 @@ class SearchRevisionsAction(OperationScopeOpsAction[DeploymentRevisionRow, Model
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -40,7 +40,7 @@ class SearchRevisionsAction(OperationScopeOpsAction[DeploymentRevisionRow, Model
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
         return (
-            ScopeRef(scope_type=ScopeType(DEPLOYMENT_ENTITY_TYPE), scope_id=self.deployment_id),
+            ScopeRef(scope_type=ScopeType(DeploymentEntityType()), scope_id=self.deployment_id),
         )
 
     @override

--- a/src/ai/backend/manager/services/deployment/actions/search_replicas.py
+++ b/src/ai/backend/manager/services/deployment/actions/search_replicas.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelReplicaData
@@ -28,7 +28,7 @@ class SearchReplicasAction(OperationScopeOpsAction[RoutingRow, ModelReplicaData]
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -38,7 +38,7 @@ class SearchReplicasAction(OperationScopeOpsAction[RoutingRow, ModelReplicaData]
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
         return (
-            ScopeRef(scope_type=ScopeType(DEPLOYMENT_ENTITY_TYPE), scope_id=self.deployment_id),
+            ScopeRef(scope_type=ScopeType(DeploymentEntityType()), scope_id=self.deployment_id),
         )
 
     @override

--- a/src/ai/backend/manager/services/deployment/processors.py
+++ b/src/ai/backend/manager/services/deployment/processors.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ai.backend.common.data.entity.deployment import DeploymentID
-from ai.backend.common.data.entity.deployment_policy import DEPLOYMENT_POLICY_FIELD_TYPE
-from ai.backend.common.data.entity.deployment_revision import DEPLOYMENT_REVISION_FIELD_TYPE
-from ai.backend.common.data.entity.deployment_token import DEPLOYMENT_TOKEN_FIELD_TYPE
-from ai.backend.common.data.entity.replica import REPLICA_FIELD_TYPE
+from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyFieldType
+from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionFieldType
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenFieldType
+from ai.backend.common.data.entity.replica import ReplicaFieldType
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
 from ai.backend.manager.actions.registry.types import FieldGroupMeta
@@ -346,25 +346,25 @@ class DeploymentProcessors:
         self, group: ProcessorGroup[ModelDeploymentData], service: DeploymentService
     ) -> None:
         revisions: LookupFieldGroup[ModelRevisionData] = group.field_group(
-            FieldGroupMeta(DEPLOYMENT_REVISION_FIELD_TYPE),
+            FieldGroupMeta(DeploymentRevisionFieldType()),
             ModelRevisionData,
             LookupDeploymentRevisionOwnerAction,
             LookupBulkDeploymentRevisionOwnerAction,
         )
         replicas: LookupFieldGroup[ModelReplicaData] = group.field_group(
-            FieldGroupMeta(REPLICA_FIELD_TYPE),
+            FieldGroupMeta(ReplicaFieldType()),
             ModelReplicaData,
             LookupReplicaOwnerAction,
             LookupBulkReplicaOwnerAction,
         )
         access_tokens: LookupFieldGroup[ModelDeploymentAccessTokenData] = group.field_group(
-            FieldGroupMeta(DEPLOYMENT_TOKEN_FIELD_TYPE),
+            FieldGroupMeta(DeploymentTokenFieldType()),
             ModelDeploymentAccessTokenData,
             LookupDeploymentAccessTokenOwnerAction,
             LookupBulkDeploymentAccessTokenOwnerAction,
         )
         policies: LookupFieldGroup[DeploymentPolicyData] = group.field_group(
-            FieldGroupMeta(DEPLOYMENT_POLICY_FIELD_TYPE),
+            FieldGroupMeta(DeploymentPolicyFieldType()),
             DeploymentPolicyData,
             LookupDeploymentPolicyOwnerAction,
             LookupBulkDeploymentPolicyOwnerAction,
@@ -372,7 +372,7 @@ class DeploymentProcessors:
         self.bulk_get_revisions = revisions.partial_bulk_get_ops(BulkGetRevisionsAction)
         self.bulk_get_replicas = replicas.partial_bulk_get_ops(BulkGetReplicasAction)
         routes: LookupFieldGroup[RouteInfo] = group.field_group(
-            FieldGroupMeta(REPLICA_FIELD_TYPE),
+            FieldGroupMeta(ReplicaFieldType()),
             RouteInfo,
             LookupReplicaOwnerAction,
             LookupBulkReplicaOwnerAction,

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/create.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalWithFieldsOpsAction
 from ai.backend.manager.data.deployment_revision_preset.types import (
@@ -40,7 +40,7 @@ class CreateDeploymentPresetAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_PRESET_ENTITY_TYPE
+        return DeploymentPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/lookup_slot_owner.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/lookup_slot_owner.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.deployment_preset import (
-    DEPLOYMENT_PRESET_ENTITY_TYPE,
+    DeploymentPresetEntityType,
     DeploymentPresetID,
 )
 from ai.backend.common.data.entity.preset_resource_slot import PresetResourceSlotID
@@ -44,7 +44,7 @@ class LookupPresetResourceSlotOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_PRESET_ENTITY_TYPE
+        return DeploymentPresetEntityType()
 
     @override
     @classmethod
@@ -75,7 +75,7 @@ class LookupBulkPresetResourceSlotOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_PRESET_ENTITY_TYPE
+        return DeploymentPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/search.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
@@ -24,7 +24,7 @@ class GlobalSearchDeploymentPresetsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_PRESET_ENTITY_TYPE
+        return DeploymentPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/search_resource_slots.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/search_resource_slots.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.deployment_preset import (
-    DEPLOYMENT_PRESET_ENTITY_TYPE,
+    DeploymentPresetEntityType,
     DeploymentPresetID,
 )
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
@@ -37,12 +37,12 @@ class SearchPresetResourceSlotsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_PRESET_ENTITY_TYPE
+        return DeploymentPresetEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
         return (
-            ScopeRef(scope_type=ScopeType(DEPLOYMENT_PRESET_ENTITY_TYPE), scope_id=self.preset_id),
+            ScopeRef(scope_type=ScopeType(DeploymentPresetEntityType()), scope_id=self.preset_id),
         )
 
     @override

--- a/src/ai/backend/manager/services/deployment_revision_preset/processors.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/processors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ai.backend.common.data.entity.preset_resource_slot import (
-    DEPLOYMENT_PRESET_RESOURCE_SLOT_FIELD_TYPE,
+    DeploymentPresetResourceSlotFieldType,
 )
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
@@ -81,7 +81,7 @@ class DeploymentPresetProcessors:
         self.purge = group.entity_purge_ops(PurgeDeploymentPresetAction)
 
         slots: LookupFieldGroup[PresetResourceSlotData] = group.field_group(
-            FieldGroupMeta(DEPLOYMENT_PRESET_RESOURCE_SLOT_FIELD_TYPE),
+            FieldGroupMeta(DeploymentPresetResourceSlotFieldType()),
             PresetResourceSlotData,
             LookupPresetResourceSlotOwnerAction,
             LookupBulkPresetResourceSlotOwnerAction,

--- a/src/ai/backend/manager/services/domain/actions/bulk_lookup.py
+++ b/src/ai/backend/manager/services/domain/actions/bulk_lookup.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID, DomainName
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID, DomainName
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import BulkLookupEntityOpsAction
 from ai.backend.manager.models.domain.lookups import DomainNamesLookup
@@ -20,7 +20,7 @@ class BulkLookupDomainsAction(BulkLookupEntityOpsAction[DomainName, DomainID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/domain/actions/create_domain.py
+++ b/src/ai/backend/manager/services/domain/actions/create_domain.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalRoleManagedEntityOpsAction
 from ai.backend.manager.data.domain.types import DomainData
@@ -18,7 +18,7 @@ class CreateDomainAction(CreateGlobalRoleManagedEntityOpsAction[DomainRow, Domai
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/domain/actions/create_domain_node.py
+++ b/src/ai/backend/manager/services/domain/actions/create_domain_node.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
@@ -21,7 +21,7 @@ class CreateDomainNodeAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/domain/actions/lookup.py
+++ b/src/ai/backend/manager/services/domain/actions/lookup.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID, DomainName
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID, DomainName
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
 from ai.backend.manager.actions.v2.ops.base import LookupEntityOpsAction
@@ -35,7 +35,7 @@ class LookupDomainAction(LookupEntityOpsAction[DomainRow, DomainID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/domain/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/domain/actions/scoped_search.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.resource_group import (
     RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
@@ -64,7 +64,7 @@ class ScopedSearchDomainsAction(OperationScopeOpsAction[DomainRow, DomainData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/domain/actions/search_domains.py
+++ b/src/ai/backend/manager/services/domain/actions/search_domains.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.domain.types import DomainData
@@ -18,7 +18,7 @@ class GlobalSearchDomainsAction(SearchGlobalOpsAction[DomainRow, DomainData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/entity_label/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/entity_label/actions/lookup_owner.py
@@ -6,8 +6,8 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.entity_label import EntityLabelID
 from ai.backend.common.data.entity.types import (
-    GLOBAL_ENTITY_TYPE,
     EntityType,
+    GlobalEntityType,
 )
 from ai.backend.manager.actions.v2.field.bulk_lookup import (
     LookupBulkRuntimeFieldOwnerOpsAction,
@@ -46,7 +46,7 @@ class LookupEntityLabelOwnerAction(LookupRuntimeFieldOwnerOpsAction[EntityLabelI
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod
@@ -75,7 +75,7 @@ class LookupBulkEntityLabelOwnerAction(LookupBulkRuntimeFieldOwnerOpsAction[Enti
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/entity_share/actions/answer.py
+++ b/src/ai/backend/manager/services/entity_share/actions/answer.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.entity_share import (
-    ENTITY_SHARE_ENTITY_TYPE,
+    EntityShareEntityType,
     EntityShareID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef, ScopeType
@@ -45,7 +45,7 @@ class _RecipientAnswerAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ENTITY_SHARE_ENTITY_TYPE
+        return EntityShareEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/entity_share/actions/create.py
+++ b/src/ai/backend/manager/services/entity_share/actions/create.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.entity_share import ENTITY_SHARE_ENTITY_TYPE
+from ai.backend.common.data.entity.entity_share import EntityShareEntityType
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
     EntityType,
@@ -39,7 +39,7 @@ class CreateEntityShareAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ENTITY_SHARE_ENTITY_TYPE
+        return EntityShareEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/entity_share/actions/search.py
+++ b/src/ai/backend/manager/services/entity_share/actions/search.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.entity_share import ENTITY_SHARE_ENTITY_TYPE
+from ai.backend.common.data.entity.entity_share import EntityShareEntityType
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
@@ -130,7 +130,7 @@ class SearchEntitySharesAction(OperationScopeOpsAction[EntityShareRow, EntitySha
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ENTITY_SHARE_ENTITY_TYPE
+        return EntityShareEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/etcd_config/actions/delete_config.py
+++ b/src/ai/backend/manager/services/etcd_config/actions/delete_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class DeleteConfigAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ETCD_CONFIG_ENTITY_TYPE
+        return EtcdConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/etcd_config/actions/get_config.py
+++ b/src/ai/backend/manager/services/etcd_config/actions/get_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class GetConfigAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ETCD_CONFIG_ENTITY_TYPE
+        return EtcdConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/etcd_config/actions/get_resource_metadata.py
+++ b/src/ai/backend/manager/services/etcd_config/actions/get_resource_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AcceleratorMetadata
 from ai.backend.manager.actions.types import ActionOperationType
@@ -19,7 +19,7 @@ class GetResourceMetadataAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ETCD_CONFIG_ENTITY_TYPE
+        return EtcdConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/etcd_config/actions/get_resource_slots.py
+++ b/src/ai/backend/manager/services/etcd_config/actions/get_resource_slots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -16,7 +16,7 @@ class GetResourceSlotsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ETCD_CONFIG_ENTITY_TYPE
+        return EtcdConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/etcd_config/actions/get_vfolder_types.py
+++ b/src/ai/backend/manager/services/etcd_config/actions/get_vfolder_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -16,7 +16,7 @@ class GetVfolderTypesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ETCD_CONFIG_ENTITY_TYPE
+        return EtcdConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/etcd_config/actions/set_config.py
+++ b/src/ai/backend/manager/services/etcd_config/actions/set_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class SetConfigAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ETCD_CONFIG_ENTITY_TYPE
+        return EtcdConfigEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/export/actions/base.py
+++ b/src/ai/backend/manager/services/export/actions/base.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.export import EXPORT_ENTITY_TYPE
+from ai.backend.common.data.entity.export import ExportEntityType
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
@@ -23,7 +23,7 @@ class ExportAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EXPORT_ENTITY_TYPE
+        return ExportEntityType()
 
 
 @dataclass
@@ -35,7 +35,7 @@ class ExportUserScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EXPORT_ENTITY_TYPE
+        return ExportEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -51,7 +51,7 @@ class ExportProjectScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EXPORT_ENTITY_TYPE
+        return ExportEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -68,7 +68,7 @@ class ExportDomainScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EXPORT_ENTITY_TYPE
+        return ExportEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -1,75 +1,75 @@
 from typing import Any
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.app_config import (
-    APP_CONFIG_ALLOW_LIST_ENTITY_TYPE,
-    APP_CONFIG_ENTITY_TYPE,
-    APP_CONFIG_FRAGMENT_ENTITY_TYPE,
+    AppConfigAllowListEntityType,
+    AppConfigEntityType,
+    AppConfigFragmentEntityType,
 )
-from ai.backend.common.data.entity.app_config_definition import APP_CONFIG_DEFINITION_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_registry import ARTIFACT_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
-from ai.backend.common.data.entity.audit_log import AUDIT_LOG_FIELD_TYPE
-from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
-from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
-from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.entity_label import ENTITY_LABEL_FIELD_TYPE
-from ai.backend.common.data.entity.entity_share import ENTITY_SHARE_ENTITY_TYPE
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
-from ai.backend.common.data.entity.export import EXPORT_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionEntityType
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
+from ai.backend.common.data.entity.audit_log import AuditLogFieldType
+from ai.backend.common.data.entity.auth import AuthEntityType
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyEntityType
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.entity_label import EntityLabelFieldType
+from ai.backend.common.data.entity.entity_share import EntityShareEntityType
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
+from ai.backend.common.data.entity.export import ExportEntityType
 from ai.backend.common.data.entity.fair_share import (
-    DOMAIN_FAIR_SHARE_ENTITY_TYPE,
-    PROJECT_FAIR_SHARE_ENTITY_TYPE,
-    USER_FAIR_SHARE_ENTITY_TYPE,
+    DomainFairShareEntityType,
+    ProjectFairShareEntityType,
+    UserFairShareEntityType,
 )
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
-from ai.backend.common.data.entity.image import IMAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.login_client_type import LOGIN_CLIENT_TYPE_ENTITY_TYPE
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
+from ai.backend.common.data.entity.image import ImageEntityType
+from ai.backend.common.data.entity.login_client_type import LoginClientTypeEntityType
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
 from ai.backend.common.data.entity.notification import (
-    NOTIFICATION_CHANNEL_ENTITY_TYPE,
-    NOTIFICATION_RULE_ENTITY_TYPE,
+    NotificationChannelEntityType,
+    NotificationRuleEntityType,
 )
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.common.data.entity.prometheus_query_preset_category import (
-    PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE,
+    PrometheusQueryPresetCategoryEntityType,
 )
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
-    PROJECT_RESOURCE_POLICY_ENTITY_TYPE,
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
+    ProjectResourcePolicyEntityType,
+    UserResourcePolicyEntityType,
 )
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
-from ai.backend.common.data.entity.retention_policy import RETENTION_POLICY_ENTITY_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.runtime_variant import RUNTIME_VARIANT_ENTITY_TYPE
-from ai.backend.common.data.entity.runtime_variant_preset import RUNTIME_VARIANT_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.secret import SECRET_ENTITY_TYPE
-from ai.backend.common.data.entity.service_catalog import SERVICE_CATALOG_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
-from ai.backend.common.data.entity.session_template import SESSION_TEMPLATE_ENTITY_TYPE
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
+from ai.backend.common.data.entity.retention_policy import RetentionPolicyEntityType
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantEntityType
+from ai.backend.common.data.entity.runtime_variant_preset import RuntimeVariantPresetEntityType
+from ai.backend.common.data.entity.secret import SecretEntityType
+from ai.backend.common.data.entity.service_catalog import ServiceCatalogEntityType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.session_template import SessionTemplateEntityType
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.common.data.entity.usage_bucket import (
-    DOMAIN_USAGE_BUCKET_FIELD_TYPE,
-    PROJECT_USAGE_BUCKET_FIELD_TYPE,
-    USER_USAGE_BUCKET_FIELD_TYPE,
+    DomainUsageBucketFieldType,
+    ProjectUsageBucketFieldType,
+    UserUsageBucketFieldType,
 )
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder_invitation import VFOLDER_INVITATION_ENTITY_TYPE
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
+from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationEntityType
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.action import RBAC_ACTION_REGISTRY
 from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -555,8 +555,8 @@ def create_processors(
     system_groups = registry.concern(ConcernMeta(Concern.SYSTEM))
     vfolder_groups = registry.concern(ConcernMeta(Concern.VFOLDER))
     visibility_groups = registry.concern(ConcernMeta(Concern.VISIBILITY))
-    artifact_revisions = artifact_groups.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+    artifact_revisions = artifact_groups.group(GroupMeta(ArtifactEntityType())).field_group(
+        FieldGroupMeta(ArtifactRevisionFieldType()),
         ArtifactRevisionData,
         LookupArtifactRevisionOwnerAction,
         LookupBulkArtifactRevisionOwnerAction,
@@ -566,256 +566,256 @@ def create_processors(
         event_fetcher=args.event_fetcher,
         events_service=services.events,
         agent=AgentProcessors(
-            resource_group_groups.group(GroupMeta(AGENT_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(AgentEntityType())),
             services.agent,
             action_monitors,
         ),
         app_config=AppConfigProcessors(
-            app_config_groups.group(GroupMeta(APP_CONFIG_ENTITY_TYPE)),
-            app_config_groups.group(GroupMeta(APP_CONFIG_DEFINITION_ENTITY_TYPE)),
-            app_config_groups.group(GroupMeta(APP_CONFIG_ALLOW_LIST_ENTITY_TYPE)),
-            app_config_groups.group(GroupMeta(APP_CONFIG_FRAGMENT_ENTITY_TYPE)),
+            app_config_groups.group(GroupMeta(AppConfigEntityType())),
+            app_config_groups.group(GroupMeta(AppConfigDefinitionEntityType())),
+            app_config_groups.group(GroupMeta(AppConfigAllowListEntityType())),
+            app_config_groups.group(GroupMeta(AppConfigFragmentEntityType())),
             services.app_config,
         ),
         domain=DomainProcessors(
-            organization_groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
+            organization_groups.group(GroupMeta(DomainEntityType())),
             services.domain,
             action_monitors,
         ),
         etcd_config=EtcdConfigProcessors(
-            system_groups.group(GroupMeta(ETCD_CONFIG_ENTITY_TYPE)), services.etcd_config
+            system_groups.group(GroupMeta(EtcdConfigEntityType())), services.etcd_config
         ),
         export=ExportProcessors(
-            visibility_groups.group(GroupMeta(EXPORT_ENTITY_TYPE)), services.export
+            visibility_groups.group(GroupMeta(ExportEntityType())), services.export
         ),
         fair_share=FairShareProcessors(
-            resource_group_groups.group(GroupMeta(DOMAIN_FAIR_SHARE_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(PROJECT_FAIR_SHARE_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(USER_FAIR_SHARE_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(DomainFairShareEntityType())),
+            resource_group_groups.group(GroupMeta(ProjectFairShareEntityType())),
+            resource_group_groups.group(GroupMeta(UserFairShareEntityType())),
             services.fair_share,
         ),
         project=ProjectProcessors(
-            organization_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)), services.project
+            organization_groups.group(GroupMeta(ProjectEntityType())), services.project
         ),
         user=UserProcessors(
-            organization_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+            organization_groups.group(GroupMeta(UserEntityType())),
             services.user,
         ),
         idle_checker=IdleCheckerProcessors(
-            session_groups.group(GroupMeta(IDLE_CHECKER_ENTITY_TYPE)),
-            session_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
+            session_groups.group(GroupMeta(IdleCheckerEntityType())),
+            session_groups.group(GroupMeta(SessionEntityType())),
             services.idle_checker,
         ),
         image=ImageProcessors(
-            container_registry_groups.group(GroupMeta(IMAGE_ENTITY_TYPE)), services.image
+            container_registry_groups.group(GroupMeta(ImageEntityType())), services.image
         ),
         container_registry=ContainerRegistryProcessors(
-            container_registry_groups.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)),
+            container_registry_groups.group(GroupMeta(ContainerRegistryEntityType())),
             services.container_registry,
         ),
         vfolder=VFolderProcessors(
-            vfolder_groups.group(GroupMeta(VFOLDER_ENTITY_TYPE)), services.vfolder
+            vfolder_groups.group(GroupMeta(VFolderEntityType())), services.vfolder
         ),
         vfolder_admin=VFolderAdminProcessors(
-            vfolder_groups.group(GroupMeta(VFOLDER_ENTITY_TYPE)), services.vfolder_admin
+            vfolder_groups.group(GroupMeta(VFolderEntityType())), services.vfolder_admin
         ),
         vfolder_file=VFolderFileProcessors(
-            vfolder_groups.group(GroupMeta(VFOLDER_ENTITY_TYPE)), services.vfolder_file
+            vfolder_groups.group(GroupMeta(VFolderEntityType())), services.vfolder_file
         ),
         vfolder_invite=VFolderInviteProcessors(
-            vfolder_groups.group(GroupMeta(VFOLDER_INVITATION_ENTITY_TYPE)),
+            vfolder_groups.group(GroupMeta(VFolderInvitationEntityType())),
             services.vfolder_invite,
         ),
         vfolder_sharing=VFolderSharingProcessors(
-            vfolder_groups.group(GroupMeta(VFOLDER_ENTITY_TYPE)), services.vfolder_sharing
+            vfolder_groups.group(GroupMeta(VFolderEntityType())), services.vfolder_sharing
         ),
         session=SessionProcessors(
-            session_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+            session_groups.group(GroupMeta(SessionEntityType())),
+            resource_group_groups.group(GroupMeta(ResourceGroupEntityType())),
             ResourceAllocationProcessors(
-                resource_group_groups.group(GroupMeta(USER_ENTITY_TYPE)),
-                resource_group_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-                resource_group_groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-                resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-                resource_group_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-                resource_group_groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+                resource_group_groups.group(GroupMeta(UserEntityType())),
+                resource_group_groups.group(GroupMeta(ProjectEntityType())),
+                resource_group_groups.group(GroupMeta(DomainEntityType())),
+                resource_group_groups.group(GroupMeta(ResourceGroupEntityType())),
+                resource_group_groups.group(GroupMeta(SessionEntityType())),
+                resource_group_groups.group(GroupMeta(ResourcePresetEntityType())),
                 services.resource_allocation,
             ),
             services.session,
         ),
         keypair_resource_policy=KeypairResourcePolicyProcessors(
-            resource_policy_groups.group(GroupMeta(KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE))
+            resource_policy_groups.group(GroupMeta(KeyPairResourcePolicyEntityType()))
         ),
         manager_admin=ManagerAdminProcessors(
-            system_groups.group(GroupMeta(MANAGER_ADMIN_ENTITY_TYPE)), services.manager_admin
+            system_groups.group(GroupMeta(ManagerAdminEntityType())), services.manager_admin
         ),
         secret=SecretProcessors(
-            system_groups.group(GroupMeta(SECRET_ENTITY_TYPE)), services.secret
+            system_groups.group(GroupMeta(SecretEntityType())), services.secret
         ),
         user_resource_policy=UserResourcePolicyProcessors(
-            resource_policy_groups.group(GroupMeta(USER_RESOURCE_POLICY_ENTITY_TYPE))
+            resource_policy_groups.group(GroupMeta(UserResourcePolicyEntityType()))
         ),
         project_resource_policy=ProjectResourcePolicyProcessors(
-            resource_policy_groups.group(GroupMeta(PROJECT_RESOURCE_POLICY_ENTITY_TYPE))
+            resource_policy_groups.group(GroupMeta(ProjectResourcePolicyEntityType()))
         ),
         prometheus_query_preset=PrometheusQueryPresetProcessors(
-            metric_groups.group(GroupMeta(PROMETHEUS_QUERY_PRESET_ENTITY_TYPE)),
+            metric_groups.group(GroupMeta(PrometheusQueryPresetEntityType())),
             services.prometheus_query_preset,
         ),
         prometheus_query_preset_category=PrometheusQueryPresetCategoryProcessors(
-            metric_groups.group(GroupMeta(PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE))
+            metric_groups.group(GroupMeta(PrometheusQueryPresetCategoryEntityType()))
         ),
         resource_preset=ResourcePresetProcessors(
-            resource_group_groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(ResourcePresetEntityType())),
             services.resource_preset,
         ),
         resource_slot=ResourceSlotProcessors(
-            system_groups.group(GroupMeta(RESOURCE_SLOT_TYPE_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(AGENT_ENTITY_TYPE)),
+            system_groups.group(GroupMeta(ResourceSlotTypeEntityType())),
+            resource_group_groups.group(GroupMeta(SessionEntityType())),
+            resource_group_groups.group(GroupMeta(AgentEntityType())),
             services.resource_slot,
         ),
         retention_policy=RetentionPolicyProcessors(
-            system_groups.group(GroupMeta(RETENTION_POLICY_ENTITY_TYPE))
+            system_groups.group(GroupMeta(RetentionPolicyEntityType()))
         ),
         role_preset=RolePresetProcessors(
-            rbac_groups.group(GroupMeta(ROLE_PRESET_ENTITY_TYPE)), services.role_preset
+            rbac_groups.group(GroupMeta(RolePresetEntityType())), services.role_preset
         ),
         runtime_variant=RuntimeVariantProcessors(
-            system_groups.group(GroupMeta(RUNTIME_VARIANT_ENTITY_TYPE))
+            system_groups.group(GroupMeta(RuntimeVariantEntityType()))
         ),
         client_ip_masking=ClientIPMaskingProcessors(
-            system_groups.group(GroupMeta(CLIENT_IP_MASKING_POLICY_ENTITY_TYPE))
+            system_groups.group(GroupMeta(ClientIPMaskingPolicyEntityType()))
         ),
         rbac=RbacProcessors(
             rbac_groups.relation_group(),
-            rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+            rbac_groups.group(GroupMeta(UserEntityType())),
             services.rbac_relation,
             services.rbac_roster,
             services.rbac_role,
             action_monitors,
         ),
         entity_share=EntityShareProcessors(
-            rbac_groups.group(GroupMeta(ENTITY_SHARE_ENTITY_TYPE)),
+            rbac_groups.group(GroupMeta(EntityShareEntityType())),
             services.entity_share,
         ),
         runtime_variant_preset=RuntimeVariantPresetProcessors(
-            system_groups.group(GroupMeta(RUNTIME_VARIANT_PRESET_ENTITY_TYPE)),
+            system_groups.group(GroupMeta(RuntimeVariantPresetEntityType())),
             services.runtime_variant_preset,
         ),
         deployment_revision_preset=DeploymentPresetProcessors(
-            deployment_groups.group(GroupMeta(DEPLOYMENT_PRESET_ENTITY_TYPE)),
+            deployment_groups.group(GroupMeta(DeploymentPresetEntityType())),
             services.deployment_revision_preset,
         ),
         model_card=ModelCardProcessors(
-            deployment_groups.group(GroupMeta(MODEL_CARD_ENTITY_TYPE)), services.model_card
+            deployment_groups.group(GroupMeta(ModelCardEntityType())), services.model_card
         ),
         resource_usage=ResourceUsageProcessors(
             resource_group_groups.dangling_field_group(
-                FieldGroupMeta(DOMAIN_USAGE_BUCKET_FIELD_TYPE), DomainUsageBucketData
+                FieldGroupMeta(DomainUsageBucketFieldType()), DomainUsageBucketData
             ),
             resource_group_groups.dangling_field_group(
-                FieldGroupMeta(PROJECT_USAGE_BUCKET_FIELD_TYPE), ProjectUsageBucketData
+                FieldGroupMeta(ProjectUsageBucketFieldType()), ProjectUsageBucketData
             ),
             resource_group_groups.dangling_field_group(
-                FieldGroupMeta(USER_USAGE_BUCKET_FIELD_TYPE), UserUsageBucketData
+                FieldGroupMeta(UserUsageBucketFieldType()), UserUsageBucketData
             ),
         ),
         resource_group=ResourceGroupProcessors(
-            resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(ResourceGroupEntityType())),
             services.resource_group,
         ),
         metric=MetricProcessors(
-            metric_groups.group(GroupMeta(PROMETHEUS_QUERY_PRESET_ENTITY_TYPE)),
-            metric_groups.group(GroupMeta(USER_ENTITY_TYPE)),
-            session_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
+            metric_groups.group(GroupMeta(PrometheusQueryPresetEntityType())),
+            metric_groups.group(GroupMeta(UserEntityType())),
+            session_groups.group(GroupMeta(SessionEntityType())),
             services.metric,
         ),
         model_serving=ModelServingProcessors(
-            deployment_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), services.model_serving
+            deployment_groups.group(GroupMeta(DeploymentEntityType())), services.model_serving
         ),
         model_serving_auto_scaling=ModelServingAutoScalingProcessors(
-            deployment_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+            deployment_groups.group(GroupMeta(DeploymentEntityType())),
             services.model_serving_auto_scaling,
         ),
         auth=AuthProcessors(
-            organization_groups.group(GroupMeta(AUTH_ENTITY_TYPE)),
-            organization_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+            organization_groups.group(GroupMeta(AuthEntityType())),
+            organization_groups.group(GroupMeta(UserEntityType())),
             services.auth,
         ),
         login_client_type=LoginClientTypeProcessors(
-            system_groups.group(GroupMeta(LOGIN_CLIENT_TYPE_ENTITY_TYPE))
+            system_groups.group(GroupMeta(LoginClientTypeEntityType()))
         ),
         notification=NotificationProcessors(
-            notification_groups.group(GroupMeta(NOTIFICATION_CHANNEL_ENTITY_TYPE)),
-            notification_groups.group(GroupMeta(NOTIFICATION_RULE_ENTITY_TYPE)),
+            notification_groups.group(GroupMeta(NotificationChannelEntityType())),
+            notification_groups.group(GroupMeta(NotificationRuleEntityType())),
             services.notification,
         ),
         object_storage=ObjectStorageProcessors(
-            artifact_groups.group(GroupMeta(OBJECT_STORAGE_ENTITY_TYPE)),
+            artifact_groups.group(GroupMeta(ObjectStorageEntityType())),
             artifact_revisions,
             services.object_storage,
         ),
         permission_controller=PermissionControllerProcessors(
-            rbac_groups.group(GroupMeta(ROLE_ENTITY_TYPE)),
+            rbac_groups.group(GroupMeta(RoleEntityType())),
             services.permission_controller,
             action_monitors,
             validators,
         ),
         vfs_storage=VFSStorageProcessors(
-            artifact_groups.group(GroupMeta(VFS_STORAGE_ENTITY_TYPE)), services.vfs_storage
+            artifact_groups.group(GroupMeta(VFSStorageEntityType())), services.vfs_storage
         ),
         artifact=ArtifactProcessors(
-            artifact_groups.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            artifact_groups.group(GroupMeta(ArtifactEntityType())),
             artifact_revisions,
             ArtifactRevisionProcessors(
-                artifact_groups.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+                artifact_groups.group(GroupMeta(ArtifactEntityType())),
                 artifact_revisions,
                 services.artifact_revision,
             ),
             services.artifact,
         ),
         artifact_registry=ArtifactRegistryProcessors(
-            artifact_groups.group(GroupMeta(ARTIFACT_REGISTRY_ENTITY_TYPE)),
+            artifact_groups.group(GroupMeta(ArtifactRegistryEntityType())),
             services.artifact_registry,
         ),
         deployment=DeploymentProcessors(
-            deployment_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), services.deployment
+            deployment_groups.group(GroupMeta(DeploymentEntityType())), services.deployment
         ),
         storage_namespace=StorageNamespaceProcessors(
-            artifact_groups.group(GroupMeta(STORAGE_NAMESPACE_ENTITY_TYPE))
+            artifact_groups.group(GroupMeta(StorageNamespaceEntityType()))
         ),
         audit_log=AuditLogProcessors(
             visibility_groups.dangling_field_group(
-                FieldGroupMeta(AUDIT_LOG_FIELD_TYPE), AuditLogData
+                FieldGroupMeta(AuditLogFieldType()), AuditLogData
             )
         ),
         entity_label=EntityLabelProcessors(
             registry.dangling_lookup_field_group(
-                FieldGroupMeta(ENTITY_LABEL_FIELD_TYPE),
+                FieldGroupMeta(EntityLabelFieldType()),
                 EntityLabelData,
                 LookupEntityLabelOwnerAction,
                 LookupBulkEntityLabelOwnerAction,
             )
         ),
         idle_checker_assignment=IdleCheckerAssignmentProcessors(
-            session_groups.group(GroupMeta(IDLE_CHECKER_ENTITY_TYPE)),
+            session_groups.group(GroupMeta(IdleCheckerEntityType())),
             services.idle_checker_assignment,
         ),
         scheduling_history=SchedulingHistoryProcessors(
-            session_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            deployment_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
-            deployment_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+            session_groups.group(GroupMeta(SessionEntityType())),
+            deployment_groups.group(GroupMeta(DeploymentEntityType())),
+            deployment_groups.group(GroupMeta(DeploymentEntityType())),
             services.scheduling_history,
         ),
         service_catalog=ServiceCatalogProcessors(
-            system_groups.group(GroupMeta(SERVICE_CATALOG_ENTITY_TYPE))
+            system_groups.group(GroupMeta(ServiceCatalogEntityType()))
         ),
         template=TemplateProcessors(
-            session_groups.group(GroupMeta(SESSION_TEMPLATE_ENTITY_TYPE)), services.template
+            session_groups.group(GroupMeta(SessionTemplateEntityType())), services.template
         ),
         stream=StreamProcessors(
-            session_groups.group(GroupMeta(SESSION_ENTITY_TYPE)), services.stream
+            session_groups.group(GroupMeta(SessionEntityType())), services.stream
         ),
     )
     return ProcessorsBundle(processors=processors, registry=registry)

--- a/src/ai/backend/manager/services/fair_share/actions.py
+++ b/src/ai/backend/manager/services/fair_share/actions.py
@@ -14,9 +14,9 @@ from decimal import Decimal
 from typing import override
 
 from ai.backend.common.data.entity.fair_share import (
-    DOMAIN_FAIR_SHARE_ENTITY_TYPE,
-    PROJECT_FAIR_SHARE_ENTITY_TYPE,
-    USER_FAIR_SHARE_ENTITY_TYPE,
+    DomainFairShareEntityType,
+    ProjectFairShareEntityType,
+    UserFairShareEntityType,
 )
 from ai.backend.common.data.entity.resource_group import (
     RESOURCE_GROUP_SCOPE_TYPE,
@@ -60,7 +60,7 @@ class DomainFairShareAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_FAIR_SHARE_ENTITY_TYPE
+        return DomainFairShareEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -100,7 +100,7 @@ class GlobalSearchDomainFairSharesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_FAIR_SHARE_ENTITY_TYPE
+        return DomainFairShareEntityType()
 
     @override
     @classmethod
@@ -207,7 +207,7 @@ class ProjectFairShareAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_FAIR_SHARE_ENTITY_TYPE
+        return ProjectFairShareEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -247,7 +247,7 @@ class GlobalSearchProjectFairSharesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_FAIR_SHARE_ENTITY_TYPE
+        return ProjectFairShareEntityType()
 
     @override
     @classmethod
@@ -356,7 +356,7 @@ class UserFairShareAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_FAIR_SHARE_ENTITY_TYPE
+        return UserFairShareEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -397,7 +397,7 @@ class GlobalSearchUserFairSharesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_FAIR_SHARE_ENTITY_TYPE
+        return UserFairShareEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/idle_checker/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/idle_checker/KNOWLEDGE.md
@@ -3,7 +3,7 @@ name: idle-checker-service-shapes
 type: decision-table
 description: idle_checker knowledge - why the definition catalog and the session exclude/include edits share one package, why two groups are wired, why create and update keep a service, why the purge is bulk while the API names one
 scope: src/ai/backend/manager/services/idle_checker
-keywords: [CreateIdleCheckerAction, UpdateIdleCheckerAction, BulkPurgeIdleCheckersAction, AdminSearchIdleCheckersAction, ExcludeSessionIdleChecksAction, IdleCheckerCreator, IdleCheckerUpdater, global_scope, global_partial_bulk_purge_ops, IDLE_CHECKER_ENTITY_TYPE]
+keywords: [CreateIdleCheckerAction, UpdateIdleCheckerAction, BulkPurgeIdleCheckersAction, AdminSearchIdleCheckersAction, ExcludeSessionIdleChecksAction, IdleCheckerCreator, IdleCheckerUpdater, global_scope, global_partial_bulk_purge_ops, IdleCheckerEntityType]
 sources:
   - src/ai/backend/manager/services/idle_checker
   - src/ai/backend/manager/api/adapters/idle_checker

--- a/src/ai/backend/manager/services/idle_checker/actions/admin_search.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/admin_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.idle_checker.types import IdleCheckerData
@@ -20,7 +20,7 @@ class AdminSearchIdleCheckersAction(SearchGlobalOpsAction[IdleCheckerRow, IdleCh
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/idle_checker/actions/create.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.idle_checker.types import IdleCheckerData
@@ -20,7 +20,7 @@ class CreateIdleCheckerAction(CreateGlobalOpsAction[IdleCheckerRow, IdleCheckerD
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/idle_checker/actions/update.py
+++ b/src/ai/backend/manager/services/idle_checker/actions/update.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import UpdateGlobalOpsAction
 from ai.backend.manager.data.idle_checker.types import IdleCheckerData
@@ -20,7 +20,7 @@ class UpdateIdleCheckerAction(UpdateGlobalOpsAction[IdleCheckerRow, IdleCheckerD
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/idle_checker_assignment/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/idle_checker_assignment/KNOWLEDGE.md
@@ -3,7 +3,7 @@ name: idle-checker-assignment-service-shapes
 type: decision-table
 description: idle_checker_assignment knowledge - why a binding is a relation and not an entity, why its writes are the rbac boundary's and only the reads stay here, why the id the API names is resolved by a lookup first, what a permission on a binding has to name, why enabled is the relation lifecycle
 scope: src/ai/backend/manager/services/idle_checker_assignment
-keywords: [CreateRelationAction, DeleteRelationAction, RestoreRelationAction, PurgeRelationAction, LookupIdleCheckerAssignmentAction, LookupIdleCheckerAssignmentByPairAction, ScopedSearchIdleCheckerAssignmentsAction, IdleCheckerAssignmentCreator, RelationCreator, RelationLifecycleUpdater, relation_group, IDLE_CHECKER_ENTITY_TYPE]
+keywords: [CreateRelationAction, DeleteRelationAction, RestoreRelationAction, PurgeRelationAction, LookupIdleCheckerAssignmentAction, LookupIdleCheckerAssignmentByPairAction, ScopedSearchIdleCheckerAssignmentsAction, IdleCheckerAssignmentCreator, RelationCreator, RelationLifecycleUpdater, relation_group, IdleCheckerEntityType]
 sources:
   - src/ai/backend/manager/services/idle_checker_assignment
   - src/ai/backend/manager/api/adapters/idle_checker_assignment

--- a/src/ai/backend/manager/services/idle_checker_assignment/actions/admin_search.py
+++ b/src/ai/backend/manager/services/idle_checker_assignment/actions/admin_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -20,7 +20,7 @@ class AdminSearchIdleCheckerAssignmentsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/idle_checker_assignment/actions/lookup.py
+++ b/src/ai/backend/manager/services/idle_checker_assignment/actions/lookup.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.idle_checker import (
-    IDLE_CHECKER_ENTITY_TYPE,
     IdleCheckerAssignmentID,
+    IdleCheckerEntityType,
     IdleCheckerID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
@@ -48,7 +48,7 @@ class LookupIdleCheckerAssignmentAction(BaseLookupAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod
@@ -100,7 +100,7 @@ class LookupIdleCheckerAssignmentByPairAction(BaseLookupAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/idle_checker_assignment/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/idle_checker_assignment/actions/scoped_search.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -31,7 +31,7 @@ class ScopedSearchIdleCheckerAssignmentsAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IDLE_CHECKER_ENTITY_TYPE
+        return IdleCheckerEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/image/actions/base.py
+++ b/src/ai/backend/manager/services/image/actions/base.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.image import IMAGE_ENTITY_TYPE, ImageID
+from ai.backend.common.data.entity.image import ImageEntityType, ImageID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -14,7 +14,7 @@ class ImageAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return IMAGE_ENTITY_TYPE
+        return ImageEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/keypair_resource_policy/actions/create_keypair_resource_policy.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/actions/create_keypair_resource_policy.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -26,7 +26,7 @@ class CreateKeyPairResourcePolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE
+        return KeyPairResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/keypair_resource_policy/actions/global_search_keypair_resource_policies.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/actions/global_search_keypair_resource_policies.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -26,7 +26,7 @@ class GlobalSearchKeypairResourcePoliciesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE
+        return KeyPairResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/keypair_resource_policy/actions/lookup.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
     KeyPairResourcePolicyUUID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -42,7 +42,7 @@ class LookupKeypairResourcePolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE
+        return KeyPairResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/keypair_resource_policy/actions/search_keypair_resource_policies.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/actions/search_keypair_resource_policies.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
@@ -34,7 +34,7 @@ class SearchKeypairResourcePoliciesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE
+        return KeyPairResourcePolicyEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/login_client_type/actions/create.py
+++ b/src/ai/backend/manager/services/login_client_type/actions/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.login_client_type import LOGIN_CLIENT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.login_client_type import LoginClientTypeEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
@@ -20,7 +20,7 @@ class CreateLoginClientTypeAction(CreateGlobalOpsAction[LoginClientTypeRow, Logi
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return LOGIN_CLIENT_TYPE_ENTITY_TYPE
+        return LoginClientTypeEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/login_client_type/actions/search.py
+++ b/src/ai/backend/manager/services/login_client_type/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.login_client_type import LOGIN_CLIENT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.login_client_type import LoginClientTypeEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.login_client_type.types import LoginClientTypeData
@@ -20,7 +20,7 @@ class SearchLoginClientTypesAction(SearchGlobalOpsAction[LoginClientTypeRow, Log
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return LOGIN_CLIENT_TYPE_ENTITY_TYPE
+        return LoginClientTypeEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/manager_admin/actions/fetch_status.py
+++ b/src/ai/backend/manager/services/manager_admin/actions/fetch_status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -16,7 +16,7 @@ class FetchManagerStatusAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MANAGER_ADMIN_ENTITY_TYPE
+        return ManagerAdminEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/manager_admin/actions/get_announcement.py
+++ b/src/ai/backend/manager/services/manager_admin/actions/get_announcement.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -16,7 +16,7 @@ class GetAnnouncementAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MANAGER_ADMIN_ENTITY_TYPE
+        return ManagerAdminEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/manager_admin/actions/get_db_cxn_status.py
+++ b/src/ai/backend/manager/services/manager_admin/actions/get_db_cxn_status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import override
 
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -17,7 +17,7 @@ class GetDbCxnStatusAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MANAGER_ADMIN_ENTITY_TYPE
+        return ManagerAdminEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/manager_admin/actions/perform_scheduler_ops.py
+++ b/src/ai/backend/manager/services/manager_admin/actions/perform_scheduler_ops.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class PerformSchedulerOpsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MANAGER_ADMIN_ENTITY_TYPE
+        return ManagerAdminEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/manager_admin/actions/update_announcement.py
+++ b/src/ai/backend/manager/services/manager_admin/actions/update_announcement.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class UpdateAnnouncementAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MANAGER_ADMIN_ENTITY_TYPE
+        return ManagerAdminEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/manager_admin/actions/update_status.py
+++ b/src/ai/backend/manager/services/manager_admin/actions/update_status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class UpdateManagerStatusAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MANAGER_ADMIN_ENTITY_TYPE
+        return ManagerAdminEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/metric/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/metric/KNOWLEDGE.md
@@ -10,7 +10,7 @@ keywords:
   - PublicSearchContainerMetricMetadataAction
   - BatchGetKernelLiveStatsAction
   - LookupBulkKernelOwnerAction
-  - PROMETHEUS_QUERY_PRESET_ENTITY_TYPE
+  - PrometheusQueryPresetEntityType
   - PublicActionProcessor
   - Concern.METRIC
 sources:

--- a/src/ai/backend/manager/services/metric/actions/base.py
+++ b/src/ai/backend/manager/services/metric/actions/base.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
@@ -21,7 +21,7 @@ class QueryMetricAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_ENTITY_TYPE
+        return PrometheusQueryPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/model_card/actions/base.py
+++ b/src/ai/backend/manager/services/model_card/actions/base.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE, ModelCardID
+from ai.backend.common.data.entity.model_card import ModelCardEntityType, ModelCardID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -17,7 +17,7 @@ class ModelCardAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
 
 @dataclass
@@ -27,7 +27,7 @@ class ModelCardScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/model_card/actions/create.py
+++ b/src/ai/backend/manager/services/model_card/actions/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import CreateEntityWithFieldsOpsAction
@@ -38,7 +38,7 @@ class CreateModelCardAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/model_card/actions/lookup_requirement_owner.py
+++ b/src/ai/backend/manager/services/model_card/actions/lookup_requirement_owner.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE, ModelCardID
+from ai.backend.common.data.entity.model_card import ModelCardEntityType, ModelCardID
 from ai.backend.common.data.entity.model_card_resource_requirement import (
     ModelCardResourceRequirementID,
 )
@@ -43,7 +43,7 @@ class LookupModelCardResourceRequirementOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
     @override
     @classmethod
@@ -74,7 +74,7 @@ class LookupBulkModelCardResourceRequirementOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/model_card/actions/search.py
+++ b/src/ai/backend/manager/services/model_card/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.model_card.types import ModelCardData
@@ -20,7 +20,7 @@ class GlobalSearchModelCardsAction(SearchGlobalOpsAction[ModelCardRow, ModelCard
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/model_card/actions/search_in_project.py
+++ b/src/ai/backend/manager/services/model_card/actions/search_in_project.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
@@ -25,7 +25,7 @@ class SearchModelCardsInProjectAction(OperationScopeOpsAction[ModelCardRow, Mode
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return MODEL_CARD_ENTITY_TYPE
+        return ModelCardEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/model_card/processors.py
+++ b/src/ai/backend/manager/services/model_card/processors.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from ai.backend.common.data.entity.model_card import ModelCardID
 from ai.backend.common.data.entity.model_card_resource_requirement import (
-    MODEL_CARD_RESOURCE_REQUIREMENT_FIELD_TYPE,
+    ModelCardResourceRequirementFieldType,
 )
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
@@ -96,7 +96,7 @@ class ModelCardProcessors:
         )
 
         requirements: LookupFieldGroup[ModelCardResourceRequirementData] = group.field_group(
-            FieldGroupMeta(MODEL_CARD_RESOURCE_REQUIREMENT_FIELD_TYPE),
+            FieldGroupMeta(ModelCardResourceRequirementFieldType()),
             ModelCardResourceRequirementData,
             LookupModelCardResourceRequirementOwnerAction,
             LookupBulkModelCardResourceRequirementOwnerAction,

--- a/src/ai/backend/manager/services/model_serving/actions/base.py
+++ b/src/ai/backend/manager/services/model_serving/actions/base.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -31,7 +31,7 @@ class ModelServiceScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/notification/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/notification/KNOWLEDGE.md
@@ -3,7 +3,7 @@ name: notification-service-shapes
 type: decision-table
 description: notification knowledge: why channels and rules are two entity types in one package, which three operations keep a service and why, what a rule read returns
 scope: src/ai/backend/manager/services/notification
-keywords: [CreateChannelAction, CreateRuleAction, ValidateChannelAction, ValidateRuleAction, ProcessNotificationAction, MatchingNotificationRuleData, global_create_ops, global_scope, NOTIFICATION_CHANNEL_ENTITY_TYPE, NOTIFICATION_RULE_ENTITY_TYPE]
+keywords: [CreateChannelAction, CreateRuleAction, ValidateChannelAction, ValidateRuleAction, ProcessNotificationAction, MatchingNotificationRuleData, global_create_ops, global_scope, NotificationChannelEntityType, NotificationRuleEntityType]
 sources:
   - src/ai/backend/manager/services/notification
   - src/ai/backend/manager/api/rest/v2/notification

--- a/src/ai/backend/manager/services/notification/actions/create_channel.py
+++ b/src/ai/backend/manager/services/notification/actions/create_channel.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.notification import NOTIFICATION_CHANNEL_ENTITY_TYPE
+from ai.backend.common.data.entity.notification import NotificationChannelEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.notification.types import NotificationChannelData
@@ -20,7 +20,7 @@ class CreateChannelAction(CreateGlobalOpsAction[NotificationChannelRow, Notifica
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return NOTIFICATION_CHANNEL_ENTITY_TYPE
+        return NotificationChannelEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/notification/actions/create_rule.py
+++ b/src/ai/backend/manager/services/notification/actions/create_rule.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.notification import NOTIFICATION_RULE_ENTITY_TYPE
+from ai.backend.common.data.entity.notification import NotificationRuleEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.notification.types import NotificationRuleData
@@ -20,7 +20,7 @@ class CreateRuleAction(CreateGlobalOpsAction[NotificationRuleRow, NotificationRu
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return NOTIFICATION_RULE_ENTITY_TYPE
+        return NotificationRuleEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/notification/actions/list_channels.py
+++ b/src/ai/backend/manager/services/notification/actions/list_channels.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.notification import NOTIFICATION_CHANNEL_ENTITY_TYPE
+from ai.backend.common.data.entity.notification import NotificationChannelEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.notification.types import NotificationChannelData
@@ -20,7 +20,7 @@ class SearchChannelsAction(SearchGlobalOpsAction[NotificationChannelRow, Notific
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return NOTIFICATION_CHANNEL_ENTITY_TYPE
+        return NotificationChannelEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/notification/actions/list_rules.py
+++ b/src/ai/backend/manager/services/notification/actions/list_rules.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.notification import NOTIFICATION_RULE_ENTITY_TYPE
+from ai.backend.common.data.entity.notification import NotificationRuleEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.notification.types import NotificationRuleData
@@ -20,7 +20,7 @@ class SearchRulesAction(SearchGlobalOpsAction[NotificationRuleRow, NotificationR
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return NOTIFICATION_RULE_ENTITY_TYPE
+        return NotificationRuleEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/notification/actions/process_notification.py
+++ b/src/ai/backend/manager/services/notification/actions/process_notification.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import override
 from uuid import UUID
 
-from ai.backend.common.data.entity.notification import NOTIFICATION_RULE_ENTITY_TYPE
+from ai.backend.common.data.entity.notification import NotificationRuleEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.notification import NotifiableMessage, NotificationRuleType
 from ai.backend.manager.actions.types import ActionOperationType
@@ -30,7 +30,7 @@ class ProcessNotificationAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return NOTIFICATION_RULE_ENTITY_TYPE
+        return NotificationRuleEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/object_storage/actions/create.py
+++ b/src/ai/backend/manager/services/object_storage/actions/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.object_storage.types import ObjectStorageData
@@ -20,7 +20,7 @@ class CreateObjectStorageAction(CreateGlobalOpsAction[ObjectStorageRow, ObjectSt
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return OBJECT_STORAGE_ENTITY_TYPE
+        return ObjectStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/object_storage/actions/list.py
+++ b/src/ai/backend/manager/services/object_storage/actions/list.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.object_storage.types import ObjectStorageData
@@ -20,7 +20,7 @@ class ListObjectStorageAction(SearchGlobalOpsAction[ObjectStorageRow, ObjectStor
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return OBJECT_STORAGE_ENTITY_TYPE
+        return ObjectStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/object_storage/actions/search.py
+++ b/src/ai/backend/manager/services/object_storage/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.object_storage.types import ObjectStorageData
@@ -20,7 +20,7 @@ class SearchObjectStoragesAction(SearchGlobalOpsAction[ObjectStorageRow, ObjectS
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return OBJECT_STORAGE_ENTITY_TYPE
+        return ObjectStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/actions/create_role.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/create_role.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.v2.ops.base import CreateEntityOpsAction
 from ai.backend.manager.data.permission.role import RoleData
@@ -19,7 +19,7 @@ class CreateRoleAction(CreateEntityOpsAction[RoleRow, RoleData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_ENTITY_TYPE
+        return RoleEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/permission_contoller/actions/lookup_permission_owner.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/lookup_permission_owner.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.permission import PermissionID
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE, RoleID
+from ai.backend.common.data.entity.role import RoleEntityType, RoleID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
@@ -37,7 +37,7 @@ class LookupRolePermissionOwnerAction(LookupFieldOwnerOpsAction[PermissionID, Ro
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_ENTITY_TYPE
+        return RoleEntityType()
 
     @override
     @classmethod
@@ -66,7 +66,7 @@ class LookupBulkRolePermissionOwnerAction(LookupBulkFieldOwnerOpsAction[Permissi
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_ENTITY_TYPE
+        return RoleEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/processors.py
+++ b/src/ai/backend/manager/services/permission_contoller/processors.py
@@ -1,4 +1,4 @@
-from ai.backend.common.data.entity.permission import PERMISSION_FIELD_TYPE
+from ai.backend.common.data.entity.permission import PermissionFieldType
 from ai.backend.manager.actions.monitors.monitor import ActionMonitor
 from ai.backend.manager.actions.processor import ActionProcessor
 from ai.backend.manager.actions.processor.scope import ScopeActionProcessor
@@ -142,7 +142,7 @@ class PermissionControllerProcessors:
             service.search_users_assigned_to_role, action_monitors
         )
         permissions: LookupFieldGroup[PermissionData] = role_group.field_group(
-            FieldGroupMeta(PERMISSION_FIELD_TYPE),
+            FieldGroupMeta(PermissionFieldType()),
             PermissionData,
             LookupRolePermissionOwnerAction,
             LookupBulkRolePermissionOwnerAction,

--- a/src/ai/backend/manager/services/project/actions/create_project.py
+++ b/src/ai/backend/manager/services/project/actions/create_project.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import CreateRoleManagedEntityOpsAction
 from ai.backend.manager.data.project.types import ProjectData
@@ -21,7 +21,7 @@ class CreateProjectAction(CreateRoleManagedEntityOpsAction[ProjectRow, ProjectDa
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/project/actions/lookup.py
+++ b/src/ai/backend/manager/services/project/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.domain import DomainName
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
 from ai.backend.manager.actions.v2.ops.base import LookupEntityOpsAction
@@ -38,7 +38,7 @@ class LookupProjectAction(LookupEntityOpsAction[ProjectRow, ProjectID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/project/actions/scoped_search.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
@@ -91,7 +91,7 @@ class ScopedSearchProjectsAction(OperationScopeOpsAction[ProjectRow, ProjectData
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project/actions/search_projects.py
+++ b/src/ai/backend/manager/services/project/actions/search_projects.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import (
     GetSingleEntityOpsAction,
@@ -26,7 +26,7 @@ class GlobalSearchProjectsAction(SearchGlobalOpsAction[ProjectRow, ProjectData])
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project/actions/usage_per_month.py
+++ b/src/ai/backend/manager/services/project/actions/usage_per_month.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, override
 from uuid import UUID
 
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -18,7 +18,7 @@ class UsagePerMonthAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project/actions/usage_per_period.py
+++ b/src/ai/backend/manager/services/project/actions/usage_per_period.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Any, override
 from uuid import UUID
 
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -19,7 +19,7 @@ class UsagePerPeriodAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project_resource_policy/actions/create_project_resource_policy.py
+++ b/src/ai/backend/manager/services/project_resource_policy/actions/create_project_resource_policy.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    PROJECT_RESOURCE_POLICY_ENTITY_TYPE,
+    ProjectResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -26,7 +26,7 @@ class CreateProjectResourcePolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_RESOURCE_POLICY_ENTITY_TYPE
+        return ProjectResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project_resource_policy/actions/lookup.py
+++ b/src/ai/backend/manager/services/project_resource_policy/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.resource_policy import (
-    PROJECT_RESOURCE_POLICY_ENTITY_TYPE,
+    ProjectResourcePolicyEntityType,
     ProjectResourcePolicyUUID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -42,7 +42,7 @@ class LookupProjectResourcePolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_RESOURCE_POLICY_ENTITY_TYPE
+        return ProjectResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project_resource_policy/actions/search_project_resource_policies.py
+++ b/src/ai/backend/manager/services/project_resource_policy/actions/search_project_resource_policies.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    PROJECT_RESOURCE_POLICY_ENTITY_TYPE,
+    ProjectResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -26,7 +26,7 @@ class SearchProjectResourcePoliciesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_RESOURCE_POLICY_ENTITY_TYPE
+        return ProjectResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/prometheus_query_preset/actions/base.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/actions/base.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -18,4 +18,4 @@ class PrometheusQueryPresetGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_ENTITY_TYPE
+        return PrometheusQueryPresetEntityType()

--- a/src/ai/backend/manager/services/prometheus_query_preset/actions/create.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/actions/create.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -26,7 +26,7 @@ class CreatePresetAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_ENTITY_TYPE
+        return PrometheusQueryPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/prometheus_query_preset/actions/search.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset/actions/search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -26,7 +26,7 @@ class SearchPresetsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_ENTITY_TYPE
+        return PrometheusQueryPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/prometheus_query_preset_category/actions/create.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset_category/actions/create.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.prometheus_query_preset_category import (
-    PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE,
+    PrometheusQueryPresetCategoryEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -30,7 +30,7 @@ class CreateCategoryAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE
+        return PrometheusQueryPresetCategoryEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/prometheus_query_preset_category/actions/search.py
+++ b/src/ai/backend/manager/services/prometheus_query_preset_category/actions/search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.prometheus_query_preset_category import (
-    PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE,
+    PrometheusQueryPresetCategoryEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -30,7 +30,7 @@ class SearchCategoriesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE
+        return PrometheusQueryPresetCategoryEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/rbac/actions/roster/base.py
+++ b/src/ai/backend/manager/services/rbac/actions/roster/base.py
@@ -4,7 +4,7 @@ from typing import override
 
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 
 __all__ = ("ProjectRosterAction",)
@@ -29,4 +29,4 @@ class ProjectRosterAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()

--- a/src/ai/backend/manager/services/resource_group/actions/base.py
+++ b/src/ai/backend/manager/services/resource_group/actions/base.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
@@ -28,4 +28,4 @@ class ResourceGroupGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_GROUP_ENTITY_TYPE
+        return ResourceGroupEntityType()

--- a/src/ai/backend/manager/services/resource_group/actions/bulk_lookup.py
+++ b/src/ai/backend/manager/services/resource_group/actions/bulk_lookup.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupID,
     ResourceGroupName,
 )
@@ -28,7 +28,7 @@ class BulkLookupResourceGroupsAction(BulkLookupEntityOpsAction[ResourceGroupName
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_GROUP_ENTITY_TYPE
+        return ResourceGroupEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_group/actions/lookup.py
+++ b/src/ai/backend/manager/services/resource_group/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupID,
     ResourceGroupName,
 )
@@ -39,7 +39,7 @@ class LookupResourceGroupAction(LookupEntityOpsAction[ResourceGroupRow, Resource
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_GROUP_ENTITY_TYPE
+        return ResourceGroupEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_group/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/resource_group/actions/scoped_search.py
@@ -9,7 +9,7 @@ from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
@@ -103,7 +103,7 @@ class ScopedSearchResourceGroupsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_GROUP_ENTITY_TYPE
+        return ResourceGroupEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_preset/actions/base.py
+++ b/src/ai/backend/manager/services/resource_preset/actions/base.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -17,4 +17,4 @@ class ResourcePresetAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_PRESET_ENTITY_TYPE
+        return ResourcePresetEntityType()

--- a/src/ai/backend/manager/services/resource_preset/actions/lookup.py
+++ b/src/ai/backend/manager/services/resource_preset/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.resource_preset import (
-    RESOURCE_PRESET_ENTITY_TYPE,
+    ResourcePresetEntityType,
     ResourcePresetID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -41,7 +41,7 @@ class LookupResourcePresetAction(LookupEntityOpsAction[ResourcePresetRow, Resour
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_PRESET_ENTITY_TYPE
+        return ResourcePresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/create.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
@@ -22,7 +22,7 @@ class CreateResourceSlotTypeAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
+        return ResourceSlotTypeEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/get_domain_resource_overview.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/get_domain_resource_overview.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -27,7 +27,7 @@ class GetDomainResourceOverviewAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/resource_slot/actions/get_project_resource_overview.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/get_project_resource_overview.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -22,7 +22,7 @@ class GetProjectResourceOverviewAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/resource_slot/actions/lookup.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.resource_slot import (
-    RESOURCE_SLOT_TYPE_ENTITY_TYPE,
+    ResourceSlotTypeEntityType,
     ResourceSlotTypeUUID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -40,7 +40,7 @@ class LookupResourceSlotTypeAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
+        return ResourceSlotTypeEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/lookup_kernel_owner.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/lookup_kernel_owner.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.kernel import KernelID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerByKeyOpsAction
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -35,7 +35,7 @@ class LookupKernelOwnerAction(LookupFieldOwnerByKeyOpsAction[SessionID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/search_agent_resources.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/search_agent_resources.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -20,7 +20,7 @@ class GlobalSearchAgentResourcesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return AGENT_ENTITY_TYPE
+        return AgentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/search_resource_allocations.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/search_resource_allocations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -20,7 +20,7 @@ class GlobalSearchResourceAllocationsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/search_resource_slot_types.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/search_resource_slot_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
@@ -22,7 +22,7 @@ class SearchResourceSlotTypesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
+        return ResourceSlotTypeEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/update.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/update.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import UpdateGlobalOpsAction
 from ai.backend.manager.data.resource_slot.types import ResourceSlotTypeData
@@ -26,7 +26,7 @@ class UpdateResourceSlotTypeAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_SLOT_TYPE_ENTITY_TYPE
+        return ResourceSlotTypeEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/global_search_domain_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/global_search_domain_usage_buckets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.resource_usage_history.types import DomainUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import DomainUsageBucketRow
@@ -23,7 +23,7 @@ class GlobalSearchDomainUsageBucketsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/global_search_project_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/global_search_project_usage_buckets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.resource_usage_history.types import ProjectUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import ProjectUsageBucketRow
@@ -23,7 +23,7 @@ class GlobalSearchProjectUsageBucketsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/global_search_user_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/global_search_user_usage_buckets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.resource_usage_history.types import UserUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import UserUsageBucketRow
@@ -23,7 +23,7 @@ class GlobalSearchUserUsageBucketsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import DomainUsageBucketData
@@ -30,7 +30,7 @@ class SearchDomainUsageBucketsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DOMAIN_ENTITY_TYPE
+        return DomainEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import ProjectUsageBucketData
@@ -30,7 +30,7 @@ class SearchProjectUsageBucketsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return PROJECT_ENTITY_TYPE
+        return ProjectEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import UserUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import UserUsageBucketRow
@@ -30,7 +30,7 @@ class SearchUserUsageBucketsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/retention_policy/actions/create.py
+++ b/src/ai/backend/manager/services/retention_policy/actions/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.retention_policy import RETENTION_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.retention_policy import RetentionPolicyEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.retention.types import RetentionPolicyData
@@ -20,7 +20,7 @@ class CreateRetentionPolicyAction(CreateGlobalOpsAction[RetentionPolicyRow, Rete
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RETENTION_POLICY_ENTITY_TYPE
+        return RetentionPolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/retention_policy/actions/search.py
+++ b/src/ai/backend/manager/services/retention_policy/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.retention_policy import RETENTION_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.retention_policy import RetentionPolicyEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.retention.types import RetentionPolicyData
@@ -20,7 +20,7 @@ class SearchRetentionPoliciesAction(SearchGlobalOpsAction[RetentionPolicyRow, Re
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RETENTION_POLICY_ENTITY_TYPE
+        return RetentionPolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/role_preset/actions/create.py
+++ b/src/ai/backend/manager/services/role_preset/actions/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalWithFieldsOpsAction
 from ai.backend.manager.data.role_preset.types import (
@@ -39,7 +39,7 @@ class CreateRolePresetAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_PRESET_ENTITY_TYPE
+        return RolePresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/role_preset/actions/lookup_permission_owner.py
+++ b/src/ai/backend/manager/services/role_preset/actions/lookup_permission_owner.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.role_permission_preset import RolePermissionPresetID
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE, RolePresetID
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
@@ -41,7 +41,7 @@ class LookupRolePermissionPresetOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_PRESET_ENTITY_TYPE
+        return RolePresetEntityType()
 
     @override
     @classmethod
@@ -72,7 +72,7 @@ class LookupBulkRolePermissionPresetOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_PRESET_ENTITY_TYPE
+        return RolePresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/role_preset/actions/search.py
+++ b/src/ai/backend/manager/services/role_preset/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.role_preset.types import RolePresetData
@@ -20,7 +20,7 @@ class SearchRolePresetsAction(SearchGlobalOpsAction[RolePresetRow, RolePresetDat
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_PRESET_ENTITY_TYPE
+        return RolePresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/role_preset/actions/search_permission_presets.py
+++ b/src/ai/backend/manager/services/role_preset/actions/search_permission_presets.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE, RolePresetID
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.role_preset.types import RolePermissionPresetData
@@ -36,11 +36,11 @@ class SearchRolePermissionPresetsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return ROLE_PRESET_ENTITY_TYPE
+        return RolePresetEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=ScopeType(ROLE_PRESET_ENTITY_TYPE), scope_id=self.preset_id),)
+        return (ScopeRef(scope_type=ScopeType(RolePresetEntityType()), scope_id=self.preset_id),)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/role_preset/processors.py
+++ b/src/ai/backend/manager/services/role_preset/processors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ai.backend.common.data.entity.role_permission_preset import (
-    ROLE_PERMISSION_PRESET_FIELD_TYPE,
+    RolePermissionPresetFieldType,
 )
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
@@ -100,7 +100,7 @@ class RolePresetProcessors:
         self.bulk_purge = preset_group.global_partial_bulk_purge_ops(BulkPurgeRolePresetsAction)
 
         permissions: LookupFieldGroup[RolePermissionPresetData] = preset_group.field_group(
-            FieldGroupMeta(ROLE_PERMISSION_PRESET_FIELD_TYPE),
+            FieldGroupMeta(RolePermissionPresetFieldType()),
             RolePermissionPresetData,
             LookupRolePermissionPresetOwnerAction,
             LookupBulkRolePermissionPresetOwnerAction,

--- a/src/ai/backend/manager/services/runtime_variant/actions/create.py
+++ b/src/ai/backend/manager/services/runtime_variant/actions/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.runtime_variant import RUNTIME_VARIANT_ENTITY_TYPE
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
@@ -20,7 +20,7 @@ class CreateRuntimeVariantAction(CreateGlobalOpsAction[RuntimeVariantRow, Runtim
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RUNTIME_VARIANT_ENTITY_TYPE
+        return RuntimeVariantEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/runtime_variant/actions/lookup.py
+++ b/src/ai/backend/manager/services/runtime_variant/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.runtime_variant import (
-    RUNTIME_VARIANT_ENTITY_TYPE,
+    RuntimeVariantEntityType,
     RuntimeVariantID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -42,7 +42,7 @@ class LookupRuntimeVariantAction(LookupEntityOpsAction[RuntimeVariantRow, Runtim
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RUNTIME_VARIANT_ENTITY_TYPE
+        return RuntimeVariantEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/runtime_variant/actions/search.py
+++ b/src/ai/backend/manager/services/runtime_variant/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.runtime_variant import RUNTIME_VARIANT_ENTITY_TYPE
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.runtime_variant.types import RuntimeVariantData
@@ -20,7 +20,7 @@ class SearchRuntimeVariantsAction(SearchGlobalOpsAction[RuntimeVariantRow, Runti
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RUNTIME_VARIANT_ENTITY_TYPE
+        return RuntimeVariantEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/runtime_variant_preset/actions/base.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/actions/base.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.runtime_variant_preset import (
-    RUNTIME_VARIANT_PRESET_ENTITY_TYPE,
+    RuntimeVariantPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -21,4 +21,4 @@ class RuntimeVariantPresetGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RUNTIME_VARIANT_PRESET_ENTITY_TYPE
+        return RuntimeVariantPresetEntityType()

--- a/src/ai/backend/manager/services/runtime_variant_preset/actions/create.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/actions/create.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.runtime_variant_preset import (
-    RUNTIME_VARIANT_PRESET_ENTITY_TYPE,
+    RuntimeVariantPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -24,7 +24,7 @@ class CreateRuntimeVariantPresetAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RUNTIME_VARIANT_PRESET_ENTITY_TYPE
+        return RuntimeVariantPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/runtime_variant_preset/actions/search.py
+++ b/src/ai/backend/manager/services/runtime_variant_preset/actions/search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.runtime_variant_preset import (
-    RUNTIME_VARIANT_PRESET_ENTITY_TYPE,
+    RuntimeVariantPresetEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -26,7 +26,7 @@ class SearchRuntimeVariantPresetsAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RUNTIME_VARIANT_PRESET_ENTITY_TYPE
+        return RuntimeVariantPresetEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/global_search_replica_group_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/global_search_replica_group_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import GLOBAL_ENTITY_TYPE, EntityType
+from ai.backend.common.data.entity.types import EntityType, GlobalEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.data.deployment.types import ReplicaGroupHistoryData
@@ -19,7 +19,7 @@ class GlobalSearchReplicaGroupHistoryAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return GLOBAL_ENTITY_TYPE
+        return GlobalEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/lookup_owner.py
@@ -6,11 +6,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.deployment_history import DeploymentHistoryID
 from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.data.entity.route_history import RouteHistoryID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.session_scheduling_history import SessionSchedulingHistoryID
 from ai.backend.common.data.entity.types import EntityType, FieldIdentifier
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
@@ -50,7 +50,7 @@ class LookupSessionSchedulingHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod
@@ -81,7 +81,7 @@ class LookupBulkSessionSchedulingHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod
@@ -112,7 +112,7 @@ class LookupKernelSchedulingHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod
@@ -143,7 +143,7 @@ class LookupBulkKernelSchedulingHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod
@@ -174,7 +174,7 @@ class LookupDeploymentHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -205,7 +205,7 @@ class LookupBulkDeploymentHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -234,7 +234,7 @@ class LookupRouteHistoryOwnerAction(LookupFieldOwnerOpsAction[RouteHistoryID, De
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod
@@ -265,7 +265,7 @@ class LookupBulkRouteHistoryOwnerAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/scoped_search_replica_group_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/scoped_search_replica_group_history.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.deployment import (
-    DEPLOYMENT_ENTITY_TYPE,
     DEPLOYMENT_SCOPE_TYPE,
+    DeploymentEntityType,
     DeploymentID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
@@ -63,7 +63,7 @@ class ScopedSearchReplicaGroupHistoryAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_deployment_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_deployment_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.types import DeploymentHistoryData
@@ -21,7 +21,7 @@ class SearchDeploymentHistoryAction(SchedulingHistoryAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_deployment_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_deployment_scoped_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.types import DeploymentHistoryData
@@ -27,7 +27,7 @@ class SearchDeploymentScopedHistoryAction(DeploymentSchedulingHistoryAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -25,7 +25,7 @@ class SearchKernelHistoryAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.session import (
-    SESSION_ENTITY_TYPE,
     SESSION_SCOPE_TYPE,
+    SessionEntityType,
     SessionID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
@@ -87,7 +87,7 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_route_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_route_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.types import RouteHistoryData
@@ -21,7 +21,7 @@ class SearchRouteHistoryAction(SchedulingHistoryAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_route_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_route_scoped_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.types import RouteHistoryData
@@ -27,7 +27,7 @@ class SearchRouteScopedHistoryAction(SchedulingHistoryAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return DEPLOYMENT_ENTITY_TYPE
+        return DeploymentEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_session_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_session_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionSchedulingHistoryData
@@ -21,7 +21,7 @@ class SearchSessionHistoryAction(SchedulingHistoryAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_session_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_session_scoped_history.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionSchedulingHistoryData
@@ -29,7 +29,7 @@ class SearchSessionScopedHistoryAction(SessionSchedulingHistoryAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/processors.py
+++ b/src/ai/backend/manager/services/scheduling_history/processors.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from ai.backend.common.data.entity.deployment_history import DEPLOYMENT_HISTORY_FIELD_TYPE
+from ai.backend.common.data.entity.deployment_history import DeploymentHistoryFieldType
 from ai.backend.common.data.entity.kernel_scheduling_history import (
-    KERNEL_SCHEDULING_HISTORY_FIELD_TYPE,
+    KernelSchedulingHistoryFieldType,
 )
-from ai.backend.common.data.entity.route_history import ROUTE_HISTORY_FIELD_TYPE
+from ai.backend.common.data.entity.route_history import RouteHistoryFieldType
 from ai.backend.common.data.entity.session_scheduling_history import (
-    SESSION_SCHEDULING_HISTORY_FIELD_TYPE,
+    SessionSchedulingHistoryFieldType,
 )
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
@@ -128,25 +128,25 @@ class SchedulingHistoryProcessors:
         service: SchedulingHistoryService,
     ) -> None:
         session_histories: LookupFieldGroup[SessionSchedulingHistoryData] = session.field_group(
-            FieldGroupMeta(SESSION_SCHEDULING_HISTORY_FIELD_TYPE),
+            FieldGroupMeta(SessionSchedulingHistoryFieldType()),
             SessionSchedulingHistoryData,
             LookupSessionSchedulingHistoryOwnerAction,
             LookupBulkSessionSchedulingHistoryOwnerAction,
         )
         kernel_histories: LookupFieldGroup[KernelSchedulingHistoryData] = session.field_group(
-            FieldGroupMeta(KERNEL_SCHEDULING_HISTORY_FIELD_TYPE),
+            FieldGroupMeta(KernelSchedulingHistoryFieldType()),
             KernelSchedulingHistoryData,
             LookupKernelSchedulingHistoryOwnerAction,
             LookupBulkKernelSchedulingHistoryOwnerAction,
         )
         deployment_histories: LookupFieldGroup[DeploymentHistoryData] = deployment.field_group(
-            FieldGroupMeta(DEPLOYMENT_HISTORY_FIELD_TYPE),
+            FieldGroupMeta(DeploymentHistoryFieldType()),
             DeploymentHistoryData,
             LookupDeploymentHistoryOwnerAction,
             LookupBulkDeploymentHistoryOwnerAction,
         )
         route_histories: LookupFieldGroup[RouteHistoryData] = deployment.field_group(
-            FieldGroupMeta(ROUTE_HISTORY_FIELD_TYPE),
+            FieldGroupMeta(RouteHistoryFieldType()),
             RouteHistoryData,
             LookupRouteHistoryOwnerAction,
             LookupBulkRouteHistoryOwnerAction,

--- a/src/ai/backend/manager/services/secret/actions/reencrypt.py
+++ b/src/ai/backend/manager/services/secret/actions/reencrypt.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.secret import SECRET_ENTITY_TYPE
+from ai.backend.common.data.entity.secret import SecretEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -17,7 +17,7 @@ class ReencryptSecretsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SECRET_ENTITY_TYPE
+        return SecretEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/secret/actions/status.py
+++ b/src/ai/backend/manager/services/secret/actions/status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.secret import SECRET_ENTITY_TYPE
+from ai.backend.common.data.entity.secret import SecretEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -17,7 +17,7 @@ class GetSecretStatusAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SECRET_ENTITY_TYPE
+        return SecretEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/service_catalog/actions/search.py
+++ b/src/ai/backend/manager/services/service_catalog/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.service_catalog import SERVICE_CATALOG_ENTITY_TYPE
+from ai.backend.common.data.entity.service_catalog import ServiceCatalogEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.service_catalog.types import ServiceCatalogData
@@ -20,7 +20,7 @@ class SearchServiceCatalogsAction(SearchGlobalOpsAction[ServiceCatalogRow, Servi
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SERVICE_CATALOG_ENTITY_TYPE
+        return ServiceCatalogEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/lookup.py
+++ b/src/ai/backend/manager/services/session/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 from uuid import UUID
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
 from ai.backend.manager.actions.v2.ops.base import LookupEntityOpsAction
@@ -38,7 +38,7 @@ class LookupSessionAction(LookupEntityOpsAction[SessionRow, SessionID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/lookup_bulk_kernel_owner.py
+++ b/src/ai/backend/manager/services/session/actions/lookup_bulk_kernel_owner.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.kernel import KernelID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -36,7 +36,7 @@ class LookupBulkKernelOwnerAction(LookupBulkFieldOwnerOpsAction[KernelID, Sessio
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/base.py
+++ b/src/ai/backend/manager/services/session/base.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -32,7 +32,7 @@ class SessionGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
 
 @dataclass
@@ -42,7 +42,7 @@ class SessionScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
 
 @dataclass

--- a/src/ai/backend/manager/services/session/resource_allocation/actions/check_preset_availability.py
+++ b/src/ai/backend/manager/services/session/resource_allocation/actions/check_preset_availability.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
@@ -33,7 +33,7 @@ class CheckPresetAvailabilityAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_PRESET_ENTITY_TYPE
+        return ResourcePresetEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/session/resource_allocation/actions/get_effective_allocation.py
+++ b/src/ai/backend/manager/services/session/resource_allocation/actions/get_effective_allocation.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
@@ -32,7 +32,7 @@ class GetEffectiveAllocationAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/session/resource_allocation/actions/get_resource_group_usage.py
+++ b/src/ai/backend/manager/services/session/resource_allocation/actions/get_resource_group_usage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -23,7 +23,7 @@ class GetResourceGroupUsageAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return RESOURCE_GROUP_ENTITY_TYPE
+        return ResourceGroupEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/storage_namespace/actions/base.py
+++ b/src/ai/backend/manager/services/storage_namespace/actions/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -15,4 +15,4 @@ class StorageNamespaceGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return STORAGE_NAMESPACE_ENTITY_TYPE
+        return StorageNamespaceEntityType()

--- a/src/ai/backend/manager/services/storage_namespace/actions/get_multi.py
+++ b/src/ai/backend/manager/services/storage_namespace/actions/get_multi.py
@@ -4,7 +4,7 @@ import uuid
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
@@ -27,7 +27,7 @@ class GetNamespacesAction(SearchGlobalOpsAction[StorageNamespaceRow, StorageName
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return STORAGE_NAMESPACE_ENTITY_TYPE
+        return StorageNamespaceEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/storage_namespace/actions/lookup.py
+++ b/src/ai/backend/manager/services/storage_namespace/actions/lookup.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.storage_namespace import (
-    STORAGE_NAMESPACE_ENTITY_TYPE,
+    StorageNamespaceEntityType,
     StorageNamespaceID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -47,7 +47,7 @@ class LookupStorageNamespaceAction(LookupEntityOpsAction[StorageNamespaceRow, St
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return STORAGE_NAMESPACE_ENTITY_TYPE
+        return StorageNamespaceEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/storage_namespace/actions/register.py
+++ b/src/ai/backend/manager/services/storage_namespace/actions/register.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
@@ -20,7 +20,7 @@ class RegisterNamespaceAction(CreateGlobalOpsAction[StorageNamespaceRow, Storage
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return STORAGE_NAMESPACE_ENTITY_TYPE
+        return StorageNamespaceEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/storage_namespace/actions/search.py
+++ b/src/ai/backend/manager/services/storage_namespace/actions/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.storage_namespace.types import StorageNamespaceData
@@ -22,7 +22,7 @@ class SearchStorageNamespacesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return STORAGE_NAMESPACE_ENTITY_TYPE
+        return StorageNamespaceEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/stream/actions/gc_stale_connections.py
+++ b/src/ai/backend/manager/services/stream/actions/gc_stale_connections.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import SessionId
 from ai.backend.manager.actions.types import ActionOperationType
@@ -23,7 +23,7 @@ class GCStaleConnectionsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_ENTITY_TYPE
+        return SessionEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/template/actions/base.py
+++ b/src/ai/backend/manager/services/template/actions/base.py
@@ -6,7 +6,7 @@ from typing import override
 
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.session_template import (
-    SESSION_TEMPLATE_ENTITY_TYPE,
+    SessionTemplateEntityType,
     SessionTemplateID,
 )
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
@@ -37,7 +37,7 @@ class TemplateProjectScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_TEMPLATE_ENTITY_TYPE
+        return SessionTemplateEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -53,7 +53,7 @@ class TemplateUserScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return SESSION_TEMPLATE_ENTITY_TYPE
+        return SessionTemplateEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/user/actions/admin_month_stats.py
+++ b/src/ai/backend/manager/services/user/actions/admin_month_stats.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -18,7 +18,7 @@ class AdminMonthStatsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/create_user.py
+++ b/src/ai/backend/manager/services/user/actions/create_user.py
@@ -6,7 +6,7 @@ from typing import override
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -34,7 +34,7 @@ class CreateUserAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -69,7 +69,7 @@ class BulkCreateUserAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/keypair_ops.py
+++ b/src/ai/backend/manager/services/user/actions/keypair_ops.py
@@ -13,7 +13,7 @@ from typing import override
 
 from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
@@ -181,7 +181,7 @@ class SearchMyKeypairsAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -265,7 +265,7 @@ class AdminSearchKeypairsAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/lookup.py
+++ b/src/ai/backend/manager/services/user/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
 from ai.backend.manager.actions.v2.ops.base import LookupEntityOpsAction
 from ai.backend.manager.models.user.lookups import UserEmailLookup
@@ -35,7 +35,7 @@ class LookupUserAction(LookupEntityOpsAction[UserRow, UserID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/lookup_keypair.py
+++ b/src/ai/backend/manager/services/user/actions/lookup_keypair.py
@@ -5,7 +5,7 @@ from typing import override
 
 from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldByKeyOpsAction
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -22,7 +22,7 @@ class LookupKeypairByAccessKeyAction(LookupFieldByKeyOpsAction[KeyPairID, UserID
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/lookup_keypair_owner.py
+++ b/src/ai/backend/manager/services/user/actions/lookup_keypair_owner.py
@@ -6,7 +6,7 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.lookup import (
@@ -44,7 +44,7 @@ class LookupKeypairOwnerAction(LookupFieldOwnerOpsAction[KeyPairID, UserID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -73,7 +73,7 @@ class LookupBulkKeypairOwnerAction(LookupBulkFieldOwnerOpsAction[KeyPairID, User
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -117,7 +117,7 @@ class LookupKeypairOwnerByAccessKeyAction(LookupFieldOwnerByKeyOpsAction[UserID]
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/purge_user.py
+++ b/src/ai/backend/manager/services/user/actions/purge_user.py
@@ -5,7 +5,7 @@ from typing import override
 from uuid import UUID
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -65,7 +65,7 @@ class BulkPurgeUserAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/user/actions/scoped_search.py
@@ -10,7 +10,7 @@ from typing import override
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.models.scopes import OperationScope
@@ -91,7 +91,7 @@ class ScopedSearchUsersAction(OperationScopeOpsAction[UserRow, UserData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/search_users.py
+++ b/src/ai/backend/manager/services/user/actions/search_users.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.models.user.row import UserRow
@@ -22,7 +22,7 @@ class GlobalSearchUsersAction(SearchGlobalOpsAction[UserRow, UserData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/search_users_by_role.py
+++ b/src/ai/backend/manager/services/user/actions/search_users_by_role.py
@@ -5,7 +5,7 @@ from typing import override
 from uuid import UUID
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.models.user.row import UserRow
@@ -28,7 +28,7 @@ class SearchUsersByRoleAction(SearchGlobalOpsAction[UserRow, UserData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/update_user.py
+++ b/src/ai/backend/manager/services/user/actions/update_user.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -54,7 +54,7 @@ class BulkUpdateUserAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/error_log/actions/global_search.py
+++ b/src/ai/backend/manager/services/user/error_log/actions/global_search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.error_log.types import ErrorLogData
 from ai.backend.manager.models.error_log.row import ErrorLogRow
@@ -20,7 +20,7 @@ class GlobalSearchErrorLogsAction(SearchGlobalOpsAction[ErrorLogRow, ErrorLogDat
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/error_log/actions/lookup_owner.py
+++ b/src/ai/backend/manager/services/user/error_log/actions/lookup_owner.py
@@ -6,7 +6,7 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.error_log import ErrorLogID
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.field.bulk_lookup import LookupBulkFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.field.lookup import LookupFieldOwnerOpsAction
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
@@ -37,7 +37,7 @@ class LookupErrorLogOwnerAction(LookupFieldOwnerOpsAction[ErrorLogID, UserID]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod
@@ -66,7 +66,7 @@ class LookupBulkErrorLogOwnerAction(LookupBulkFieldOwnerOpsAction[ErrorLogID, Us
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/error_log/actions/search.py
+++ b/src/ai/backend/manager/services/user/error_log/actions/search.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.error_log.types import ErrorLogData
 from ai.backend.manager.models.error_log.row import ErrorLogRow
@@ -24,7 +24,7 @@ class SearchErrorLogsAction(OperationScopeOpsAction[ErrorLogRow, ErrorLogData]):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_ENTITY_TYPE
+        return UserEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/user/processors.py
+++ b/src/ai/backend/manager/services/user/processors.py
@@ -1,5 +1,5 @@
-from ai.backend.common.data.entity.error_log import ERROR_LOG_FIELD_TYPE
-from ai.backend.common.data.entity.keypair import KEYPAIR_FIELD_TYPE
+from ai.backend.common.data.entity.error_log import ErrorLogFieldType
+from ai.backend.common.data.entity.keypair import KeyPairFieldType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.registry.field import LookupFieldGroup
 from ai.backend.manager.actions.registry.group import ProcessorGroup
@@ -260,7 +260,7 @@ class UserProcessors:
         )
 
         self.keypair_group = group.field_group(
-            FieldGroupMeta(KEYPAIR_FIELD_TYPE),
+            FieldGroupMeta(KeyPairFieldType()),
             KeyPairData,
             LookupKeypairOwnerAction,
             LookupBulkKeypairOwnerAction,
@@ -278,7 +278,7 @@ class UserProcessors:
         )
         self.error_log = ErrorLogProcessors(
             group.field_group(
-                FieldGroupMeta(ERROR_LOG_FIELD_TYPE),
+                FieldGroupMeta(ErrorLogFieldType()),
                 ErrorLogData,
                 LookupErrorLogOwnerAction,
                 LookupBulkErrorLogOwnerAction,

--- a/src/ai/backend/manager/services/user_resource_policy/actions/create_user_resource_policy.py
+++ b/src/ai/backend/manager/services/user_resource_policy/actions/create_user_resource_policy.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    UserResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
@@ -26,7 +26,7 @@ class CreateUserResourcePolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_RESOURCE_POLICY_ENTITY_TYPE
+        return UserResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user_resource_policy/actions/global_search_user_resource_policies.py
+++ b/src/ai/backend/manager/services/user_resource_policy/actions/global_search_user_resource_policies.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    UserResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
@@ -26,7 +26,7 @@ class GlobalSearchUserResourcePoliciesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_RESOURCE_POLICY_ENTITY_TYPE
+        return UserResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user_resource_policy/actions/lookup.py
+++ b/src/ai/backend/manager/services/user_resource_policy/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.resource_policy import (
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    UserResourcePolicyEntityType,
     UserResourcePolicyUUID,
 )
 from ai.backend.common.data.entity.types import EntityType
@@ -42,7 +42,7 @@ class LookupUserResourcePolicyAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_RESOURCE_POLICY_ENTITY_TYPE
+        return UserResourcePolicyEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user_resource_policy/actions/search_user_resource_policies.py
+++ b/src/ai/backend/manager/services/user_resource_policy/actions/search_user_resource_policies.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    UserResourcePolicyEntityType,
 )
 from ai.backend.common.data.entity.types import EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
@@ -34,7 +34,7 @@ class SearchUserResourcePoliciesAction(
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return USER_RESOURCE_POLICY_ENTITY_TYPE
+        return UserResourcePolicyEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/vfolder/actions/base.py
+++ b/src/ai/backend/manager/services/vfolder/actions/base.py
@@ -5,7 +5,7 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.types import (
     AccessKey,
     KernelId,
@@ -85,7 +85,7 @@ class VFolderGlobalAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFOLDER_ENTITY_TYPE
+        return VFolderEntityType()
 
     @override
     @classmethod
@@ -100,7 +100,7 @@ class VFolderScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFOLDER_ENTITY_TYPE
+        return VFolderEntityType()
 
     @override
     @classmethod
@@ -411,7 +411,7 @@ class LookupAccessibleVFolderAction(BaseLookupAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFOLDER_ENTITY_TYPE
+        return VFolderEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfolder/actions/invite.py
+++ b/src/ai/backend/manager/services/vfolder/actions/invite.py
@@ -9,7 +9,7 @@ from typing import (
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
 from ai.backend.common.data.entity.vfolder_invitation import (
-    VFOLDER_INVITATION_ENTITY_TYPE,
+    VFolderInvitationEntityType,
     VFolderInvitationID,
 )
 from ai.backend.manager.actions.types import ActionOperationType
@@ -47,7 +47,7 @@ class VFolderInvitationScopeAction(BaseScopeAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFOLDER_INVITATION_ENTITY_TYPE
+        return VFolderInvitationEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:

--- a/src/ai/backend/manager/services/vfolder/actions/lookup.py
+++ b/src/ai/backend/manager/services/vfolder/actions/lookup.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.manager.actions.v2.lookup.base import (
     BaseLookupAction,
     BaseLookupActionResult,
@@ -43,7 +43,7 @@ class LookupVFolderAction(BaseLookupAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFOLDER_ENTITY_TYPE
+        return VFolderEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/create.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/create.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.vfs_storage.types import VFSStorageData
 from ai.backend.manager.models.vfs_storage.creators import VFSStorageCreator
@@ -20,7 +20,7 @@ class CreateVFSStorageAction(CreateGlobalOpsAction[VFSStorageRow, VFSStorageData
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/get_quota_scope.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/get_quota_scope.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -15,7 +15,7 @@ class GetQuotaScopeAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/list.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/list.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.vfs_storage.types import VFSStorageData
 from ai.backend.manager.models.vfs_storage.row import VFSStorageRow
@@ -20,7 +20,7 @@ class ListVFSStorageAction(SearchGlobalOpsAction[VFSStorageRow, VFSStorageData])
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/lookup.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/lookup.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any, override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE, VFSStorageID
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType, VFSStorageID
 from ai.backend.manager.actions.v2.lookup.base import LookupKey
 from ai.backend.manager.actions.v2.ops.base import LookupEntityOpsAction
 from ai.backend.manager.models.vfs_storage.lookups import VFSStorageLookup
@@ -39,7 +39,7 @@ class LookupVFSStorageAction(LookupEntityOpsAction[VFSStorageRow, VFSStorageID])
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/search.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/search.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.vfs_storage.types import VFSStorageData
 from ai.backend.manager.models.vfs_storage.row import VFSStorageRow
@@ -20,7 +20,7 @@ class SearchVFSStoragesAction(SearchGlobalOpsAction[VFSStorageRow, VFSStorageDat
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/search_quota_scopes.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/search_quota_scopes.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -21,7 +21,7 @@ class SearchQuotaScopesAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/set_quota_scope.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/set_quota_scope.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -16,7 +16,7 @@ class SetQuotaScopeAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfs_storage/actions/unset_quota_scope.py
+++ b/src/ai/backend/manager/services/vfs_storage/actions/unset_quota_scope.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.types import EntityType
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 
@@ -15,7 +15,7 @@ class UnsetQuotaScopeAction(BaseGlobalAction):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return VFS_STORAGE_ENTITY_TYPE
+        return VFSStorageEntityType()
 
     @override
     @classmethod

--- a/tests/component/agent_api/conftest.py
+++ b/tests/component/agent_api/conftest.py
@@ -9,7 +9,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.types import HostPortPair
@@ -94,7 +94,7 @@ def agent_processors(
         own_check=BulkOwnCheck(PermissionControllerRepository(database_engine), config_provider),
     )
     return AgentProcessors(
-        processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(AgentEntityType())),
         service,
         [],
     )

--- a/tests/component/app_config/conftest.py
+++ b/tests/component/app_config/conftest.py
@@ -13,11 +13,11 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.entity.app_config import (
-    APP_CONFIG_ALLOW_LIST_ENTITY_TYPE,
-    APP_CONFIG_ENTITY_TYPE,
+    AppConfigAllowListEntityType,
+    AppConfigEntityType,
     AppConfigScopeID,
 )
-from ai.backend.common.data.entity.app_config_definition import APP_CONFIG_DEFINITION_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionEntityType
 from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import (
@@ -73,10 +73,10 @@ def app_config_processors(database_engine: ExtendedAsyncSAEngine) -> AppConfigPr
         )
     )
     return AppConfigProcessors(
-        registry.group(GroupMeta(APP_CONFIG_ENTITY_TYPE)),
-        ops_processor_group(database_engine, GroupMeta(APP_CONFIG_ENTITY_TYPE)),
-        registry.group(GroupMeta(APP_CONFIG_DEFINITION_ENTITY_TYPE)),
-        registry.group(GroupMeta(APP_CONFIG_ALLOW_LIST_ENTITY_TYPE)),
+        registry.group(GroupMeta(AppConfigEntityType())),
+        ops_processor_group(database_engine, GroupMeta(AppConfigEntityType())),
+        registry.group(GroupMeta(AppConfigDefinitionEntityType())),
+        registry.group(GroupMeta(AppConfigAllowListEntityType())),
         AppConfigService(OpsRepository(V2DBOpsProvider(database_engine))),
     )
 

--- a/tests/component/artifact/conftest.py
+++ b/tests/component/artifact/conftest.py
@@ -11,8 +11,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import FieldGroupMeta, GroupMeta
 from ai.backend.manager.api.rest.artifact.handler import ArtifactHandler
@@ -98,17 +98,17 @@ def artifact_processors(
         storage_manager=storage_manager,
         config_provider=config_provider,
     )
-    artifact_revisions = processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+    artifact_revisions = processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+        FieldGroupMeta(ArtifactRevisionFieldType()),
         ArtifactRevisionData,
         LookupArtifactRevisionOwnerAction,
         LookupBulkArtifactRevisionOwnerAction,
     )
     return ArtifactProcessors(
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(ArtifactEntityType())),
         artifact_revisions,
         ArtifactRevisionProcessors(
-            processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            processor_registry.group(GroupMeta(ArtifactEntityType())),
             artifact_revisions,
             MagicMock(),
         ),
@@ -155,9 +155,9 @@ def artifact_revision_processors(
         background_task_manager=background_task_manager,
     )
     return ArtifactRevisionProcessors(
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        processor_registry.group(GroupMeta(ArtifactEntityType())),
+        processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+            FieldGroupMeta(ArtifactRevisionFieldType()),
             ArtifactRevisionData,
             LookupArtifactRevisionOwnerAction,
             LookupBulkArtifactRevisionOwnerAction,

--- a/tests/component/artifact_registry/conftest.py
+++ b/tests/component/artifact_registry/conftest.py
@@ -12,8 +12,8 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.data.artifact.types import ArtifactRegistryType
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import FieldGroupMeta, GroupMeta
 from ai.backend.manager.api.rest.artifact_registry.handler import ArtifactRegistryHandler
@@ -105,17 +105,17 @@ def artifact_processors(
         storage_manager=storage_manager,
         config_provider=config_provider,
     )
-    artifact_revisions = processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+    artifact_revisions = processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+        FieldGroupMeta(ArtifactRevisionFieldType()),
         ArtifactRevisionData,
         LookupArtifactRevisionOwnerAction,
         LookupBulkArtifactRevisionOwnerAction,
     )
     return ArtifactProcessors(
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(ArtifactEntityType())),
         artifact_revisions,
         ArtifactRevisionProcessors(
-            processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            processor_registry.group(GroupMeta(ArtifactEntityType())),
             artifact_revisions,
             MagicMock(),
         ),
@@ -162,9 +162,9 @@ def artifact_revision_processors(
         background_task_manager=background_task_manager,
     )
     return ArtifactRevisionProcessors(
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        processor_registry.group(GroupMeta(ArtifactEntityType())),
+        processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+            FieldGroupMeta(ArtifactRevisionFieldType()),
             ArtifactRevisionData,
             LookupArtifactRevisionOwnerAction,
             LookupBulkArtifactRevisionOwnerAction,

--- a/tests/component/artifact_revision/conftest.py
+++ b/tests/component/artifact_revision/conftest.py
@@ -12,8 +12,8 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.data.artifact.types import ArtifactRegistryType
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import FieldGroupMeta, GroupMeta
 from ai.backend.manager.api.rest.artifact.handler import ArtifactHandler
@@ -103,17 +103,17 @@ def artifact_processors(
         storage_manager=storage_manager,
         config_provider=config_provider,
     )
-    artifact_revisions = processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+    artifact_revisions = processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+        FieldGroupMeta(ArtifactRevisionFieldType()),
         ArtifactRevisionData,
         LookupArtifactRevisionOwnerAction,
         LookupBulkArtifactRevisionOwnerAction,
     )
     return ArtifactProcessors(
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(ArtifactEntityType())),
         artifact_revisions,
         ArtifactRevisionProcessors(
-            processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            processor_registry.group(GroupMeta(ArtifactEntityType())),
             artifact_revisions,
             MagicMock(),
         ),
@@ -160,9 +160,9 @@ def artifact_revision_processors(
         background_task_manager=background_task_manager,
     )
     return ArtifactRevisionProcessors(
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        processor_registry.group(GroupMeta(ArtifactEntityType())),
+        processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+            FieldGroupMeta(ArtifactRevisionFieldType()),
             ArtifactRevisionData,
             LookupArtifactRevisionOwnerAction,
             LookupBulkArtifactRevisionOwnerAction,

--- a/tests/component/auth/test_auth.py
+++ b/tests/component/auth/test_auth.py
@@ -19,8 +19,8 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.exceptions import AuthenticationError, InvalidRequestError, NotFoundError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.auth.request import (
     AuthorizeRequest,
     GetRoleRequest,
@@ -1145,9 +1145,9 @@ class TestSignup:
                 .join(scope, scope.id == EntityMembershipRow.virtual_entity_id)
                 .join(member, member.id == EntityMembershipRow.member_entity_id)
                 .where(
-                    scope.entity_type == PROJECT_ENTITY_TYPE,
+                    scope.entity_type == ProjectEntityType(),
                     scope.entity_id == signup_default_project.project_id,
-                    member.entity_type == USER_ENTITY_TYPE,
+                    member.entity_type == UserEntityType(),
                     member.entity_id == user_uuid,
                 ),
             )

--- a/tests/component/auto_scaling_rule/conftest.py
+++ b/tests/component/auto_scaling_rule/conftest.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.resource_group import ResourceGroupName
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
@@ -79,7 +79,7 @@ def deployment_processors(
         appproxy_client_pool=mock_appproxy_client_pool,
     )
     return DeploymentProcessors(
-        processor_registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(DeploymentEntityType())), service
     )
 
 

--- a/tests/component/client_ip_masking/conftest.py
+++ b/tests/component/client_ip_masking/conftest.py
@@ -13,7 +13,7 @@ import yarl
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.client_ip_masking import CLIENT_IP_MASKING_POLICY_ENTITY_TYPE
+from ai.backend.common.data.entity.client_ip_masking import ClientIPMaskingPolicyEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.adapters.client_ip_masking.adapter import ClientIPMaskingAdapter
@@ -38,7 +38,7 @@ def client_ip_masking_processors(
     processor_registry: ProcessorRegistry[Any],
 ) -> ClientIPMaskingProcessors:
     return ClientIPMaskingProcessors(
-        processor_registry.group(GroupMeta(CLIENT_IP_MASKING_POLICY_ENTITY_TYPE))
+        processor_registry.group(GroupMeta(ClientIPMaskingPolicyEntityType()))
     )
 
 

--- a/tests/component/config/conftest.py
+++ b/tests/component/config/conftest.py
@@ -10,9 +10,9 @@ import pytest
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.config import (
     CreateDomainDotfileRequest,
     CreateDotfileResponse,
@@ -81,12 +81,12 @@ def server_module_registries(
     """Load only the modules required for config-domain tests."""
     v2_ops = V2DBOpsProvider(database_engine)
     domain = DomainProcessors(
-        config_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
+        config_registry.group(GroupMeta(DomainEntityType())),
         DomainService(DomainRepository(database_engine, v2_ops)),
         [],
     )
     project = ProjectProcessors(
-        config_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)),
+        config_registry.group(GroupMeta(ProjectEntityType())),
         ProjectService(
             MagicMock(),
             MagicMock(),
@@ -99,7 +99,7 @@ def server_module_registries(
         ),
     )
     user = UserProcessors(
-        config_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        config_registry.group(GroupMeta(UserEntityType())),
         UserService(
             MagicMock(),
             MagicMock(),

--- a/tests/component/conftest.py
+++ b/tests/component/conftest.py
@@ -46,10 +46,10 @@ from ai.backend.common.clients.valkey_client.valkey_stream.client import ValkeyS
 from ai.backend.common.configs.etcd import EtcdConfig
 from ai.backend.common.configs.pyroscope import PyroscopeConfig
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
+from ai.backend.common.data.entity.auth import AuthEntityType
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.permission.types import EntityType, ScopeType
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.defs import (
@@ -1573,8 +1573,8 @@ def auth_processors(
         key_provider_pool=KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
     )
     return AuthProcessors(
-        processor_registry.group(GroupMeta(AUTH_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(AuthEntityType())),
+        processor_registry.group(GroupMeta(UserEntityType())),
         service,
     )
 

--- a/tests/component/container_registry/conftest.py
+++ b/tests/component/container_registry/conftest.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.container_registry import ContainerRegistryType
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import Concern, ConcernMeta, GroupMeta
 from ai.backend.manager.api.adapters.container_registry.adapter import ContainerRegistryAdapter
@@ -52,7 +52,7 @@ def container_registry_processors(
     repo = ContainerRegistryRepository(database_engine, RelationOpsProvider(database_engine))
     service = ContainerRegistryService(database_engine, repo)
     return ContainerRegistryProcessors(
-        processor_registry.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ContainerRegistryEntityType())), service
     )
 
 
@@ -65,7 +65,7 @@ def rbac_processors(
     rbac_groups = processor_registry.concern(ConcernMeta(Concern.RBAC))
     return RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         RbacRelationService(RbacRelationRepository(RelationOpsProvider(database_engine))),
         RbacRosterService(RbacRosterRepository(RosterOpsProvider(database_engine))),
         RbacRoleService(

--- a/tests/component/deployment/conftest.py
+++ b/tests/component/deployment/conftest.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.container_registry import ContainerRegistryType
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.image import ImageID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
@@ -149,7 +149,7 @@ def deployment_processors(
         appproxy_client_pool=mock_appproxy_client_pool,
     )
     return DeploymentProcessors(
-        processor_registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(DeploymentEntityType())), service
     )
 
 

--- a/tests/component/deployment_revision_preset/conftest.py
+++ b/tests/component/deployment_revision_preset/conftest.py
@@ -19,7 +19,7 @@ from ai.backend.manager.repositories.ops.v2.provider import V2DBOpsProvider
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
-from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
 from ai.backend.manager.actions.registry.types import (
     GroupMeta,
 )
@@ -71,7 +71,7 @@ def deployment_revision_preset_processors(
     repo = DeploymentPresetRepository(V2DBOpsProvider(database_engine))
     service = DeploymentPresetService(repo)
     return DeploymentPresetProcessors(
-        processor_registry.group(GroupMeta(DEPLOYMENT_PRESET_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(DeploymentPresetEntityType())), service
     )
 
 

--- a/tests/component/domain/conftest.py
+++ b/tests/component/domain/conftest.py
@@ -11,8 +11,8 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.dto.manager.domain import (
     CreateDomainRequest,
     CreateDomainResponse,
@@ -45,13 +45,13 @@ def domain_processors(
 ) -> DomainProcessors:
     repo = DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     service = DomainService(repo)
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()
 def project_processors(processor_registry: ProcessorRegistry[Any]) -> ProjectProcessors:
     """Only the ops-backed create is exercised here, so the service is a stub."""
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), MagicMock())
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), MagicMock())
 
 
 @pytest.fixture()

--- a/tests/component/error_log/conftest.py
+++ b/tests/component/error_log/conftest.py
@@ -7,8 +7,8 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.error_log import ERROR_LOG_FIELD_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.error_log import ErrorLogFieldType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.registry.types import (
     FieldGroupMeta,
     GroupMeta,
@@ -31,8 +31,8 @@ from ai.backend.testutils.processors import ops_processor_group
 @pytest.fixture()
 def error_log_processors(database_engine: ExtendedAsyncSAEngine) -> ErrorLogProcessors:
     return ErrorLogProcessors(
-        ops_processor_group(database_engine, GroupMeta(USER_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ERROR_LOG_FIELD_TYPE),
+        ops_processor_group(database_engine, GroupMeta(UserEntityType())).field_group(
+            FieldGroupMeta(ErrorLogFieldType()),
             ErrorLogData,
             LookupErrorLogOwnerAction,
             LookupBulkErrorLogOwnerAction,

--- a/tests/component/etcd_config/conftest.py
+++ b/tests/component/etcd_config/conftest.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import pytest
 
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
@@ -35,7 +35,7 @@ def container_registry_processors(
     repo = ContainerRegistryRepository(database_engine, RelationOpsProvider(database_engine))
     service = ContainerRegistryService(database_engine, repo)
     return ContainerRegistryProcessors(
-        processor_registry.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ContainerRegistryEntityType())), service
     )
 
 
@@ -55,7 +55,7 @@ def etcd_config_processors(
         valkey_stat=valkey_clients.stat,
     )
     return EtcdConfigProcessors(
-        processor_registry.group(GroupMeta(ETCD_CONFIG_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(EtcdConfigEntityType())), service
     )
 
 

--- a/tests/component/export/conftest.py
+++ b/tests/component/export/conftest.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.export import EXPORT_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.export import ExportEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.rest.export.handler import ExportHandler
@@ -30,7 +30,7 @@ def export_processors(
     registry = ExportReportRegistry.create_default()
     repo = ExportRepository(db_source, registry)
     service = ExportService(repo)
-    return ExportProcessors(processor_registry.group(GroupMeta(EXPORT_ENTITY_TYPE)), service)
+    return ExportProcessors(processor_registry.group(GroupMeta(ExportEntityType())), service)
 
 
 @pytest.fixture()
@@ -45,7 +45,7 @@ def server_module_registries(
             ExportHandler(
                 export=export_processors,
                 domain=DomainProcessors(
-                    processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), AsyncMock(), []
+                    processor_registry.group(GroupMeta(DomainEntityType())), AsyncMock(), []
                 ),
                 export_config=MagicMock(),
             ),

--- a/tests/component/fair_share/conftest.py
+++ b/tests/component/fair_share/conftest.py
@@ -10,19 +10,19 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.data.entity.fair_share import (
-    DOMAIN_FAIR_SHARE_ENTITY_TYPE,
-    PROJECT_FAIR_SHARE_ENTITY_TYPE,
-    USER_FAIR_SHARE_ENTITY_TYPE,
+    DomainFairShareEntityType,
+    ProjectFairShareEntityType,
+    UserFairShareEntityType,
 )
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupID,
     ResourceGroupName,
 )
 from ai.backend.common.data.entity.usage_bucket import (
-    DOMAIN_USAGE_BUCKET_FIELD_TYPE,
-    PROJECT_USAGE_BUCKET_FIELD_TYPE,
-    USER_USAGE_BUCKET_FIELD_TYPE,
+    DomainUsageBucketFieldType,
+    ProjectUsageBucketFieldType,
+    UserUsageBucketFieldType,
 )
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -71,9 +71,9 @@ def fair_share_processors(
     service = FairShareService(FairShareRepository(database_engine))
     fair_share_groups = processor_registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
     return FairShareProcessors(
-        fair_share_groups.group(GroupMeta(DOMAIN_FAIR_SHARE_ENTITY_TYPE)),
-        fair_share_groups.group(GroupMeta(PROJECT_FAIR_SHARE_ENTITY_TYPE)),
-        fair_share_groups.group(GroupMeta(USER_FAIR_SHARE_ENTITY_TYPE)),
+        fair_share_groups.group(GroupMeta(DomainFairShareEntityType())),
+        fair_share_groups.group(GroupMeta(ProjectFairShareEntityType())),
+        fair_share_groups.group(GroupMeta(UserFairShareEntityType())),
         service,
     )
 
@@ -84,13 +84,13 @@ def resource_usage_processors(
 ) -> ResourceUsageProcessors:
     return ResourceUsageProcessors(
         processor_registry.dangling_field_group(
-            FieldGroupMeta(DOMAIN_USAGE_BUCKET_FIELD_TYPE), DomainUsageBucketData
+            FieldGroupMeta(DomainUsageBucketFieldType()), DomainUsageBucketData
         ),
         processor_registry.dangling_field_group(
-            FieldGroupMeta(PROJECT_USAGE_BUCKET_FIELD_TYPE), ProjectUsageBucketData
+            FieldGroupMeta(ProjectUsageBucketFieldType()), ProjectUsageBucketData
         ),
         processor_registry.dangling_field_group(
-            FieldGroupMeta(USER_USAGE_BUCKET_FIELD_TYPE), UserUsageBucketData
+            FieldGroupMeta(UserUsageBucketFieldType()), UserUsageBucketData
         ),
     )
 
@@ -104,7 +104,7 @@ def resource_group_processors(
         ResourceGroupRepository(database_engine, V2DBOpsProvider(database_engine))
     )
     return ResourceGroupProcessors(
-        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ResourceGroupEntityType())), service
     )
 
 

--- a/tests/component/group/conftest.py
+++ b/tests/component/group/conftest.py
@@ -9,7 +9,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
 from ai.backend.common.data.permission.types import ScopeType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
@@ -76,7 +76,7 @@ def container_registry_processors(
     quota_service = cast(AbstractPerProjectContainerRegistryQuotaService, InMemoryQuotaService())
     service = ContainerRegistryService(database_engine, repo, quota_service=quota_service)
     return ContainerRegistryProcessors(
-        processor_registry.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ContainerRegistryEntityType())), service
     )
 
 

--- a/tests/component/idle_checker_assignment/conftest.py
+++ b/tests/component/idle_checker_assignment/conftest.py
@@ -17,13 +17,13 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.idle_checker import (
-    IDLE_CHECKER_ENTITY_TYPE,
     IdleCheckerAssignmentID,
+    IdleCheckerEntityType,
     IdleCheckerID,
 )
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.idle_checker.types import (
     CheckerType,
     IdleCheckerSpec,
@@ -193,7 +193,7 @@ def idle_checker_assignment_processors(
     )
     groups = action_registry.concern(ConcernMeta(Concern.SESSION))
     return IdleCheckerAssignmentProcessors(
-        groups.group(GroupMeta(IDLE_CHECKER_ENTITY_TYPE)),
+        groups.group(GroupMeta(IdleCheckerEntityType())),
         service,
     )
 
@@ -207,7 +207,7 @@ def rbac_processors(
     rbac_groups = action_registry.concern(ConcernMeta(Concern.RBAC))
     return RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         RbacRelationService(RbacRelationRepository(RelationOpsProvider(database_engine))),
         RbacRosterService(RbacRosterRepository(RosterOpsProvider(database_engine))),
         RbacRoleService(
@@ -435,7 +435,7 @@ async def project_assignment_read_permission(
         regular_user_fixture.user_uuid,
         ScopeType.PROJECT,
         assignment_seed.project_id,
-        IDLE_CHECKER_ENTITY_TYPE,
+        IdleCheckerEntityType(),
         (OperationType.READ,),
     ):
         yield
@@ -465,15 +465,15 @@ async def project_assignment_manage_permission(
             regular_user_fixture.user_uuid,
             ScopeType.PROJECT,
             assignment_seed.project_id,
-            IDLE_CHECKER_ENTITY_TYPE,
+            IdleCheckerEntityType(),
             (OperationType.READ,),
         ):
             async for _ in _grant(
                 database_engine,
                 regular_user_fixture.user_uuid,
-                IDLE_CHECKER_ENTITY_TYPE,
+                IdleCheckerEntityType(),
                 assignment_seed.checker_id,
-                IDLE_CHECKER_ENTITY_TYPE,
+                IdleCheckerEntityType(),
                 (OperationType.SOFT_DELETE, OperationType.HARD_DELETE),
             ):
                 yield
@@ -508,7 +508,7 @@ async def user_self_scope_permission(
             regular_user_fixture.user_uuid,
             ScopeType.USER,
             regular_user_fixture.user_uuid,
-            IDLE_CHECKER_ENTITY_TYPE,
+            IdleCheckerEntityType(),
             (OperationType.READ,),
         ):
             yield

--- a/tests/component/image/conftest.py
+++ b/tests/component/image/conftest.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.container_registry import ContainerRegistryType
-from ai.backend.common.data.entity.image import IMAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.image import ImageEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.actions.validators.rbac.scope import ScopeActionRBACValidator
@@ -53,7 +53,7 @@ def image_processors(
     service = ImageService(agent_registry, repo, config_provider)
     mock_scope = MagicMock(spec=ScopeActionRBACValidator)
     mock_scope.validate = AsyncMock()
-    return ImageProcessors(processor_registry.group(GroupMeta(IMAGE_ENTITY_TYPE)), service)
+    return ImageProcessors(processor_registry.group(GroupMeta(ImageEntityType())), service)
 
 
 @pytest.fixture()

--- a/tests/component/infra/conftest.py
+++ b/tests/component/infra/conftest.py
@@ -9,14 +9,14 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.etcd_config import ETCD_CONFIG_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.etcd_config import EtcdConfigEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -94,7 +94,7 @@ def container_registry_processors(
     repo = ContainerRegistryRepository(database_engine, RelationOpsProvider(database_engine))
     service = ContainerRegistryService(database_engine, repo)
     return ContainerRegistryProcessors(
-        processor_registry.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ContainerRegistryEntityType())), service
     )
 
 
@@ -114,7 +114,7 @@ def etcd_config_processors(
         valkey_stat=valkey_clients.stat,
     )
     return EtcdConfigProcessors(
-        processor_registry.group(GroupMeta(ETCD_CONFIG_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(EtcdConfigEntityType())), service
     )
 
 
@@ -128,7 +128,7 @@ def resource_preset_processors(
     repo = ResourcePresetRepository(database_engine, valkey_clients.stat, config_provider)
     service = ResourcePresetService(repo)
     return ResourcePresetProcessors(
-        processor_registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ResourcePresetEntityType())), service
     )
 
 
@@ -166,7 +166,7 @@ def agent_processors(
         own_check=BulkOwnCheck(PermissionControllerRepository(database_engine), config_provider),
     )
     return AgentProcessors(
-        processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(AgentEntityType())),
         service,
         [],
     )
@@ -189,7 +189,7 @@ def project_processors(
     )
     group_repos = ProjectRepositories(repository=group_repo)
     service = ProjectService(storage_manager, config_provider, valkey_clients.stat, group_repos)
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), service)
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), service)
 
 
 @pytest.fixture()
@@ -207,7 +207,7 @@ def user_processors(
     )
     service = UserService(storage_manager, valkey_clients.stat, AsyncMock(), user_repo, AsyncMock())
     return UserProcessors(
-        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(UserEntityType())),
         service,
     )
 
@@ -220,7 +220,7 @@ def resource_group_processors(
     repo = ResourceGroupRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ResourceGroupService(repo, appproxy_client_pool=AsyncMock())
     return ResourceGroupProcessors(
-        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ResourceGroupEntityType())), service
     )
 
 
@@ -233,7 +233,7 @@ def domain_processors(
     service = DomainService(
         repository=DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     )
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()

--- a/tests/component/keypair/conftest.py
+++ b/tests/component/keypair/conftest.py
@@ -16,7 +16,7 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import (
     GroupMeta,
@@ -58,7 +58,7 @@ def user_processors(
         scheduling_controller=MagicMock(),
     )
     return UserProcessors(
-        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(UserEntityType())),
         user_service,
     )
 

--- a/tests/component/model_card/conftest.py
+++ b/tests/component/model_card/conftest.py
@@ -16,10 +16,10 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.permission.types import EntityType, Permission, ScopeType
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType, VFolderUsageMode
@@ -117,7 +117,7 @@ def model_card_processors(
     """Real ModelCardProcessors with real RBAC enforcement."""
     repo = ModelCardRepository(V2DBOpsProvider(database_engine))
     service = ModelCardService(repo, storage_manager)
-    return ModelCardProcessors(processor_registry.group(GroupMeta(MODEL_CARD_ENTITY_TYPE)), service)
+    return ModelCardProcessors(processor_registry.group(GroupMeta(ModelCardEntityType())), service)
 
 
 @pytest.fixture()
@@ -143,7 +143,7 @@ def group_processors(
         valkey_stat_client=valkey_clients.stat,
         group_repositories=repositories,
     )
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), service)
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), service)
 
 
 @pytest.fixture()
@@ -161,7 +161,7 @@ def permission_controller_processors(
         rbac_action_registry=[],
     )
     return PermissionControllerProcessors(
-        processor_registry.group(GroupMeta(ROLE_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RoleEntityType())),
         service=service,
         action_monitors=[],
         validators=_build_validators(database_engine, config_provider),
@@ -186,7 +186,7 @@ def user_processors(
         ),
         scheduling_controller=AsyncMock(),
     )
-    return UserProcessors(processor_registry.group(GroupMeta(USER_ENTITY_TYPE)), service)
+    return UserProcessors(processor_registry.group(GroupMeta(UserEntityType())), service)
 
 
 @pytest.fixture()
@@ -198,7 +198,7 @@ def rbac_processors(
     rbac_groups = processor_registry.concern(ConcernMeta(Concern.RBAC))
     return RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         RbacRelationService(RbacRelationRepository(RelationOpsProvider(database_engine))),
         RbacRosterService(RbacRosterRepository(RosterOpsProvider(database_engine))),
         RbacRoleService(

--- a/tests/component/model_serving/conftest.py
+++ b/tests/component/model_serving/conftest.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.events.hub.hub import EventHub
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
@@ -71,7 +71,7 @@ def model_serving_processors(
         route_controller=AsyncMock(),
     )
     return ModelServingProcessors(
-        processor_registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(DeploymentEntityType())), service
     )
 
 
@@ -84,7 +84,7 @@ def auto_scaling_processors(
     repo = ModelServingRepository(database_engine, V2DBOpsProvider(database_engine))
     service = AutoScalingService(repository=repo)
     return ModelServingAutoScalingProcessors(
-        processor_registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(DeploymentEntityType())), service
     )
 
 
@@ -118,7 +118,7 @@ def deployment_processors(
         appproxy_client_pool=mock_appproxy_client_pool,
     )
     return DeploymentProcessors(
-        processor_registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(DeploymentEntityType())), service
     )
 
 

--- a/tests/component/notification/conftest.py
+++ b/tests/component/notification/conftest.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import pytest
 
 from ai.backend.common.data.entity.notification import (
-    NOTIFICATION_CHANNEL_ENTITY_TYPE,
-    NOTIFICATION_RULE_ENTITY_TYPE,
+    NotificationChannelEntityType,
+    NotificationRuleEntityType,
 )
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.rest.notification.handler import NotificationHandler
@@ -29,9 +29,9 @@ def notification_processors(
     # Create properly structured ActionValidators mock with async validators
     return NotificationProcessors(
         channel_group=ops_processor_group(
-            database_engine, GroupMeta(NOTIFICATION_CHANNEL_ENTITY_TYPE)
+            database_engine, GroupMeta(NotificationChannelEntityType())
         ),
-        rule_group=ops_processor_group(database_engine, GroupMeta(NOTIFICATION_RULE_ENTITY_TYPE)),
+        rule_group=ops_processor_group(database_engine, GroupMeta(NotificationRuleEntityType())),
         service=service,
     )
 

--- a/tests/component/object_storage/conftest.py
+++ b/tests/component/object_storage/conftest.py
@@ -9,10 +9,10 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import FieldGroupMeta, GroupMeta
 from ai.backend.manager.api.rest.middleware import auth as _auth_api
@@ -70,9 +70,9 @@ def object_storage_processors(
         config_provider=config_provider,
     )
     return ObjectStorageProcessors(
-        processor_registry.group(GroupMeta(OBJECT_STORAGE_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        processor_registry.group(GroupMeta(ObjectStorageEntityType())),
+        processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+            FieldGroupMeta(ArtifactRevisionFieldType()),
             ArtifactRevisionData,
             LookupArtifactRevisionOwnerAction,
             LookupBulkArtifactRevisionOwnerAction,
@@ -86,7 +86,7 @@ def storage_namespace_processors(
     database_engine: ExtendedAsyncSAEngine,
 ) -> StorageNamespaceProcessors:
     return StorageNamespaceProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(STORAGE_NAMESPACE_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(StorageNamespaceEntityType()))
     )
 
 

--- a/tests/component/operations/conftest.py
+++ b/tests/component/operations/conftest.py
@@ -8,10 +8,10 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.error_log import ERROR_LOG_FIELD_TYPE
-from ai.backend.common.data.entity.manager_admin import MANAGER_ADMIN_ENTITY_TYPE
+from ai.backend.common.data.entity.error_log import ErrorLogFieldType
+from ai.backend.common.data.entity.manager_admin import ManagerAdminEntityType
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.etcd import AsyncEtcd, ConfigScopes
 from ai.backend.common.types import HostPortPair
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -46,8 +46,8 @@ from ai.backend.testutils.processors import ops_processor_group
 @pytest.fixture()
 def error_log_processors(database_engine: ExtendedAsyncSAEngine) -> ErrorLogProcessors:
     return ErrorLogProcessors(
-        ops_processor_group(database_engine, GroupMeta(USER_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ERROR_LOG_FIELD_TYPE),
+        ops_processor_group(database_engine, GroupMeta(UserEntityType())).field_group(
+            FieldGroupMeta(ErrorLogFieldType()),
             ErrorLogData,
             LookupErrorLogOwnerAction,
             LookupBulkErrorLogOwnerAction,
@@ -89,7 +89,7 @@ def manager_admin_processors(
         valkey_stat=valkey_clients.stat,
     )
     return ManagerAdminProcessors(
-        processor_registry.group(GroupMeta(MANAGER_ADMIN_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ManagerAdminEntityType())), service
     )
 
 

--- a/tests/component/project/conftest.py
+++ b/tests/component/project/conftest.py
@@ -23,10 +23,10 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.permission.types import RelationType
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -156,7 +156,7 @@ def group_processors(
         valkey_stat_client=valkey_clients.stat,
         group_repositories=repositories,
     )
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), service)
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), service)
 
 
 @pytest.fixture()
@@ -182,7 +182,7 @@ def user_processors(
         scheduling_controller=AsyncMock(),
     )
     return UserProcessors(
-        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(UserEntityType())),
         service,
     )
 
@@ -201,7 +201,7 @@ def permission_controller_processors(
         rbac_action_registry=[],
     )
     return PermissionControllerProcessors(
-        processor_registry.group(GroupMeta(ROLE_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RoleEntityType())),
         service=service,
         action_monitors=[],
         validators=_build_validators(database_engine, config_provider),
@@ -217,7 +217,7 @@ def domain_processors(
     service = DomainService(
         repository=DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     )
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()
@@ -229,7 +229,7 @@ def rbac_processors(
     rbac_groups = processor_registry.concern(ConcernMeta(Concern.RBAC))
     return RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         RbacRelationService(RbacRelationRepository(RelationOpsProvider(database_engine))),
         RbacRosterService(RbacRosterRepository(RosterOpsProvider(database_engine))),
         RbacRoleService(

--- a/tests/component/prometheus_query_preset/conftest.py
+++ b/tests/component/prometheus_query_preset/conftest.py
@@ -17,7 +17,7 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
@@ -93,7 +93,7 @@ def prometheus_query_preset_processors(
         ops_repository=OpsRepository(V2DBOpsProvider(database_engine)),
     )
     return PrometheusQueryPresetProcessors(
-        processor_registry.group(GroupMeta(PROMETHEUS_QUERY_PRESET_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(PrometheusQueryPresetEntityType())), service
     )
 
 

--- a/tests/component/quota_scope/conftest.py
+++ b/tests/component/quota_scope/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.rest.admin.handler import AdminHandler
@@ -29,7 +29,7 @@ def vfs_storage_processors(
     repo = VFSStorageRepository(database_engine)
     service = VFSStorageService(repo, storage_manager=storage_manager)
     return VFSStorageProcessors(
-        processor_registry.group(GroupMeta(VFS_STORAGE_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(VFSStorageEntityType())), service
     )
 
 

--- a/tests/component/rbac/conftest.py
+++ b/tests/component/rbac/conftest.py
@@ -10,8 +10,8 @@ import pytest
 
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.rbac.request import (
     CreateRoleRequest,
     PurgeRoleRequest,
@@ -59,7 +59,7 @@ def permission_controller_processors(
         rbac=RBACValidators(scope=AsyncMock()),
     )
     return PermissionControllerProcessors(
-        processor_registry.group(GroupMeta(ROLE_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RoleEntityType())),
         service=service,
         action_monitors=[],
         validators=validators,
@@ -75,7 +75,7 @@ def rbac_processors(
     rbac_groups = processor_registry.concern(ConcernMeta(Concern.RBAC))
     return RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         MagicMock(),
         MagicMock(),
         RbacRoleService(

--- a/tests/component/rbac/test_rbac_role_v2.py
+++ b/tests/component/rbac/test_rbac_role_v2.py
@@ -13,7 +13,7 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.exceptions import PermissionDeniedError
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.dto.manager.v2.rbac.request import (
     AssignRoleInput,
     RevokeRoleInput,
@@ -66,7 +66,7 @@ def permission_controller_processors(
         rbac=RBACValidators(scope=AsyncMock()),
     )
     return PermissionControllerProcessors(
-        processor_registry.group(GroupMeta(ROLE_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RoleEntityType())),
         service=service,
         action_monitors=[],
         validators=validators,

--- a/tests/component/rbac/test_rbac_scoped_role_search.py
+++ b/tests/component/rbac/test_rbac_scoped_role_search.py
@@ -14,7 +14,7 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.dto.manager.v2.rbac.request import SearchRolesInput
 from ai.backend.common.dto.manager.v2.rbac.response import AdminSearchRolesPayload
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -65,7 +65,7 @@ def permission_controller_processors(
         rbac=RBACValidators(scope=AsyncMock()),
     )
     return PermissionControllerProcessors(
-        processor_registry.group(GroupMeta(ROLE_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(RoleEntityType())),
         service=service,
         action_monitors=[],
         validators=validators,

--- a/tests/component/resource_allocation/conftest.py
+++ b/tests/component/resource_allocation/conftest.py
@@ -16,12 +16,12 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import (
     Concern,
@@ -89,12 +89,12 @@ def resource_allocation_processors(
     )
     groups = processor_registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
     return ResourceAllocationProcessors(
-        groups.group(GroupMeta(USER_ENTITY_TYPE)),
-        groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-        groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-        groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-        groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+        groups.group(GroupMeta(UserEntityType())),
+        groups.group(GroupMeta(ProjectEntityType())),
+        groups.group(GroupMeta(DomainEntityType())),
+        groups.group(GroupMeta(ResourceGroupEntityType())),
+        groups.group(GroupMeta(SessionEntityType())),
+        groups.group(GroupMeta(ResourcePresetEntityType())),
         service,
     )
 
@@ -117,7 +117,7 @@ def user_processors(
         ),
         scheduling_controller=AsyncMock(),
     )
-    return UserProcessors(processor_registry.group(GroupMeta(USER_ENTITY_TYPE)), service)
+    return UserProcessors(processor_registry.group(GroupMeta(UserEntityType())), service)
 
 
 @pytest.fixture()
@@ -129,7 +129,7 @@ def domain_processors(
     service = DomainService(
         repository=DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     )
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()

--- a/tests/component/resource_allocation/test_resource_allocation_visibility.py
+++ b/tests/component/resource_allocation/test_resource_allocation_visibility.py
@@ -18,15 +18,15 @@ import yarl
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupName,
 )
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.v2.resource_allocation.request import (
     EffectiveResourceAllocationInput,
 )
@@ -166,12 +166,12 @@ class TestHideAgentsVisibility:
         )
         groups = processor_registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
         return ResourceAllocationProcessors(
-            groups.group(GroupMeta(USER_ENTITY_TYPE)),
-            groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            groups.group(GroupMeta(UserEntityType())),
+            groups.group(GroupMeta(ProjectEntityType())),
+            groups.group(GroupMeta(DomainEntityType())),
+            groups.group(GroupMeta(ResourceGroupEntityType())),
+            groups.group(GroupMeta(SessionEntityType())),
+            groups.group(GroupMeta(ResourcePresetEntityType())),
             service,
         )
 
@@ -302,12 +302,12 @@ class TestGroupResourceVisibility:
         )
         groups = processor_registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
         return ResourceAllocationProcessors(
-            groups.group(GroupMeta(USER_ENTITY_TYPE)),
-            groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            groups.group(GroupMeta(UserEntityType())),
+            groups.group(GroupMeta(ProjectEntityType())),
+            groups.group(GroupMeta(DomainEntityType())),
+            groups.group(GroupMeta(ResourceGroupEntityType())),
+            groups.group(GroupMeta(SessionEntityType())),
+            groups.group(GroupMeta(ResourcePresetEntityType())),
             service,
         )
 

--- a/tests/component/resource_group/conftest.py
+++ b/tests/component/resource_group/conftest.py
@@ -16,9 +16,9 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import Concern, ConcernMeta, GroupMeta
 from ai.backend.manager.api.adapters.resource_group.adapter import ResourceGroupAdapter
@@ -60,7 +60,7 @@ def resource_group_processors(
     repo = ResourceGroupRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ResourceGroupService(repo)
     return ResourceGroupProcessors(
-        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ResourceGroupEntityType())), service
     )
 
 
@@ -73,7 +73,7 @@ def domain_processors(
     service = DomainService(
         repository=DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     )
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()
@@ -85,7 +85,7 @@ def rbac_processors(
     rbac_groups = processor_registry.concern(ConcernMeta(Concern.RBAC))
     return RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         RbacRelationService(RbacRelationRepository(RelationOpsProvider(database_engine))),
         RbacRosterService(RbacRosterRepository(RosterOpsProvider(database_engine))),
         RbacRoleService(

--- a/tests/component/resource_group/test_resource_group_allow.py
+++ b/tests/component/resource_group/test_resource_group_allow.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.dto.manager.v2.resource_group.request import (
     UpdateAllowedDomainsForResourceGroupInput,
     UpdateAllowedProjectsForResourceGroupInput,
@@ -72,7 +72,7 @@ async def _seed_scaling_group(conn: Any, name: str, description: str) -> None:
     ).scalar_one()
     await conn.execute(
         sa.insert(VirtualEntityRow.__table__).values(
-            entity_type=RESOURCE_GROUP_ENTITY_TYPE,
+            entity_type=ResourceGroupEntityType(),
             entity_id=resource_group_id,
         )
     )

--- a/tests/component/resource_policy/conftest.py
+++ b/tests/component/resource_policy/conftest.py
@@ -18,9 +18,9 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
-    PROJECT_RESOURCE_POLICY_ENTITY_TYPE,
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
+    ProjectResourcePolicyEntityType,
+    UserResourcePolicyEntityType,
 )
 from ai.backend.common.dto.manager.v2.common import BinarySizeInput
 from ai.backend.common.dto.manager.v2.resource_policy.request import (
@@ -77,14 +77,14 @@ def resource_policy_processors(
     ProjectResourcePolicyProcessors,
 ]:
     kp_processors = KeypairResourcePolicyProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(KeyPairResourcePolicyEntityType()))
     )
     up_processors = UserResourcePolicyProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(USER_RESOURCE_POLICY_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(UserResourcePolicyEntityType()))
     )
 
     pp_processors = ProjectResourcePolicyProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(PROJECT_RESOURCE_POLICY_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(ProjectResourcePolicyEntityType()))
     )
 
     return kp_processors, up_processors, pp_processors

--- a/tests/component/resource_preset/conftest.py
+++ b/tests/component/resource_preset/conftest.py
@@ -9,11 +9,11 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -85,7 +85,7 @@ def container_registry_processors(
     repo = ContainerRegistryRepository(database_engine, RelationOpsProvider(database_engine))
     service = ContainerRegistryService(database_engine, repo)
     return ContainerRegistryProcessors(
-        processor_registry.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ContainerRegistryEntityType())), service
     )
 
 
@@ -99,7 +99,7 @@ def resource_preset_processors(
     repo = ResourcePresetRepository(database_engine, valkey_clients.stat, config_provider)
     service = ResourcePresetService(repo)
     return ResourcePresetProcessors(
-        processor_registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ResourcePresetEntityType())), service
     )
 
 
@@ -137,7 +137,7 @@ def agent_processors(
         own_check=BulkOwnCheck(PermissionControllerRepository(database_engine), config_provider),
     )
     return AgentProcessors(
-        processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(AgentEntityType())),
         service,
         [],
     )
@@ -160,7 +160,7 @@ def project_processors(
     )
     group_repos = ProjectRepositories(repository=group_repo)
     service = ProjectService(storage_manager, config_provider, valkey_clients.stat, group_repos)
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), service)
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), service)
 
 
 @pytest.fixture()
@@ -178,7 +178,7 @@ def user_processors(
     )
     service = UserService(storage_manager, valkey_clients.stat, AsyncMock(), user_repo, AsyncMock())
     return UserProcessors(
-        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(UserEntityType())),
         service,
     )
 

--- a/tests/component/runtime_variant/conftest.py
+++ b/tests/component/runtime_variant/conftest.py
@@ -16,7 +16,7 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
-from ai.backend.common.data.entity.runtime_variant import RUNTIME_VARIANT_ENTITY_TYPE
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantEntityType
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.adapters.runtime_variant.adapter import RuntimeVariantAdapter
 from ai.backend.manager.api.rest.routing import RouteRegistry
@@ -36,7 +36,7 @@ def runtime_variant_processors(
     database_engine: ExtendedAsyncSAEngine,
 ) -> RuntimeVariantProcessors:
     return RuntimeVariantProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(RUNTIME_VARIANT_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(RuntimeVariantEntityType()))
     )
 
 

--- a/tests/component/scaling_group/conftest.py
+++ b/tests/component/scaling_group/conftest.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.rest.resource_group.handler import ResourceGroupHandler
@@ -37,7 +37,7 @@ def resource_group_processors(
     repo = ResourceGroupRepository(database_engine, V2DBOpsProvider(database_engine))
     service = ResourceGroupService(repo)
     return ResourceGroupProcessors(
-        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(ResourceGroupEntityType())), service
     )
 
 
@@ -49,7 +49,7 @@ def domain_processors(
     service = DomainService(
         repository=DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     )
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()
@@ -71,7 +71,7 @@ def project_processors(
         )
     )
     service = ProjectService(storage_manager, config_provider, valkey_clients.stat, repositories)
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), service)
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), service)
 
 
 @pytest.fixture()

--- a/tests/component/scheduling_history/conftest.py
+++ b/tests/component/scheduling_history/conftest.py
@@ -15,14 +15,14 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.data.entity.replica_group import ReplicaGroupID
 from ai.backend.common.data.entity.replica_group_history import (
     ReplicaGroupHistoryID,
 )
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.session_group import SessionGroupID
 from ai.backend.common.schema.deployment import IntOrPercent, ReplicaGroupRolloutSpec
 from ai.backend.common.types import KernelId
@@ -85,9 +85,9 @@ def scheduling_history_processors(
     service = SchedulingHistoryService(repo)
     groups = processor_registry.concern(ConcernMeta(Concern.SESSION))
     return SchedulingHistoryProcessors(
-        groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
-        groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+        groups.group(GroupMeta(SessionEntityType())),
+        groups.group(GroupMeta(DeploymentEntityType())),
+        groups.group(GroupMeta(DeploymentEntityType())),
         service,
     )
 
@@ -106,7 +106,7 @@ def scheduling_history_adapter(
     processors.scheduling_history = scheduling_history_processors
     processors.resource_slot = MagicMock()
     processors.resource_slot.lookup_kernel_owner = processor_registry.group(
-        GroupMeta(SESSION_ENTITY_TYPE)
+        GroupMeta(SessionEntityType())
     ).key_owner_lookup_ops(LookupKernelOwnerAction)
     return SchedulingHistoryAdapter(processors.scheduling_history, processors.resource_slot)
 

--- a/tests/component/secret/conftest.py
+++ b/tests/component/secret/conftest.py
@@ -16,7 +16,7 @@ from ai.backend.client.v2.v2_registry import V2ClientRegistry
 if TYPE_CHECKING:
     from tests.component.conftest import ServerInfo, UserFixtureData
 
-from ai.backend.common.data.entity.secret import SECRET_ENTITY_TYPE
+from ai.backend.common.data.entity.secret import SecretEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.adapters.secret.adapter import SecretAdapter
@@ -43,7 +43,7 @@ def secret_processors(
     pool = KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN)
     repository = SecretRepository(SecretOpsProvider(database_engine), pool)
     return SecretProcessors(
-        processor_registry.group(GroupMeta(SECRET_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(SecretEntityType())),
         SecretService(repository),
     )
 

--- a/tests/component/session/conftest.py
+++ b/tests/component/session/conftest.py
@@ -14,18 +14,18 @@ from dateutil.tz import tzutc
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupID,
     ResourceGroupName,
 )
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
+from ai.backend.common.data.entity.user import UserEntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.plugin.monitor import ErrorPluginContext
 from ai.backend.common.types import AgentId, SessionTypes
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
@@ -129,15 +129,15 @@ async def session_processors(
     service = SessionService(args)
     groups = processor_registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
     return SessionProcessors(
-        processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(SessionEntityType())),
+        groups.group(GroupMeta(ResourceGroupEntityType())),
         ResourceAllocationProcessors(
-            groups.group(GroupMeta(USER_ENTITY_TYPE)),
-            groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            groups.group(GroupMeta(UserEntityType())),
+            groups.group(GroupMeta(ProjectEntityType())),
+            groups.group(GroupMeta(DomainEntityType())),
+            groups.group(GroupMeta(ResourceGroupEntityType())),
+            groups.group(GroupMeta(SessionEntityType())),
+            groups.group(GroupMeta(ResourcePresetEntityType())),
             AsyncMock(),
         ),
         service,
@@ -148,7 +148,7 @@ async def session_processors(
 def agent_processors_mock(processor_registry: ProcessorRegistry[Any]) -> AgentProcessors:
     """AgentProcessors with a mocked AgentService."""
     return AgentProcessors(
-        processor_registry.group(GroupMeta(AGENT_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(AgentEntityType())),
         AsyncMock(),
         [],
     )
@@ -157,7 +157,7 @@ def agent_processors_mock(processor_registry: ProcessorRegistry[Any]) -> AgentPr
 @pytest.fixture()
 def vfolder_processors_mock(processor_registry: ProcessorRegistry[Any]) -> VFolderProcessors:
     """VFolderProcessors with a mocked VFolderService."""
-    return VFolderProcessors(processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), AsyncMock())
+    return VFolderProcessors(processor_registry.group(GroupMeta(VFolderEntityType())), AsyncMock())
 
 
 @pytest.fixture()
@@ -175,10 +175,10 @@ def server_module_registries(
         register_session_routes(
             SessionHandler(
                 project=ProjectProcessors(
-                    processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), AsyncMock()
+                    processor_registry.group(GroupMeta(ProjectEntityType())), AsyncMock()
                 ),
                 user=UserProcessors(
-                    processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+                    processor_registry.group(GroupMeta(UserEntityType())),
                     AsyncMock(),
                 ),
                 auth=auth_processors,

--- a/tests/component/session/test_session_query.py
+++ b/tests/component/session/test_session_query.py
@@ -21,10 +21,10 @@ from ai.backend.client.v2.exceptions import (
     PermissionDeniedError,
 )
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
 from ai.backend.common.data.entity.session import SessionID
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.compute_session import (
     SearchComputeSessionsRequest,
     SearchComputeSessionsResponse,
@@ -90,10 +90,10 @@ def server_module_registries(
         register_session_routes(
             SessionHandler(
                 project=ProjectProcessors(
-                    processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), AsyncMock()
+                    processor_registry.group(GroupMeta(ProjectEntityType())), AsyncMock()
                 ),
                 user=UserProcessors(
-                    processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+                    processor_registry.group(GroupMeta(UserEntityType())),
                     AsyncMock(),
                 ),
                 auth=auth_processors,

--- a/tests/component/session_v2/conftest.py
+++ b/tests/component/session_v2/conftest.py
@@ -21,17 +21,17 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.container_registry import ContainerRegistryType
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.image import ImageID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_ENTITY_TYPE,
+    ResourceGroupEntityType,
     ResourceGroupID,
     ResourceGroupName,
 )
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.permission.types import (
     EntityType,
     Permission,
@@ -167,15 +167,15 @@ async def session_processors(
     )
     service = SessionService(args)
     return SessionProcessors(
-        processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(SessionEntityType())),
+        processor_registry.group(GroupMeta(ResourceGroupEntityType())),
         ResourceAllocationProcessors(
-            processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            processor_registry.group(GroupMeta(UserEntityType())),
+            processor_registry.group(GroupMeta(ProjectEntityType())),
+            processor_registry.group(GroupMeta(DomainEntityType())),
+            processor_registry.group(GroupMeta(ResourceGroupEntityType())),
+            processor_registry.group(GroupMeta(SessionEntityType())),
+            processor_registry.group(GroupMeta(ResourcePresetEntityType())),
             MagicMock(),
         ),
         service,
@@ -718,15 +718,15 @@ async def compute_session_processors(
     )
     service = SessionService(args)
     return SessionProcessors(
-        processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(SessionEntityType())),
+        processor_registry.group(GroupMeta(ResourceGroupEntityType())),
         ResourceAllocationProcessors(
-            processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            processor_registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            processor_registry.group(GroupMeta(UserEntityType())),
+            processor_registry.group(GroupMeta(ProjectEntityType())),
+            processor_registry.group(GroupMeta(DomainEntityType())),
+            processor_registry.group(GroupMeta(ResourceGroupEntityType())),
+            processor_registry.group(GroupMeta(SessionEntityType())),
+            processor_registry.group(GroupMeta(ResourcePresetEntityType())),
             MagicMock(),
         ),
         service,

--- a/tests/component/storage/conftest.py
+++ b/tests/component/storage/conftest.py
@@ -4,11 +4,11 @@ from typing import Any
 
 import pytest
 
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import FieldGroupMeta, GroupMeta
 from ai.backend.manager.api.rest.middleware import auth as _auth_api
@@ -64,9 +64,9 @@ def object_storage_processors(
         config_provider=config_provider,
     )
     return ObjectStorageProcessors(
-        processor_registry.group(GroupMeta(OBJECT_STORAGE_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        processor_registry.group(GroupMeta(ObjectStorageEntityType())),
+        processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+            FieldGroupMeta(ArtifactRevisionFieldType()),
             ArtifactRevisionData,
             LookupArtifactRevisionOwnerAction,
             LookupBulkArtifactRevisionOwnerAction,
@@ -80,7 +80,7 @@ def storage_namespace_processors(
     database_engine: ExtendedAsyncSAEngine,
 ) -> StorageNamespaceProcessors:
     return StorageNamespaceProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(STORAGE_NAMESPACE_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(StorageNamespaceEntityType()))
     )
 
 
@@ -96,7 +96,7 @@ def vfs_storage_processors(
         storage_manager=storage_manager,
     )
     return VFSStorageProcessors(
-        processor_registry.group(GroupMeta(VFS_STORAGE_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(VFSStorageEntityType())), service
     )
 
 

--- a/tests/component/storage_namespace/conftest.py
+++ b/tests/component/storage_namespace/conftest.py
@@ -9,10 +9,10 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import FieldGroupMeta, GroupMeta
 from ai.backend.manager.api.rest.middleware import auth as _auth_api
@@ -67,9 +67,9 @@ def object_storage_processors(
         config_provider=config_provider,
     )
     return ObjectStorageProcessors(
-        processor_registry.group(GroupMeta(OBJECT_STORAGE_ENTITY_TYPE)),
-        processor_registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-            FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+        processor_registry.group(GroupMeta(ObjectStorageEntityType())),
+        processor_registry.group(GroupMeta(ArtifactEntityType())).field_group(
+            FieldGroupMeta(ArtifactRevisionFieldType()),
             ArtifactRevisionData,
             LookupArtifactRevisionOwnerAction,
             LookupBulkArtifactRevisionOwnerAction,
@@ -83,7 +83,7 @@ def storage_namespace_processors(
     database_engine: ExtendedAsyncSAEngine,
 ) -> StorageNamespaceProcessors:
     return StorageNamespaceProcessors(
-        group=ops_processor_group(database_engine, GroupMeta(STORAGE_NAMESPACE_ENTITY_TYPE))
+        group=ops_processor_group(database_engine, GroupMeta(StorageNamespaceEntityType()))
     )
 
 

--- a/tests/component/stream/conftest.py
+++ b/tests/component/stream/conftest.py
@@ -14,7 +14,7 @@ from dateutil.tz import tzutc
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.plugin.monitor import ErrorPluginContext
 from ai.backend.common.types import SessionTypes
@@ -83,7 +83,7 @@ def stream_processors(
         valkey_live=valkey_clients.live,
         etcd=async_etcd,
     )
-    return StreamProcessors(processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)), service)
+    return StreamProcessors(processor_registry.group(GroupMeta(SessionEntityType())), service)
 
 
 @pytest.fixture()
@@ -114,7 +114,7 @@ async def session_processors(
         )
     )
     processors = MagicMock()
-    group = processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE))
+    group = processor_registry.group(GroupMeta(SessionEntityType()))
     processors.resolve_session_name = group.single_entity(
         ResolveSessionNameAction, service.resolve_session_name
     )

--- a/tests/component/streaming/conftest.py
+++ b/tests/component/streaming/conftest.py
@@ -14,7 +14,7 @@ from dateutil.tz import tzutc
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.plugin.monitor import ErrorPluginContext
 from ai.backend.common.types import SessionTypes
@@ -83,7 +83,7 @@ def stream_processors(
         valkey_live=valkey_clients.live,
         etcd=async_etcd,
     )
-    return StreamProcessors(processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE)), service)
+    return StreamProcessors(processor_registry.group(GroupMeta(SessionEntityType())), service)
 
 
 @pytest.fixture()
@@ -112,7 +112,7 @@ async def session_processors(
         )
     )
     processors = MagicMock()
-    group = processor_registry.group(GroupMeta(SESSION_ENTITY_TYPE))
+    group = processor_registry.group(GroupMeta(SessionEntityType()))
     processors.resolve_session_name = group.single_entity(
         ResolveSessionNameAction, service.resolve_session_name
     )

--- a/tests/component/template/conftest.py
+++ b/tests/component/template/conftest.py
@@ -8,8 +8,8 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.session_template import SESSION_TEMPLATE_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.session_template import SessionTemplateEntityType
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.actions.validators import ActionValidators
@@ -51,7 +51,7 @@ def template_processors(
     repo = TemplateRepository(database_engine)
     service = TemplateService(repository=repo)
     return TemplateProcessors(
-        processor_registry.group(GroupMeta(SESSION_TEMPLATE_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(SessionTemplateEntityType())), service
     )
 
 
@@ -72,7 +72,7 @@ def project_processors(
     )
     group_repos = ProjectRepositories(repository=group_repo)
     service = ProjectService(storage_manager, config_provider, valkey_clients.stat, group_repos)
-    return ProjectProcessors(processor_registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), service)
+    return ProjectProcessors(processor_registry.group(GroupMeta(ProjectEntityType())), service)
 
 
 @pytest.fixture()

--- a/tests/component/user/conftest.py
+++ b/tests/component/user/conftest.py
@@ -15,8 +15,8 @@ from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.user import (
     CreateUserRequest,
     CreateUserResponse,
@@ -94,7 +94,7 @@ def user_processors(
         scheduling_controller=AsyncMock(),
     )
     return UserProcessors(
-        processor_registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        processor_registry.group(GroupMeta(UserEntityType())),
         service,
     )
 
@@ -107,7 +107,7 @@ def domain_processors(
     service = DomainService(
         repository=DomainRepository(database_engine, V2DBOpsProvider(database_engine))
     )
-    return DomainProcessors(processor_registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), service, [])
+    return DomainProcessors(processor_registry.group(GroupMeta(DomainEntityType())), service, [])
 
 
 @pytest.fixture()

--- a/tests/component/user/test_user_crud.py
+++ b/tests/component/user/test_user_crud.py
@@ -11,9 +11,9 @@ from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.client.v2.exceptions import ConflictError, NotFoundError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.id import EntityMembershipID
 from ai.backend.common.dto.manager.user import (
@@ -124,7 +124,7 @@ class TestUserCreateCrud:
             membership = (
                 await conn.execute(
                     _membership_query(
-                        PROJECT_ENTITY_TYPE, group_fixture, USER_ENTITY_TYPE, result.user.id
+                        ProjectEntityType(), group_fixture, UserEntityType(), result.user.id
                     )
                 )
             ).fetchone()
@@ -156,8 +156,8 @@ class TestUserCreateCrud:
                     .join(EntityMembershipRow, EntityMembershipRow.member_entity_id == member.id)
                     .where(
                         EntityMembershipRow.virtual_entity_id
-                        == _node_id(PROJECT_ENTITY_TYPE, project_id),
-                        member.entity_type == USER_ENTITY_TYPE,
+                        == _node_id(ProjectEntityType(), project_id),
+                        member.entity_type == UserEntityType(),
                     )
                 )
             ).all()
@@ -473,7 +473,7 @@ class TestUserCreateAutoAssignRoles:
                 name=name,
                 status=RoleStatus.ACTIVE,
                 auto_assign=True,
-                scope_type=PROJECT_ENTITY_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=project_id,
             )
         )
@@ -481,13 +481,13 @@ class TestUserCreateAutoAssignRoles:
         await conn.execute(
             sa.insert(VirtualEntityRow.__table__).values(
                 id=role_node_id,
-                entity_type=ROLE_ENTITY_TYPE,
+                entity_type=RoleEntityType(),
                 entity_id=role_id,
             )
         )
         await conn.execute(
             sa.insert(EntityMembershipRow.__table__).values(
-                virtual_entity_id=_node_id(PROJECT_ENTITY_TYPE, project_id),
+                virtual_entity_id=_node_id(ProjectEntityType(), project_id),
                 member_entity_id=role_node_id,
                 capped=False,
             )
@@ -501,7 +501,7 @@ class TestUserCreateAutoAssignRoles:
         )
         await conn.execute(
             VirtualEntityRow.__table__.delete().where(
-                VirtualEntityRow.__table__.c.entity_type == ROLE_ENTITY_TYPE,
+                VirtualEntityRow.__table__.c.entity_type == RoleEntityType(),
                 VirtualEntityRow.__table__.c.entity_id == role_id,
             )
         )
@@ -606,7 +606,7 @@ class TestUserCreateAutoAssignRoles:
             membership = (
                 await conn.execute(
                     _membership_query(
-                        PROJECT_ENTITY_TYPE, group_fixture, USER_ENTITY_TYPE, result.user.id
+                        ProjectEntityType(), group_fixture, UserEntityType(), result.user.id
                     )
                 )
             ).fetchone()
@@ -636,7 +636,7 @@ class TestUserCreateAutoAssignRoles:
             membership = (
                 await conn.execute(
                     _membership_query(
-                        PROJECT_ENTITY_TYPE, model_store_project, USER_ENTITY_TYPE, result.user.id
+                        ProjectEntityType(), model_store_project, UserEntityType(), result.user.id
                     )
                 )
             ).fetchone()

--- a/tests/component/vfolder/conftest.py
+++ b/tests/component/vfolder/conftest.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder_invitation import VFOLDER_INVITATION_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
+from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationEntityType
 from ai.backend.common.data.permission.types import (
     EntityType,
     Permission,
@@ -141,7 +141,7 @@ def vfolder_processors(
         user_repository=user_repository,
         valkey_stat_client=valkey_clients.stat,
     )
-    return VFolderProcessors(processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), service)
+    return VFolderProcessors(processor_registry.group(GroupMeta(VFolderEntityType())), service)
 
 
 @pytest.fixture()
@@ -164,7 +164,7 @@ def vfolder_file_processors(
         vfolder_repository=vfolder_repository,
         user_repository=user_repository,
     )
-    return VFolderFileProcessors(processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), service)
+    return VFolderFileProcessors(processor_registry.group(GroupMeta(VFolderEntityType())), service)
 
 
 @pytest.fixture()
@@ -186,7 +186,7 @@ def vfolder_invite_processors(
         user_repository=user_repository,
     )
     return VFolderInviteProcessors(
-        processor_registry.group(GroupMeta(VFOLDER_INVITATION_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(VFolderInvitationEntityType())), service
     )
 
 
@@ -209,7 +209,7 @@ def vfolder_sharing_processors(
         user_repository=user_repository,
     )
     return VFolderSharingProcessors(
-        processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(VFolderEntityType())), service
     )
 
 
@@ -339,7 +339,7 @@ async def vfolder_factory(
             node_id = uuid.uuid4()
             await conn.execute(
                 sa.insert(VirtualEntityRow.__table__).values(
-                    id=node_id, entity_type=VFOLDER_ENTITY_TYPE, entity_id=defaults["id"]
+                    id=node_id, entity_type=VFolderEntityType(), entity_id=defaults["id"]
                 )
             )
             await conn.execute(
@@ -362,7 +362,7 @@ async def vfolder_factory(
         for vid in reversed(created_ids):
             await conn.execute(
                 VirtualEntityRow.__table__.delete().where(
-                    VirtualEntityRow.__table__.c.entity_type == VFOLDER_ENTITY_TYPE,
+                    VirtualEntityRow.__table__.c.entity_type == VFolderEntityType(),
                     VirtualEntityRow.__table__.c.entity_id == vid,
                 )
             )

--- a/tests/component/vfolder/test_vfolder_clone.py
+++ b/tests/component/vfolder/test_vfolder_clone.py
@@ -25,7 +25,7 @@ from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.bgtask.types import TaskID
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.dto.manager.v2.vfolder.request import CloneVFolderInput
 from ai.backend.common.dto.manager.vfolder import CloneVFolderReq
 from ai.backend.common.types import QuotaScopeID, QuotaScopeType
@@ -78,7 +78,7 @@ def vfolder_admin_processors(
 ) -> VFolderAdminProcessors:
     repo = VFolderAdminRepository(database_engine)
     service = VFolderAdminService(vfolder_admin_repository=repo)
-    return VFolderAdminProcessors(processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), service)
+    return VFolderAdminProcessors(processor_registry.group(GroupMeta(VFolderEntityType())), service)
 
 
 @pytest.fixture()
@@ -179,7 +179,7 @@ async def _fetch_scope_graph(
                 sa.select(sa.func.count())
                 .select_from(scopes)
                 .where(
-                    scopes.c.entity_type == VFOLDER_ENTITY_TYPE,
+                    scopes.c.entity_type == VFolderEntityType(),
                     scopes.c.entity_id == vfolder_id,
                 )
             )
@@ -194,7 +194,7 @@ async def _fetch_scope_graph(
                     )
                 )
                 .where(
-                    members.c.entity_type == VFOLDER_ENTITY_TYPE,
+                    members.c.entity_type == VFolderEntityType(),
                     members.c.entity_id == vfolder_id,
                     scopes.c.entity_type == PROJECT_SCOPE_TYPE,
                     scopes.c.entity_id == owner_project_id,

--- a/tests/component/vfolder/test_vfolder_sharing.py
+++ b/tests/component/vfolder/test_vfolder_sharing.py
@@ -9,8 +9,8 @@ import sqlalchemy as sa
 
 from ai.backend.client.exceptions import BackendAPIError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.dto.manager.field import VFolderPermissionField
 from ai.backend.common.dto.manager.vfolder import (
@@ -626,8 +626,8 @@ async def _share_caps(db_engine: Any, vfolder_id: uuid.UUID) -> dict[uuid.UUID, 
         )
         .where(
             EntityMembershipRow.capped.is_(True),
-            scope.c.entity_type == PROJECT_ENTITY_TYPE,
-            member.c.entity_type == VFOLDER_ENTITY_TYPE,
+            scope.c.entity_type == ProjectEntityType(),
+            member.c.entity_type == VFolderEntityType(),
             member.c.entity_id == vfolder_id,
             ProjectRow.type == ProjectType.PERSONAL,
         )

--- a/tests/component/vfolder_v2/conftest.py
+++ b/tests/component/vfolder_v2/conftest.py
@@ -15,7 +15,7 @@ import yarl
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.types import (
     QuotaScopeID,
     QuotaScopeType,
@@ -112,7 +112,7 @@ def vfolder_processors(
         user_repository=user_repository,
         valkey_stat_client=MagicMock(),
     )
-    return VFolderProcessors(processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), service)
+    return VFolderProcessors(processor_registry.group(GroupMeta(VFolderEntityType())), service)
 
 
 @pytest.fixture()

--- a/tests/component/vfolder_v2/test_vfolder_mutation.py
+++ b/tests/component/vfolder_v2/test_vfolder_mutation.py
@@ -20,7 +20,7 @@ import yarl
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.dto.manager.field import VFolderPermissionField
 from ai.backend.common.dto.manager.v2.vfolder.request import CreateVFolderInScopeInput
 from ai.backend.common.types import (
@@ -126,7 +126,7 @@ def vfolder_processors(
         user_repository=user_repository,
         valkey_stat_client=MagicMock(),
     )
-    return VFolderProcessors(processor_registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), service)
+    return VFolderProcessors(processor_registry.group(GroupMeta(VFolderEntityType())), service)
 
 
 @pytest.fixture()

--- a/tests/component/vfs_storage/conftest.py
+++ b/tests/component/vfs_storage/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio.engine import AsyncEngine as SAEngine
 
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE, VFSStorageID
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType, VFSStorageID
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import GroupMeta
 from ai.backend.manager.api.rest.middleware import auth as _auth_api
@@ -42,7 +42,7 @@ def vfs_storage_processors(
         storage_manager=storage_manager,
     )
     return VFSStorageProcessors(
-        processor_registry.group(GroupMeta(VFS_STORAGE_ENTITY_TYPE)), service
+        processor_registry.group(GroupMeta(VFSStorageEntityType())), service
     )
 
 

--- a/tests/unit/common/data/entity/BUILD
+++ b/tests/unit/common/data/entity/BUILD
@@ -1,0 +1,1 @@
+python_tests()

--- a/tests/unit/common/data/entity/test_types.py
+++ b/tests/unit/common/data/entity/test_types.py
@@ -1,0 +1,74 @@
+"""Every entity and field type class answers its name, description and owner."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import pickle
+import pkgutil
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+import ai.backend.common.data.entity as entity_package
+from ai.backend.common.data.entity.agent import AgentEntityType
+from ai.backend.common.data.entity.types import DanglingFieldType, EntityType, FieldType
+
+
+def _subclasses[T: type](base: T) -> list[T]:
+    found: list[T] = []
+    for sub in base.__subclasses__():
+        found.append(sub)
+        found.extend(_subclasses(sub))
+    return found
+
+
+def _load_package() -> None:
+    for module in pkgutil.iter_modules(entity_package.__path__):
+        importlib.import_module(f"{entity_package.__name__}.{module.name}")
+
+
+_load_package()
+ENTITY_TYPES = _subclasses(EntityType)
+FIELD_TYPES = [cls for cls in _subclasses(FieldType) if cls is not DanglingFieldType]
+
+
+@pytest.mark.parametrize("cls", [*ENTITY_TYPES, *FIELD_TYPES], ids=lambda cls: cls.__name__)
+def test_type_class_answers_its_value(cls: type[EntityType] | type[FieldType]) -> None:
+    value = cls()
+    assert type(value) is cls
+    assert value == cls.name()
+    assert cls.description()
+    assert type(copy.deepcopy(value)) is cls
+    assert type(pickle.loads(pickle.dumps(value))) is cls
+
+
+@pytest.mark.parametrize("cls", FIELD_TYPES, ids=lambda cls: cls.__name__)
+def test_field_type_names_its_owner(cls: type[FieldType]) -> None:
+    owner = cls.owner_type()
+    if issubclass(cls, DanglingFieldType):
+        assert owner is None
+    else:
+        assert owner in ENTITY_TYPES
+
+
+def test_names_are_unique_per_kind() -> None:
+    entity_names = [cls.name() for cls in ENTITY_TYPES]
+    field_names = [cls.name() for cls in FIELD_TYPES]
+    assert len(entity_names) == len(set(entity_names))
+    assert len(field_names) == len(set(field_names))
+
+
+def test_pydantic_keeps_a_kind_and_accepts_its_name_alone() -> None:
+    assert type(TypeAdapter(AgentEntityType).validate_python("agent")) is AgentEntityType
+    with pytest.raises(ValidationError):
+        TypeAdapter(AgentEntityType).validate_python("user")
+
+
+def test_value_rebuilt_from_a_string_is_a_bare_base() -> None:
+    rebuilt = EntityType("agent")
+    assert type(rebuilt) is EntityType
+    assert rebuilt == "agent"
+    assert type(pickle.loads(pickle.dumps(rebuilt))) is EntityType
+    with pytest.raises(NotImplementedError):
+        rebuilt.name()

--- a/tests/unit/manager/actions/test_bulk_v2_processor.py
+++ b/tests/unit/manager/actions/test_bulk_v2_processor.py
@@ -14,6 +14,7 @@ from typing import override
 
 import pytest
 
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
@@ -31,7 +32,7 @@ from ai.backend.manager.actions.v2.bulk.result import (
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
 from ai.backend.manager.actions.v2.bulk.validator.base import AtomicBulkActionValidator
 
-_SESSION_ENTITY_TYPE = EntityType("session")
+_SESSION_ENTITY_TYPE = SessionEntityType()
 
 
 class _SessionID(EntityIdentifier):

--- a/tests/unit/manager/actions/test_denied_recording.py
+++ b/tests/unit/manager/actions/test_denied_recording.py
@@ -13,6 +13,7 @@ from typing import override
 import pytest
 
 from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -34,7 +35,7 @@ class _StubEntityID(EntityIdentifier):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType("vfolder")
+        return VFolderEntityType()
 
 
 @dataclass

--- a/tests/unit/manager/actions/test_field_owner_wiring.py
+++ b/tests/unit/manager/actions/test_field_owner_wiring.py
@@ -1,0 +1,40 @@
+"""The owner a field group is wired under vs the owner its field type declares.
+
+A field group hangs under the entity group that owns its rows, and the field type
+declares that owner itself. The two are written in different places, so a field
+classified under the wrong entity shows up here as a disagreement.
+
+Kept apart from ``test_registry_catalog`` because reading the production wiring
+imports every service package, which would widen the import closure that module's
+defined-vs-wired sweep measures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from ai.backend.common.data.entity.types import GlobalEntityType
+from ai.backend.manager.services.catalog import load_wiring_catalog
+
+
+def test_field_wiring_owner_matches_the_declared_owner_type() -> None:
+    catalog = asyncio.run(load_wiring_catalog())
+    mismatched: list[str] = []
+    checked = 0
+    for wiring in catalog:
+        if wiring.field_type is None:
+            continue
+        checked += 1
+        declared = wiring.field_type.owner_type()
+        wired = wiring.entity_type
+        if declared is None:
+            if not isinstance(wired, GlobalEntityType):
+                mismatched.append(
+                    f"{wiring.field_type} declares no owner but is wired under {wired}"
+                )
+        elif type(wired) is not declared:
+            mismatched.append(
+                f"{wiring.field_type} declares owner {declared.name()} but is wired under {wired}"
+            )
+    assert checked, "no field operation was wired; the sweep would pass vacuously"
+    assert not mismatched, "\n".join(sorted(set(mismatched)))

--- a/tests/unit/manager/actions/test_lookup_permission_gate.py
+++ b/tests/unit/manager/actions/test_lookup_permission_gate.py
@@ -16,6 +16,7 @@ import pytest
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.image import ImageEntityType
 from ai.backend.common.data.entity.kernel import KernelID
 from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.common.data.entity.session import SessionID
@@ -57,7 +58,7 @@ from ai.backend.manager.services.user.actions.lookup_keypair_owner import (
 )
 
 _ACCESS_KEY = AccessKey("AKIAIOSFODNN7EXAMPLE")
-_SECRET_ENTITY_TYPE = EntityType("image")
+_SECRET_ENTITY_TYPE = ImageEntityType()
 
 
 class _ImageID(EntityIdentifier):

--- a/tests/unit/manager/actions/test_lookup_processor.py
+++ b/tests/unit/manager/actions/test_lookup_processor.py
@@ -14,6 +14,7 @@ import pytest
 
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.image import ImageEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
@@ -29,7 +30,7 @@ from ai.backend.manager.actions.v2.lookup.result import LookupActionProcessResul
 from ai.backend.manager.errors.image import ImageNotFound
 from ai.backend.manager.errors.user import UserNotFound
 
-_LOOKUP_ENTITY_TYPE = EntityType("image")
+_LOOKUP_ENTITY_TYPE = ImageEntityType()
 
 
 class _ImageID(EntityIdentifier):
@@ -63,7 +64,7 @@ class _Action(BaseLookupAction):
     @classmethod
     @override
     def entity_type(cls) -> EntityType:
-        return EntityType("image")
+        return ImageEntityType()
 
     @classmethod
     @override

--- a/tests/unit/manager/actions/test_ops_action_results.py
+++ b/tests/unit/manager/actions/test_ops_action_results.py
@@ -24,7 +24,20 @@ from ai.backend.manager.actions.v2.ops.result import (
 )
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
 
-_ENTITY_TYPE = EntityType("preset")
+
+class _PresetEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "preset"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The test preset entity."
+
+
+_ENTITY_TYPE = _PresetEntityType()
 
 
 class _PresetID(EntityIdentifier):

--- a/tests/unit/manager/actions/test_partial_bulk_get_processor.py
+++ b/tests/unit/manager/actions/test_partial_bulk_get_processor.py
@@ -16,6 +16,7 @@ import pytest
 
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
@@ -37,7 +38,7 @@ from ai.backend.manager.errors.permission import NotEnoughPermission
 from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.errors.user import UserNotFound
 
-_STORAGE_ENTITY_TYPE = EntityType("object_storage")
+_STORAGE_ENTITY_TYPE = ObjectStorageEntityType()
 
 
 class _StorageID(EntityIdentifier):

--- a/tests/unit/manager/actions/test_public_processor.py
+++ b/tests/unit/manager/actions/test_public_processor.py
@@ -15,6 +15,7 @@ import pytest
 
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
@@ -36,7 +37,7 @@ class _SearchAction(BaseGlobalAction):
     @classmethod
     @override
     def entity_type(cls) -> EntityType:
-        return EntityType("resource_slot_type")
+        return ResourceSlotTypeEntityType()
 
     @classmethod
     @override

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -19,67 +19,67 @@ import re
 from typing import Any
 from unittest.mock import MagicMock
 
-from ai.backend.common.data.entity.agent import AGENT_ENTITY_TYPE
+from ai.backend.common.data.entity.agent import AgentEntityType
 from ai.backend.common.data.entity.app_config import (
-    APP_CONFIG_ALLOW_LIST_ENTITY_TYPE,
-    APP_CONFIG_ENTITY_TYPE,
-    APP_CONFIG_FRAGMENT_ENTITY_TYPE,
+    AppConfigAllowListEntityType,
+    AppConfigEntityType,
+    AppConfigFragmentEntityType,
 )
-from ai.backend.common.data.entity.app_config_definition import APP_CONFIG_DEFINITION_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact import ARTIFACT_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_registry import ARTIFACT_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.artifact_revision import ARTIFACT_REVISION_FIELD_TYPE
-from ai.backend.common.data.entity.audit_log import AUDIT_LOG_FIELD_TYPE
-from ai.backend.common.data.entity.auth import AUTH_ENTITY_TYPE
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_ENTITY_TYPE
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE
-from ai.backend.common.data.entity.deployment_preset import DEPLOYMENT_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE
-from ai.backend.common.data.entity.entity_label import ENTITY_LABEL_FIELD_TYPE
-from ai.backend.common.data.entity.entity_share import ENTITY_SHARE_ENTITY_TYPE
-from ai.backend.common.data.entity.export import EXPORT_ENTITY_TYPE
+from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionEntityType
+from ai.backend.common.data.entity.artifact import ArtifactEntityType
+from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryEntityType
+from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType
+from ai.backend.common.data.entity.audit_log import AuditLogFieldType
+from ai.backend.common.data.entity.auth import AuthEntityType
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.entity_label import EntityLabelFieldType
+from ai.backend.common.data.entity.entity_share import EntityShareEntityType
+from ai.backend.common.data.entity.export import ExportEntityType
 from ai.backend.common.data.entity.fair_share import (
-    DOMAIN_FAIR_SHARE_ENTITY_TYPE,
-    PROJECT_FAIR_SHARE_ENTITY_TYPE,
-    USER_FAIR_SHARE_ENTITY_TYPE,
+    DomainFairShareEntityType,
+    ProjectFairShareEntityType,
+    UserFairShareEntityType,
 )
-from ai.backend.common.data.entity.idle_checker import IDLE_CHECKER_ENTITY_TYPE
-from ai.backend.common.data.entity.image import IMAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.login_client_type import LOGIN_CLIENT_TYPE_ENTITY_TYPE
-from ai.backend.common.data.entity.model_card import MODEL_CARD_ENTITY_TYPE
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
+from ai.backend.common.data.entity.image import ImageEntityType
+from ai.backend.common.data.entity.login_client_type import LoginClientTypeEntityType
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
 from ai.backend.common.data.entity.notification import (
-    NOTIFICATION_CHANNEL_ENTITY_TYPE,
-    NOTIFICATION_RULE_ENTITY_TYPE,
+    NotificationChannelEntityType,
+    NotificationRuleEntityType,
 )
-from ai.backend.common.data.entity.object_storage import OBJECT_STORAGE_ENTITY_TYPE
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
+from ai.backend.common.data.entity.object_storage import ObjectStorageEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.prometheus_query_preset import (
-    PROMETHEUS_QUERY_PRESET_ENTITY_TYPE,
+    PrometheusQueryPresetEntityType,
 )
 from ai.backend.common.data.entity.prometheus_query_preset_category import (
-    PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE,
+    PrometheusQueryPresetCategoryEntityType,
 )
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.resource_policy import (
-    KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE,
-    PROJECT_RESOURCE_POLICY_ENTITY_TYPE,
-    USER_RESOURCE_POLICY_ENTITY_TYPE,
+    KeyPairResourcePolicyEntityType,
+    ProjectResourcePolicyEntityType,
+    UserResourcePolicyEntityType,
 )
-from ai.backend.common.data.entity.resource_preset import RESOURCE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.resource_slot import RESOURCE_SLOT_TYPE_ENTITY_TYPE
-from ai.backend.common.data.entity.retention_policy import RETENTION_POLICY_ENTITY_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.runtime_variant import RUNTIME_VARIANT_ENTITY_TYPE
-from ai.backend.common.data.entity.runtime_variant_preset import RUNTIME_VARIANT_PRESET_ENTITY_TYPE
-from ai.backend.common.data.entity.service_catalog import SERVICE_CATALOG_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE
-from ai.backend.common.data.entity.session_template import SESSION_TEMPLATE_ENTITY_TYPE
-from ai.backend.common.data.entity.storage_namespace import STORAGE_NAMESPACE_ENTITY_TYPE
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
-from ai.backend.common.data.entity.vfolder_invitation import VFOLDER_INVITATION_ENTITY_TYPE
-from ai.backend.common.data.entity.vfs_storage import VFS_STORAGE_ENTITY_TYPE
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
+from ai.backend.common.data.entity.retention_policy import RetentionPolicyEntityType
+from ai.backend.common.data.entity.role import RoleEntityType
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantEntityType
+from ai.backend.common.data.entity.runtime_variant_preset import RuntimeVariantPresetEntityType
+from ai.backend.common.data.entity.service_catalog import ServiceCatalogEntityType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.session_template import SessionTemplateEntityType
+from ai.backend.common.data.entity.storage_namespace import StorageNamespaceEntityType
+from ai.backend.common.data.entity.user import UserEntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
+from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationEntityType
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType
 from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry
 from ai.backend.manager.actions.registry.types import (
@@ -345,8 +345,8 @@ def test_every_defined_v2_action_is_wired() -> None:
     # through it, so its wired_actions() is the complete catalog of registered actions.
     registry = _ops_registry()
     fair_share_groups = registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
-    artifact_revisions = registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+    artifact_revisions = registry.group(GroupMeta(ArtifactEntityType())).field_group(
+        FieldGroupMeta(ArtifactRevisionFieldType()),
         ArtifactRevisionData,
         LookupArtifactRevisionOwnerAction,
         LookupBulkArtifactRevisionOwnerAction,
@@ -355,159 +355,155 @@ def test_every_defined_v2_action_is_wired() -> None:
     scheduling_history_groups = registry.concern(ConcernMeta(Concern.SESSION))
     resource_allocation_groups = registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
     agent_groups = registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
-    AgentProcessors(agent_groups.group(GroupMeta(AGENT_ENTITY_TYPE)), MagicMock(), [])
+    AgentProcessors(agent_groups.group(GroupMeta(AgentEntityType())), MagicMock(), [])
     AppConfigProcessors(
-        registry.group(GroupMeta(APP_CONFIG_ENTITY_TYPE)),
-        registry.group(GroupMeta(APP_CONFIG_DEFINITION_ENTITY_TYPE)),
-        registry.group(GroupMeta(APP_CONFIG_ALLOW_LIST_ENTITY_TYPE)),
-        registry.group(GroupMeta(APP_CONFIG_FRAGMENT_ENTITY_TYPE)),
+        registry.group(GroupMeta(AppConfigEntityType())),
+        registry.group(GroupMeta(AppConfigDefinitionEntityType())),
+        registry.group(GroupMeta(AppConfigAllowListEntityType())),
+        registry.group(GroupMeta(AppConfigFragmentEntityType())),
         MagicMock(),
     )
     ResourceSlotProcessors(
-        resource_slot_groups.group(GroupMeta(RESOURCE_SLOT_TYPE_ENTITY_TYPE)),
-        resource_slot_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        resource_slot_groups.group(GroupMeta(AGENT_ENTITY_TYPE)),
+        resource_slot_groups.group(GroupMeta(ResourceSlotTypeEntityType())),
+        resource_slot_groups.group(GroupMeta(SessionEntityType())),
+        resource_slot_groups.group(GroupMeta(AgentEntityType())),
         MagicMock(),
     )
     IdleCheckerProcessors(
-        registry.group(GroupMeta(IDLE_CHECKER_ENTITY_TYPE)),
-        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        registry.group(GroupMeta(IdleCheckerEntityType())),
+        registry.group(GroupMeta(SessionEntityType())),
         MagicMock(),
     )
     IdleCheckerAssignmentProcessors(
-        scheduling_history_groups.group(GroupMeta(IDLE_CHECKER_ENTITY_TYPE)),
+        scheduling_history_groups.group(GroupMeta(IdleCheckerEntityType())),
         MagicMock(),
     )
-    RetentionPolicyProcessors(registry.group(GroupMeta(RETENTION_POLICY_ENTITY_TYPE)))
-    LoginClientTypeProcessors(registry.group(GroupMeta(LOGIN_CLIENT_TYPE_ENTITY_TYPE)))
-    ServiceCatalogProcessors(registry.group(GroupMeta(SERVICE_CATALOG_ENTITY_TYPE)))
-    ProjectResourcePolicyProcessors(registry.group(GroupMeta(PROJECT_RESOURCE_POLICY_ENTITY_TYPE)))
-    UserResourcePolicyProcessors(registry.group(GroupMeta(USER_RESOURCE_POLICY_ENTITY_TYPE)))
-    KeypairResourcePolicyProcessors(registry.group(GroupMeta(KEYPAIR_RESOURCE_POLICY_ENTITY_TYPE)))
-    RolePresetProcessors(registry.group(GroupMeta(ROLE_PRESET_ENTITY_TYPE)), MagicMock())
-    EntityShareProcessors(registry.group(GroupMeta(ENTITY_SHARE_ENTITY_TYPE)), MagicMock())
+    RetentionPolicyProcessors(registry.group(GroupMeta(RetentionPolicyEntityType())))
+    LoginClientTypeProcessors(registry.group(GroupMeta(LoginClientTypeEntityType())))
+    ServiceCatalogProcessors(registry.group(GroupMeta(ServiceCatalogEntityType())))
+    ProjectResourcePolicyProcessors(registry.group(GroupMeta(ProjectResourcePolicyEntityType())))
+    UserResourcePolicyProcessors(registry.group(GroupMeta(UserResourcePolicyEntityType())))
+    KeypairResourcePolicyProcessors(registry.group(GroupMeta(KeyPairResourcePolicyEntityType())))
+    RolePresetProcessors(registry.group(GroupMeta(RolePresetEntityType())), MagicMock())
+    EntityShareProcessors(registry.group(GroupMeta(EntityShareEntityType())), MagicMock())
     rbac_groups = registry.concern(ConcernMeta(Concern.RBAC))
     RbacProcessors(
         rbac_groups.relation_group(),
-        rbac_groups.group(GroupMeta(USER_ENTITY_TYPE)),
+        rbac_groups.group(GroupMeta(UserEntityType())),
         MagicMock(),
         MagicMock(),
         MagicMock(),
         [],
     )
-    RuntimeVariantProcessors(registry.group(GroupMeta(RUNTIME_VARIANT_ENTITY_TYPE)))
+    RuntimeVariantProcessors(registry.group(GroupMeta(RuntimeVariantEntityType())))
     ObjectStorageProcessors(
-        registry.group(GroupMeta(OBJECT_STORAGE_ENTITY_TYPE)),
+        registry.group(GroupMeta(ObjectStorageEntityType())),
         artifact_revisions,
         MagicMock(),
     )
-    VFSStorageProcessors(registry.group(GroupMeta(VFS_STORAGE_ENTITY_TYPE)), MagicMock())
+    VFSStorageProcessors(registry.group(GroupMeta(VFSStorageEntityType())), MagicMock())
     NotificationProcessors(
-        registry.group(GroupMeta(NOTIFICATION_CHANNEL_ENTITY_TYPE)),
-        registry.group(GroupMeta(NOTIFICATION_RULE_ENTITY_TYPE)),
+        registry.group(GroupMeta(NotificationChannelEntityType())),
+        registry.group(GroupMeta(NotificationRuleEntityType())),
         MagicMock(),
     )
     PrometheusQueryPresetCategoryProcessors(
-        registry.group(GroupMeta(PROMETHEUS_QUERY_PRESET_CATEGORY_ENTITY_TYPE))
+        registry.group(GroupMeta(PrometheusQueryPresetCategoryEntityType()))
     )
     MetricProcessors(
-        registry.group(GroupMeta(PROMETHEUS_QUERY_PRESET_ENTITY_TYPE)),
-        registry.group(GroupMeta(USER_ENTITY_TYPE)),
-        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
+        registry.group(GroupMeta(PrometheusQueryPresetEntityType())),
+        registry.group(GroupMeta(UserEntityType())),
+        registry.group(GroupMeta(SessionEntityType())),
         MagicMock(),
     )
     RuntimeVariantPresetProcessors(
-        registry.group(GroupMeta(RUNTIME_VARIANT_PRESET_ENTITY_TYPE)), MagicMock()
+        registry.group(GroupMeta(RuntimeVariantPresetEntityType())), MagicMock()
     )
     AuditLogProcessors(
-        registry.dangling_field_group(FieldGroupMeta(AUDIT_LOG_FIELD_TYPE), AuditLogData)
+        registry.dangling_field_group(FieldGroupMeta(AuditLogFieldType()), AuditLogData)
     )
     EntityLabelProcessors(
         registry.dangling_lookup_field_group(
-            FieldGroupMeta(ENTITY_LABEL_FIELD_TYPE),
+            FieldGroupMeta(EntityLabelFieldType()),
             EntityLabelData,
             LookupEntityLabelOwnerAction,
             LookupBulkEntityLabelOwnerAction,
         )
     )
     PrometheusQueryPresetProcessors(
-        registry.group(GroupMeta(PROMETHEUS_QUERY_PRESET_ENTITY_TYPE)), MagicMock()
+        registry.group(GroupMeta(PrometheusQueryPresetEntityType())), MagicMock()
     )
-    StorageNamespaceProcessors(registry.group(GroupMeta(STORAGE_NAMESPACE_ENTITY_TYPE)))
-    DeploymentPresetProcessors(
-        registry.group(GroupMeta(DEPLOYMENT_PRESET_ENTITY_TYPE)), MagicMock()
-    )
-    DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    StorageNamespaceProcessors(registry.group(GroupMeta(StorageNamespaceEntityType())))
+    DeploymentPresetProcessors(registry.group(GroupMeta(DeploymentPresetEntityType())), MagicMock())
+    DomainProcessors(registry.group(GroupMeta(DomainEntityType())), MagicMock(), [])
     PermissionControllerProcessors(
-        registry.group(GroupMeta(ROLE_ENTITY_TYPE)), MagicMock(), [], MagicMock()
+        registry.group(GroupMeta(RoleEntityType())), MagicMock(), [], MagicMock()
     )
-    ProjectProcessors(registry.group(GroupMeta(PROJECT_ENTITY_TYPE)), MagicMock())
+    ProjectProcessors(registry.group(GroupMeta(ProjectEntityType())), MagicMock())
     UserProcessors(
-        registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        registry.group(GroupMeta(UserEntityType())),
         MagicMock(),
     )
     AuthProcessors(
-        registry.group(GroupMeta(AUTH_ENTITY_TYPE)),
-        registry.group(GroupMeta(USER_ENTITY_TYPE)),
+        registry.group(GroupMeta(AuthEntityType())),
+        registry.group(GroupMeta(UserEntityType())),
         MagicMock(),
     )
     FairShareProcessors(
-        fair_share_groups.group(GroupMeta(DOMAIN_FAIR_SHARE_ENTITY_TYPE)),
-        fair_share_groups.group(GroupMeta(PROJECT_FAIR_SHARE_ENTITY_TYPE)),
-        fair_share_groups.group(GroupMeta(USER_FAIR_SHARE_ENTITY_TYPE)),
+        fair_share_groups.group(GroupMeta(DomainFairShareEntityType())),
+        fair_share_groups.group(GroupMeta(ProjectFairShareEntityType())),
+        fair_share_groups.group(GroupMeta(UserFairShareEntityType())),
         MagicMock(),
     )
-    ResourcePresetProcessors(registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)), MagicMock())
-    ResourceGroupProcessors(registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), MagicMock())
+    ResourcePresetProcessors(registry.group(GroupMeta(ResourcePresetEntityType())), MagicMock())
+    ResourceGroupProcessors(registry.group(GroupMeta(ResourceGroupEntityType())), MagicMock())
     ArtifactProcessors(
-        registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        registry.group(GroupMeta(ArtifactEntityType())),
         artifact_revisions,
         ArtifactRevisionProcessors(
-            registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            registry.group(GroupMeta(ArtifactEntityType())),
             artifact_revisions,
             MagicMock(),
         ),
         MagicMock(),
     )
-    ArtifactRegistryProcessors(
-        registry.group(GroupMeta(ARTIFACT_REGISTRY_ENTITY_TYPE)), MagicMock()
-    )
-    ModelCardProcessors(registry.group(GroupMeta(MODEL_CARD_ENTITY_TYPE)), MagicMock())
+    ArtifactRegistryProcessors(registry.group(GroupMeta(ArtifactRegistryEntityType())), MagicMock())
+    ModelCardProcessors(registry.group(GroupMeta(ModelCardEntityType())), MagicMock())
     ContainerRegistryProcessors(
-        registry.group(GroupMeta(CONTAINER_REGISTRY_ENTITY_TYPE)), MagicMock()
+        registry.group(GroupMeta(ContainerRegistryEntityType())), MagicMock()
     )
-    ImageProcessors(registry.group(GroupMeta(IMAGE_ENTITY_TYPE)), MagicMock())
-    ExportProcessors(registry.group(GroupMeta(EXPORT_ENTITY_TYPE)), MagicMock())
-    TemplateProcessors(registry.group(GroupMeta(SESSION_TEMPLATE_ENTITY_TYPE)), MagicMock())
+    ImageProcessors(registry.group(GroupMeta(ImageEntityType())), MagicMock())
+    ExportProcessors(registry.group(GroupMeta(ExportEntityType())), MagicMock())
+    TemplateProcessors(registry.group(GroupMeta(SessionTemplateEntityType())), MagicMock())
     SchedulingHistoryProcessors(
-        scheduling_history_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        scheduling_history_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
-        scheduling_history_groups.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+        scheduling_history_groups.group(GroupMeta(SessionEntityType())),
+        scheduling_history_groups.group(GroupMeta(DeploymentEntityType())),
+        scheduling_history_groups.group(GroupMeta(DeploymentEntityType())),
         MagicMock(),
     )
     SessionProcessors(
-        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        resource_allocation_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+        registry.group(GroupMeta(SessionEntityType())),
+        resource_allocation_groups.group(GroupMeta(ResourceGroupEntityType())),
         ResourceAllocationProcessors(
-            resource_allocation_groups.group(GroupMeta(USER_ENTITY_TYPE)),
-            resource_allocation_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            resource_allocation_groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            resource_allocation_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            resource_allocation_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            resource_allocation_groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            resource_allocation_groups.group(GroupMeta(UserEntityType())),
+            resource_allocation_groups.group(GroupMeta(ProjectEntityType())),
+            resource_allocation_groups.group(GroupMeta(DomainEntityType())),
+            resource_allocation_groups.group(GroupMeta(ResourceGroupEntityType())),
+            resource_allocation_groups.group(GroupMeta(SessionEntityType())),
+            resource_allocation_groups.group(GroupMeta(ResourcePresetEntityType())),
             MagicMock(),
         ),
         MagicMock(),
     )
-    DeploymentProcessors(registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), MagicMock())
-    VFolderProcessors(registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), MagicMock())
-    VFolderAdminProcessors(registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), MagicMock())
-    VFolderFileProcessors(registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), MagicMock())
-    VFolderInviteProcessors(registry.group(GroupMeta(VFOLDER_INVITATION_ENTITY_TYPE)), MagicMock())
-    VFolderSharingProcessors(registry.group(GroupMeta(VFOLDER_ENTITY_TYPE)), MagicMock())
-    ModelServingProcessors(registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), MagicMock())
+    DeploymentProcessors(registry.group(GroupMeta(DeploymentEntityType())), MagicMock())
+    VFolderProcessors(registry.group(GroupMeta(VFolderEntityType())), MagicMock())
+    VFolderAdminProcessors(registry.group(GroupMeta(VFolderEntityType())), MagicMock())
+    VFolderFileProcessors(registry.group(GroupMeta(VFolderEntityType())), MagicMock())
+    VFolderInviteProcessors(registry.group(GroupMeta(VFolderInvitationEntityType())), MagicMock())
+    VFolderSharingProcessors(registry.group(GroupMeta(VFolderEntityType())), MagicMock())
+    ModelServingProcessors(registry.group(GroupMeta(DeploymentEntityType())), MagicMock())
     ModelServingAutoScalingProcessors(
-        registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), MagicMock()
+        registry.group(GroupMeta(DeploymentEntityType())), MagicMock()
     )
 
     # One action class may be wired more than once -- an owner lookup is built by every
@@ -553,21 +549,21 @@ def test_resource_preset_reads_keep_their_judged_gates() -> None:
     so it is judged on that entity like the update and the delete beside it.
     """
     registry = _ops_registry()
-    ResourcePresetProcessors(registry.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)), MagicMock())
+    ResourcePresetProcessors(registry.group(GroupMeta(ResourcePresetEntityType())), MagicMock())
 
     judged = {
         ListResourcePresetsAction: (
-            RESOURCE_PRESET_ENTITY_TYPE,
+            ResourcePresetEntityType(),
             ActionKind.GLOBAL,
             ActionGate.PUBLIC,
         ),
         CheckResourcePresetsAction: (
-            RESOURCE_PRESET_ENTITY_TYPE,
+            ResourcePresetEntityType(),
             ActionKind.GLOBAL,
             ActionGate.PUBLIC,
         ),
         GetResourcePresetAction: (
-            RESOURCE_PRESET_ENTITY_TYPE,
+            ResourcePresetEntityType(),
             ActionKind.SINGLE_ENTITY,
             ActionGate.PERMISSION,
         ),
@@ -588,18 +584,18 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
     """
     registry = _ops_registry()
     resource_group_groups = registry.concern(ConcernMeta(Concern.RESOURCE_GROUP))
-    AgentProcessors(resource_group_groups.group(GroupMeta(AGENT_ENTITY_TYPE)), MagicMock(), [])
-    DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    AgentProcessors(resource_group_groups.group(GroupMeta(AgentEntityType())), MagicMock(), [])
+    DomainProcessors(registry.group(GroupMeta(DomainEntityType())), MagicMock(), [])
     SessionProcessors(
-        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
+        registry.group(GroupMeta(SessionEntityType())),
+        resource_group_groups.group(GroupMeta(ResourceGroupEntityType())),
         ResourceAllocationProcessors(
-            resource_group_groups.group(GroupMeta(USER_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(PROJECT_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(DOMAIN_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(SESSION_ENTITY_TYPE)),
-            resource_group_groups.group(GroupMeta(RESOURCE_PRESET_ENTITY_TYPE)),
+            resource_group_groups.group(GroupMeta(UserEntityType())),
+            resource_group_groups.group(GroupMeta(ProjectEntityType())),
+            resource_group_groups.group(GroupMeta(DomainEntityType())),
+            resource_group_groups.group(GroupMeta(ResourceGroupEntityType())),
+            resource_group_groups.group(GroupMeta(SessionEntityType())),
+            resource_group_groups.group(GroupMeta(ResourcePresetEntityType())),
             MagicMock(),
         ),
         MagicMock(),
@@ -607,48 +603,48 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
 
     judged = {
         ComputeScheduleAction: (
-            RESOURCE_GROUP_ENTITY_TYPE,
+            ResourceGroupEntityType(),
             ActionKind.SINGLE_ENTITY,
             ActionGate.PERMISSION,
         ),
         GetDomainAction: (
-            DOMAIN_ENTITY_TYPE,
+            DomainEntityType(),
             ActionKind.SINGLE_ENTITY,
             ActionGate.PERMISSION,
         ),
-        GetTotalResourcesAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
+        GetTotalResourcesAction: (AgentEntityType(), ActionKind.GLOBAL, ActionGate.PERMISSION),
         # Admin search surfaces only: the DataLoaders read per named agent below.
-        SearchAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
-        LoadContainerCountsAction: (AGENT_ENTITY_TYPE, ActionKind.GLOBAL, ActionGate.PERMISSION),
+        SearchAgentsAction: (AgentEntityType(), ActionKind.GLOBAL, ActionGate.PERMISSION),
+        LoadContainerCountsAction: (AgentEntityType(), ActionKind.GLOBAL, ActionGate.PERMISSION),
         # What the DataLoaders read: checked per agent.
-        BulkGetAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.BULK, ActionGate.PERMISSION),
+        BulkGetAgentsAction: (AgentEntityType(), ActionKind.BULK, ActionGate.PERMISSION),
         BulkLoadContainerCountsAction: (
-            AGENT_ENTITY_TYPE,
+            AgentEntityType(),
             ActionKind.BULK,
             ActionGate.PERMISSION,
         ),
         BulkLoadAgentPermissionsAction: (
-            AGENT_ENTITY_TYPE,
+            AgentEntityType(),
             ActionKind.BULK,
             ActionGate.PERMISSION,
         ),
         # The lookup carries no permission; the read that follows it is checked.
-        LookupAgentAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),
-        BulkLookupAgentsAction: (AGENT_ENTITY_TYPE, ActionKind.LOOKUP, ActionGate.PUBLIC),
+        LookupAgentAction: (AgentEntityType(), ActionKind.LOOKUP, ActionGate.PUBLIC),
+        BulkLookupAgentsAction: (AgentEntityType(), ActionKind.LOOKUP, ActionGate.PUBLIC),
         # The slot rows are field rows of the agent: read per named agent, owner resolved
         # through the lookups the field group builds.
         LookupAgentResourceOwnerAction: (
-            AGENT_ENTITY_TYPE,
+            AgentEntityType(),
             ActionKind.LOOKUP,
             ActionGate.PERMISSION,
         ),
         LookupBulkAgentResourceOwnerAction: (
-            AGENT_ENTITY_TYPE,
+            AgentEntityType(),
             ActionKind.LOOKUP,
             ActionGate.PERMISSION,
         ),
         ScopedSearchAgentResourcesAction: (
-            AGENT_ENTITY_TYPE,
+            AgentEntityType(),
             ActionKind.BULK,
             ActionGate.PERMISSION,
         ),
@@ -664,16 +660,14 @@ def test_resource_domain_and_agent_reads_keep_their_judged_gates() -> None:
 def test_artifact_registry_metas_read_is_a_partial_bulk_permission_read() -> None:
     """The named registries are read one permission check per registry, not superadmin-only."""
     registry = _ops_registry()
-    ArtifactRegistryProcessors(
-        registry.group(GroupMeta(ARTIFACT_REGISTRY_ENTITY_TYPE)), MagicMock()
-    )
+    ArtifactRegistryProcessors(registry.group(GroupMeta(ArtifactRegistryEntityType())), MagicMock())
 
     recorded = {
         record.action_cls: (record.entity_type, record.kind, record.gate)
         for record in registry.wired_processors()
     }
     assert recorded[GetArtifactRegistryMetasAction] == (
-        ARTIFACT_REGISTRY_ENTITY_TYPE,
+        ArtifactRegistryEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
@@ -682,14 +676,14 @@ def test_artifact_registry_metas_read_is_a_partial_bulk_permission_read() -> Non
 def test_rg_domain_read_is_a_scoped_permission_read() -> None:
     """The domains a resource group serves are read within the resource-group scope."""
     registry = _ops_registry()
-    DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    DomainProcessors(registry.group(GroupMeta(DomainEntityType())), MagicMock(), [])
 
     recorded = {
         record.action_cls: (record.entity_type, record.kind, record.gate)
         for record in registry.wired_processors()
     }
     assert recorded[ScopedSearchDomainsAction] == (
-        DOMAIN_ENTITY_TYPE,
+        DomainEntityType(),
         ActionKind.SCOPE,
         ActionGate.PERMISSION,
     )
@@ -698,14 +692,14 @@ def test_rg_domain_read_is_a_scoped_permission_read() -> None:
 def test_scoped_deployment_read_is_a_scoped_permission_read() -> None:
     """A user's own deployments and a project's deployments are read within that scope."""
     registry = _ops_registry()
-    DeploymentProcessors(registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), MagicMock())
+    DeploymentProcessors(registry.group(GroupMeta(DeploymentEntityType())), MagicMock())
 
     recorded = {
         record.action_cls: (record.entity_type, record.kind, record.gate)
         for record in registry.wired_processors()
     }
     assert recorded[ScopedSearchDeploymentsAction] == (
-        DEPLOYMENT_ENTITY_TYPE,
+        DeploymentEntityType(),
         ActionKind.SCOPE,
         ActionGate.PERMISSION,
     )
@@ -718,11 +712,11 @@ def test_field_data_loader_reads_are_partial_permission_reads() -> None:
     permission-gated record: it refuses nothing, the read that follows answers per owner.
     """
     registry = _ops_registry()
-    DeploymentProcessors(registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), MagicMock())
+    DeploymentProcessors(registry.group(GroupMeta(DeploymentEntityType())), MagicMock())
     SchedulingHistoryProcessors(
-        registry.group(GroupMeta(SESSION_ENTITY_TYPE)),
-        registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
-        registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)),
+        registry.group(GroupMeta(SessionEntityType())),
+        registry.group(GroupMeta(DeploymentEntityType())),
+        registry.group(GroupMeta(DeploymentEntityType())),
         MagicMock(),
     )
 
@@ -731,7 +725,7 @@ def test_field_data_loader_reads_are_partial_permission_reads() -> None:
         for record in registry.wired_processors()
         if record.kind == ActionKind.BULK
     }
-    partial = (DEPLOYMENT_ENTITY_TYPE, ActionKind.BULK, ActionGate.PERMISSION)
+    partial = (DeploymentEntityType(), ActionKind.BULK, ActionGate.PERMISSION)
     assert recorded[BulkGetRevisionsAction] == partial
     assert recorded[BulkGetReplicasAction] == partial
     assert recorded[BulkGetRoutesAction] == partial
@@ -740,12 +734,12 @@ def test_field_data_loader_reads_are_partial_permission_reads() -> None:
     assert recorded[BulkGetDeploymentHistoriesAction] == partial
     assert recorded[BulkGetRouteHistoriesAction] == partial
     assert recorded[BulkGetSessionHistoriesAction] == (
-        SESSION_ENTITY_TYPE,
+        SessionEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
     assert recorded[BulkGetKernelHistoriesAction] == (
-        SESSION_ENTITY_TYPE,
+        SessionEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
@@ -770,24 +764,24 @@ def test_entity_data_loader_reads_are_checked_per_entity_except_domains() -> Non
     entity; the domain one is public, since a regular user holds no read on domains.
     """
     registry = _ops_registry()
-    ResourceGroupProcessors(registry.group(GroupMeta(RESOURCE_GROUP_ENTITY_TYPE)), MagicMock())
-    DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    ResourceGroupProcessors(registry.group(GroupMeta(ResourceGroupEntityType())), MagicMock())
+    DomainProcessors(registry.group(GroupMeta(DomainEntityType())), MagicMock(), [])
     NotificationProcessors(
-        registry.group(GroupMeta(NOTIFICATION_CHANNEL_ENTITY_TYPE)),
-        registry.group(GroupMeta(NOTIFICATION_RULE_ENTITY_TYPE)),
+        registry.group(GroupMeta(NotificationChannelEntityType())),
+        registry.group(GroupMeta(NotificationRuleEntityType())),
         MagicMock(),
     )
-    artifact_revisions = registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)).field_group(
-        FieldGroupMeta(ARTIFACT_REVISION_FIELD_TYPE),
+    artifact_revisions = registry.group(GroupMeta(ArtifactEntityType())).field_group(
+        FieldGroupMeta(ArtifactRevisionFieldType()),
         ArtifactRevisionData,
         LookupArtifactRevisionOwnerAction,
         LookupBulkArtifactRevisionOwnerAction,
     )
     ArtifactProcessors(
-        registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+        registry.group(GroupMeta(ArtifactEntityType())),
         artifact_revisions,
         ArtifactRevisionProcessors(
-            registry.group(GroupMeta(ARTIFACT_ENTITY_TYPE)),
+            registry.group(GroupMeta(ArtifactEntityType())),
             artifact_revisions,
             MagicMock(),
         ),
@@ -799,42 +793,42 @@ def test_entity_data_loader_reads_are_checked_per_entity_except_domains() -> Non
         for record in registry.wired_processors()
     }
     assert recorded[BulkGetResourceGroupsAction] == (
-        RESOURCE_GROUP_ENTITY_TYPE,
+        ResourceGroupEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
     assert recorded[BulkLookupResourceGroupsAction] == (
-        RESOURCE_GROUP_ENTITY_TYPE,
+        ResourceGroupEntityType(),
         ActionKind.LOOKUP,
         ActionGate.PUBLIC,
     )
     assert recorded[BulkGetChannelsAction] == (
-        NOTIFICATION_CHANNEL_ENTITY_TYPE,
+        NotificationChannelEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
     assert recorded[BulkGetRulesAction] == (
-        NOTIFICATION_RULE_ENTITY_TYPE,
+        NotificationRuleEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
     assert recorded[BulkGetArtifactsAction] == (
-        ARTIFACT_ENTITY_TYPE,
+        ArtifactEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
     assert recorded[BulkGetArtifactRevisionsAction] == (
-        ARTIFACT_ENTITY_TYPE,
+        ArtifactEntityType(),
         ActionKind.BULK,
         ActionGate.PERMISSION,
     )
     assert recorded[BulkGetDomainsAction] == (
-        DOMAIN_ENTITY_TYPE,
+        DomainEntityType(),
         ActionKind.BULK,
         ActionGate.PUBLIC,
     )
     assert recorded[BulkLookupDomainsAction] == (
-        DOMAIN_ENTITY_TYPE,
+        DomainEntityType(),
         ActionKind.LOOKUP,
         ActionGate.PUBLIC,
     )

--- a/tests/unit/manager/actions/test_relation_processor.py
+++ b/tests/unit/manager/actions/test_relation_processor.py
@@ -17,7 +17,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.data.entity.types import ScopeRef, ScopeType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.exception import PermissionDeniedError
@@ -33,8 +35,8 @@ from ai.backend.manager.actions.v2.relation.validator.rbac import (
 )
 from ai.backend.manager.errors.permission import NotEnoughPermission
 
-_RESOURCE_GROUP = ScopeType(EntityType("resource_group"))
-_DOMAIN = ScopeType(EntityType("domain"))
+_RESOURCE_GROUP = ScopeType(ResourceGroupEntityType())
+_DOMAIN = ScopeType(DomainEntityType())
 
 _RG_ID = uuid.uuid5(uuid.NAMESPACE_OID, "rg")
 _DOMAIN_ID = uuid.uuid5(uuid.NAMESPACE_OID, "domain")

--- a/tests/unit/manager/actions/test_scoped_read_gate_wiring.py
+++ b/tests/unit/manager/actions/test_scoped_read_gate_wiring.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.resource_group import (
     RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
@@ -83,7 +83,7 @@ async def test_rg_domain_search_is_answered_for_the_resource_group(
     denying_scope: _DenyingScopeValidator,
     regular_user: UserData,
 ) -> None:
-    processors = DomainProcessors(registry.group(GroupMeta(DOMAIN_ENTITY_TYPE)), MagicMock(), [])
+    processors = DomainProcessors(registry.group(GroupMeta(DomainEntityType())), MagicMock(), [])
     resource_group_id = ResourceGroupID(uuid.uuid4())
     action = ScopedSearchDomainsAction(
         items=[ResourceGroupDomainScopeItem(resource_group_id=resource_group_id)],

--- a/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
@@ -22,7 +22,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import (
     EntityID,
     EntityIdentifier,
@@ -31,6 +32,7 @@ from ai.backend.common.data.entity.types import (
     ScopeRef,
     ScopeType,
 )
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import (
     EntityType as PermEntityType,
@@ -122,7 +124,7 @@ class _StubEntityID(EntityIdentifier):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType("vfolder")
+        return VFolderEntityType()
 
 
 class _ProjectCreateScopeAction(BaseScopeAction):
@@ -136,7 +138,7 @@ class _ProjectCreateScopeAction(BaseScopeAction):
     @classmethod
     @override
     def entity_type(cls) -> EntityType:
-        return EntityType("project")
+        return ProjectEntityType()
 
     @override
     def scope_targets(self) -> Sequence[ScopeRef]:
@@ -232,11 +234,11 @@ class _VfolderID(EntityIdentifier):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType("vfolder")
+        return VFolderEntityType()
 
 
 def _domain_scope(scope_id: ScopeID) -> ScopeRef:
-    return ScopeRef(scope_type=ScopeType(EntityType("domain")), scope_id=scope_id)
+    return ScopeRef(scope_type=ScopeType(DomainEntityType()), scope_id=scope_id)
 
 
 def _make_user_data(user_id: uuid.UUID, *, is_superadmin: bool) -> UserData:

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -14,7 +14,7 @@ import pytest
 from ai.backend.common.api_handlers import SENTINEL
 from ai.backend.common.config import ModelConfig, ModelDefinition, ModelServiceConfig
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_ENTITY_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionID
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.common.data.entity.domain import DomainID
@@ -210,7 +210,7 @@ class TestDeploymentSearchGates:
         )
         processors = MagicMock()
         processors.deployment = DeploymentProcessors(
-            registry.group(GroupMeta(DEPLOYMENT_ENTITY_TYPE)), service
+            registry.group(GroupMeta(DeploymentEntityType())), service
         )
         return DeploymentAdapter(processors.deployment, MagicMock())
 

--- a/tests/unit/manager/conftest.py
+++ b/tests/unit/manager/conftest.py
@@ -13,7 +13,7 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import (
-    DOMAIN_ENTITY_TYPE,
+    DomainEntityType,
     DomainID,
     DomainName,
 )
@@ -180,7 +180,7 @@ def domain_factory() -> DomainFactory:
             # sides to be in the graph already.
             await conn.execute(
                 sa.insert(VirtualEntityRow.__table__).values(
-                    entity_type=DOMAIN_ENTITY_TYPE, entity_id=row.id
+                    entity_type=DomainEntityType(), entity_id=row.id
                 )
             )
         return DomainFixtureData(domain_name=DomainName(row.name), domain_id=DomainID(row.id))

--- a/tests/unit/manager/models/rbac_models/test_permission_specs.py
+++ b/tests/unit/manager/models/rbac_models/test_permission_specs.py
@@ -1,9 +1,9 @@
 import uuid
 
-from ai.backend.common.data.entity.permission import PERMISSION_FIELD_TYPE, PermissionID
+from ai.backend.common.data.entity.permission import PermissionFieldType, PermissionID
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.role import RoleID
-from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.manager.data.permission.types import Permission
 from ai.backend.manager.models.rbac_models.permission.creators import RolePermissionCreator
 from ai.backend.manager.models.rbac_models.permission.lookups import RolePermissionOwnerLookup
@@ -17,7 +17,7 @@ class TestRolePermissionCreator:
         role_id = RoleID(uuid.uuid4())
         scope = ProjectID(uuid.uuid4())
         creator = RolePermissionCreator(
-            scope=scope, entity_type=EntityType("session"), permission=Permission.READ
+            scope=scope, entity_type=SessionEntityType(), permission=Permission.READ
         )
 
         row = creator.build_row(role_id)
@@ -31,7 +31,7 @@ class TestRolePermissionCreator:
     def test_a_duplicate_entry_is_mapped_to_a_domain_error(self) -> None:
         creator = RolePermissionCreator(
             scope=ProjectID(uuid.uuid4()),
-            entity_type=EntityType("session"),
+            entity_type=SessionEntityType(),
             permission=Permission.READ,
         )
 
@@ -43,14 +43,14 @@ class TestRolePermissionCreator:
         permission_id = PermissionID(uuid.uuid4())
         creator = RolePermissionCreator(
             scope=ProjectID(uuid.uuid4()),
-            entity_type=EntityType("session"),
+            entity_type=SessionEntityType(),
             permission=Permission.READ,
         )
 
         field_id = creator.field_id(PermissionRow(id=permission_id))
 
         assert field_id == permission_id
-        assert PermissionID.field_type() == PERMISSION_FIELD_TYPE
+        assert PermissionID.field_type() == PermissionFieldType()
 
 
 class TestRolePermissionReadSpecs:

--- a/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
+++ b/tests/unit/manager/repositories/container_registry/test_container_registry_repository.py
@@ -11,11 +11,11 @@ import sqlalchemy as sa
 
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.entity.container_registry import (
-    CONTAINER_REGISTRY_ENTITY_TYPE,
+    ContainerRegistryEntityType,
     ContainerRegistryID,
 )
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import ResourceSlot
@@ -240,7 +240,7 @@ class TestContainerRegistryRepository:
                 )
                 session.add(group)
                 await session.flush()
-                session.add(VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=group.id))
+                session.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=group.id))
                 group_ids.append(group.id)
 
             await session.commit()
@@ -496,7 +496,7 @@ class TestContainerRegistryRepository:
                 )
                 session.add(group)
                 await session.flush()
-                session.add(VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=group.id))
+                session.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=group.id))
                 group_ids.append(str(group.id))
             await session.commit()
 
@@ -868,7 +868,7 @@ class TestContainerRegistryRepository:
             session.add(registry)
             await session.flush()
             session.add(
-                VirtualEntityRow(entity_type=CONTAINER_REGISTRY_ENTITY_TYPE, entity_id=registry.id)
+                VirtualEntityRow(entity_type=ContainerRegistryEntityType(), entity_id=registry.id)
             )
             await session.commit()
             await session.refresh(registry)
@@ -932,7 +932,7 @@ class TestContainerRegistryRepository:
             session.add(registry)
             await session.flush()
             session.add(
-                VirtualEntityRow(entity_type=CONTAINER_REGISTRY_ENTITY_TYPE, entity_id=registry.id)
+                VirtualEntityRow(entity_type=ContainerRegistryEntityType(), entity_id=registry.id)
             )
 
             # Create resource policies
@@ -963,7 +963,7 @@ class TestContainerRegistryRepository:
                 )
                 session.add(group)
                 await session.flush()
-                session.add(VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=group.id))
+                session.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=group.id))
                 group_ids.append(group.id)
 
                 # Associate with registry
@@ -1050,7 +1050,7 @@ class TestContainerRegistryRepository:
             session.add(registry)
             await session.flush()
             session.add(
-                VirtualEntityRow(entity_type=CONTAINER_REGISTRY_ENTITY_TYPE, entity_id=registry.id)
+                VirtualEntityRow(entity_type=ContainerRegistryEntityType(), entity_id=registry.id)
             )
 
             # Create resource policies
@@ -1081,7 +1081,7 @@ class TestContainerRegistryRepository:
                 )
                 session.add(group)
                 await session.flush()
-                session.add(VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=group.id))
+                session.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=group.id))
                 group_ids.append(group.id)
 
             # Associate first 2 groups with the registry

--- a/tests/unit/manager/repositories/entity_share/test_repository.py
+++ b/tests/unit/manager/repositories/entity_share/test_repository.py
@@ -18,9 +18,10 @@ from sqlalchemy.orm import aliased
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.entity_share import EntityShareID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, RuntimeEntityID
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, RuntimeEntityID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import BackendAIError
 from ai.backend.common.types import ResourceSlot
@@ -71,7 +72,7 @@ ensure_all_tables_registered()
 _DOMAIN = "invitation-test-domain"
 _DOMAIN_ID = DomainID(uuid4())
 _POLICY = "invitation-test-policy"
-_TARGET_TYPE = EntityType("vfolder")
+_TARGET_TYPE = VFolderEntityType()
 
 _INVITER_ID = UserID(uuid4())
 _INVITEE_ID = UserID(uuid4())
@@ -221,11 +222,11 @@ async def database(
             # invitation joins the target and the grant lands in the invitee's scope.
             session.add_all([
                 VirtualEntityRow(entity_type=_TARGET_TYPE, entity_id=_TARGET_ID),
-                VirtualEntityRow(entity_type=USER_ENTITY_TYPE, entity_id=_INVITEE_ID),
-                VirtualEntityRow(entity_type=USER_ENTITY_TYPE, entity_id=_OUTSIDER_ID),
-                VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=_INVITEE_PROJECT_ID),
-                VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=_OUTSIDER_PROJECT_ID),
-                VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=_TEAM_PROJECT_ID),
+                VirtualEntityRow(entity_type=UserEntityType(), entity_id=_INVITEE_ID),
+                VirtualEntityRow(entity_type=UserEntityType(), entity_id=_OUTSIDER_ID),
+                VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=_INVITEE_PROJECT_ID),
+                VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=_OUTSIDER_PROJECT_ID),
+                VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=_TEAM_PROJECT_ID),
             ])
         yield database_connection
 
@@ -483,7 +484,7 @@ class TestAProjectAnswering:
         created = await repository.create(_creator_to(_TEAM_PROJECT_ID))
         data = await repository.accept(created.id, _TEAM_PROJECT_ID)
         assert data.status == EntityShareStatus.ACCEPTED
-        assert data.recipient == RuntimeEntityID(PROJECT_ENTITY_TYPE, _TEAM_PROJECT_ID)
+        assert data.recipient == RuntimeEntityID(ProjectEntityType(), _TEAM_PROJECT_ID)
         assert await _cap(database, _TEAM_PROJECT_ID) == (True, Permission.READ)
 
     async def test_a_project_gives_back_what_it_took(
@@ -539,7 +540,7 @@ class TestAddressedByEmail:
         created = await repository.create(_creator())
         assert created.recipient is None
         data = await repository.accept(created.id, _INVITEE_ID)
-        assert data.recipient == RuntimeEntityID(USER_ENTITY_TYPE, _INVITEE_ID)
+        assert data.recipient == RuntimeEntityID(UserEntityType(), _INVITEE_ID)
 
 
 class TestRevoke:

--- a/tests/unit/manager/repositories/image/test_customized_image_creator.py
+++ b/tests/unit/manager/repositories/image/test_customized_image_creator.py
@@ -17,14 +17,14 @@ import sqlalchemy as sa
 
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.entity.container_registry import (
-    CONTAINER_REGISTRY_ENTITY_TYPE,
+    ContainerRegistryEntityType,
     ContainerRegistryID,
 )
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.image import ImageID
 from ai.backend.common.data.entity.project import (
-    PROJECT_ENTITY_TYPE,
     PROJECT_SCOPE_TYPE,
+    ProjectEntityType,
     ProjectID,
 )
 from ai.backend.common.data.entity.user import UserID
@@ -189,7 +189,7 @@ class TestImageOwnershipGraph:
                 )
             )
             await VirtualEntitySeeder().get_or_create_node(
-                sess, CONTAINER_REGISTRY_ENTITY_TYPE, registry_id
+                sess, ContainerRegistryEntityType(), registry_id
             )
             await sess.commit()
         return registry_id
@@ -239,7 +239,7 @@ class TestImageOwnershipGraph:
                     resource_policy=PROJECT_RESOURCE_POLICY_NAME,
                 )
             )
-            await VirtualEntitySeeder().get_or_create_node(sess, PROJECT_ENTITY_TYPE, project_id)
+            await VirtualEntitySeeder().get_or_create_node(sess, ProjectEntityType(), project_id)
             await sess.commit()
         return project_id
 

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -21,7 +21,9 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.role_preset import (
+    RolePresetEntityType,
     RolePresetID,
 )
 from ai.backend.common.data.entity.types import (
@@ -191,11 +193,28 @@ class _PresetBulkQuerier(BulkEntityQuerier[RolePresetRow, RolePresetData]):
         return row.to_data()
 
 
+class _PresetFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "test_preset_field"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A field row of the test preset."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType] | None:
+        return None
+
+
 class _PresetFieldID(FieldIdentifier):
     @override
     @classmethod
     def field_type(cls) -> FieldType:
-        return FieldType("test_preset_field")
+        return _PresetFieldType()
 
 
 @dataclass(frozen=True)
@@ -718,7 +737,7 @@ class _SearchPresetsAction(BaseScopeAction, SearchOpsAction[RolePresetRow, _Pres
     @classmethod
     @override
     def entity_type(cls) -> EntityType:
-        return EntityType("role_preset")
+        return RolePresetEntityType()
 
     @classmethod
     @override
@@ -781,7 +800,7 @@ class TestFullStack:
             service.execute
         )
         action = _SearchPresetsAction(
-            scope=ScopeRef(scope_type=ScopeType(EntityType("domain")), scope_id=uuid.uuid4()),
+            scope=ScopeRef(scope_type=ScopeType(DomainEntityType()), scope_id=uuid.uuid4()),
             scopes=(_NamedScope(name="default"),),
         )
 

--- a/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
+++ b/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
@@ -33,6 +33,7 @@ from sqlalchemy.orm import InstrumentedAttribute, Mapped, aliased, mapped_column
 
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
     EntityType,
@@ -119,8 +120,21 @@ class _EntityData:
 _SCOPE_TYPE = PROJECT_SCOPE_TYPE
 _PARENT_SCOPE_TYPE = DOMAIN_SCOPE_TYPE
 
+
 # A scope type outside every permission-layer enum — the chain accepts it as-is.
-_OPEN_SCOPE_TYPE = ScopeType(EntityType("not_an_rbac_element_type"))
+class _OpenEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "not_an_rbac_element_type"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A kind outside every permission-layer enum."
+
+
+_OPEN_SCOPE_TYPE = ScopeType(_OpenEntityType())
 
 
 class _EntityID(EntityIdentifier):
@@ -535,7 +549,7 @@ async def _scope_roles(database: ExtendedAsyncSAEngine, scope_id: UUID) -> dict[
                 .join(EntityMembershipRow, EntityMembershipRow.member_entity_id == role_node.id)
                 .where(
                     EntityMembershipRow.virtual_entity_id == _node_id(_SCOPE_TYPE, scope_id),
-                    role_node.entity_type == EntityType("role"),
+                    role_node.entity_type == RoleEntityType(),
                 )
             )
         ).all()
@@ -558,8 +572,7 @@ async def _scope_governs_role(
     async with database.begin_readonly_session() as sess:
         row = await sess.scalar(
             sa.select(ScopeBindingRow.scope_entity_id).where(
-                ScopeBindingRow.virtual_entity_id
-                == _node_id(ScopeType(EntityType("role")), role_id),
+                ScopeBindingRow.virtual_entity_id == _node_id(ScopeType(RoleEntityType()), role_id),
                 ScopeBindingRow.scope_entity_id == _node_id(_SCOPE_TYPE, scope_id),
             )
         )
@@ -921,7 +934,24 @@ class TestEntityPurge:
 # =============================================================================
 
 
-_SIDECAR_FIELD_TYPE = FieldType("test_sidecar")
+class _SidecarFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "test_sidecar"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A row that rides beside the graph."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType] | None:
+        return None
+
+
+_SIDECAR_FIELD_TYPE = _SidecarFieldType()
 
 
 class _SidecarID(FieldIdentifier):

--- a/tests/unit/manager/repositories/ops/v2/test_permission_field_scopes.py
+++ b/tests/unit/manager/repositories/ops/v2/test_permission_field_scopes.py
@@ -22,8 +22,10 @@ from uuid import UUID
 import pytest
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.id import FieldPath
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -43,8 +45,8 @@ from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntit
 from ai.backend.manager.repositories.ops.v2.permission.provider import PermissionOpsProvider
 from ai.backend.testutils.db import with_tables
 
-_SCOPE_TYPE = EntityType("project")
-_ENTITY_TYPE = EntityType("vfolder")
+_SCOPE_TYPE = ProjectEntityType()
+_ENTITY_TYPE = VFolderEntityType()
 
 _NAME = FieldPath("name")
 _DATA = FieldPath("data")

--- a/tests/unit/manager/repositories/ops/v2/test_relation_write.py
+++ b/tests/unit/manager/repositories/ops/v2/test_relation_write.py
@@ -22,6 +22,8 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.errors.common import ObjectNotFound
@@ -51,8 +53,8 @@ from ai.backend.manager.repositories.ops.v2.relation.provider import RelationOps
 from ai.backend.manager.repositories.ops.v2.share.provider import ShareOpsProvider
 from ai.backend.testutils.db import with_tables
 
-_SCOPE_TYPE = EntityType("project")
-_TARGET_TYPE = EntityType("resource_group")
+_SCOPE_TYPE = ProjectEntityType()
+_TARGET_TYPE = ResourceGroupEntityType()
 
 
 class _ScopeID(EntityIdentifier):

--- a/tests/unit/manager/repositories/ops/v2/test_role_preset_sync.py
+++ b/tests/unit/manager/repositories/ops/v2/test_role_preset_sync.py
@@ -12,8 +12,9 @@ import sqlalchemy as sa
 from sqlalchemy import Table
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.role_preset import RolePresetID
-from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
@@ -125,7 +126,7 @@ async def _add_role(
                 source=RoleSource.SYSTEM,
                 status=RoleStatus.ACTIVE,
                 role_preset_id=preset_id,
-                scope_type=EntityType("project"),
+                scope_type=ProjectEntityType(),
                 scope_id=project_id,
             )
         )
@@ -133,9 +134,9 @@ async def _add_role(
         sess.add(
             PermissionRow(
                 role_id=role_id,
-                scope_type=EntityType("project"),
+                scope_type=ProjectEntityType(),
                 scope_id=str(project_id),
-                entity_type=EntityType("vfolder"),
+                entity_type=VFolderEntityType(),
                 permission=Permission.READ,
                 all_fields=True,
             )

--- a/tests/unit/manager/repositories/ops/v2/test_share_field_scopes.py
+++ b/tests/unit/manager/repositories/ops/v2/test_share_field_scopes.py
@@ -26,6 +26,8 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserEntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.id import FieldPath
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.errors.permission import InvalidFieldPermission
@@ -42,8 +44,8 @@ from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntit
 from ai.backend.manager.repositories.ops.v2.share.provider import ShareOpsProvider
 from ai.backend.testutils.db import with_tables
 
-_GRANTEE_TYPE = EntityType("user")
-_ENTITY_TYPE = EntityType("vfolder")
+_GRANTEE_TYPE = UserEntityType()
+_ENTITY_TYPE = VFolderEntityType()
 
 _TOKEN = FieldPath("token")
 _DATA = FieldPath("data")

--- a/tests/unit/manager/repositories/ops/v2/user/test_create_user.py
+++ b/tests/unit/manager/repositories/ops/v2/user/test_create_user.py
@@ -9,14 +9,14 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy import Table
 
-from ai.backend.common.data.entity.domain import DOMAIN_ENTITY_TYPE, DomainID, DomainName
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID, DomainName
 from ai.backend.common.data.entity.project import (
-    PROJECT_ENTITY_TYPE,
     PROJECT_SCOPE_TYPE,
+    ProjectEntityType,
     ProjectID,
 )
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE, RoleID
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE, UserID
+from ai.backend.common.data.entity.role import RoleEntityType, RoleID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import RoleStatus
 from ai.backend.common.types import AccessKey, ResourceSlot, VFolderHostPermissionMap
@@ -229,8 +229,8 @@ async def _project_member_ids(db: ExtendedAsyncSAEngine, project_id: ProjectID) 
                     )
                     .where(
                         EntityMembershipRow.virtual_entity_id
-                        == _node_of(PROJECT_ENTITY_TYPE, project_id),
-                        VirtualEntityRow.entity_type == USER_ENTITY_TYPE,
+                        == _node_of(ProjectEntityType(), project_id),
+                        VirtualEntityRow.entity_type == UserEntityType(),
                     )
                 )
             ).all()
@@ -313,9 +313,9 @@ class TestPersonalProjectProvisioning:
                 .select_from(EntityMembershipRow)
                 .where(
                     EntityMembershipRow.virtual_entity_id
-                    == _node_of(DOMAIN_ENTITY_TYPE, domain.domain_id),
+                    == _node_of(DomainEntityType(), domain.domain_id),
                     EntityMembershipRow.member_entity_id
-                    == _node_of(PROJECT_ENTITY_TYPE, project_id),
+                    == _node_of(ProjectEntityType(), project_id),
                 )
             )
         assert owned == 1
@@ -412,8 +412,8 @@ class TestUserGraphProvisioning:
         """``created_in`` puts the user on the domain's list and under its roles."""
         user_id = await _create_user(provider, domain.domain_id, "alice")
 
-        domain_node = (DOMAIN_ENTITY_TYPE, domain.domain_id)
-        user_node = (USER_ENTITY_TYPE, user_id)
+        domain_node = (DomainEntityType(), domain.domain_id)
+        user_node = (UserEntityType(), user_id)
         assert await _owns(db, domain_node, user_node)
         assert await _governs(db, domain_node, user_node)
 
@@ -509,7 +509,7 @@ async def _enrol_auto_assign_role(db: ExtendedAsyncSAEngine, project_id: Project
                 scope_id=project_id,
             )
         )
-        role_node = VirtualEntityRow(entity_type=ROLE_ENTITY_TYPE, entity_id=role_id)
+        role_node = VirtualEntityRow(entity_type=RoleEntityType(), entity_id=role_id)
         session.add(role_node)
         await session.flush()
         project_node_id = await session.scalar(

--- a/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
@@ -16,13 +16,13 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_ENTITY_TYPE
-from ai.backend.common.data.entity.role_preset import ROLE_PRESET_ENTITY_TYPE, RolePresetID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeRef, ScopeType
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import ResourceSlot
@@ -90,9 +90,9 @@ _ORM_CLUSTER = (
     ResourceGroupForDomainRow,
 )
 
-_TARGET_ENTITY_TYPE = EntityType("vfolder")
+_TARGET_ENTITY_TYPE = VFolderEntityType()
 # Wired, but not a member of the legacy RBAC enum the permissions table used to carry.
-_UNMAPPED_ENTITY_TYPE = ROLE_PRESET_ENTITY_TYPE
+_UNMAPPED_ENTITY_TYPE = RolePresetEntityType()
 
 
 @dataclass
@@ -277,7 +277,7 @@ class TestCheckPermissionViaVirtualEntity:
                 DomainRow(id=domain_id, name=domain_name, total_resource_slots=ResourceSlot())
             )
             db_sess.add_all(
-                self._chain_nodes(ids, ScopeType(EntityType("project")), _TARGET_ENTITY_TYPE)
+                self._chain_nodes(ids, ScopeType(ProjectEntityType()), _TARGET_ENTITY_TYPE)
             )
             await db_sess.flush()
 
@@ -544,7 +544,7 @@ class TestCheckPermissionViaVirtualEntity:
         does not name."""
         async with db.begin_session() as db_sess:
             db_sess.add_all(
-                self._chain_nodes(ids, ScopeType(EntityType("project")), _UNMAPPED_ENTITY_TYPE)
+                self._chain_nodes(ids, ScopeType(ProjectEntityType()), _UNMAPPED_ENTITY_TYPE)
             )
             await db_sess.flush()
             db_sess.add(
@@ -562,7 +562,7 @@ class TestCheckPermissionViaVirtualEntity:
             db_sess.add(
                 PermissionRow(
                     role_id=ids.role_id,
-                    scope_type=ScopeType(EntityType("project")),
+                    scope_type=ScopeType(ProjectEntityType()),
                     scope_id=str(ids.bound_scope_id),
                     entity_type=_UNMAPPED_ENTITY_TYPE,
                     permission=Permission.READ,
@@ -605,7 +605,7 @@ class TestCheckPermissionViaVirtualEntity:
                 ),
                 {
                     "role_id": fixture_ids.role_id,
-                    "scope_type": str(ScopeType(EntityType("project"))),
+                    "scope_type": str(ScopeType(ProjectEntityType())),
                     "scope_id": str(fixture_ids.bound_scope_id),
                     "entity_type": str(_UNMAPPED_ENTITY_TYPE),
                     "permission": int(Permission.READ),
@@ -804,7 +804,7 @@ class TestUserRosterEnrollment:
                     VirtualEntityRow.entity_id == project_id,
                 )
             )
-            session_node = VirtualEntityRow(entity_type=SESSION_ENTITY_TYPE, entity_id=session_id)
+            session_node = VirtualEntityRow(entity_type=SessionEntityType(), entity_id=session_id)
             db_sess.add(session_node)
             await db_sess.flush()
             db_sess.add(
@@ -935,7 +935,7 @@ class TestUserRosterEnrollment:
                 )
             )
             assert project_ve_id is not None
-            vfolder_node = VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id)
+            vfolder_node = VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id)
             db_sess.add(vfolder_node)
             await db_sess.flush()
             await VirtualEntitySeeder().cap_edge(db_sess, project_ve_id, vfolder_node.id, cap)
@@ -978,8 +978,8 @@ class TestUserRosterEnrollment:
 
         key = GovernCheckKey(
             user_id=ids.user_id,
-            scope=ScopeRef(scope_type=ScopeType(VFOLDER_ENTITY_TYPE), scope_id=vfolder_id),
-            entity_type=SESSION_ENTITY_TYPE,
+            scope=ScopeRef(scope_type=ScopeType(VFolderEntityType()), scope_id=vfolder_id),
+            entity_type=SessionEntityType(),
         )
         result = await repository.governed_permissions([key])
         assert result[key] == (Permission.READ if reaches else Permission.NONE)
@@ -1002,10 +1002,10 @@ class TestUserRosterEnrollment:
             )
             assert project_ve_id is not None
             rg_node = VirtualEntityRow(
-                entity_type=RESOURCE_GROUP_ENTITY_TYPE, entity_id=uuid.uuid4()
+                entity_type=ResourceGroupEntityType(), entity_id=uuid.uuid4()
             )
             other_node = VirtualEntityRow(
-                entity_type=PROJECT_ENTITY_TYPE, entity_id=other_project_id
+                entity_type=ProjectEntityType(), entity_id=other_project_id
             )
             db_sess.add_all([rg_node, other_node])
             await db_sess.flush()

--- a/tests/unit/manager/repositories/permission_controller/test_own_check_query.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_check_query.py
@@ -26,12 +26,12 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SessionID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import ResourceSlot
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -63,7 +63,7 @@ from ai.backend.manager.repositories.ops.v2.permission.provider import Permissio
 from ai.backend.manager.repositories.ops.v2.permission.read import PermissionReadOps, _GroupKey
 from ai.backend.testutils.db import with_tables
 
-_DOMAIN = EntityType("domain")
+_DOMAIN = DomainEntityType()
 
 
 @dataclass
@@ -229,25 +229,25 @@ async def seed_deep_own(sess: AsyncSession, count: int) -> _Seed:
     """Sessions owned by a project and the user, the project governed by the
     domain; the domain role reads, the project role updates."""
     user_id, domain_id, user_node, domain_node = await _user_in_domain(sess)
-    seed = _Seed(user_id=user_id, entity_type=SESSION_ENTITY_TYPE)
+    seed = _Seed(user_id=user_id, entity_type=SessionEntityType())
     project_id = uuid.uuid4()
-    project_node = await _node(sess, PROJECT_ENTITY_TYPE, project_id)
+    project_node = await _node(sess, ProjectEntityType(), project_id)
     await _govern(sess, domain_node, project_node)
     await _role(
         sess,
         user_id,
-        _permission_rows(uuid.uuid4(), _DOMAIN, domain_id, SESSION_ENTITY_TYPE, Permission.READ),
+        _permission_rows(uuid.uuid4(), _DOMAIN, domain_id, SessionEntityType(), Permission.READ),
     )
     await _role(
         sess,
         user_id,
         _permission_rows(
-            uuid.uuid4(), PROJECT_ENTITY_TYPE, project_id, SESSION_ENTITY_TYPE, Permission.UPDATE
+            uuid.uuid4(), ProjectEntityType(), project_id, SessionEntityType(), Permission.UPDATE
         ),
     )
     for _ in range(count):
         session_id = SessionID(uuid.uuid4())
-        node = await _node(sess, SESSION_ENTITY_TYPE, session_id)
+        node = await _node(sess, SessionEntityType(), session_id)
         await _own(sess, project_node, node)
         await _own(sess, user_node, node)
         await _govern(sess, project_node, node)
@@ -260,7 +260,7 @@ async def seed_shares(sess: AsyncSession, count: int) -> _Seed:
     """Vfolders shared to the user under READ while the user's own scope holds
     READ|UPDATE on vfolders, so the cap clips every answer to READ."""
     user_id, _, user_node, _ = await _user_in_domain(sess)
-    seed = _Seed(user_id=user_id, entity_type=VFOLDER_ENTITY_TYPE)
+    seed = _Seed(user_id=user_id, entity_type=VFolderEntityType())
     await _role(
         sess,
         user_id,
@@ -268,13 +268,13 @@ async def seed_shares(sess: AsyncSession, count: int) -> _Seed:
             uuid.uuid4(),
             USER_SCOPE_TYPE,
             user_id,
-            VFOLDER_ENTITY_TYPE,
+            VFolderEntityType(),
             Permission.READ | Permission.UPDATE,
         ),
     )
     for _ in range(count):
         vfolder_id = VFolderUUID(uuid.uuid4())
-        node = await _node(sess, VFOLDER_ENTITY_TYPE, vfolder_id)
+        node = await _node(sess, VFolderEntityType(), vfolder_id)
         await _share(sess, user_node, node, Permission.READ)
         seed.entity_ids.append(vfolder_id)
     return seed
@@ -516,10 +516,10 @@ async def seed_at_scale(database: ExtendedAsyncSAEngine, scale: _Scale) -> _Scal
     def nodes() -> Iterable[tuple[uuid.UUID, str, uuid.UUID]]:
         for kind, ids in (
             (str(_DOMAIN), domain_ids),
-            (str(PROJECT_ENTITY_TYPE), project_ids),
+            (str(ProjectEntityType()), project_ids),
             (str(USER_SCOPE_TYPE), user_ids),
-            (str(SESSION_ENTITY_TYPE), session_ids),
-            (str(VFOLDER_ENTITY_TYPE), vfolder_ids),
+            (str(SessionEntityType()), session_ids),
+            (str(VFolderEntityType()), vfolder_ids),
         ):
             for entity_id in ids:
                 node_id = uuid.uuid4()
@@ -589,14 +589,14 @@ async def seed_at_scale(database: ExtendedAsyncSAEngine, scale: _Scale) -> _Scal
             yield (rid, f"measured-project-{i}", "system", "active", False)
 
     def permissions() -> Iterable[tuple[uuid.UUID, str, str, str, int, bool]]:
-        kinds = [str(SESSION_ENTITY_TYPE), str(VFOLDER_ENTITY_TYPE)] + [
+        kinds = [str(SessionEntityType()), str(VFolderEntityType())] + [
             f"kind_{k}" for k in range(8)
         ]
         for i, rid in enumerate(role_ids):
             for k in range(scale.permissions_per_role):
                 if i % 2:
                     scope_type, scope_id = (
-                        str(PROJECT_ENTITY_TYPE),
+                        str(ProjectEntityType()),
                         project_ids[(i + k) % scale.projects],
                     )
                 else:
@@ -607,7 +607,7 @@ async def seed_at_scale(database: ExtendedAsyncSAEngine, scale: _Scale) -> _Scal
             domain_role,
             str(_DOMAIN),
             str(domain_ids[0]),
-            str(SESSION_ENTITY_TYPE),
+            str(SessionEntityType()),
             int(Permission.READ),
             True,
         )
@@ -616,16 +616,16 @@ async def seed_at_scale(database: ExtendedAsyncSAEngine, scale: _Scale) -> _Scal
                 vfolder_role,
                 str(USER_SCOPE_TYPE),
                 str(measured),
-                str(VFOLDER_ENTITY_TYPE),
+                str(VFolderEntityType()),
                 int(bit),
                 True,
             )
         for i, rid in enumerate(project_roles):
             yield (
                 rid,
-                str(PROJECT_ENTITY_TYPE),
+                str(ProjectEntityType()),
                 str(project_ids[i]),
-                str(SESSION_ENTITY_TYPE),
+                str(SessionEntityType()),
                 int(Permission.UPDATE),
                 True,
             )
@@ -759,11 +759,11 @@ async def test_benchmark_at_scale(database: ExtendedAsyncSAEngine) -> None:
 
     cases = {
         "sessions (1000 owned + 1000 others)": (
-            SESSION_ENTITY_TYPE,
+            SessionEntityType(),
             seed.owned_sessions + seed.other_sessions,
         ),
         f"vfolders ({len(seed.shared_vfolders)} shared + {len(seed.other_vfolders)} unshared)": (
-            VFOLDER_ENTITY_TYPE,
+            VFolderEntityType(),
             seed.shared_vfolders + seed.other_vfolders,
         ),
     }

--- a/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_assignment.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.auth.hash import PasswordHashAlgorithm
@@ -554,7 +554,7 @@ class TestRoleAssignment:
                 )
             )
             await session.flush()
-            role_node = VirtualEntityRow(entity_type=ROLE_ENTITY_TYPE, entity_id=role_id)
+            role_node = VirtualEntityRow(entity_type=RoleEntityType(), entity_id=role_id)
             session.add(role_node)
             await session.flush()
             project_node_id = await session.scalar(

--- a/tests/unit/manager/repositories/permission_controller/test_role_permission_write.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permission_write.py
@@ -10,9 +10,9 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.permission import PermissionID
-from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.role import RoleID
-from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.manager.data.permission.permission import PermissionData
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import Permission, RoleSource
@@ -57,7 +57,7 @@ class TestRolePermissionWrite:
         async with db_with_tables.begin_session() as db_sess:
             await db_sess.execute(
                 sa.insert(RoleRow).values(
-                    scope_type=EntityType("project"),
+                    scope_type=ProjectEntityType(),
                     scope_id=uuid.uuid4(),
                     id=role_id,
                     name="reader",
@@ -69,7 +69,7 @@ class TestRolePermissionWrite:
 
     def _read_sessions_in(self, project_id: ProjectID) -> RolePermissionCreator:
         return RolePermissionCreator(
-            scope=project_id, entity_type=EntityType("session"), permission=Permission.READ
+            scope=project_id, entity_type=SessionEntityType(), permission=Permission.READ
         )
 
     async def test_create_and_purge_are_answered_by_the_role(

--- a/tests/unit/manager/repositories/permission_controller/test_role_write.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_write.py
@@ -10,7 +10,7 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE, RoleID
+from ai.backend.common.data.entity.role import RoleEntityType, RoleID
 from ai.backend.common.data.permission.types import RoleSource
 from ai.backend.manager.data.permission.role import RoleData
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -169,7 +169,7 @@ class TestRoleCreate:
         role_node = (
             sa.select(VirtualEntityRow.id)
             .where(
-                VirtualEntityRow.entity_type == ROLE_ENTITY_TYPE,
+                VirtualEntityRow.entity_type == RoleEntityType(),
                 VirtualEntityRow.entity_id == role_id,
             )
             .scalar_subquery()

--- a/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_permissions.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.manager.data.permission.types import (
     EntityType,
     OperationType,
@@ -141,7 +141,7 @@ class TestSearchPermissions:
     ) -> None:
         querier = BatchQuerier(
             conditions=[
-                ScopedPermissionConditions.by_entity_type(VFOLDER_ENTITY_TYPE),
+                ScopedPermissionConditions.by_entity_type(VFolderEntityType()),
             ],
             orders=[],
             pagination=OffsetPagination(limit=10, offset=0),

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles.py
@@ -14,8 +14,8 @@ import pytest
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.filter_specs import (
     StringMatchSpec,
     UUIDEqualMatchSpec,
@@ -119,7 +119,7 @@ class TestSearchRoles:
 
         async with db_with_rbac_tables.begin_session() as db_sess:
             home = uuid.uuid4()
-            db_sess.add(VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=home))
+            db_sess.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=home))
             for i, (name, description) in enumerate([
                 ("admin-role", "Admin role"),
                 ("editor-role", "Editor role"),
@@ -130,7 +130,7 @@ class TestSearchRoles:
                     name=name,
                     description=description,
                     created_at=created_at,
-                    scope_type=PROJECT_ENTITY_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=home,
                 )
                 db_sess.add(role)
@@ -344,9 +344,9 @@ class TestSearchRoles:
         project_id = uuid.uuid4()
 
         async with db_with_rbac_tables.begin_session() as db_sess:
-            scope_node = VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=project_id)
+            scope_node = VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=project_id)
             role_node = VirtualEntityRow(
-                entity_type=ROLE_ENTITY_TYPE, entity_id=created_roles[0].role_id
+                entity_type=RoleEntityType(), entity_id=created_roles[0].role_id
             )
             db_sess.add_all([scope_node, role_node])
             await db_sess.flush()
@@ -360,7 +360,7 @@ class TestSearchRoles:
             await db_sess.execute(
                 sa.update(RoleRow)
                 .where(RoleRow.id == created_roles[0].role_id)
-                .values(scope_type=PROJECT_ENTITY_TYPE, scope_id=project_id)
+                .values(scope_type=ProjectEntityType(), scope_id=project_id)
             )
             await db_sess.flush()
 
@@ -378,7 +378,7 @@ class TestSearchRoles:
         querier = BatchQuerier(
             conditions=[
                 RoleConditions.by_mapped_scope([
-                    RoleConditions.by_scope_type_equals(PROJECT_ENTITY_TYPE),
+                    RoleConditions.by_scope_type_equals(ProjectEntityType()),
                     RoleConditions.by_scope_id_equals(
                         UUIDEqualMatchSpec(value=uuid.UUID(project_scope_id), negated=False)
                     ),
@@ -436,13 +436,13 @@ class TestSearchRolesTotalCountNotInflated:
 
         async with db_with_rbac_tables.begin_session() as db_sess:
             home = uuid.uuid4()
-            db_sess.add(VirtualEntityRow(entity_type=PROJECT_ENTITY_TYPE, entity_id=home))
+            db_sess.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=home))
             # Role with multiple object permissions
             role_with_perms = RoleRow(
                 name="role-with-perms",
                 description="Role that has multiple object permissions",
                 created_at=base_time,
-                scope_type=PROJECT_ENTITY_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=home,
             )
             db_sess.add(role_with_perms)
@@ -468,7 +468,7 @@ class TestSearchRolesTotalCountNotInflated:
             # Role with zero object permissions
             role_without_perms = RoleRow(
                 name="role-without-perms",
-                scope_type=PROJECT_ENTITY_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=home,
                 description="Role that has no object permissions",
                 created_at=base_time + timedelta(minutes=1),

--- a/tests/unit/manager/repositories/permission_controller/test_search_roles_in_scope.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_roles_in_scope.py
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_ENTITY_TYPE, ProjectID
-from ai.backend.common.data.entity.role import ROLE_ENTITY_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.agent import AgentRow
 
@@ -72,7 +72,7 @@ async def _add_role(
     role = RoleRow(name=name, description=name, scope_type=scope_type, scope_id=scope_id)
     db_sess.add(role)
     await db_sess.flush()
-    role_node = VirtualEntityRow(entity_type=ROLE_ENTITY_TYPE, entity_id=role.id)
+    role_node = VirtualEntityRow(entity_type=RoleEntityType(), entity_id=role.id)
     db_sess.add(role_node)
     await db_sess.flush()
     db_sess.add(EntityMembershipRow(virtual_entity_id=role_node.id, member_entity_id=role_node.id))
@@ -115,9 +115,9 @@ class TestSearchRolesInScope:
         project_id = uuid.uuid4()
 
         async with db_with_tables.begin_session() as db_sess:
-            role_in = await _add_role(db_sess, "role-in-scope", PROJECT_ENTITY_TYPE, project_id)
+            role_in = await _add_role(db_sess, "role-in-scope", ProjectEntityType(), project_id)
             role_out = await _add_role(
-                db_sess, "role-outside-scope", PROJECT_ENTITY_TYPE, uuid.uuid4()
+                db_sess, "role-outside-scope", ProjectEntityType(), uuid.uuid4()
             )
 
         return ScopedRoleFixture(
@@ -190,7 +190,7 @@ class TestSearchRolesInScope:
         scope_id = uuid.uuid4()
 
         async with db_with_tables.begin_session() as db_sess:
-            await _add_role(db_sess, "project-only-role", PROJECT_ENTITY_TYPE, scope_id)
+            await _add_role(db_sess, "project-only-role", ProjectEntityType(), scope_id)
 
         querier = BatchQuerier(
             conditions=[],

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import aliased
 from ai.backend.common.data.entity.domain import DomainID, DomainName
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import (
     BinarySize,
@@ -118,7 +118,7 @@ async def _membership_cap(
                 .where(
                     VirtualEntityRow.entity_type == PROJECT_SCOPE_TYPE,
                     VirtualEntityRow.entity_id == personal_project_id,
-                    member.entity_type == VFOLDER_ENTITY_TYPE,
+                    member.entity_type == VFolderEntityType(),
                     member.entity_id == vfolder_id,
                 )
             )
@@ -465,7 +465,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 quota_scope_id=f"user:{user_a_id}",
             )
             db_sess.add(vfolder_row)
-            db_sess.add(VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id))
+            db_sess.add(VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id))
             await db_sess.flush()
 
         # Grant A owner permission (creates scope-entity mapping + permissions)
@@ -528,7 +528,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 quota_scope_id=f"user:{user_a_id}",
             )
             db_sess.add(vfolder_row)
-            db_sess.add(VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id))
+            db_sess.add(VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id))
             await db_sess.flush()
 
         await repo.create_vfolder_permission(
@@ -594,7 +594,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 quota_scope_id=f"user:{user_a_id}",
             )
             db_sess.add(vfolder_row)
-            db_sess.add(VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id))
+            db_sess.add(VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id))
             await db_sess.flush()
 
         # A gets owner permission
@@ -671,7 +671,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 quota_scope_id=f"user:{user_a_id}",
             )
             db_sess.add(vfolder_row)
-            db_sess.add(VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id))
+            db_sess.add(VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id))
             await db_sess.flush()
 
         # Grant A owner permission
@@ -735,7 +735,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 quota_scope_id=f"user:{user_a_id}",
             )
             db_sess.add(vfolder_row)
-            db_sess.add(VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id))
+            db_sess.add(VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id))
             await db_sess.flush()
 
         # Grant B invitee permission (legacy vfolder_permissions record)

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -19,7 +19,7 @@ from ai.backend.common.data.entity.container_registry import ContainerRegistryID
 from ai.backend.common.data.entity.domain import DomainID, DomainName
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
-from ai.backend.common.data.entity.vfolder import VFOLDER_ENTITY_TYPE, VFolderUUID
+from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.types import (
     BinarySize,
     ClusterMode,
@@ -1103,7 +1103,7 @@ class TestVfolderRepositoryPurge:
                 status=status,
             )
             db_sess.add(vfolder)
-            db_sess.add(VirtualEntityRow(entity_type=VFOLDER_ENTITY_TYPE, entity_id=vfolder_id))
+            db_sess.add(VirtualEntityRow(entity_type=VFolderEntityType(), entity_id=vfolder_id))
             await db_sess.flush()
 
     async def _vfolder_exists(self, db: ExtendedAsyncSAEngine, vfolder_id: uuid.UUID) -> bool:

--- a/tests/unit/manager/services/notification/test_notification_processing.py
+++ b/tests/unit/manager/services/notification/test_notification_processing.py
@@ -18,9 +18,9 @@ import pytest
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.notification import (
-    NOTIFICATION_CHANNEL_ENTITY_TYPE,
-    NOTIFICATION_RULE_ENTITY_TYPE,
+    NotificationChannelEntityType,
     NotificationChannelID,
+    NotificationRuleEntityType,
     NotificationRuleID,
 )
 from ai.backend.common.data.notification import SessionStartedMessage
@@ -84,8 +84,8 @@ def notification_processors(
     # built but never reached, so the groups may sit on a stand-in engine.
     engine = MagicMock()
     return NotificationProcessors(
-        channel_group=ops_processor_group(engine, GroupMeta(NOTIFICATION_CHANNEL_ENTITY_TYPE)),
-        rule_group=ops_processor_group(engine, GroupMeta(NOTIFICATION_RULE_ENTITY_TYPE)),
+        channel_group=ops_processor_group(engine, GroupMeta(NotificationChannelEntityType())),
+        rule_group=ops_processor_group(engine, GroupMeta(NotificationRuleEntityType())),
         service=service,
     )
 

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -25,7 +25,8 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.role_preset import RolePresetID
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.types import (
     EntityData,
     EntityIdentifier,
@@ -36,6 +37,7 @@ from ai.backend.common.data.entity.types import (
     ScopeRef,
     ScopeType,
 )
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction
@@ -145,11 +147,28 @@ from ai.backend.manager.services.ops.service import (
     UpdateService,
 )
 
-_ENTITY_TYPE = EntityType("role_preset")
+_ENTITY_TYPE = RolePresetEntityType()
 _SCOPE_TYPE = ScopeType(_ENTITY_TYPE)
 
 
-_FIELD_TYPE = FieldType("test_field")
+class _TestFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "test_field"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A field row of the test entity."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType] | None:
+        return None
+
+
+_FIELD_TYPE = _TestFieldType()
 
 
 class _FieldID(FieldIdentifier):
@@ -183,7 +202,7 @@ class _StubEntityID(EntityIdentifier):
     @override
     @classmethod
     def entity_type(cls) -> EntityType:
-        return EntityType("vfolder")
+        return VFolderEntityType()
 
 
 @dataclass(frozen=True)
@@ -1383,7 +1402,7 @@ def authenticated_user() -> UserData:
 
 @pytest.fixture
 def scope() -> ScopeRef:
-    return ScopeRef(scope_type=ScopeType(EntityType("project")), scope_id=uuid.uuid4())
+    return ScopeRef(scope_type=ScopeType(ProjectEntityType()), scope_id=uuid.uuid4())
 
 
 @pytest.fixture

--- a/tests/unit/manager/services/rbac/test_relation_actions.py
+++ b/tests/unit/manager/services/rbac/test_relation_actions.py
@@ -23,7 +23,7 @@ from ai.backend.common.data.entity.container_registry import (
 )
 from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
 from ai.backend.common.data.entity.idle_checker import (
-    IDLE_CHECKER_ENTITY_TYPE,
+    IdleCheckerEntityType,
     IdleCheckerID,
 )
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
@@ -179,7 +179,7 @@ class TestEveryPairBecomesTheRunsScopes:
                 ActionOperationType.DELETE,
                 [
                     (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (ScopeType(IDLE_CHECKER_ENTITY_TYPE), _IDLE_CHECKER_ID),
+                    (ScopeType(IdleCheckerEntityType()), _IDLE_CHECKER_ID),
                 ],
             ),
             (
@@ -190,7 +190,7 @@ class TestEveryPairBecomesTheRunsScopes:
                 ActionOperationType.RESTORE,
                 [
                     (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (ScopeType(IDLE_CHECKER_ENTITY_TYPE), _IDLE_CHECKER_ID),
+                    (ScopeType(IdleCheckerEntityType()), _IDLE_CHECKER_ID),
                 ],
             ),
         ],

--- a/tests/unit/manager/services/resource_group/conftest.py
+++ b/tests/unit/manager/services/resource_group/conftest.py
@@ -20,7 +20,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy import text
 
-from ai.backend.common.data.entity.user import USER_ENTITY_TYPE
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.types import DefaultForUnspecified, ResourceSlot, VFolderHostPermissionMap
 from ai.backend.manager.data.user.types import UserStatus
@@ -291,7 +291,7 @@ async def admin_user_fixture(
         )
         await conn.execute(
             sa.insert(VirtualEntityRow.__table__).values(
-                entity_type=USER_ENTITY_TYPE,
+                entity_type=UserEntityType(),
                 entity_id=str(user_uuid),
             )
         )
@@ -346,7 +346,7 @@ async def regular_user_fixture(
         )
         await conn.execute(
             sa.insert(VirtualEntityRow.__table__).values(
-                entity_type=USER_ENTITY_TYPE,
+                entity_type=UserEntityType(),
                 entity_id=str(user_uuid),
             )
         )

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -17,7 +17,7 @@ from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedu
 from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.common.data.entity.replica_group import ReplicaGroupID
 from ai.backend.common.data.entity.replica_group_history import ReplicaGroupHistoryID
-from ai.backend.common.data.entity.session import SESSION_ENTITY_TYPE, SESSION_SCOPE_TYPE, SessionID
+from ai.backend.common.data.entity.session import SESSION_SCOPE_TYPE, SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import ScopeRef
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.data.deployment.types import (
@@ -428,7 +428,7 @@ class TestSearchKernelScopedHistoryAction:
         assert action.scope_targets() == (
             ScopeRef(scope_type=SESSION_SCOPE_TYPE, scope_id=_SESSION_ID),
         )
-        assert action.entity_type() == SESSION_ENTITY_TYPE
+        assert action.entity_type() == SessionEntityType()
         mock_repository.search_kernel_scoped_history.assert_awaited_once_with(
             querier=querier,
             scopes=[SessionKernelHistoryOperationScope(session_id=_SESSION_ID)],


### PR DESCRIPTION
## Summary

- Each entity and field type is now a class that answers its own `name()` and `description()`, replacing the 53 `*_ENTITY_TYPE` and 32 `*_FIELD_TYPE` module constants. A value is built at its use site as `AgentEntityType()`.
- A field kind answers the entity kind owning its rows through `owner_type()`. A kind whose owner is a value on the row rather than one fixed kind is a `DanglingFieldType`, which covers audit log, audit log scope, label and the three usage buckets.
- A value rebuilt from a string stays a bare base instance and answers no metadata. That is reserved for a boundary reading one, such as a row column, a legacy action or an RBAC element, and the rule is written in `common/data/entity/KNOWLEDGE.md`.
- Adds `backend.ai mgr ops types`, which lists every declared type by the ownership it declares, and a guard comparing the owner a field group is wired under against the owner its field type declares.

The three usage bucket kinds were declaring `domain`, `project` and `user` as owners while being wired as dangling field groups. The new guard caught that, and they are now declared dangling to match.

## Test plan

- [ ] `pants lint` and `pants check` pass over the changed set
- [ ] `pants test --changed-since=origin/main --changed-dependents=direct`
- [ ] `tests/unit/common/data/entity/test_types.py` sweeps every kind for name, description, owner and round-tripping
- [ ] `tests/unit/manager/actions/test_field_owner_wiring.py` cross-checks the declarations against the production wiring
- [ ] `backend.ai mgr ops types` prints the catalog

## Not in this change

- `secret` and the fair share kinds should become dangling field types, but their operations are service-backed and `FieldGroup` offers only ops-spec wiring, so moving them needs a framework addition.
- `auth`, `etcd_config`, `export` and `manager_admin` name no row and are left as they are.

Resolves BA-7775

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145xGLj7NBzqsNjxrGMpo2p