### PR TITLE
doc(BA-7780): revise the entity and field type descriptions

### DIFF
--- a/changes/14450.doc.md
+++ b/changes/14450.doc.md
@@ -1,1 +1,1 @@
-Correct the app config definition entity description: the row registers a config name and does not carry a value type.
+Revise the entity and field type descriptions listed by `backend.ai mgr ops types`. Several named columns that belong to another table or claimed behaviour the record does not have: a deployment policy holds a rollout strategy rather than scaling and routing, an app config is merged from every scope the caller sees rather than read from one, and a client IP is stored unmasked when no masking policy row exists.

--- a/changes/14450.doc.md
+++ b/changes/14450.doc.md
@@ -1,0 +1,1 @@
+Correct the app config definition entity description: the row registers a config name and does not carry a value type.

--- a/changes/14450.doc.md
+++ b/changes/14450.doc.md
@@ -1,1 +1,1 @@
-Revise the entity and field type descriptions listed by `backend.ai mgr ops types`. Several named columns that belong to another table or claimed behaviour the record does not have: a deployment policy holds a rollout strategy rather than scaling and routing, an app config is merged from every scope the caller sees rather than read from one, and a client IP is stored unmasked when no masking policy row exists.
+Correct the entity and field type descriptions listed by `backend.ai mgr ops types`, several of which described the wrong table.

--- a/src/ai/backend/common/data/entity/agent.py
+++ b/src/ai/backend/common/data/entity/agent.py
@@ -17,7 +17,7 @@ class AgentEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A compute node that runs kernels and reports its resources."
+        return "A compute node that runs kernels, in one resource group."
 
 
 class AgentUUID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/agent_resource.py
+++ b/src/ai/backend/common/data/entity/agent_resource.py
@@ -19,7 +19,7 @@ class AgentResourceFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One slot of a resource an agent offers."
+        return "One slot's capacity and usage on one agent."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/app_config.py
+++ b/src/ai/backend/common/data/entity/app_config.py
@@ -9,7 +9,6 @@ __all__ = (
 )
 
 
-# The merged config a caller reads; the fragments it is merged from are their own type.
 class AppConfigEntityType(EntityType):
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/app_config.py
+++ b/src/ai/backend/common/data/entity/app_config.py
@@ -4,35 +4,9 @@ from uuid import UUID
 from ai.backend.common.data.entity.types import EntityType
 
 __all__ = (
-    "AppConfigAllowListEntityType",
     "AppConfigEntityType",
-    "AppConfigFragmentEntityType",
     "AppConfigScopeID",
 )
-
-
-class AppConfigAllowListEntityType(EntityType):
-    @override
-    @classmethod
-    def name(cls) -> str:
-        return "app_config_allow_list"
-
-    @override
-    @classmethod
-    def description(cls) -> str:
-        return "The set of app config keys a scope may set."
-
-
-class AppConfigFragmentEntityType(EntityType):
-    @override
-    @classmethod
-    def name(cls) -> str:
-        return "app_config_fragment"
-
-    @override
-    @classmethod
-    def description(cls) -> str:
-        return "One key and value of an app config, set in one scope."
 
 
 # The merged config a caller reads; the fragments it is merged from are their own type.

--- a/src/ai/backend/common/data/entity/app_config.py
+++ b/src/ai/backend/common/data/entity/app_config.py
@@ -19,7 +19,7 @@ class AppConfigEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "The app config read from a scope, built from its fragments."
+        return "The value of one app config key, merged from its fragments in every visible scope."
 
 
 # Who an app config fragment belongs to. Polymorphic across scope kinds (domain/user); the

--- a/src/ai/backend/common/data/entity/app_config_allow_list.py
+++ b/src/ai/backend/common/data/entity/app_config_allow_list.py
@@ -17,7 +17,7 @@ class AppConfigAllowListEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "The set of app config keys a scope may set."
+        return "One app config key a scope type may set, and the rank its fragments merge at."
 
 
 class AppConfigAllowListID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/app_config_allow_list.py
+++ b/src/ai/backend/common/data/entity/app_config_allow_list.py
@@ -1,9 +1,23 @@
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("AppConfigAllowListID",)
+__all__ = (
+    "AppConfigAllowListEntityType",
+    "AppConfigAllowListID",
+)
+
+
+class AppConfigAllowListEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "app_config_allow_list"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The set of app config keys a scope may set."
 
 
 class AppConfigAllowListID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/app_config_definition.py
+++ b/src/ai/backend/common/data/entity/app_config_definition.py
@@ -17,7 +17,7 @@ class AppConfigDefinitionEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "The declaration of an app config key and its value type."
+        return "An app config key registered for use."
 
 
 class AppConfigDefinitionID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/app_config_fragment.py
+++ b/src/ai/backend/common/data/entity/app_config_fragment.py
@@ -17,7 +17,7 @@ class AppConfigFragmentEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One key and value of an app config, set in one scope."
+        return "One scope's contribution to an app config key, as a JSON document."
 
 
 class AppConfigFragmentID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/app_config_fragment.py
+++ b/src/ai/backend/common/data/entity/app_config_fragment.py
@@ -1,9 +1,23 @@
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("AppConfigFragmentID",)
+__all__ = (
+    "AppConfigFragmentEntityType",
+    "AppConfigFragmentID",
+)
+
+
+class AppConfigFragmentEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "app_config_fragment"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One key and value of an app config, set in one scope."
 
 
 class AppConfigFragmentID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/artifact.py
+++ b/src/ai/backend/common/data/entity/artifact.py
@@ -16,7 +16,7 @@ class ArtifactEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A model or dataset pulled from an artifact registry."
+        return "A model, package or image in an artifact registry."
 
 
 class ArtifactID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/artifact_registry.py
+++ b/src/ai/backend/common/data/entity/artifact_registry.py
@@ -16,7 +16,7 @@ class ArtifactRegistryEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A source artifacts are pulled from."
+        return "A named registry that artifacts are stored in and pulled from."
 
 
 class ArtifactRegistryID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/artifact_revision.py
+++ b/src/ai/backend/common/data/entity/artifact_revision.py
@@ -22,7 +22,7 @@ class ArtifactRevisionFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One version of an artifact."
+        return "A version of an artifact, created by a registry scan and imported on its own."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/audit_log.py
+++ b/src/ai/backend/common/data/entity/audit_log.py
@@ -19,7 +19,7 @@ class AuditLogFieldType(DanglingFieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One record of an action, owned by whatever entity the action was about."
+        return "One record of an action, naming who ran it and what it acted on."
 
 
 class AuditLogScopeFieldType(DanglingFieldType):
@@ -31,7 +31,10 @@ class AuditLogScopeFieldType(DanglingFieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One scope an audit record sits in."
+        return (
+            "The scope a scope or relation action targeted. The record itself names the"
+            " entity that was touched, so only this makes a search by the scope find it."
+        )
 
 
 class AuditLogID(FieldIdentifier):

--- a/src/ai/backend/common/data/entity/auth.py
+++ b/src/ai/backend/common/data/entity/auth.py
@@ -14,4 +14,4 @@ class AuthEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "The authentication operations, which name no row."
+        return "An authentication operation that names no user, such as a login."

--- a/src/ai/backend/common/data/entity/client_ip_masking.py
+++ b/src/ai/backend/common/data/entity/client_ip_masking.py
@@ -19,7 +19,10 @@ class ClientIPMaskingPolicyEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A rule masking client addresses in recorded logs."
+        return (
+            "How a client address is masked before it is stored in the login history or an"
+            " audit log. Without a row of its own or a default row, the address is not masked."
+        )
 
 
 class ClientIPMaskingPolicyID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/container_registry.py
+++ b/src/ai/backend/common/data/entity/container_registry.py
@@ -18,7 +18,7 @@ class ContainerRegistryEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A registry images are pulled from."
+        return "A registry that container images are pulled from, with the credentials to reach it."
 
 
 CONTAINER_REGISTRY_SCOPE_TYPE = ScopeType(ContainerRegistryEntityType())

--- a/src/ai/backend/common/data/entity/deployment.py
+++ b/src/ai/backend/common/data/entity/deployment.py
@@ -16,7 +16,7 @@ class DeploymentEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A served model with its replicas and revisions."
+        return "A model service holding the replica count to keep and the replica group serving it."
 
 
 DEPLOYMENT_SCOPE_TYPE = ScopeType(DeploymentEntityType())

--- a/src/ai/backend/common/data/entity/deployment_history.py
+++ b/src/ai/backend/common/data/entity/deployment_history.py
@@ -21,7 +21,7 @@ class DeploymentHistoryFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One state change of a deployment."
+        return "One run of a deployment handler, recording any status change and its result."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/deployment_policy.py
+++ b/src/ai/backend/common/data/entity/deployment_policy.py
@@ -21,7 +21,7 @@ class DeploymentPolicyFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "The scaling and routing policy of a deployment."
+        return "How a deployment rolls out a new revision, rolling update or blue-green."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/deployment_preset.py
+++ b/src/ai/backend/common/data/entity/deployment_preset.py
@@ -17,7 +17,7 @@ class DeploymentPresetEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A reusable revision setting a deployment can start from."
+        return "A named template for one runtime variant, holding what a deployment starts with."
 
 
 class DeploymentPresetID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/deployment_revision.py
+++ b/src/ai/backend/common/data/entity/deployment_revision.py
@@ -22,7 +22,7 @@ class DeploymentRevisionFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One configuration a deployment has run with."
+        return "One snapshot of a deployment's configuration, numbered within that deployment."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/deployment_token.py
+++ b/src/ai/backend/common/data/entity/deployment_token.py
@@ -21,7 +21,7 @@ class DeploymentTokenFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "An access token issued for a deployment."
+        return "A token for calling a deployment, fixing the user it acts as."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/error_log.py
+++ b/src/ai/backend/common/data/entity/error_log.py
@@ -24,7 +24,7 @@ class ErrorLogFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One error recorded for a user."
+        return "One error surfaced to a user, which they can mark read or clear away."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/fair_share.py
+++ b/src/ai/backend/common/data/entity/fair_share.py
@@ -20,7 +20,7 @@ class DomainFairShareEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A domain's fair-share weight in a resource group."
+        return "A domain's scheduling priority in a resource group, from past usage and weight."
 
 
 class ProjectFairShareEntityType(EntityType):
@@ -32,7 +32,7 @@ class ProjectFairShareEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A project's fair-share weight in a resource group."
+        return "A project's scheduling priority in a resource group, from past usage and weight."
 
 
 class UserFairShareEntityType(EntityType):
@@ -44,4 +44,4 @@ class UserFairShareEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A user's fair-share weight in a resource group."
+        return "A user's scheduling priority in a resource group, from past usage and weight."

--- a/src/ai/backend/common/data/entity/idle_checker.py
+++ b/src/ai/backend/common/data/entity/idle_checker.py
@@ -19,7 +19,10 @@ class IdleCheckerEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A rule that ends idle sessions, assigned to scopes."
+        return (
+            "A rule terminating sessions by lifetime, network silence or utilization,"
+            " assigned to scopes."
+        )
 
 
 class IdleCheckerID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/image.py
+++ b/src/ai/backend/common/data/entity/image.py
@@ -16,7 +16,7 @@ class ImageEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A container image known to a container registry."
+        return "A container image in a registry, one row per architecture."
 
 
 class ImageID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/kernel_scheduling_history.py
+++ b/src/ai/backend/common/data/entity/kernel_scheduling_history.py
@@ -21,7 +21,7 @@ class KernelSchedulingHistoryFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One scheduling step recorded for a kernel."
+        return "One step of a kernel's progress from image pull to termination, with the result."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/keypair.py
+++ b/src/ai/backend/common/data/entity/keypair.py
@@ -22,7 +22,7 @@ class KeyPairFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "An access key and secret key pair of a user."
+        return "An access key and secret key a user signs API calls with."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/login_session.py
+++ b/src/ai/backend/common/data/entity/login_session.py
@@ -24,7 +24,7 @@ class LoginSessionFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One live login of a user."
+        return "One login of a user, holding its session token and the client it came from."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/network.py
+++ b/src/ai/backend/common/data/entity/network.py
@@ -17,7 +17,7 @@ class NetworkEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "An overlay network sessions of a project attach to."
+        return "A network a network plugin created for a project, that its sessions attach to."
 
 
 class NetworkID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/notification.py
+++ b/src/ai/backend/common/data/entity/notification.py
@@ -31,7 +31,7 @@ class NotificationRuleEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A rule choosing which events reach a notification channel."
+        return "A rule sending one kind of event to a channel, with the message it writes."
 
 
 class NotificationChannelID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/object_storage.py
+++ b/src/ai/backend/common/data/entity/object_storage.py
@@ -17,7 +17,7 @@ class ObjectStorageEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "An object storage backend behind a storage namespace."
+        return "An S3-compatible object storage, with the endpoint and credentials to reach it."
 
 
 class ObjectStorageID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/permission.py
+++ b/src/ai/backend/common/data/entity/permission.py
@@ -22,7 +22,7 @@ class PermissionFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One permission a role grants."
+        return "One permission a role grants on one entity type, within one scope."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/prometheus_query_preset.py
+++ b/src/ai/backend/common/data/entity/prometheus_query_preset.py
@@ -17,7 +17,7 @@ class PrometheusQueryPresetEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A saved Prometheus query."
+        return "A named Prometheus query template with the time window it is run over."
 
 
 class PrometheusQueryPresetID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/replica.py
+++ b/src/ai/backend/common/data/entity/replica.py
@@ -21,7 +21,7 @@ class ReplicaFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One running copy of a deployment."
+        return "One session serving a deployment, taking a share of its traffic when healthy."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/replica_group.py
+++ b/src/ai/backend/common/data/entity/replica_group.py
@@ -21,7 +21,10 @@ class ReplicaGroupFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A set of replicas of a deployment that share a revision."
+        return (
+            "A group of a deployment's replicas, rolling from one revision to the next and"
+            " taking a share of the traffic."
+        )
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/replica_group_history.py
+++ b/src/ai/backend/common/data/entity/replica_group_history.py
@@ -21,7 +21,7 @@ class ReplicaGroupHistoryFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One state change of a replica group."
+        return "One run of a replica group handler, recording any status change and its result."
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/resource_allocation.py
+++ b/src/ai/backend/common/data/entity/resource_allocation.py
@@ -19,7 +19,10 @@ class ResourceAllocationFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One slot's amount allocated to one kernel of a session."
+        return (
+            "How much of one resource a kernel asked for, was given and actually used, each"
+            " with the time it happened."
+        )
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/resource_group.py
+++ b/src/ai/backend/common/data/entity/resource_group.py
@@ -19,7 +19,10 @@ class ResourceGroupEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A pool of agents sessions are scheduled onto."
+        return (
+            "A pool of agents with its own scheduler, opened to the domains, projects and"
+            " keypairs allowed to use it."
+        )
 
 
 RESOURCE_GROUP_SCOPE_TYPE = ScopeType(ResourceGroupEntityType())

--- a/src/ai/backend/common/data/entity/route_history.py
+++ b/src/ai/backend/common/data/entity/route_history.py
@@ -21,7 +21,10 @@ class RouteHistoryFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One routing change recorded for a deployment."
+        return (
+            "One run of a route handler over one replica, recording any status change and"
+            " its result."
+        )
 
     @override
     @classmethod

--- a/src/ai/backend/common/data/entity/service_catalog.py
+++ b/src/ai/backend/common/data/entity/service_catalog.py
@@ -17,7 +17,7 @@ class ServiceCatalogEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A registered service and its endpoint."
+        return "One running component that announced itself to the manager."
 
 
 class ServiceCatalogID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/session_group.py
+++ b/src/ai/backend/common/data/entity/session_group.py
@@ -17,7 +17,10 @@ class SessionGroupEntityType(EntityType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "A set of sessions placed together or apart."
+        return (
+            "A set of sessions packed onto the same agents or spread across them, strictly"
+            " or as a preference."
+        )
 
 
 class SessionGroupID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/session_scheduling_history.py
+++ b/src/ai/backend/common/data/entity/session_scheduling_history.py
@@ -21,7 +21,9 @@ class SessionSchedulingHistoryFieldType(FieldType):
     @override
     @classmethod
     def description(cls) -> str:
-        return "One scheduling step recorded for a session."
+        return (
+            "One run of a session scheduling handler, recording any status change and its result."
+        )
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/app_config/actions/allow_list/admin_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/allow_list/admin_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigAllowListEntityType
+from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigAllowListData

--- a/src/ai/backend/manager/services/app_config/actions/allow_list/create.py
+++ b/src/ai/backend/manager/services/app_config/actions/allow_list/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigAllowListEntityType
+from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateGlobalOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigAllowListData

--- a/src/ai/backend/manager/services/app_config/actions/fragment/admin_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/admin_search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import SearchGlobalOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData

--- a/src/ai/backend/manager/services/app_config/actions/fragment/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/bulk_upsert.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
     EntityType,

--- a/src/ai/backend/manager/services/app_config/actions/fragment/global_bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/global_bulk_upsert.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.app_config import AppConfigFragmentEntityType
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.v2.ops.base import AtomicUpsertGlobalEntityOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData

--- a/src/ai/backend/manager/services/app_config/actions/fragment/scoped_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/scoped_search.py
@@ -5,10 +5,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.app_config.types import AppConfigScopeType
-from ai.backend.common.data.entity.app_config import (
-    AppConfigFragmentEntityType,
-    AppConfigScopeID,
-)
+from ai.backend.common.data.entity.app_config import AppConfigScopeID
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
     EntityType,

--- a/src/ai/backend/manager/services/factory.py
+++ b/src/ai/backend/manager/services/factory.py
@@ -1,12 +1,10 @@
 from typing import Any
 
 from ai.backend.common.data.entity.agent import AgentEntityType
-from ai.backend.common.data.entity.app_config import (
-    AppConfigAllowListEntityType,
-    AppConfigEntityType,
-    AppConfigFragmentEntityType,
-)
+from ai.backend.common.data.entity.app_config import AppConfigEntityType
+from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionEntityType
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.artifact import ArtifactEntityType
 from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryEntityType
 from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType

--- a/tests/component/app_config/conftest.py
+++ b/tests/component/app_config/conftest.py
@@ -12,11 +12,8 @@ from ai.backend.client.v2.auth import HMACAuth, NoAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.data.app_config.types import AppConfigScopeType
-from ai.backend.common.data.entity.app_config import (
-    AppConfigAllowListEntityType,
-    AppConfigEntityType,
-    AppConfigScopeID,
-)
+from ai.backend.common.data.entity.app_config import AppConfigEntityType, AppConfigScopeID
+from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionEntityType
 from ai.backend.manager.actions.monitors import ActionMonitors
 from ai.backend.manager.actions.registry.registry import ProcessorRegistry

--- a/tests/unit/manager/actions/test_registry_catalog.py
+++ b/tests/unit/manager/actions/test_registry_catalog.py
@@ -20,12 +20,10 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from ai.backend.common.data.entity.agent import AgentEntityType
-from ai.backend.common.data.entity.app_config import (
-    AppConfigAllowListEntityType,
-    AppConfigEntityType,
-    AppConfigFragmentEntityType,
-)
+from ai.backend.common.data.entity.app_config import AppConfigEntityType
+from ai.backend.common.data.entity.app_config_allow_list import AppConfigAllowListEntityType
 from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionEntityType
+from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
 from ai.backend.common.data.entity.artifact import ArtifactEntityType
 from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryEntityType
 from ai.backend.common.data.entity.artifact_revision import ArtifactRevisionFieldType


### PR DESCRIPTION
## Summary

- Revises 43 of the `description()` strings introduced in #14447, each read against the row it names. Wording was only the surface: several named columns that live in another table, claimed a lifecycle the row does not have, or restated the type name.
- Files the app config allow list and fragment entity types with their `EntityIdentifier`, which sat in `app_config.py` while the id lived in the file named after the kind and imported the type back.

Corrections that changed a claim rather than the phrasing:

| Kind | Was | Why it was wrong |
| --- | --- | --- |
| `deployment_policy` | the scaling and routing policy | the row holds only a rollout strategy; scaling and routing are other tables |
| `replica_group` | replicas that share a revision | a group carries two revision pointers, which is how a rollout works |
| `artifact` | a model or dataset | `ArtifactType` is MODEL, PACKAGE, IMAGE; there is no dataset |
| `app_config` | read from a scope | a read merges every scope the caller sees |
| `client_ip_masking_policy` | masks addresses in recorded logs | no row is seeded, so the absence of one leaves the address unmasked |
| `service_catalog` | a service and its endpoint | the manager consumes these registrations rather than publishing one, and endpoints are their own table |
| `audit_log_scope` | a scope the record sits in | it is what lets a scope find a record naming something else |
| `deployment_revision` | a configuration it has run with | a revision exists before anything runs it |
| `object_storage` | behind a storage namespace | one object storage holds many namespaces |
| `login_session` | one live login | an invalidated session stays as a row |
| `artifact_revision` | one version of an artifact | said nothing the name did not; a revision is created by a registry scan |

Four history kinds (`deployment_history`, `replica_group_history`, `route_history`, `session_scheduling_history`) share `ReconcileHistoryMixin` and now share one shape, since each records runs that changed no status and merges a repeated transition onto the same row.

## Row-less entity types — deferred

These entity types name no table. Their descriptions are inconsistent about saying so: some spell it out, some read as though a table exists. They are collected here to be settled together in a follow-up, along with whether a row-less concern should be an `EntityType` at all — `common/data/entity/KNOWLEDGE.md` already classifies `app_config` under **Virtual** ("built without a row of its own, existing only as the subject of audit and authorization") but lists none of the others.

| Kind | Backing | Description says it names no row |
| --- | --- | --- |
| `global` | none — the wiring fallback | yes |
| `export` | none | yes |
| `manager_admin` | none | yes |
| `auth` | none | revised here to name what it covers |
| `etcd_config` | etcd, not the database | **no** |
| `secret` | service-backed | **no** |
| `app_config` | merged from `app_config_fragments` | **no**, and it is the only one `KNOWLEDGE.md` records |

Not in this group: `fair_share` and `usage_bucket` do have tables (`domain_fair_shares`, `user_usage_buckets`, …) and are missing only an `EntityIdentifier`.

## Left as they are

`deployment_preset` is named for no table — the row is `DeploymentRevisionPresetRow` / `deployment_revision_presets`, and `DeploymentPresetID` is its primary key. Only the description is corrected here; the naming is left alone.

Resolves BA-7780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBsFx7jcZZgrvTQYHvGNQV
