### PR TITLE
refactor(BA-7793): compose the storage proxy startup dependencies

### DIFF
--- a/changes/14468.enhance.md
+++ b/changes/14468.enhance.md
@@ -1,0 +1,1 @@
+Compose the storage proxy startup dependencies and load the storage backend plugin context once.

--- a/src/ai/backend/storage/KNOWLEDGE.md
+++ b/src/ai/backend/storage/KNOWLEDGE.md
@@ -1,15 +1,16 @@
 ---
 name: storage-proxy-trust-split
 type: design-rationale
-description: The storage proxy as a stateless data plane, the trust split between client JWTs and the manager shared secret, absence of a relational database, the quota-scope model with per-backend capabilities, the privileged watcher subprocess, TUS upload leases in Valkey
+description: The storage proxy as a stateless data plane, the trust split between client JWTs and the manager shared secret, absence of a relational database, the quota-scope model with per-backend capabilities, the privileged watcher subprocess, TUS upload leases in Valkey, the composed startup dependency stages
 scope: src/ai/backend/storage
-keywords: [storage-proxy, JWT, quota-scope, AbstractVolume, CAP_QUOTA, TUS, watcher, stateless]
+keywords: [storage-proxy, JWT, quota-scope, AbstractVolume, CAP_QUOTA, TUS, watcher, stateless, StorageDependencyComposer, StoragePluginContext]
 sources:
   - src/ai/backend/storage/api
   - src/ai/backend/storage/volumes/abc.py
+  - src/ai/backend/storage/dependencies
 generated:
-  by: claude-code/fable-5
-  at: 2026-08-10
+  by: claude-code/opus-5
+  at: 2026-09-10
 status: stable
 ---
 
@@ -47,3 +48,13 @@ interface.
 - Every vendor sits behind `AbstractVolume` + `AbstractQuotaModel` + `AbstractFSOpModel`.
 - Backends may mutate host state (XFS edits `/etc/projects` via sudo).
 - Operations that need root in the proxy itself go through the opt-in watcher subprocess (ZeroMQ IPC, task objects) — no inline sudo inside handlers.
+
+## Startup is one composed dependency graph
+
+- `StorageDependencyComposer` owns every startup resource, and the server,
+  `dependencies verify` and `health check` all drive it — a resource assembled
+  by hand in one path is invisible to the others.
+- Plugin contexts are composed once and injected: the volume registry receives
+  the backend classes it needs instead of loading the plugin group itself.
+- `RootContext` is assembled in `server.py` from the composed resources — it is
+  a carrier, not a stage.

--- a/src/ai/backend/storage/cli/dependencies.py
+++ b/src/ai/backend/storage/cli/dependencies.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-from pathlib import Path
 
 import click
 
@@ -88,9 +87,7 @@ def verify(
             async with stack:
                 from ai.backend.storage.dependencies.composer import DependencyInput
 
-                dependency_input = DependencyInput(
-                    config_path=config_path or Path("storage-proxy.toml"),
-                )
+                dependency_input = DependencyInput(config_path=config_path)
                 composer = StorageDependencyComposer()
 
                 # Initialize all dependencies through the composer

--- a/src/ai/backend/storage/cli/health.py
+++ b/src/ai/backend/storage/cli/health.py
@@ -76,7 +76,7 @@ def check(
 
     @asynccontextmanager
     async def _initialize_and_check_all_components(
-        config_path: Path,
+        config_path: Path | None,
         probe: HealthProbe,
     ) -> AsyncIterator[None]:
         """
@@ -174,10 +174,7 @@ def check(
         print("Initializing and checking components...\n")
 
         try:
-            async with _initialize_and_check_all_components(
-                config_path or Path("storage-proxy.toml"),
-                probe,
-            ):
+            async with _initialize_and_check_all_components(config_path, probe):
                 pass
         except Exception as e:
             print(f"✗ Failed to initialize dependencies: {str(e).strip()}\n")

--- a/src/ai/backend/storage/context.py
+++ b/src/ai/backend/storage/context.py
@@ -38,45 +38,13 @@ from .services.service import VolumeService
 from .storages.storage_pool import StoragePool
 from .types import VolumeInfo
 from .volumes.abc import AbstractVolume
-from .volumes.cephfs import CephFSVolume
-from .volumes.ddn import EXAScalerFSVolume
-from .volumes.dellemc import DellEMCOneFSVolume
-from .volumes.gpfs import GPFSVolume
-from .volumes.hammerspace.volume.base import BaseHammerspaceVolume
-from .volumes.hammerspace.volume.extended import HammerspaceVolume
-from .volumes.netapp import NetAppVolume
-from .volumes.noop import NoopVolume
 from .volumes.pool import VolumePool
-from .volumes.purestorage import FlashBladeVolume
 from .volumes.stats import VolumeState, VolumeStatsObserver
-from .volumes.vast import VASTVolume
-from .volumes.vfs import BaseVolume
-from .volumes.weka import WekaVolume
-from .volumes.xfs import XfsVolume
 from .watcher import WatcherClient
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 EVENT_DISPATCHER_CONSUMER_GROUP: Final = "storage-proxy"
-
-DEFAULT_BACKENDS: Mapping[str, type[AbstractVolume]] = {
-    FlashBladeVolume.name: FlashBladeVolume,
-    BaseVolume.name: BaseVolume,
-    XfsVolume.name: XfsVolume,
-    NetAppVolume.name: NetAppVolume,
-    # NOTE: Dell EMC has two different storage: PowerStore and PowerScale (OneFS).
-    #       We support the latter only for now.
-    DellEMCOneFSVolume.name: DellEMCOneFSVolume,
-    WekaVolume.name: WekaVolume,
-    GPFSVolume.name: GPFSVolume,  # IBM SpectrumScale or GPFS
-    "spectrumscale": GPFSVolume,  # IBM SpectrumScale or GPFS
-    CephFSVolume.name: CephFSVolume,
-    VASTVolume.name: VASTVolume,
-    EXAScalerFSVolume.name: EXAScalerFSVolume,
-    NoopVolume.name: NoopVolume,
-    HammerspaceVolume.name: HammerspaceVolume,
-    BaseHammerspaceVolume.name: BaseHammerspaceVolume,
-}
 
 
 class ServiceContext:
@@ -159,7 +127,3 @@ class RootContext:
     async def shutdown_volumes(self) -> None:
         for volume in self.volumes.values():
             await volume.shutdown()
-
-    async def shutdown_manager_http_clients(self) -> None:
-        """Close all manager HTTP client sessions."""
-        await self.manager_client_pool.cleanup()

--- a/src/ai/backend/storage/dependencies/__init__.py
+++ b/src/ai/backend/storage/dependencies/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from .composer import DependencyResources, StorageDependencyComposer
+from .composer import DependencyInput, DependencyResources, StorageDependencyComposer
 
 __all__ = [
+    "DependencyInput",
     "DependencyResources",
     "StorageDependencyComposer",
 ]

--- a/src/ai/backend/storage/dependencies/bootstrap/__init__.py
+++ b/src/ai/backend/storage/dependencies/bootstrap/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .composer import BootstrapComposer, BootstrapInput, BootstrapResources
 from .config import ConfigProvider, ConfigProviderInput
+from .metrics import MetricRegistryProvider
 
 __all__ = [
     "BootstrapComposer",
@@ -9,4 +10,5 @@ __all__ = [
     "BootstrapResources",
     "ConfigProvider",
     "ConfigProviderInput",
+    "MetricRegistryProvider",
 ]

--- a/src/ai/backend/storage/dependencies/bootstrap/composer.py
+++ b/src/ai/backend/storage/dependencies/bootstrap/composer.py
@@ -7,16 +7,20 @@ from pathlib import Path
 from typing import override
 
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
+from ai.backend.common.metrics.metric import CommonMetricRegistry
+from ai.backend.logging.types import LogLevel
 from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
 
 from .config import ConfigProvider, ConfigProviderInput
+from .metrics import MetricRegistryProvider
 
 
 @dataclass
 class BootstrapInput:
     """Input required for bootstrap stage."""
 
-    config_path: Path
+    config_path: Path | None
+    log_level: LogLevel = LogLevel.NOTSET
 
 
 @dataclass
@@ -24,6 +28,7 @@ class BootstrapResources:
     """Container for bootstrap stage resources."""
 
     config: StorageProxyUnifiedConfig
+    metric_registry: CommonMetricRegistry
 
 
 class BootstrapComposer(DependencyComposer[BootstrapInput, BootstrapResources]):
@@ -42,11 +47,13 @@ class BootstrapComposer(DependencyComposer[BootstrapInput, BootstrapResources]):
         setup_input: BootstrapInput,
     ) -> AsyncIterator[BootstrapResources]:
         """Compose bootstrap dependencies."""
-        # Load config
-        config_provider = ConfigProvider()
         config = await stack.enter_dependency(
-            config_provider,
-            ConfigProviderInput(config_path=setup_input.config_path),
+            ConfigProvider(),
+            ConfigProviderInput(
+                config_path=setup_input.config_path,
+                log_level=setup_input.log_level,
+            ),
         )
+        metric_registry = await stack.enter_dependency(MetricRegistryProvider(), None)
 
-        yield BootstrapResources(config=config)
+        yield BootstrapResources(config=config, metric_registry=metric_registry)

--- a/src/ai/backend/storage/dependencies/bootstrap/config.py
+++ b/src/ai/backend/storage/dependencies/bootstrap/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import override
 
 from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.logging.types import LogLevel
 from ai.backend.storage.config.loaders import load_local_config
 from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
 
@@ -15,7 +16,8 @@ from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
 class ConfigProviderInput:
     """Input for config provider."""
 
-    config_path: Path
+    config_path: Path | None
+    log_level: LogLevel = LogLevel.NOTSET
 
 
 class ConfigProvider(
@@ -34,5 +36,5 @@ class ConfigProvider(
         self, setup_input: ConfigProviderInput
     ) -> AsyncIterator[StorageProxyUnifiedConfig]:
         """Load and provide storage proxy configuration."""
-        config = load_local_config(setup_input.config_path)
+        config = load_local_config(setup_input.config_path, log_level=setup_input.log_level)
         yield config

--- a/src/ai/backend/storage/dependencies/bootstrap/metrics.py
+++ b/src/ai/backend/storage/dependencies/bootstrap/metrics.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import override
+
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.metrics.metric import CommonMetricRegistry
+
+
+class MetricRegistryProvider(NonMonitorableDependencyProvider[object, CommonMetricRegistry]):
+    """Provider for the common metric registry."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "metrics"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: object) -> AsyncIterator[CommonMetricRegistry]:
+        yield CommonMetricRegistry.instance()

--- a/src/ai/backend/storage/dependencies/composer.py
+++ b/src/ai/backend/storage/dependencies/composer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import override
 
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
+from ai.backend.logging.types import LogLevel
 
 from .bootstrap import BootstrapComposer, BootstrapInput, BootstrapResources
 from .infrastructure.composer import (
@@ -14,23 +15,46 @@ from .infrastructure.composer import (
     InfrastructureComposerInput,
     InfrastructureResources,
 )
+from .messaging.composer import (
+    MessagingComposer,
+    MessagingComposerInput,
+    MessagingResources,
+)
+from .plugins.base import PluginsInput
+from .plugins.composer import PluginsComposer, PluginsResources
 from .storage.composer import StorageComposer, StorageComposerInput, StorageResources
+from .system.composer import SystemComposer, SystemComposerInput, SystemResources
 
 
 @dataclass
 class DependencyInput:
     """Input required for complete dependency setup."""
 
-    config_path: Path
+    config_path: Path | None
+    pidx: int = 0
+    log_level: LogLevel = LogLevel.NOTSET
 
 
 @dataclass
 class DependencyResources:
-    """All dependency resources for storage proxy."""
+    """All dependency resources for storage proxy.
+
+    Holds all dependencies in the correct initialization order:
+    0. Bootstrap stage: config, metric registry
+    1. Infrastructure stage: etcd, redis config, valkey clients
+    2. Plugins stage: storage backend plugin context, volume backend registry
+    3. Messaging stage: message queue, event producer, event dispatcher
+    4. Storage stage: storage pool, volume pool, bgtask manager, watcher,
+       volume stats, manager client pool
+    5. System stage: health probe, service discovery
+    """
 
     bootstrap: BootstrapResources
     infrastructure: InfrastructureResources
+    plugins: PluginsResources
+    messaging: MessagingResources
     storage: StorageResources
+    system: SystemResources
 
 
 class StorageDependencyComposer(DependencyComposer[DependencyInput, DependencyResources]):
@@ -49,26 +73,63 @@ class StorageDependencyComposer(DependencyComposer[DependencyInput, DependencyRe
         setup_input: DependencyInput,
     ) -> AsyncIterator[DependencyResources]:
         """Compose all storage proxy dependencies."""
-        # Stage 1: Bootstrap (config loading)
         bootstrap = await stack.enter_composer(
             BootstrapComposer(),
-            BootstrapInput(config_path=setup_input.config_path),
+            BootstrapInput(
+                config_path=setup_input.config_path,
+                log_level=setup_input.log_level,
+            ),
         )
+        local_config = bootstrap.config
 
-        # Stage 2: Infrastructure (etcd, redis)
         infrastructure = await stack.enter_composer(
             InfrastructureComposer(),
-            InfrastructureComposerInput(local_config=bootstrap.config),
+            InfrastructureComposerInput(local_config=local_config, pidx=setup_input.pidx),
         )
 
-        # Stage 3: Storage (storage-pool)
+        plugins = await stack.enter_composer(
+            PluginsComposer(),
+            PluginsInput(etcd=infrastructure.etcd, local_config=local_config.model_dump()),
+        )
+
+        messaging = await stack.enter_composer(
+            MessagingComposer(),
+            MessagingComposerInput(
+                local_config=local_config,
+                redis_config=infrastructure.redis_config,
+                metric_registry=bootstrap.metric_registry,
+            ),
+        )
+
         storage = await stack.enter_composer(
             StorageComposer(),
-            StorageComposerInput(local_config=bootstrap.config),
+            StorageComposerInput(
+                local_config=local_config,
+                pidx=setup_input.pidx,
+                etcd=infrastructure.etcd,
+                valkey=infrastructure.valkey,
+                event_dispatcher=messaging.event_dispatcher,
+                event_producer=messaging.event_producer,
+                backends=plugins.backends,
+            ),
+        )
+
+        system = await stack.enter_composer(
+            SystemComposer(),
+            SystemComposerInput(
+                local_config=local_config,
+                etcd=infrastructure.etcd,
+                redis_config=infrastructure.redis_config,
+                valkey=infrastructure.valkey,
+                event_producer=messaging.event_producer,
+            ),
         )
 
         yield DependencyResources(
             bootstrap=bootstrap,
             infrastructure=infrastructure,
+            plugins=plugins,
+            messaging=messaging,
             storage=storage,
+            system=system,
         )

--- a/src/ai/backend/storage/dependencies/infrastructure/__init__.py
+++ b/src/ai/backend/storage/dependencies/infrastructure/__init__.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from .composer import InfrastructureComposer, InfrastructureComposerInput, InfrastructureResources
 from .etcd import EtcdProvider
-from .redis import RedisProvider, StorageProxyValkeyClients
+from .redis import RedisProvider, RedisProviderInput, StorageProxyValkeyClients
+from .redis_config import RedisConfigProvider
 
 __all__ = [
     "EtcdProvider",
     "InfrastructureComposer",
     "InfrastructureComposerInput",
     "InfrastructureResources",
+    "RedisConfigProvider",
     "RedisProvider",
+    "RedisProviderInput",
     "StorageProxyValkeyClients",
 ]

--- a/src/ai/backend/storage/dependencies/infrastructure/composer.py
+++ b/src/ai/backend/storage/dependencies/infrastructure/composer.py
@@ -5,12 +5,14 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.configs.redis import RedisConfig
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
 
 from .etcd import EtcdProvider
-from .redis import RedisProvider, StorageProxyValkeyClients
+from .redis import RedisProvider, RedisProviderInput, StorageProxyValkeyClients
+from .redis_config import RedisConfigProvider
 
 
 @dataclass
@@ -18,6 +20,7 @@ class InfrastructureComposerInput:
     """Input for Infrastructure composer."""
 
     local_config: StorageProxyUnifiedConfig
+    pidx: int
 
 
 @dataclass
@@ -25,6 +28,7 @@ class InfrastructureResources:
     """All infrastructure resources for storage proxy."""
 
     etcd: AsyncEtcd
+    redis_config: RedisConfig
     valkey: StorageProxyValkeyClients
 
 
@@ -48,11 +52,15 @@ class InfrastructureComposer(
         """Compose all infrastructure dependencies."""
         local_config = setup_input.local_config
 
-        # Setup infrastructure in dependency order
         etcd = await stack.enter_dependency(EtcdProvider(), local_config)
-        valkey = await stack.enter_dependency(RedisProvider(), etcd)
+        redis_config = await stack.enter_dependency(RedisConfigProvider(), etcd)
+        valkey = await stack.enter_dependency(
+            RedisProvider(),
+            RedisProviderInput(redis_config=redis_config, pidx=setup_input.pidx),
+        )
 
         yield InfrastructureResources(
             etcd=etcd,
+            redis_config=redis_config,
             valkey=valkey,
         )

--- a/src/ai/backend/storage/dependencies/infrastructure/redis.py
+++ b/src/ai/backend/storage/dependencies/infrastructure/redis.py
@@ -9,10 +9,16 @@ from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
     ValkeyArtifactDownloadTrackingClient,
 )
 from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
+from ai.backend.common.clients.valkey_client.valkey_tus.client import ValkeyTusClient
+from ai.backend.common.clients.valkey_client.valkey_volume_stats import ValkeyVolumeStatsClient
 from ai.backend.common.configs.redis import RedisConfig
-from ai.backend.common.defs import REDIS_BGTASK_DB, REDIS_STATISTICS_DB, RedisRole
+from ai.backend.common.defs import (
+    REDIS_BGTASK_DB,
+    REDIS_STATISTICS_DB,
+    REDIS_TUS_DB,
+    RedisRole,
+)
 from ai.backend.common.dependencies import DependencyProvider
-from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.health_checker import (
     CID_REDIS_ARTIFACT,
     CID_REDIS_BGTASK,
@@ -22,15 +28,25 @@ from ai.backend.common.health_checker.checkers.valkey import ValkeyHealthChecker
 
 
 @dataclass
+class RedisProviderInput:
+    """Input for the Valkey client provider."""
+
+    redis_config: RedisConfig
+    pidx: int
+
+
+@dataclass
 class StorageProxyValkeyClients:
     """Valkey clients for storage proxy."""
 
     bgtask: ValkeyBgtaskClient
     artifact: ValkeyArtifactDownloadTrackingClient
+    tus: ValkeyTusClient
+    volume_stats: ValkeyVolumeStatsClient
 
 
-class RedisProvider(DependencyProvider[AsyncEtcd, StorageProxyValkeyClients]):
-    """Provider for Redis configuration and Valkey clients."""
+class RedisProvider(DependencyProvider[RedisProviderInput, StorageProxyValkeyClients]):
+    """Provider for the Valkey clients of the storage proxy."""
 
     @property
     @override
@@ -39,39 +55,52 @@ class RedisProvider(DependencyProvider[AsyncEtcd, StorageProxyValkeyClients]):
 
     @asynccontextmanager
     @override
-    async def provide(self, setup_input: AsyncEtcd) -> AsyncIterator[StorageProxyValkeyClients]:
-        """Load and provide Redis configuration and Valkey clients."""
-        # Load Redis config from etcd
-        # TODO: Override UnifiedConfig with etcd values
-        raw_redis_config = await setup_input.get_prefix("config/redis")
-        redis_config = RedisConfig.model_validate(raw_redis_config)
+    async def provide(
+        self, setup_input: RedisProviderInput
+    ) -> AsyncIterator[StorageProxyValkeyClients]:
+        pidx = setup_input.pidx
+        redis_profile_target = setup_input.redis_config.to_redis_profile_target()
 
-        redis_profile_target = redis_config.to_redis_profile_target()
-
-        # Create ValkeyBgtaskClient
         bgtask_client = await ValkeyBgtaskClient.create(
             redis_profile_target.profile_target(RedisRole.BGTASK).to_valkey_target(),
-            human_readable_name="storage_bgtask",
+            human_readable_name=f"storage-proxy-bgtask-{pidx}",
             db_id=REDIS_BGTASK_DB,
         )
 
-        # Create ValkeyArtifactDownloadTrackingClient
         artifact_client = await ValkeyArtifactDownloadTrackingClient.create(
             valkey_target=redis_profile_target.profile_target(
                 RedisRole.STATISTICS
             ).to_valkey_target(),
             db_id=REDIS_STATISTICS_DB,
-            human_readable_name="storage_artifact",
+            human_readable_name=f"storage-proxy-artifact-download-tracker-{pidx}",
+        )
+
+        tus_client = await ValkeyTusClient.create(
+            valkey_target=redis_profile_target.profile_target(RedisRole.TUS).to_valkey_target(),
+            db_id=REDIS_TUS_DB,
+            human_readable_name=f"storage-proxy-tus-{pidx}",
+        )
+
+        volume_stats_client = await ValkeyVolumeStatsClient.create(
+            valkey_target=redis_profile_target.profile_target(
+                RedisRole.STATISTICS
+            ).to_valkey_target(),
+            db_id=REDIS_STATISTICS_DB,
+            human_readable_name=f"storage-proxy-volume-stats-{pidx}",
         )
 
         try:
             yield StorageProxyValkeyClients(
                 bgtask=bgtask_client,
                 artifact=artifact_client,
+                tus=tus_client,
+                volume_stats=volume_stats_client,
             )
         finally:
             await bgtask_client.close()
             await artifact_client.close()
+            await tus_client.close()
+            await volume_stats_client.close()
 
     @override
     def gen_liveness_checker(self, resource: StorageProxyValkeyClients) -> ServiceHealthChecker:

--- a/src/ai/backend/storage/dependencies/infrastructure/redis_config.py
+++ b/src/ai/backend/storage/dependencies/infrastructure/redis_config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import override
+
+from ai.backend.common.configs.redis import RedisConfig
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.types import safe_print_redis_config
+from ai.backend.logging import BraceStyleAdapter
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class RedisConfigProvider(NonMonitorableDependencyProvider[AsyncEtcd, RedisConfig]):
+    """Provider for the Redis configuration stored in etcd."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "redis-config"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: AsyncEtcd) -> AsyncIterator[RedisConfig]:
+        # TODO: Override UnifiedConfig with etcd values
+        raw_redis_config = await setup_input.get_prefix("config/redis")
+        redis_config = RedisConfig.model_validate(raw_redis_config)
+        log.info("configured redis_config: {0}", safe_print_redis_config(redis_config))
+        yield redis_config

--- a/src/ai/backend/storage/dependencies/messaging/__init__.py
+++ b/src/ai/backend/storage/dependencies/messaging/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from .composer import MessagingComposer, MessagingComposerInput, MessagingResources
+from .event import (
+    EventDispatcherInput,
+    EventDispatcherProvider,
+    EventProducerInput,
+    EventProducerProvider,
+)
+from .message_queue import MessageQueueInput, MessageQueueProvider
+
+__all__ = [
+    "EventDispatcherInput",
+    "EventDispatcherProvider",
+    "EventProducerInput",
+    "EventProducerProvider",
+    "MessageQueueInput",
+    "MessageQueueProvider",
+    "MessagingComposer",
+    "MessagingComposerInput",
+    "MessagingResources",
+]

--- a/src/ai/backend/storage/dependencies/messaging/composer.py
+++ b/src/ai/backend/storage/dependencies/messaging/composer.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.configs.redis import RedisConfig
+from ai.backend.common.dependencies import DependencyComposer, DependencyStack
+from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
+from ai.backend.common.message_queue.queue import AbstractMessageQueue
+from ai.backend.common.metrics.metric import CommonMetricRegistry
+from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+
+from .event import (
+    EventDispatcherInput,
+    EventDispatcherProvider,
+    EventProducerInput,
+    EventProducerProvider,
+)
+from .message_queue import MessageQueueInput, MessageQueueProvider
+
+
+@dataclass
+class MessagingComposerInput:
+    """Input for Messaging composer."""
+
+    local_config: StorageProxyUnifiedConfig
+    redis_config: RedisConfig
+    metric_registry: CommonMetricRegistry
+
+
+@dataclass
+class MessagingResources:
+    """All messaging resources for storage proxy."""
+
+    message_queue: AbstractMessageQueue
+    event_producer: EventProducer
+    event_dispatcher: EventDispatcher
+
+
+class MessagingComposer(DependencyComposer[MessagingComposerInput, MessagingResources]):
+    """Composer for messaging layer dependencies."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "messaging"
+
+    @asynccontextmanager
+    @override
+    async def compose(
+        self,
+        stack: DependencyStack,
+        setup_input: MessagingComposerInput,
+    ) -> AsyncIterator[MessagingResources]:
+        """Compose all messaging dependencies."""
+        local_config = setup_input.local_config
+        log_events = local_config.debug.log_events
+
+        message_queue = await stack.enter_dependency(
+            MessageQueueProvider(),
+            MessageQueueInput(
+                redis_config=setup_input.redis_config,
+                node_id=local_config.storage_proxy.node_id,
+            ),
+        )
+        event_producer = await stack.enter_dependency(
+            EventProducerProvider(),
+            EventProducerInput(message_queue=message_queue, log_events=log_events),
+        )
+        event_dispatcher = await stack.enter_dependency(
+            EventDispatcherProvider(),
+            EventDispatcherInput(
+                message_queue=message_queue,
+                log_events=log_events,
+                metric_registry=setup_input.metric_registry,
+            ),
+        )
+
+        yield MessagingResources(
+            message_queue=message_queue,
+            event_producer=event_producer,
+            event_dispatcher=event_dispatcher,
+        )

--- a/src/ai/backend/storage/dependencies/messaging/event.py
+++ b/src/ai/backend/storage/dependencies/messaging/event.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
+from ai.backend.common.message_queue.queue import AbstractMessageQueue
+from ai.backend.common.metrics.metric import CommonMetricRegistry
+from ai.backend.common.types import AGENTID_STORAGE
+
+
+@dataclass
+class EventProducerInput:
+    """Input required for the event producer setup."""
+
+    message_queue: AbstractMessageQueue
+    log_events: bool
+
+
+@dataclass
+class EventDispatcherInput:
+    """Input required for the event dispatcher setup."""
+
+    message_queue: AbstractMessageQueue
+    log_events: bool
+    metric_registry: CommonMetricRegistry
+
+
+class EventProducerProvider(NonMonitorableDependencyProvider[EventProducerInput, EventProducer]):
+    """Provider for the event producer."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "event-producer"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: EventProducerInput) -> AsyncIterator[EventProducer]:
+        producer = EventProducer(
+            setup_input.message_queue,
+            source=AGENTID_STORAGE,
+            log_events=setup_input.log_events,
+        )
+        try:
+            yield producer
+        finally:
+            await producer.close()
+
+
+class EventDispatcherProvider(
+    NonMonitorableDependencyProvider[EventDispatcherInput, EventDispatcher]
+):
+    """Provider for the event dispatcher."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "event-dispatcher"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: EventDispatcherInput) -> AsyncIterator[EventDispatcher]:
+        dispatcher = EventDispatcher(
+            setup_input.message_queue,
+            log_events=setup_input.log_events,
+            event_observer=setup_input.metric_registry.event,
+        )
+        await dispatcher.start()
+        try:
+            yield dispatcher
+        finally:
+            await dispatcher.close()

--- a/src/ai/backend/storage/dependencies/messaging/message_queue.py
+++ b/src/ai/backend/storage/dependencies/messaging/message_queue.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.configs.redis import RedisConfig
+from ai.backend.common.defs import REDIS_STREAM_DB, RedisRole
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.message_queue.queue import AbstractMessageQueue
+from ai.backend.common.message_queue.redis_queue import RedisMQArgs, RedisQueue
+from ai.backend.storage.context import EVENT_DISPATCHER_CONSUMER_GROUP
+
+
+@dataclass
+class MessageQueueInput:
+    """Input required for the message queue setup."""
+
+    redis_config: RedisConfig
+    node_id: str
+
+
+class MessageQueueProvider(
+    NonMonitorableDependencyProvider[MessageQueueInput, AbstractMessageQueue]
+):
+    """Provider for the event message queue."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "message-queue"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: MessageQueueInput) -> AsyncIterator[AbstractMessageQueue]:
+        redis_profile_target = setup_input.redis_config.to_redis_profile_target()
+        queue = await RedisQueue.create(
+            redis_profile_target.profile_target(RedisRole.STREAM),
+            RedisMQArgs(
+                anycast_stream_key="events",
+                broadcast_channel="events_all",
+                consume_stream_keys=None,
+                subscribe_channels={
+                    "events_all",
+                },
+                group_name=EVENT_DISPATCHER_CONSUMER_GROUP,
+                node_id=setup_input.node_id,
+                db=REDIS_STREAM_DB,
+            ),
+        )
+        yield queue

--- a/src/ai/backend/storage/dependencies/plugins/__init__.py
+++ b/src/ai/backend/storage/dependencies/plugins/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import PluginDependency, PluginsInput
+from .composer import PluginsComposer, PluginsResources
+from .storage_backend import StorageBackendPluginDependency
+
+__all__ = [
+    "PluginDependency",
+    "PluginsComposer",
+    "PluginsInput",
+    "PluginsResources",
+    "StorageBackendPluginDependency",
+]

--- a/src/ai/backend/storage/dependencies/plugins/base.py
+++ b/src/ai/backend/storage/dependencies/plugins/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider, ResourceT
+from ai.backend.common.etcd import AsyncEtcd
+
+
+@dataclass
+class PluginsInput:
+    """Input required for plugin context setup."""
+
+    etcd: AsyncEtcd
+    local_config: Mapping[str, Any]
+
+
+class PluginDependency(NonMonitorableDependencyProvider[PluginsInput, ResourceT]):
+    """Base class for plugin context dependencies."""
+
+    pass

--- a/src/ai/backend/storage/dependencies/plugins/composer.py
+++ b/src/ai/backend/storage/dependencies/plugins/composer.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.dependencies import DependencyComposer, DependencyStack
+from ai.backend.storage.plugin import StoragePluginContext
+from ai.backend.storage.volumes.abc import AbstractVolume
+from ai.backend.storage.volumes.backends import DEFAULT_BACKENDS
+
+from .base import PluginsInput
+from .storage_backend import StorageBackendPluginDependency
+
+
+@dataclass
+class PluginsResources:
+    """Container for all plugin context resources."""
+
+    storage_backend_plugin_ctx: StoragePluginContext
+    backends: Mapping[str, type[AbstractVolume]]
+
+
+class PluginsComposer(DependencyComposer[PluginsInput, PluginsResources]):
+    """Composes plugin context dependencies and the volume backend registry."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "plugins"
+
+    @asynccontextmanager
+    @override
+    async def compose(
+        self,
+        stack: DependencyStack,
+        setup_input: PluginsInput,
+    ) -> AsyncIterator[PluginsResources]:
+        storage_backend_plugin_ctx = await stack.enter_dependency(
+            StorageBackendPluginDependency(),
+            setup_input,
+        )
+
+        yield PluginsResources(
+            storage_backend_plugin_ctx=storage_backend_plugin_ctx,
+            backends=self._build_backends(storage_backend_plugin_ctx),
+        )
+
+    def _build_backends(
+        self,
+        plugin_ctx: StoragePluginContext,
+    ) -> Mapping[str, type[AbstractVolume]]:
+        backends: dict[str, type[AbstractVolume]] = {**DEFAULT_BACKENDS}
+        for plugin_name, plugin_instance in plugin_ctx.plugins.items():
+            backends[plugin_name] = plugin_instance.get_volume_class()
+        return backends

--- a/src/ai/backend/storage/dependencies/plugins/storage_backend.py
+++ b/src/ai/backend/storage/dependencies/plugins/storage_backend.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import override
+
+from ai.backend.logging import BraceStyleAdapter
+from ai.backend.storage.plugin import StoragePluginContext
+
+from .base import PluginDependency, PluginsInput
+
+log = BraceStyleAdapter(logging.getLogger(__spec__.name))
+
+
+class StorageBackendPluginDependency(PluginDependency[StoragePluginContext]):
+    """Provides the storage backend plugin context lifecycle."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "storage-backend-plugin"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: PluginsInput) -> AsyncIterator[StoragePluginContext]:
+        ctx = StoragePluginContext(setup_input.etcd, setup_input.local_config)
+        await ctx.init()
+        log.info("StoragePluginContext initialized with plugins: {}", list(ctx.plugins.keys()))
+        try:
+            yield ctx
+        finally:
+            await ctx.cleanup()

--- a/src/ai/backend/storage/dependencies/storage/__init__.py
+++ b/src/ai/backend/storage/dependencies/storage/__init__.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
+from .bgtask import BackgroundTaskManagerInput, BackgroundTaskManagerProvider
 from .composer import StorageComposer, StorageComposerInput, StorageResources
-from .storage_pool import StoragePoolProvider
+from .manager_client_pool import ManagerClientPoolProvider
+from .storage_pool import StoragePoolInput, StoragePoolProvider
+from .volume_pool import VolumePoolInput, VolumePoolProvider
+from .volume_stats import VolumeStatsInput, VolumeStatsProvider, VolumeStatsResources
+from .watcher import WatcherInput, WatcherProvider
 
 __all__ = [
+    "BackgroundTaskManagerInput",
+    "BackgroundTaskManagerProvider",
+    "ManagerClientPoolProvider",
     "StorageComposer",
     "StorageComposerInput",
+    "StoragePoolInput",
     "StoragePoolProvider",
     "StorageResources",
+    "VolumePoolInput",
+    "VolumePoolProvider",
+    "VolumeStatsInput",
+    "VolumeStatsProvider",
+    "VolumeStatsResources",
+    "WatcherInput",
+    "WatcherProvider",
 ]

--- a/src/ai/backend/storage/dependencies/storage/bgtask.py
+++ b/src/ai/backend/storage/dependencies/storage/bgtask.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
+from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.storage.bgtask.registry import BgtaskHandlerRegistryCreator
+from ai.backend.storage.volumes.pool import VolumePool
+
+
+@dataclass
+class BackgroundTaskManagerInput:
+    """Input required for the background task manager setup."""
+
+    event_producer: EventProducer
+    valkey_bgtask: ValkeyBgtaskClient
+    volume_pool: VolumePool
+    server_id: str
+
+
+class BackgroundTaskManagerProvider(
+    NonMonitorableDependencyProvider[BackgroundTaskManagerInput, BackgroundTaskManager]
+):
+    """Provider for the background task manager."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "background-task-manager"
+
+    @asynccontextmanager
+    @override
+    async def provide(
+        self, setup_input: BackgroundTaskManagerInput
+    ) -> AsyncIterator[BackgroundTaskManager]:
+        registry_creator = BgtaskHandlerRegistryCreator(
+            setup_input.volume_pool,
+            setup_input.event_producer,
+        )
+        manager = BackgroundTaskManager(
+            BackgroundTaskManagerArgs(
+                event_producer=setup_input.event_producer,
+                task_registry=registry_creator.create(),
+                valkey_client=setup_input.valkey_bgtask,
+                server_id=setup_input.server_id,
+            )
+        )
+        await manager.init()
+        try:
+            yield manager
+        finally:
+            await manager.shutdown()

--- a/src/ai/backend/storage/dependencies/storage/composer.py
+++ b/src/ai/backend/storage/dependencies/storage/composer.py
@@ -1,15 +1,28 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import override
 
+from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.dependencies import DependencyComposer, DependencyStack
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
+from ai.backend.storage.client.manager import ManagerHTTPClientPool
 from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+from ai.backend.storage.dependencies.infrastructure.redis import StorageProxyValkeyClients
 from ai.backend.storage.storages.storage_pool import StoragePool
+from ai.backend.storage.volumes.abc import AbstractVolume
+from ai.backend.storage.volumes.pool import VolumePool
+from ai.backend.storage.watcher import WatcherClient
 
-from .storage_pool import StoragePoolProvider
+from .bgtask import BackgroundTaskManagerInput, BackgroundTaskManagerProvider
+from .manager_client_pool import ManagerClientPoolProvider
+from .storage_pool import StoragePoolInput, StoragePoolProvider
+from .volume_pool import VolumePoolInput, VolumePoolProvider
+from .volume_stats import VolumeStatsInput, VolumeStatsProvider, VolumeStatsResources
+from .watcher import WatcherInput, WatcherProvider
 
 
 @dataclass
@@ -17,6 +30,12 @@ class StorageComposerInput:
     """Input for Storage composer."""
 
     local_config: StorageProxyUnifiedConfig
+    pidx: int
+    etcd: AsyncEtcd
+    valkey: StorageProxyValkeyClients
+    event_dispatcher: EventDispatcher
+    event_producer: EventProducer
+    backends: Mapping[str, type[AbstractVolume]]
 
 
 @dataclass
@@ -24,6 +43,11 @@ class StorageResources:
     """All storage resources for storage proxy."""
 
     storage_pool: StoragePool
+    volume_pool: VolumePool
+    background_task_manager: BackgroundTaskManager
+    watcher: WatcherClient | None
+    volume_stats: VolumeStatsResources
+    manager_client_pool: ManagerHTTPClientPool
 
 
 class StorageComposer(DependencyComposer[StorageComposerInput, StorageResources]):
@@ -44,9 +68,51 @@ class StorageComposer(DependencyComposer[StorageComposerInput, StorageResources]
         """Compose all storage dependencies."""
         local_config = setup_input.local_config
 
-        # Setup storage
-        storage_pool = await stack.enter_dependency(StoragePoolProvider(), local_config)
+        storage_pool = await stack.enter_dependency(
+            StoragePoolProvider(),
+            StoragePoolInput(local_config=local_config, pidx=setup_input.pidx),
+        )
+        volume_pool = await stack.enter_dependency(
+            VolumePoolProvider(),
+            VolumePoolInput(
+                local_config=local_config,
+                etcd=setup_input.etcd,
+                event_dispatcher=setup_input.event_dispatcher,
+                event_producer=setup_input.event_producer,
+                backends=setup_input.backends,
+            ),
+        )
+        background_task_manager = await stack.enter_dependency(
+            BackgroundTaskManagerProvider(),
+            BackgroundTaskManagerInput(
+                event_producer=setup_input.event_producer,
+                valkey_bgtask=setup_input.valkey.bgtask,
+                volume_pool=volume_pool,
+                server_id=local_config.storage_proxy.node_id,
+            ),
+        )
+        watcher = await stack.enter_dependency(
+            WatcherProvider(),
+            WatcherInput(local_config=local_config, pidx=setup_input.pidx),
+        )
+        volume_stats = await stack.enter_dependency(
+            VolumeStatsProvider(),
+            VolumeStatsInput(
+                local_config=local_config,
+                volume_pool=volume_pool,
+                valkey_volume_stats=setup_input.valkey.volume_stats,
+            ),
+        )
+        manager_client_pool = await stack.enter_dependency(
+            ManagerClientPoolProvider(),
+            local_config,
+        )
 
         yield StorageResources(
             storage_pool=storage_pool,
+            volume_pool=volume_pool,
+            background_task_manager=background_task_manager,
+            watcher=watcher,
+            volume_stats=volume_stats,
+            manager_client_pool=manager_client_pool,
         )

--- a/src/ai/backend/storage/dependencies/storage/manager_client_pool.py
+++ b/src/ai/backend/storage/dependencies/storage/manager_client_pool.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import override
+
+from ai.backend.common.data.artifact.types import ArtifactRegistryType
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.storage.client.manager import ManagerHTTPClientPool
+from ai.backend.storage.config.unified import (
+    LegacyReservoirConfig,
+    ReservoirConfig,
+    StorageProxyUnifiedConfig,
+)
+
+
+class ManagerClientPoolProvider(
+    NonMonitorableDependencyProvider[StorageProxyUnifiedConfig, ManagerHTTPClientPool]
+):
+    """Provider for the HTTP client pool talking to the reservoir manager registries."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "manager-client-pool"
+
+    @asynccontextmanager
+    @override
+    async def provide(
+        self, setup_input: StorageProxyUnifiedConfig
+    ) -> AsyncIterator[ManagerHTTPClientPool]:
+        registry_configs: dict[str, ReservoirConfig] = {
+            name: registry.reservoir
+            for name, registry in setup_input.artifact_registries.items()
+            if registry.registry_type == ArtifactRegistryType.RESERVOIR
+            and registry.reservoir is not None
+        }
+        for legacy_registry in setup_input.registries:
+            if isinstance(legacy_registry.config, LegacyReservoirConfig):
+                registry_configs[legacy_registry.name] = legacy_registry.config
+
+        pool = ManagerHTTPClientPool(registry_configs, setup_input.reservoir_client)
+        try:
+            yield pool
+        finally:
+            await pool.cleanup()

--- a/src/ai/backend/storage/dependencies/storage/storage_pool.py
+++ b/src/ai/backend/storage/dependencies/storage/storage_pool.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.dependencies import NonMonitorableDependencyProvider
@@ -9,7 +10,15 @@ from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
 from ai.backend.storage.storages.storage_pool import StoragePool
 
 
-class StoragePoolProvider(NonMonitorableDependencyProvider[StorageProxyUnifiedConfig, StoragePool]):
+@dataclass
+class StoragePoolInput:
+    """Input required for the storage pool setup."""
+
+    local_config: StorageProxyUnifiedConfig
+    pidx: int
+
+
+class StoragePoolProvider(NonMonitorableDependencyProvider[StoragePoolInput, StoragePool]):
     """Provider for storage pool."""
 
     @property
@@ -19,9 +28,10 @@ class StoragePoolProvider(NonMonitorableDependencyProvider[StorageProxyUnifiedCo
 
     @asynccontextmanager
     @override
-    async def provide(self, setup_input: StorageProxyUnifiedConfig) -> AsyncIterator[StoragePool]:
+    async def provide(self, setup_input: StoragePoolInput) -> AsyncIterator[StoragePool]:
         """Create and provide storage pool."""
-        storage_pool = StoragePool.from_config(setup_input)
+        storage_pool = StoragePool.from_config(setup_input.local_config)
+        if setup_input.pidx == 0:
+            storage_pool.cleanup_temporary_storages()
 
-        # StoragePool doesn't have explicit cleanup, but yield it as a context manager
         yield storage_pool

--- a/src/ai/backend/storage/dependencies/storage/volume_pool.py
+++ b/src/ai/backend/storage/dependencies/storage/volume_pool.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
+from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+from ai.backend.storage.volumes.abc import AbstractVolume
+from ai.backend.storage.volumes.pool import VolumePool
+
+
+@dataclass
+class VolumePoolInput:
+    """Input required for the volume pool setup."""
+
+    local_config: StorageProxyUnifiedConfig
+    etcd: AsyncEtcd
+    event_dispatcher: EventDispatcher
+    event_producer: EventProducer
+    backends: Mapping[str, type[AbstractVolume]]
+
+
+class VolumePoolProvider(NonMonitorableDependencyProvider[VolumePoolInput, VolumePool]):
+    """Provider for the volume pool."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "volume-pool"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: VolumePoolInput) -> AsyncIterator[VolumePool]:
+        volume_pool = await VolumePool.create(
+            local_config=setup_input.local_config,
+            etcd=setup_input.etcd,
+            event_dispatcher=setup_input.event_dispatcher,
+            event_producer=setup_input.event_producer,
+            backends=setup_input.backends,
+        )
+        try:
+            yield volume_pool
+        finally:
+            await volume_pool.shutdown()

--- a/src/ai/backend/storage/dependencies/storage/volume_stats.py
+++ b/src/ai/backend/storage/dependencies/storage/volume_stats.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.clients.valkey_client.valkey_volume_stats import ValkeyVolumeStatsClient
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.runner.types import Runner
+from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+from ai.backend.storage.volumes.pool import VolumePool
+from ai.backend.storage.volumes.stats import (
+    VolumeState,
+    VolumeStatsObserver,
+    VolumeStatsObserverOptions,
+)
+
+
+@dataclass
+class VolumeStatsInput:
+    """Input required for the volume stats setup."""
+
+    local_config: StorageProxyUnifiedConfig
+    volume_pool: VolumePool
+    valkey_volume_stats: ValkeyVolumeStatsClient
+
+
+@dataclass
+class VolumeStatsResources:
+    """Container for volume stats resources."""
+
+    observer: VolumeStatsObserver
+    state: VolumeState
+
+
+class VolumeStatsProvider(NonMonitorableDependencyProvider[VolumeStatsInput, VolumeStatsResources]):
+    """Provider for the volume stats observer loop and its cached state."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "volume-stats"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: VolumeStatsInput) -> AsyncIterator[VolumeStatsResources]:
+        volume_stats_config = setup_input.local_config.storage_proxy.volume_stats
+        options = VolumeStatsObserverOptions(
+            observe_interval=volume_stats_config.observe_interval,
+            timeout_per_volume=volume_stats_config.observe_timeout,
+            cache_ttl=volume_stats_config.cache_ttl,
+        )
+        observer = VolumeStatsObserver(
+            volume_pool=setup_input.volume_pool,
+            valkey_client=setup_input.valkey_volume_stats,
+            options=options,
+        )
+        runner = Runner(resources=[])
+        await runner.register_observer(observer)
+        await runner.start()
+        state = VolumeState(
+            volume_pool=setup_input.volume_pool,
+            valkey_client=setup_input.valkey_volume_stats,
+            options=options,
+        )
+        try:
+            yield VolumeStatsResources(observer=observer, state=state)
+        finally:
+            await runner.close()

--- a/src/ai/backend/storage/dependencies/storage/watcher.py
+++ b/src/ai/backend/storage/dependencies/storage/watcher.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+from ai.backend.storage.errors import InvalidConfigurationSourceError, InvalidSocketPathError
+from ai.backend.storage.watcher import WatcherClient
+
+
+@dataclass
+class WatcherInput:
+    """Input required for the watcher client setup."""
+
+    local_config: StorageProxyUnifiedConfig
+    pidx: int
+
+
+class WatcherProvider(NonMonitorableDependencyProvider[WatcherInput, WatcherClient | None]):
+    """Provider for the privileged watcher client."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "watcher"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: WatcherInput) -> AsyncIterator[WatcherClient | None]:
+        local_config = setup_input.local_config
+        if not local_config.storage_proxy.use_watcher:
+            yield None
+            return
+
+        if os.geteuid() != 0:
+            raise InvalidConfigurationSourceError(
+                "Storage proxy must be run as root if watcher is enabled. Else, set"
+                " `use-watcher` to false in your local config file."
+            )
+        insock_path = local_config.storage_proxy.watcher_insock_path_prefix
+        outsock_path = local_config.storage_proxy.watcher_outsock_path_prefix
+        if insock_path is None or outsock_path is None:
+            raise InvalidSocketPathError(
+                "Socket path must be not null. Please set valid socket path to"
+                " `watcher-insock-path-prefix` and `watcher-outsock-path-prefix` in your local"
+                " config file."
+            )
+        watcher_client = WatcherClient(setup_input.pidx, insock_path, outsock_path)
+        await watcher_client.init()
+        try:
+            yield watcher_client
+        finally:
+            await watcher_client.close()

--- a/src/ai/backend/storage/dependencies/system/__init__.py
+++ b/src/ai/backend/storage/dependencies/system/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .composer import SystemComposer, SystemComposerInput, SystemResources
+from .health_probe import HealthProbeInput, HealthProbeProvider
+from .service_discovery import (
+    ServiceDiscoveryInput,
+    ServiceDiscoveryProvider,
+    ServiceDiscoveryResources,
+)
+
+__all__ = [
+    "HealthProbeInput",
+    "HealthProbeProvider",
+    "ServiceDiscoveryInput",
+    "ServiceDiscoveryProvider",
+    "ServiceDiscoveryResources",
+    "SystemComposer",
+    "SystemComposerInput",
+    "SystemResources",
+]

--- a/src/ai/backend/storage/dependencies/system/composer.py
+++ b/src/ai/backend/storage/dependencies/system/composer.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.configs.redis import RedisConfig
+from ai.backend.common.dependencies import DependencyComposer, DependencyStack
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.common.health_checker import HealthProbe
+from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+from ai.backend.storage.dependencies.infrastructure.redis import StorageProxyValkeyClients
+
+from .health_probe import HealthProbeInput, HealthProbeProvider
+from .service_discovery import (
+    ServiceDiscoveryInput,
+    ServiceDiscoveryProvider,
+    ServiceDiscoveryResources,
+)
+
+
+@dataclass
+class SystemComposerInput:
+    """Input for System composer."""
+
+    local_config: StorageProxyUnifiedConfig
+    etcd: AsyncEtcd
+    redis_config: RedisConfig
+    valkey: StorageProxyValkeyClients
+    event_producer: EventProducer
+
+
+@dataclass
+class SystemResources:
+    """All system resources for storage proxy."""
+
+    health_probe: HealthProbe
+    service_discovery: ServiceDiscoveryResources
+
+
+class SystemComposer(DependencyComposer[SystemComposerInput, SystemResources]):
+    """Composer for system layer dependencies."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "system"
+
+    @asynccontextmanager
+    @override
+    async def compose(
+        self,
+        stack: DependencyStack,
+        setup_input: SystemComposerInput,
+    ) -> AsyncIterator[SystemResources]:
+        """Compose all system dependencies."""
+        health_probe = await stack.enter_dependency(
+            HealthProbeProvider(),
+            HealthProbeInput(etcd=setup_input.etcd, valkey=setup_input.valkey),
+        )
+        service_discovery = await stack.enter_dependency(
+            ServiceDiscoveryProvider(),
+            ServiceDiscoveryInput(
+                local_config=setup_input.local_config,
+                etcd=setup_input.etcd,
+                redis_config=setup_input.redis_config,
+                event_producer=setup_input.event_producer,
+            ),
+        )
+
+        yield SystemResources(
+            health_probe=health_probe,
+            service_discovery=service_discovery,
+        )

--- a/src/ai/backend/storage/dependencies/system/health_probe.py
+++ b/src/ai/backend/storage/dependencies/system/health_probe.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import override
+
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.health_checker import (
+    CID_REDIS_ARTIFACT,
+    CID_REDIS_BGTASK,
+    EtcdHealthChecker,
+    HealthProbe,
+    HealthProbeOptions,
+    ValkeyHealthChecker,
+)
+from ai.backend.storage.dependencies.infrastructure.redis import StorageProxyValkeyClients
+
+
+@dataclass
+class HealthProbeInput:
+    """Input required for health probe setup."""
+
+    etcd: AsyncEtcd
+    valkey: StorageProxyValkeyClients
+
+
+class HealthProbeProvider(NonMonitorableDependencyProvider[HealthProbeInput, HealthProbe]):
+    """Provides HealthProbe with health checker registration and lifecycle management."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "health-probe"
+
+    @asynccontextmanager
+    @override
+    async def provide(self, setup_input: HealthProbeInput) -> AsyncIterator[HealthProbe]:
+        probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
+        await probe.register_liveness(EtcdHealthChecker(etcd=setup_input.etcd))
+        await probe.register_liveness(
+            ValkeyHealthChecker(
+                clients={
+                    CID_REDIS_BGTASK: setup_input.valkey.bgtask,
+                    CID_REDIS_ARTIFACT: setup_input.valkey.artifact,
+                }
+            )
+        )
+        await probe.start()
+        try:
+            yield probe
+        finally:
+            await probe.stop()

--- a/src/ai/backend/storage/dependencies/system/service_discovery.py
+++ b/src/ai/backend/storage/dependencies/system/service_discovery.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import override
+
+from ai.backend.common.configs.redis import RedisConfig
+from ai.backend.common.defs import RedisRole
+from ai.backend.common.dependencies import NonMonitorableDependencyProvider
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.common.events.dispatcher import EventProducer
+from ai.backend.common.service_discovery.etcd_discovery.service_discovery import (
+    ETCDServiceDiscovery,
+    ETCDServiceDiscoveryArgs,
+)
+from ai.backend.common.service_discovery.event_publisher import ServiceDiscoveryEventPublisher
+from ai.backend.common.service_discovery.redis_discovery.service_discovery import (
+    RedisServiceDiscovery,
+    RedisServiceDiscoveryArgs,
+)
+from ai.backend.common.service_discovery.service_discovery import (
+    ServiceDiscovery,
+    ServiceDiscoveryLoop,
+    ServiceEndpoint,
+    ServiceMetadata,
+)
+from ai.backend.common.types import HostPortPair, ServiceDiscoveryType
+from ai.backend.storage import __version__
+from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
+
+
+@dataclass
+class ServiceDiscoveryInput:
+    """Input required for service discovery setup."""
+
+    local_config: StorageProxyUnifiedConfig
+    etcd: AsyncEtcd
+    redis_config: RedisConfig
+    event_producer: EventProducer
+
+
+@dataclass
+class ServiceDiscoveryResources:
+    """Container for service discovery resources."""
+
+    service_discovery: ServiceDiscovery
+    sd_loop: ServiceDiscoveryLoop
+
+
+class ServiceDiscoveryProvider(
+    NonMonitorableDependencyProvider[ServiceDiscoveryInput, ServiceDiscoveryResources]
+):
+    """Provides ServiceDiscovery, its announcement loop and the event publisher."""
+
+    @property
+    @override
+    def stage_name(self) -> str:
+        return "service-discovery"
+
+    @asynccontextmanager
+    @override
+    async def provide(
+        self, setup_input: ServiceDiscoveryInput
+    ) -> AsyncIterator[ServiceDiscoveryResources]:
+        local_config = setup_input.local_config
+        sd_config = local_config.service_discovery
+        sd_type = sd_config.type
+
+        service_discovery: ServiceDiscovery
+        match sd_type:
+            case ServiceDiscoveryType.ETCD:
+                service_discovery = ETCDServiceDiscovery(ETCDServiceDiscoveryArgs(setup_input.etcd))
+            case ServiceDiscoveryType.REDIS:
+                valkey_profile_target = setup_input.redis_config.to_valkey_profile_target()
+                service_discovery = await RedisServiceDiscovery.create(
+                    args=RedisServiceDiscoveryArgs(
+                        valkey_target=valkey_profile_target.profile_target(RedisRole.LIVE)
+                    )
+                )
+
+        announce_addr_config = local_config.api.manager.announce_addr
+        announce_addr = HostPortPair(
+            host=announce_addr_config.host,
+            port=announce_addr_config.port,
+        )
+        announce_internal_addr_config = local_config.api.manager.announce_internal_addr
+        announce_internal_addr = HostPortPair(
+            host=announce_internal_addr_config.host,
+            port=announce_internal_addr_config.port,
+        )
+        sd_loop = ServiceDiscoveryLoop(
+            sd_type,
+            service_discovery,
+            ServiceMetadata(
+                display_name=f"storage-{local_config.storage_proxy.node_id}",
+                service_group="storage-proxy",
+                version=__version__,
+                endpoint=ServiceEndpoint(
+                    address=str(announce_addr),
+                    port=announce_addr.port,
+                    protocol="http",
+                    prometheus_address=str(announce_internal_addr),
+                ),
+            ),
+        )
+
+        sd_event_publisher: ServiceDiscoveryEventPublisher | None = None
+        if sd_config.service_group:
+            sd_event_publisher = ServiceDiscoveryEventPublisher(
+                event_producer=setup_input.event_producer,
+                config=sd_config,
+                component_version=__version__,
+                startup_time=datetime.now(tz=UTC),
+            )
+            await sd_event_publisher.start()
+
+        try:
+            yield ServiceDiscoveryResources(
+                service_discovery=service_discovery,
+                sd_loop=sd_loop,
+            )
+        finally:
+            if sd_event_publisher is not None:
+                await sd_event_publisher.stop()
+            sd_loop.close()

--- a/src/ai/backend/storage/migration.py
+++ b/src/ai/backend/storage/migration.py
@@ -35,10 +35,11 @@ from ai.backend.logging import BraceStyleAdapter, LocalLogger, LogLevel
 from .client.manager import ManagerHTTPClientPool
 from .config.loaders import load_local_config, make_etcd
 from .config.unified import StorageProxyUnifiedConfig
-from .context import DEFAULT_BACKENDS, EVENT_DISPATCHER_CONSUMER_GROUP, RootContext
+from .context import EVENT_DISPATCHER_CONSUMER_GROUP, RootContext
 from .context_types import ArtifactVerifierContext
 from .types import VFolderID
 from .volumes.abc import CAP_FAST_SIZE, AbstractVolume
+from .volumes.backends import DEFAULT_BACKENDS
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 

--- a/src/ai/backend/storage/server.py
+++ b/src/ai/backend/storage/server.py
@@ -13,7 +13,7 @@ import sys
 import traceback
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
 from contextlib import AsyncExitStack, asynccontextmanager
-from datetime import UTC, datetime
+from dataclasses import dataclass
 from pathlib import Path
 from pprint import pformat, pprint
 from typing import Any
@@ -26,64 +26,19 @@ from aiohttp import web
 from aiohttp.typedefs import Middleware
 from setproctitle import setproctitle
 
-from ai.backend.common.bgtask.bgtask import BackgroundTaskManager, BackgroundTaskManagerArgs
-from ai.backend.common.clients.valkey_client.valkey_artifact.client import (
-    ValkeyArtifactDownloadTrackingClient,
-)
-from ai.backend.common.clients.valkey_client.valkey_bgtask.client import ValkeyBgtaskClient
-from ai.backend.common.clients.valkey_client.valkey_tus.client import (
-    ValkeyTusClient,
-)
-from ai.backend.common.clients.valkey_client.valkey_volume_stats import ValkeyVolumeStatsClient
 from ai.backend.common.config import (
     ConfigurationError,
 )
-from ai.backend.common.configs.redis import RedisConfig
-from ai.backend.common.data.artifact.types import ArtifactRegistryType
 from ai.backend.common.defs import (
     NOOP_STORAGE_VOLUME_NAME,
-    REDIS_BGTASK_DB,
-    REDIS_STATISTICS_DB,
-    REDIS_STREAM_DB,
-    REDIS_TUS_DB,
-    RedisRole,
 )
+from ai.backend.common.dependencies import DependencyBuilderStack
 from ai.backend.common.etcd import AsyncEtcd
-from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
-from ai.backend.common.health_checker.checkers.etcd import EtcdHealthChecker
-from ai.backend.common.health_checker.checkers.valkey import ValkeyHealthChecker
-from ai.backend.common.health_checker.probe import HealthProbe, HealthProbeOptions
-from ai.backend.common.health_checker.types import ComponentId
-from ai.backend.common.message_queue.queue import AbstractMessageQueue
-from ai.backend.common.message_queue.redis_queue import RedisMQArgs, RedisQueue
-from ai.backend.common.metrics.metric import CommonMetricRegistry
 from ai.backend.common.metrics.multiprocess_setup import cleanup_prometheus_multiprocess_dir
 from ai.backend.common.metrics.profiler import Profiler, PyroscopeArgs
 from ai.backend.common.msgpack import DEFAULT_PACK_OPTS, DEFAULT_UNPACK_OPTS
 from ai.backend.common.networking import force_threaded_dns_resolver
 from ai.backend.common.plugin import AbstractPlugin, BasePluginContext
-from ai.backend.common.runner.types import Runner
-from ai.backend.common.service_discovery.etcd_discovery.service_discovery import (
-    ETCDServiceDiscovery,
-    ETCDServiceDiscoveryArgs,
-)
-from ai.backend.common.service_discovery.event_publisher import ServiceDiscoveryEventPublisher
-from ai.backend.common.service_discovery.redis_discovery.service_discovery import (
-    RedisServiceDiscovery,
-    RedisServiceDiscoveryArgs,
-)
-from ai.backend.common.service_discovery.service_discovery import (
-    ServiceDiscovery,
-    ServiceDiscoveryLoop,
-    ServiceEndpoint,
-    ServiceMetadata,
-)
-from ai.backend.common.types import (
-    AGENTID_STORAGE,
-    RedisProfileTarget,
-    ServiceDiscoveryType,
-    safe_print_redis_config,
-)
 from ai.backend.common.types import HostPortPair as CommonHostPortPair
 from ai.backend.common.utils import env_info
 from ai.backend.logging import BraceStyleAdapter, Logger, LogLevel
@@ -98,28 +53,21 @@ except ImportError:
 from . import __version__ as VERSION
 from .api.client import init_client_app
 from .api.manager import init_internal_app, init_manager_app
-from .bgtask.registry import BgtaskHandlerRegistryCreator
-from .client.manager import ManagerHTTPClientPool
-from .config.loaders import load_local_config, make_etcd
+from .config.loaders import load_local_config
 from .config.unified import (
     EventLoopType,
-    LegacyReservoirConfig,
-    ReservoirConfig,
     StorageProxyUnifiedConfig,
 )
-from .context import DEFAULT_BACKENDS, EVENT_DISPATCHER_CONSUMER_GROUP, RootContext
+from .context import RootContext
+from .dependencies.composer import DependencyInput, StorageDependencyComposer
 from .errors import InvalidConfigurationSourceError, InvalidSocketPathError
 from .migration import check_latest
 from .plugin import (
     StorageClientWebappPluginContext,
     StorageManagerWebappPluginContext,
-    StoragePluginContext,
 )
-from .storages.storage_pool import StoragePool
 from .volumes.noop import init_noop_volume
-from .volumes.pool import VolumePool
-from .volumes.stats import VolumeState, VolumeStatsObserver, VolumeStatsObserverOptions
-from .watcher import WatcherClient, main_job
+from .watcher import main_job
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -128,19 +76,31 @@ def _is_root() -> bool:
     return os.geteuid() == 0
 
 
+@dataclass
+class ServerMainArgs:
+    local_config: StorageProxyUnifiedConfig
+    config_path: Path | None
+    log_endpoint: str
+    log_level: LogLevel
+
+
 @aiotools.server_context
 async def server_main_logwrapper(
     loop: asyncio.AbstractEventLoop,
     pidx: int,
-    _args: Sequence[Any],
+    tuple_args: Sequence[Any],
 ) -> AsyncGenerator[None, signal.Signals]:
     setproctitle(f"backend.ai: storage-proxy worker-{pidx}")
-    local_config: StorageProxyUnifiedConfig = _args[0]
-    log_endpoint = _args[1]
+    args = ServerMainArgs(
+        local_config=tuple_args[0],
+        config_path=tuple_args[1],
+        log_endpoint=tuple_args[2],
+        log_level=tuple_args[3],
+    )
     logger = Logger(
-        local_config.logging,
+        args.local_config.logging,
         is_master=False,
-        log_endpoint=log_endpoint,
+        log_endpoint=args.log_endpoint,
         msgpack_options={
             "pack_opts": DEFAULT_PACK_OPTS,
             "unpack_opts": DEFAULT_UNPACK_OPTS,
@@ -148,7 +108,7 @@ async def server_main_logwrapper(
     )
     try:
         with logger:
-            async with server_main(loop, pidx, _args):
+            async with server_main(loop, pidx, args):
                 yield
     except Exception:
         traceback.print_exc(file=sys.stderr)
@@ -194,186 +154,11 @@ async def aiomonitor_ctx(
 
 
 @asynccontextmanager
-async def etcd_ctx(local_config: StorageProxyUnifiedConfig) -> AsyncGenerator[AsyncEtcd]:
-    async with make_etcd(local_config) as etcd:
-        yield etcd
-
-
-@asynccontextmanager
-async def redis_ctx(etcd: AsyncEtcd, pidx: int) -> AsyncGenerator[RedisConfig]:
-    raw_redis_config = await etcd.get_prefix("config/redis")
-    redis_config = RedisConfig.model_validate(raw_redis_config)
-    log.info(
-        "PID: {0} - configured redis_config: {1}",
-        pidx,
-        safe_print_redis_config(redis_config),
-    )
-    yield redis_config
-
-
-@asynccontextmanager
-async def bgtask_ctx(
-    local_config: StorageProxyUnifiedConfig,
-    redis_config: RedisConfig,
-    event_producer: EventProducer,
-    volume_pool: VolumePool,
-) -> AsyncGenerator[BackgroundTaskManager]:
-    redis_profile_target = redis_config.to_redis_profile_target()
-    valkey_client = await ValkeyBgtaskClient.create(
-        redis_profile_target.profile_target(RedisRole.BGTASK).to_valkey_target(),
-        human_readable_name="storage_bgtask",
-        db_id=REDIS_BGTASK_DB,
-    )
-    bgtask_registry_creator = BgtaskHandlerRegistryCreator(volume_pool, event_producer)
-    registry = bgtask_registry_creator.create()
-    bgtask_mgr = BackgroundTaskManager(
-        BackgroundTaskManagerArgs(
-            event_producer=event_producer,
-            task_registry=registry,
-            valkey_client=valkey_client,
-            server_id=local_config.storage_proxy.node_id,
-        )
-    )
-    await bgtask_mgr.init()
-
-    try:
-        yield bgtask_mgr
-    finally:
-        await bgtask_mgr.shutdown()
-        await valkey_client.close()
-
-
-async def _make_message_queue(
-    local_config: StorageProxyUnifiedConfig,
-    redis_profile_target: RedisProfileTarget,
-) -> AbstractMessageQueue:
-    stream_redis_target = redis_profile_target.profile_target(RedisRole.STREAM)
-    node_id = local_config.storage_proxy.node_id
-    args = RedisMQArgs(
-        anycast_stream_key="events",
-        broadcast_channel="events_all",
-        consume_stream_keys=None,
-        subscribe_channels={
-            "events_all",
-        },
-        group_name=EVENT_DISPATCHER_CONSUMER_GROUP,
-        node_id=node_id,
-        db=REDIS_STREAM_DB,
-    )
-    return await RedisQueue.create(
-        stream_redis_target,
-        args,
-    )
-
-
-@asynccontextmanager
-async def event_ctx(
-    local_config: StorageProxyUnifiedConfig,
-    redis_config: RedisConfig,
-    pidx: int,
-    metric_registry: CommonMetricRegistry,
-) -> AsyncGenerator[tuple[EventDispatcher, EventProducer]]:
-    redis_profile_target = redis_config.to_redis_profile_target()
-    mq = await _make_message_queue(
-        local_config,
-        redis_profile_target,
-    )
-    event_producer = EventProducer(
-        mq,
-        source=AGENTID_STORAGE,
-        log_events=local_config.debug.log_events,
-    )
-    log.info(
-        "PID: {0} - Event producer created. (redis_config: {1})",
-        pidx,
-        safe_print_redis_config(redis_config),
-    )
-    event_dispatcher = EventDispatcher(
-        mq,
-        log_events=local_config.debug.log_events,
-        event_observer=metric_registry.event,
-    )
-    log.info(
-        "PID: {0} - Event dispatcher created. (redis_config: {1})",
-        pidx,
-        safe_print_redis_config(redis_config),
-    )
-    await event_dispatcher.start()
-    try:
-        yield event_dispatcher, event_producer
-    finally:
-        await event_producer.close()
-        await event_dispatcher.close()
-
-
-@asynccontextmanager
-async def watcher_ctx(
-    local_config: StorageProxyUnifiedConfig,
-    pidx: int,
-) -> AsyncGenerator[WatcherClient | None]:
-    if local_config.storage_proxy.use_watcher:
-        if not _is_root():
-            raise InvalidConfigurationSourceError(
-                "Storage proxy must be run as root if watcher is enabled. Else, set"
-                " `use-watcher` to false in your local config file."
-            )
-        insock_path: str | None = local_config.storage_proxy.watcher_insock_path_prefix
-        outsock_path: str | None = local_config.storage_proxy.watcher_outsock_path_prefix
-        if insock_path is None or outsock_path is None:
-            raise InvalidSocketPathError(
-                "Socket path must be not null. Please set valid socket path to"
-                " `watcher-insock-path-prefix` and `watcher-outsock-path-prefix` in your local"
-                " config file."
-            )
-        watcher_client = WatcherClient(pidx, insock_path, outsock_path)
-        await watcher_client.init()
-    else:
-        watcher_client = None
-    try:
-        yield watcher_client
-    finally:
-        if watcher_client is not None:
-            await watcher_client.close()
-
-
-@asynccontextmanager
-async def volume_ctx(
-    local_config: StorageProxyUnifiedConfig,
-    etcd: AsyncEtcd,
-    event_dispatcher: EventDispatcher,
-    event_producer: EventProducer,
-) -> AsyncGenerator[VolumePool]:
-    volume_pool = await VolumePool.create(
-        local_config=local_config,
-        etcd=etcd,
-        event_dispatcher=event_dispatcher,
-        event_producer=event_producer,
-    )
-    try:
-        yield volume_pool
-    finally:
-        await volume_pool.shutdown()
-
-
-@asynccontextmanager
 async def api_ctx(
     local_config: StorageProxyUnifiedConfig,
     etcd: AsyncEtcd,
     root_ctx: RootContext,
 ) -> AsyncGenerator[tuple[web.Application, web.Application, web.Application]]:
-    @asynccontextmanager
-    async def _init_storage_plugin() -> AsyncGenerator[StoragePluginContext]:
-        plugin_ctx = StoragePluginContext(etcd, local_config.model_dump())
-        await plugin_ctx.init()
-        for plugin_name, plugin_instance in plugin_ctx.plugins.items():
-            log.info("Loading storage plugin: {0}", plugin_name)
-            volume_cls = plugin_instance.get_volume_class()
-            root_ctx.backends[plugin_name] = volume_cls
-        try:
-            yield plugin_ctx
-        finally:
-            await plugin_ctx.cleanup()
-
     @asynccontextmanager
     async def _init_storage_webapp_plugin(
         plugin_ctx: BasePluginContext[AbstractPlugin], root_app: web.Application
@@ -468,7 +253,6 @@ async def api_ctx(
             await internal_api_runner.cleanup()
 
     async with AsyncExitStack() as api_init_stack:
-        await api_init_stack.enter_async_context(_init_storage_plugin())
         client_api_app = await api_init_stack.enter_async_context(client_api_ctx())
         manager_api_app = await api_init_stack.enter_async_context(manager_api_ctx())
         internal_api_app = await api_init_stack.enter_async_context(internal_api_ctx())
@@ -489,87 +273,6 @@ async def api_ctx(
         finally:
             # volume instances are lazily initialized upon their first usage by the API layers.
             await root_ctx.shutdown_volumes()
-            await root_ctx.shutdown_manager_http_clients()
-
-
-@asynccontextmanager
-async def service_discovery_ctx(
-    local_config: StorageProxyUnifiedConfig,
-    etcd: AsyncEtcd,
-    redis_config: RedisConfig,
-    event_producer: EventProducer | None = None,
-) -> AsyncGenerator[None]:
-    announce_addr_config = local_config.api.manager.announce_addr
-    announce_addr = CommonHostPortPair(
-        host=announce_addr_config.host,
-        port=announce_addr_config.port,
-    )
-    announce_internal_addr_config = local_config.api.manager.announce_internal_addr
-    announce_internal_addr = CommonHostPortPair(
-        host=announce_internal_addr_config.host,
-        port=announce_internal_addr_config.port,
-    )
-
-    sd_type = local_config.service_discovery.type
-
-    service_discovery: ServiceDiscovery
-    match sd_type:
-        case ServiceDiscoveryType.ETCD:
-            service_discovery = ETCDServiceDiscovery(ETCDServiceDiscoveryArgs(etcd))
-        case ServiceDiscoveryType.REDIS:
-            valkey_profile_target = redis_config.to_valkey_profile_target()
-            live_valkey_target = valkey_profile_target.profile_target(RedisRole.LIVE)
-            service_discovery = await RedisServiceDiscovery.create(
-                args=RedisServiceDiscoveryArgs(valkey_target=live_valkey_target)
-            )
-
-    sd_loop = ServiceDiscoveryLoop(
-        sd_type,
-        service_discovery,
-        ServiceMetadata(
-            display_name=f"storage-{local_config.storage_proxy.node_id}",
-            service_group="storage-proxy",
-            version=VERSION,
-            endpoint=ServiceEndpoint(
-                address=str(announce_addr),
-                port=announce_addr.port,
-                protocol="http",
-                prometheus_address=str(announce_internal_addr),
-            ),
-        ),
-    )
-    if local_config.otel.enabled:
-        meta = sd_loop.metadata
-        otel_spec = OpenTelemetrySpec(
-            service_name=meta.service_group,
-            service_version=meta.version,
-            log_level=local_config.otel.log_level,
-            endpoint=local_config.otel.endpoint,
-            service_instance_id=meta.id,
-            service_instance_name=meta.display_name,
-            max_queue_size=local_config.otel.max_queue_size,
-            max_export_batch_size=local_config.otel.max_export_batch_size,
-        )
-        BraceStyleAdapter.apply_otel(otel_spec)
-
-    # Start event-based SD publishing if config has service_group set
-    sd_config = local_config.service_discovery
-    sd_event_publisher: ServiceDiscoveryEventPublisher | None = None
-    if sd_config.service_group and event_producer is not None:
-        sd_event_publisher = ServiceDiscoveryEventPublisher(
-            event_producer=event_producer,
-            config=sd_config,
-            component_version=VERSION,
-            startup_time=datetime.now(tz=UTC),
-        )
-        await sd_event_publisher.start()
-
-    try:
-        yield
-    finally:
-        if sd_event_publisher is not None:
-            await sd_event_publisher.stop()
-        sd_loop.close()
 
 
 async def _on_prepare(_request: web.Request, response: web.StreamResponse) -> None:
@@ -602,114 +305,32 @@ def _init_subapp(
 async def server_main(
     loop: asyncio.AbstractEventLoop,
     pidx: int,
-    _args: Sequence[Any],
+    args: ServerMainArgs,
 ) -> AsyncIterator[None]:
-    local_config: StorageProxyUnifiedConfig = _args[0]
-    loop.set_debug(local_config.debug.asyncio)
+    loop.set_debug(args.local_config.debug.asyncio)
 
     storage_init_stack = AsyncExitStack()
     await storage_init_stack.__aenter__()
     try:
-        metric_registry = CommonMetricRegistry()
-        monitor = await storage_init_stack.enter_async_context(aiomonitor_ctx(local_config, pidx))
-        etcd = await storage_init_stack.enter_async_context(etcd_ctx(local_config))
-        redis_config = await storage_init_stack.enter_async_context(redis_ctx(etcd, pidx))
-        event_dispatcher, event_producer = await storage_init_stack.enter_async_context(
-            event_ctx(local_config, redis_config, pidx, metric_registry)
+        monitor = await storage_init_stack.enter_async_context(
+            aiomonitor_ctx(args.local_config, pidx)
         )
 
-        # Create StoragePool with both object storage and VFS storage
-        volume_pool = await storage_init_stack.enter_async_context(
-            volume_ctx(local_config, etcd, event_dispatcher, event_producer)
-        )
-        storage_pool = StoragePool.from_config(local_config)
-
-        # Clean up temporary storages only on the first process
-        if pidx == 0:
-            storage_pool.cleanup_temporary_storages()
-
-        bgtask_mgr = await storage_init_stack.enter_async_context(
-            bgtask_ctx(local_config, redis_config, event_producer, volume_pool)
-        )
-        watcher_client = await storage_init_stack.enter_async_context(
-            watcher_ctx(local_config, pidx)
+        dep_stack = DependencyBuilderStack()
+        await storage_init_stack.enter_async_context(dep_stack)
+        dep_resources = await dep_stack.enter_composer(
+            StorageDependencyComposer(),
+            DependencyInput(
+                config_path=args.config_path,
+                pidx=pidx,
+                log_level=args.log_level,
+            ),
         )
 
-        # Create ValkeyArtifactDownloadTrackingClient
-        valkey_target = redis_config.to_valkey_target()
-        valkey_artifact_client = await ValkeyArtifactDownloadTrackingClient.create(
-            valkey_target=valkey_target,
-            db_id=REDIS_STATISTICS_DB,
-            human_readable_name=f"storage-proxy-artifact-download-tracker-{pidx}",
-        )
-        storage_init_stack.push_async_callback(valkey_artifact_client.close)
-
-        valkey_tus_client = await ValkeyTusClient.create(
-            valkey_target=valkey_target,
-            db_id=REDIS_TUS_DB,
-            human_readable_name=f"storage-proxy-tus-{pidx}",
-        )
-        storage_init_stack.push_async_callback(valkey_tus_client.close)
-
-        # Initialize health probe
-        health_probe = HealthProbe(options=HealthProbeOptions(check_interval=60))
-        # Liveness-registered: also surfaced in readiness — connection-stuck
-        # issues observed where restart is the actual recovery path.
-        await health_probe.register_liveness(EtcdHealthChecker(etcd=etcd))
-        await health_probe.register_liveness(
-            ValkeyHealthChecker(
-                clients={
-                    ComponentId("bgtask"): bgtask_mgr._valkey_client,
-                    ComponentId("artifact"): valkey_artifact_client,
-                }
-            )
-        )
-        await health_probe.start()
-        storage_init_stack.push_async_callback(health_probe.stop)
-
-        # Initialize volume stats observer
-        volume_stats_options = VolumeStatsObserverOptions(
-            observe_interval=local_config.storage_proxy.volume_stats.observe_interval,
-            timeout_per_volume=local_config.storage_proxy.volume_stats.observe_timeout,
-            cache_ttl=local_config.storage_proxy.volume_stats.cache_ttl,
-        )
-        valkey_volume_stats_client = await ValkeyVolumeStatsClient.create(
-            valkey_target=valkey_target,
-            db_id=REDIS_STATISTICS_DB,
-            human_readable_name=f"storage-proxy-volume-stats-{pidx}",
-        )
-        storage_init_stack.push_async_callback(valkey_volume_stats_client.close)
-
-        volume_stats_observer = VolumeStatsObserver(
-            volume_pool=volume_pool,
-            valkey_client=valkey_volume_stats_client,
-            options=volume_stats_options,
-        )
-        volume_stats_runner = Runner(resources=[])
-        await volume_stats_runner.register_observer(volume_stats_observer)
-        await volume_stats_runner.start()
-        storage_init_stack.push_async_callback(volume_stats_runner.close)
-
-        volume_stats_state = VolumeState(
-            volume_pool=volume_pool,
-            valkey_client=valkey_volume_stats_client,
-            options=volume_stats_options,
-        )
-
-        # Build reservoir registry configs for ManagerHTTPClientPool
-        reservoir_registry_configs: dict[str, ReservoirConfig] = {
-            name: r.reservoir
-            for name, r in local_config.artifact_registries.items()
-            if r.registry_type == ArtifactRegistryType.RESERVOIR and r.reservoir is not None
-        }
-        for legacy_registry in local_config.registries:
-            if isinstance(legacy_registry.config, LegacyReservoirConfig):
-                reservoir_registry_configs[legacy_registry.name] = legacy_registry.config
-
-        manager_client_pool = ManagerHTTPClientPool(
-            reservoir_registry_configs,
-            local_config.reservoir_client,
-        )
+        local_config = dep_resources.bootstrap.config
+        etcd = dep_resources.infrastructure.etcd
+        event_dispatcher = dep_resources.messaging.event_dispatcher
+        event_producer = dep_resources.messaging.event_producer
 
         root_ctx = RootContext(
             pid=os.getpid(),
@@ -717,25 +338,25 @@ async def server_main(
             node_id=local_config.storage_proxy.node_id,
             local_config=local_config,
             etcd=etcd,
-            volume_pool=volume_pool,
-            storage_pool=storage_pool,
-            background_task_manager=bgtask_mgr,
+            volume_pool=dep_resources.storage.volume_pool,
+            storage_pool=dep_resources.storage.storage_pool,
+            background_task_manager=dep_resources.storage.background_task_manager,
             event_producer=event_producer,
             event_dispatcher=event_dispatcher,
-            watcher=watcher_client,
-            metric_registry=metric_registry,
+            watcher=dep_resources.storage.watcher,
+            metric_registry=dep_resources.bootstrap.metric_registry,
             cors_options={
                 "*": aiohttp_cors.ResourceOptions(  # type: ignore[no-untyped-call]
                     allow_credentials=False, expose_headers="*", allow_headers="*"
                 ),
             },
-            manager_client_pool=manager_client_pool,
-            valkey_artifact_client=valkey_artifact_client,
-            valkey_tus_client=valkey_tus_client,
-            health_probe=health_probe,
-            volume_stats_observer=volume_stats_observer,
-            volume_stats_state=volume_stats_state,
-            backends={**DEFAULT_BACKENDS},
+            manager_client_pool=dep_resources.storage.manager_client_pool,
+            valkey_artifact_client=dep_resources.infrastructure.valkey.artifact,
+            valkey_tus_client=dep_resources.infrastructure.valkey.tus,
+            health_probe=dep_resources.system.health_probe,
+            volume_stats_observer=dep_resources.storage.volume_stats.observer,
+            volume_stats_state=dep_resources.storage.volume_stats.state,
+            backends={**dep_resources.plugins.backends},
             volumes={
                 NOOP_STORAGE_VOLUME_NAME: init_noop_volume(etcd, event_dispatcher, event_producer)
             },
@@ -744,6 +365,20 @@ async def server_main(
         await root_ctx.init_storage_artifact_verifier_plugin()
         if pidx == 0:
             await check_latest(root_ctx)
+
+        if local_config.otel.enabled:
+            meta = dep_resources.system.service_discovery.sd_loop.metadata
+            otel_spec = OpenTelemetrySpec(
+                service_name=meta.service_group,
+                service_version=meta.version,
+                log_level=local_config.otel.log_level,
+                endpoint=local_config.otel.endpoint,
+                service_instance_id=meta.id,
+                service_instance_name=meta.display_name,
+                max_queue_size=local_config.otel.max_queue_size,
+                max_export_batch_size=local_config.otel.max_export_batch_size,
+            )
+            BraceStyleAdapter.apply_otel(otel_spec)
 
         (
             client_api_app,
@@ -754,10 +389,6 @@ async def server_main(
         monitor.console_locals["client_api_app"] = client_api_app
         monitor.console_locals["manager_api_app"] = manager_api_app
         monitor.console_locals["internal_api_app"] = internal_api_app
-
-        await storage_init_stack.enter_async_context(
-            service_discovery_ctx(local_config, etcd, redis_config, event_producer)
-        )
 
         if _is_root():
             uid = local_config.storage_proxy.user
@@ -814,8 +445,9 @@ def main(
     """Start the storage-proxy service as a foreground process."""
     force_threaded_dns_resolver()
     log_level = LogLevel.DEBUG if debug else log_level
+    resolved_config_path = config_path.resolve() if config_path is not None else None
     try:
-        local_config = load_local_config(config_path, log_level=log_level)
+        local_config = load_local_config(resolved_config_path, log_level=log_level)
     except ConfigurationError as e:
         print(
             "ConfigurationError: Could not read or validate the storage-proxy local config:",
@@ -902,7 +534,7 @@ def main(
                         server_main_logwrapper,
                         num_workers=num_workers,
                         extra_procs=extra_procs,
-                        args=(local_config, log_endpoint),
+                        args=(local_config, resolved_config_path, log_endpoint, log_level),
                         runner=runner,
                     )
                 finally:

--- a/src/ai/backend/storage/volumes/backends.py
+++ b/src/ai/backend/storage/volumes/backends.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .abc import AbstractVolume
+from .cephfs import CephFSVolume
+from .ddn import EXAScalerFSVolume
+from .dellemc import DellEMCOneFSVolume
+from .gpfs import GPFSVolume
+from .hammerspace.volume.base import BaseHammerspaceVolume
+from .hammerspace.volume.extended import HammerspaceVolume
+from .netapp import NetAppVolume
+from .noop import NoopVolume
+from .purestorage import FlashBladeVolume
+from .vast import VASTVolume
+from .vfs import BaseVolume
+from .weka import WekaVolume
+from .xfs import XfsVolume
+
+DEFAULT_BACKENDS: Mapping[str, type[AbstractVolume]] = {
+    FlashBladeVolume.name: FlashBladeVolume,
+    BaseVolume.name: BaseVolume,
+    XfsVolume.name: XfsVolume,
+    NetAppVolume.name: NetAppVolume,
+    # NOTE: Dell EMC has two different storage: PowerStore and PowerScale (OneFS).
+    #       We support the latter only for now.
+    DellEMCOneFSVolume.name: DellEMCOneFSVolume,
+    WekaVolume.name: WekaVolume,
+    GPFSVolume.name: GPFSVolume,  # IBM SpectrumScale or GPFS
+    "spectrumscale": GPFSVolume,  # IBM SpectrumScale or GPFS
+    CephFSVolume.name: CephFSVolume,
+    VASTVolume.name: VASTVolume,
+    EXAScalerFSVolume.name: EXAScalerFSVolume,
+    NoopVolume.name: NoopVolume,
+    HammerspaceVolume.name: HammerspaceVolume,
+    BaseHammerspaceVolume.name: BaseHammerspaceVolume,
+}

--- a/src/ai/backend/storage/volumes/pool.py
+++ b/src/ai/backend/storage/volumes/pool.py
@@ -13,58 +13,24 @@ from ai.backend.common.types import VolumeID
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.storage.config.unified import StorageProxyUnifiedConfig, VolumeInfoConfig
 from ai.backend.storage.errors import InvalidVolumeError
-from ai.backend.storage.plugin import StoragePluginContext
 from ai.backend.storage.types import VolumeInfo
 
 from .abc import AbstractVolume
-from .cephfs import CephFSVolume
-from .ddn import EXAScalerFSVolume
-from .dellemc import DellEMCOneFSVolume
-from .gpfs import GPFSVolume
-from .hammerspace.volume.base import BaseHammerspaceVolume
-from .hammerspace.volume.extended import HammerspaceVolume
-from .netapp import NetAppVolume
-from .purestorage import FlashBladeVolume
-from .vast import VASTVolume
-from .vfs import BaseVolume
-from .weka import WekaVolume
-from .xfs import XfsVolume
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
-
-_DEFAULT_BACKENDS: Mapping[str, type[AbstractVolume]] = {
-    FlashBladeVolume.name: FlashBladeVolume,
-    BaseVolume.name: BaseVolume,
-    XfsVolume.name: XfsVolume,
-    NetAppVolume.name: NetAppVolume,
-    # NOTE: Dell EMC has two different storage: PowerStore and PowerScale (OneFS).
-    #       We support the latter only for now.
-    DellEMCOneFSVolume.name: DellEMCOneFSVolume,
-    WekaVolume.name: WekaVolume,
-    GPFSVolume.name: GPFSVolume,  # IBM SpectrumScale or GPFS
-    "spectrumscale": GPFSVolume,  # IBM SpectrumScale or GPFS
-    CephFSVolume.name: CephFSVolume,
-    VASTVolume.name: VASTVolume,
-    EXAScalerFSVolume.name: EXAScalerFSVolume,
-    HammerspaceVolume.name: HammerspaceVolume,
-    BaseHammerspaceVolume.name: BaseHammerspaceVolume,
-}
 
 
 class VolumePool:
     _volumes: Mapping[VolumeID, AbstractVolume]
     _volumes_by_name: Mapping[str, AbstractVolume]
-    _storage_backend_plugin_ctx: StoragePluginContext
 
     def __init__(
         self,
         volumes: Mapping[VolumeID, AbstractVolume],
         volumes_by_name: Mapping[str, AbstractVolume],
-        storage_backend_plugin_ctx: StoragePluginContext,
     ) -> None:
         self._volumes = volumes
         self._volumes_by_name = volumes_by_name
-        self._storage_backend_plugin_ctx = storage_backend_plugin_ctx
 
     @classmethod
     async def create(
@@ -73,12 +39,8 @@ class VolumePool:
         etcd: AsyncEtcd,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
+        backends: Mapping[str, type[AbstractVolume]],
     ) -> Self:
-        backends = {**_DEFAULT_BACKENDS}
-        storage_backend_plugin_ctx = await cls._init_storage_backend_plugin(
-            backends, local_config, etcd
-        )
-
         volumes: dict[VolumeID, AbstractVolume] = {}
         volumes_by_name: dict[str, AbstractVolume] = {}
         for raw_volume_id, config in local_config.volume.items():
@@ -105,7 +67,6 @@ class VolumePool:
         return cls(
             volumes=volumes,
             volumes_by_name=volumes_by_name,
-            storage_backend_plugin_ctx=storage_backend_plugin_ctx,
         )
 
     @classmethod
@@ -129,25 +90,9 @@ class VolumePool:
         await volume_obj.init()
         return volume_obj
 
-    @classmethod
-    async def _init_storage_backend_plugin(
-        cls,
-        backends: dict[str, type[AbstractVolume]],
-        local_config: StorageProxyUnifiedConfig,
-        etcd: AsyncEtcd,
-    ) -> StoragePluginContext:
-        plugin_ctx = StoragePluginContext(etcd, local_config.model_dump())
-        await plugin_ctx.init()
-        for plugin_name, plugin_instance in plugin_ctx.plugins.items():
-            log.info("Loading storage plugin: {0}", plugin_name)
-            volume_cls = plugin_instance.get_volume_class()
-            backends[plugin_name] = volume_cls
-        return plugin_ctx
-
     async def shutdown(self) -> None:
         for volume in self._volumes.values():
             await volume.shutdown()
-        await self._storage_backend_plugin_ctx.cleanup()
 
     def list_volumes(self) -> Mapping[str, VolumeInfo]:
         return {str(volume_id): volume.info() for volume_id, volume in self._volumes.items()}

--- a/tests/unit/storage-proxy/vfolder/test_pool.py
+++ b/tests/unit/storage-proxy/vfolder/test_pool.py
@@ -8,7 +8,6 @@ from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.events.dispatcher import EventDispatcher, EventProducer
 from ai.backend.common.types import VolumeID
 from ai.backend.storage.errors import InvalidVolumeError
-from ai.backend.storage.plugin import StoragePluginContext
 from ai.backend.storage.types import VolumeInfo
 from ai.backend.storage.volumes.abc import AbstractVolume
 from ai.backend.storage.volumes.pool import VolumePool
@@ -43,16 +42,7 @@ def mock_volume() -> AsyncMock:
     return volume
 
 
-@pytest.fixture
-def mock_storage_plugin_ctx() -> AsyncMock:
-    ctx = AsyncMock(spec=StoragePluginContext)
-    ctx.init = AsyncMock()
-    ctx.cleanup = AsyncMock()
-    ctx.plugins = {}
-    return ctx
-
-
-async def test_get_volume(mock_volume: AsyncMock, mock_storage_plugin_ctx: AsyncMock) -> None:
+async def test_get_volume(mock_volume: AsyncMock) -> None:
     # Create a VolumePool with mocked volumes
     volume_id = VolumeID(uuid.UUID("550e8400-e29b-41d4-a716-446655440000"))
     volumes = {volume_id: mock_volume}
@@ -61,7 +51,6 @@ async def test_get_volume(mock_volume: AsyncMock, mock_storage_plugin_ctx: Async
     pool = VolumePool(
         volumes=volumes,
         volumes_by_name=volumes_by_name,
-        storage_backend_plugin_ctx=mock_storage_plugin_ctx,
     )
 
     # Test get_volume with valid volume ID

--- a/tests/unit/storage/dependencies/infrastructure/test_redis.py
+++ b/tests/unit/storage/dependencies/infrastructure/test_redis.py
@@ -13,8 +13,10 @@ from ai.backend.storage.config.loaders import make_etcd
 from ai.backend.storage.config.unified import StorageProxyUnifiedConfig
 from ai.backend.storage.dependencies.infrastructure.redis import (
     RedisProvider,
+    RedisProviderInput,
     StorageProxyValkeyClients,
 )
+from ai.backend.storage.dependencies.infrastructure.redis_config import RedisConfigProvider
 
 
 class TestRedisProvider:
@@ -67,13 +69,16 @@ class TestRedisProvider:
         etcd_client: AsyncEtcd,
     ) -> None:
         """Provider should create and cleanup all Valkey clients."""
-        provider = RedisProvider()
+        async with RedisConfigProvider().provide(etcd_client) as redis_config:
+            provider_input = RedisProviderInput(redis_config=redis_config, pidx=0)
 
-        async with provider.provide(etcd_client) as clients:
-            assert isinstance(clients, StorageProxyValkeyClients)
-            # Verify clients are created
-            assert clients.bgtask is not None
-            assert clients.artifact is not None
+            async with RedisProvider().provide(provider_input) as clients:
+                assert isinstance(clients, StorageProxyValkeyClients)
+                # Verify clients are created
+                assert clients.bgtask is not None
+                assert clients.artifact is not None
+                assert clients.tus is not None
+                assert clients.volume_stats is not None
 
     @pytest.mark.integration
     async def test_cleanup_on_exception(
@@ -81,12 +86,13 @@ class TestRedisProvider:
         etcd_client: AsyncEtcd,
     ) -> None:
         """Provider should cleanup clients even on exception."""
-        provider = RedisProvider()
+        async with RedisConfigProvider().provide(etcd_client) as redis_config:
+            provider_input = RedisProviderInput(redis_config=redis_config, pidx=0)
 
-        with pytest.raises(RuntimeError):
-            async with provider.provide(etcd_client) as clients:
-                assert isinstance(clients, StorageProxyValkeyClients)
-                raise RuntimeError("Test error")
+            with pytest.raises(RuntimeError):
+                async with RedisProvider().provide(provider_input) as clients:
+                    assert isinstance(clients, StorageProxyValkeyClients)
+                    raise RuntimeError("Test error")
 
         # Clients should be closed - we can't easily verify this,
         # but the test should complete without hanging

--- a/tests/unit/storage/dependencies/plugins/BUILD
+++ b/tests/unit/storage/dependencies/plugins/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/storage/dependencies/plugins/test_composer.py
+++ b/tests/unit/storage/dependencies/plugins/test_composer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import override
+from unittest.mock import MagicMock
+
+from ai.backend.common.dependencies import (
+    DependencyComposer,
+    DependencyProvider,
+    DependencyStack,
+    ResourcesT,
+    ResourceT,
+    SetupInputT,
+)
+from ai.backend.common.etcd import AsyncEtcd
+from ai.backend.storage.dependencies.plugins.base import PluginsInput
+from ai.backend.storage.dependencies.plugins.composer import PluginsComposer
+from ai.backend.storage.plugin import AbstractStoragePlugin, StoragePluginContext
+from ai.backend.storage.volumes.backends import DEFAULT_BACKENDS
+from ai.backend.storage.volumes.vfs import BaseVolume
+
+
+class StubStack(DependencyStack):
+    """A stack that hands back a prepared resource instead of running the provider."""
+
+    def __init__(self, resource: object) -> None:
+        self._resource = resource
+
+    @override
+    async def enter_dependency(
+        self,
+        provider: DependencyProvider[SetupInputT, ResourceT],
+        setup_input: SetupInputT,
+    ) -> ResourceT:
+        return self._resource  # type: ignore[return-value]
+
+    @override
+    async def enter_composer(
+        self,
+        composer: DependencyComposer[SetupInputT, ResourcesT],
+        setup_input: SetupInputT,
+    ) -> ResourcesT:
+        raise NotImplementedError
+
+
+def plugin_ctx(plugins: dict[str, AbstractStoragePlugin]) -> StoragePluginContext:
+    ctx = MagicMock(spec=StoragePluginContext)
+    ctx.plugins = plugins
+    return ctx
+
+
+def plugins_input() -> PluginsInput:
+    return PluginsInput(etcd=MagicMock(spec=AsyncEtcd), local_config={})
+
+
+class TestPluginsComposer:
+    """Test the volume backend registry composed from the storage plugin context."""
+
+    async def test_defaults_without_plugins(self) -> None:
+        ctx = plugin_ctx({})
+
+        async with PluginsComposer().compose(StubStack(ctx), plugins_input()) as resources:
+            assert resources.storage_backend_plugin_ctx is ctx
+            assert resources.backends == DEFAULT_BACKENDS
+
+    async def test_plugin_volume_class_is_registered(self) -> None:
+        class CustomVolume(BaseVolume):
+            name = "custom"
+
+        plugin = MagicMock(spec=AbstractStoragePlugin)
+        plugin.get_volume_class.return_value = CustomVolume
+        ctx = plugin_ctx({"custom": plugin})
+
+        async with PluginsComposer().compose(StubStack(ctx), plugins_input()) as resources:
+            assert resources.backends["custom"] is CustomVolume
+            assert all(resources.backends[name] is cls for name, cls in DEFAULT_BACKENDS.items())
+
+    async def test_plugin_overrides_default_backend(self) -> None:
+        class OverridingVolume(BaseVolume):
+            name = "vfs"
+
+        plugin = MagicMock(spec=AbstractStoragePlugin)
+        plugin.get_volume_class.return_value = OverridingVolume
+        ctx = plugin_ctx({"vfs": plugin})
+
+        async with PluginsComposer().compose(StubStack(ctx), plugins_input()) as resources:
+            assert resources.backends["vfs"] is OverridingVolume


### PR DESCRIPTION
## Summary

- Drive the storage proxy server startup from `StorageDependencyComposer` instead of the hand-rolled `AsyncExitStack` in `server_main`, so the server, `storage dependencies verify` and `storage health check` build the same resources through the same path.
- Compose `StoragePluginContext` once in a new plugins stage and inject the merged backend map into both `VolumePool` and `RootContext`; the volume registry no longer owns a plugin context as a side effect of being created, and the plugin group is no longer loaded twice.
- Extend the composer with the plugins, messaging and system stages, move the remaining hand-built resources (volume pool, background task manager, watcher, volume stats, manager client pool, health probe, service discovery, redis config, tus/volume-stats clients) into providers, and collapse the two divergent `DEFAULT_BACKENDS` copies into `volumes/backends.py`.

Stage order: bootstrap → infrastructure → plugins → messaging → storage → system.

### Behavior notes

- Workers now receive the config path and log level, and the composer loads the configuration; `main()` resolves the path before spawning so the loader's `chdir` cannot change how a relative path resolves.
- The artifact Valkey client is created once (the server used to open a second one), and the tus/artifact/volume-stats clients now resolve through their role profile target, so `override-configs` applies to them.
- The background task manager shares the composed bgtask client, removing the private `_valkey_client` access in the health probe wiring.
- The metric registry is now `CommonMetricRegistry.instance()`, the same registry the metrics endpoint exports.
- Service discovery is registered during composition, i.e. slightly before the API sites start listening — this matches the manager's ordering.

`RootContext` is unchanged and still assembled in `server.py`; breaking it up is separate work. The artifact verifier plugin context is untouched.

## Test plan

- [x] `pants fmt` / `pants fix` / `pants lint` on the changed files
- [x] `pants check` / `pants test` (CI)
- [x] Storage proxy starts and shuts down cleanly against the local halfstack: plugin context initialized once, volume stats runner and health probe started, service registered, `Started the storage-proxy service.`, clean teardown with no traceback
- [x] `backend.ai storage dependencies verify` / `backend.ai storage health check`
- [x] Startup with a storage backend plugin installed (no plugin was present in the local run)

Resolves BA-7793
