### PR TITLE
refactor(BA-7769): report an entity error under the row's own type

### DIFF
--- a/changes/14471.breaking.md
+++ b/changes/14471.breaking.md
@@ -1,0 +1,1 @@
+Report a manager error about an entity or a field row under that row's own type instead of a fixed error domain, so a missing row answers with a code naming what was missing.

--- a/src/ai/backend/common/data/entity/auto_scaling_rule.py
+++ b/src/ai/backend/common/data/entity/auto_scaling_rule.py
@@ -1,0 +1,34 @@
+"""Type and id of the endpoint_auto_scaling_rules table, a field row of a deployment."""
+
+from typing import override
+
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.types import EntityType, FieldIdentifier, FieldType
+
+__all__ = ("AutoScalingRuleFieldType", "AutoScalingRuleID")
+
+
+class AutoScalingRuleFieldType(FieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "auto_scaling_rule"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "One rule scaling a deployment's replica count by a metric."
+
+    @override
+    @classmethod
+    def owner_type(cls) -> type[EntityType]:
+        return DeploymentEntityType
+
+
+class AutoScalingRuleID(FieldIdentifier):
+    """An auto-scaling rule row's id."""
+
+    @override
+    @classmethod
+    def field_type(cls) -> FieldType:
+        return AutoScalingRuleFieldType()

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import enum
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Self, override
@@ -209,13 +209,15 @@ class ErrorOperation(enum.StrEnum):
 
     GENERIC = "generic"  # Whenever possible, use specific operation names instead of this one.
     CREATE = "create"
+    UPSERT = "upsert"
     ACCESS = "access"
     READ = "read"
+    SEARCH = "search"
     UPDATE = "update"
     START = "start"
     SOFT_DELETE = "soft-delete"
+    RESTORE = "restore"
     HARD_DELETE = "purge"
-    LIST = "list-query"
     AUTH = "auth"
     HOOK = "hook"
     REQUEST = "request"
@@ -300,9 +302,13 @@ class ErrorCode:
 
     The error_detail field describes the specific error that occurred during the operation.
     If it consists of two or more words, they should be connected with a hyphen (-).
+
+    The domain is an open string: an ``ErrorDomain`` value for a system error, the
+    entity or field type for an entity error. No part carries an underscore, so a
+    compound word is hyphenated.
     """
 
-    domain: ErrorDomain
+    domain: str
     operation: ErrorOperation
     error_detail: ErrorDetail
 
@@ -337,15 +343,30 @@ class ErrorCode:
             raise InvalidErrorCode(f"Invalid error code format: {code_str}")
         domain_str, operation_str, error_detail_str = parts
         try:
-            domain = ErrorDomain(domain_str)
             operation = ErrorOperation(operation_str)
             error_detail = ErrorDetail(error_detail_str)
         except ValueError as e:
             raise InvalidErrorCode(f"Invalid error code value. Err: {e}") from e
-        return cls(domain=domain, operation=operation, error_detail=error_detail)
+        return cls(domain=domain_str, operation=operation, error_detail=error_detail)
 
 
-class BackendAIError(web.HTTPError, ABC):
+class ErrorMeta(ABCMeta):
+    """Refuses to construct an error that still owes an abstract method.
+
+    ``object.__new__`` makes that refusal for an ordinary abstract class by reading
+    what ``ABCMeta`` recorded, but an exception is constructed through
+    ``Exception.__new__``, which does not read it. This hook runs before either.
+    """
+
+    @override
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        if cls.__abstractmethods__:
+            owed = ", ".join(sorted(cls.__abstractmethods__))
+            raise TypeError(f"{cls.__name__} is an abstract error; it still owes {owed}")
+        return super().__call__(*args, **kwargs)
+
+
+class BackendAIError(web.HTTPError, metaclass=ErrorMeta):
     """
     An RFC-7807 error class as a drop-in replacement of the original
     aiohttp.web.HTTPError subclasses.

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from ai.backend.common.data.entity.types import EntityType, ScopeType
 from ai.backend.common.data.permission.types import OperationType, Permission
+from ai.backend.common.exception import ErrorOperation
 
 # Placeholder substituted when an id (request_id, entity_id, ...) is absent while
 # materializing action metadata into audit/report records.
@@ -133,6 +134,31 @@ class ActionOperationType(enum.StrEnum):
                 return OperationType.HARD_DELETE
             case ActionOperationType.RESTORE:
                 return OperationType.SOFT_DELETE
+
+    def to_error_operation(self) -> ErrorOperation:
+        """The ``ErrorCode`` operation an error raised under this operation reports.
+
+        Every operation but ``LOOKUP`` has its own counterpart. ``LOOKUP`` reads the one
+        row a key names, so it reports as a read like ``GET``. ``DELETE`` and ``PURGE``
+        report under the names that say which delete they are.
+        """
+        match self:
+            case ActionOperationType.GET | ActionOperationType.LOOKUP:
+                return ErrorOperation.READ
+            case ActionOperationType.SEARCH:
+                return ErrorOperation.SEARCH
+            case ActionOperationType.CREATE:
+                return ErrorOperation.CREATE
+            case ActionOperationType.UPSERT:
+                return ErrorOperation.UPSERT
+            case ActionOperationType.UPDATE:
+                return ErrorOperation.UPDATE
+            case ActionOperationType.RESTORE:
+                return ErrorOperation.RESTORE
+            case ActionOperationType.DELETE:
+                return ErrorOperation.SOFT_DELETE
+            case ActionOperationType.PURGE:
+                return ErrorOperation.HARD_DELETE
 
     def to_permission(self) -> Permission:
         """The permission an action performing this operation must hold.

--- a/src/ai/backend/manager/actions/v2/field/bulk_processor.py
+++ b/src/ai/backend/manager/actions/v2/field/bulk_processor.py
@@ -29,7 +29,7 @@ from ai.backend.manager.actions.v2.field.bulk_lookup import (
 )
 from ai.backend.manager.actions.v2.lookup.bulk_processor import BulkLookupActionProcessor
 from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 
 __all__ = (
     "AtomicFieldResultJudge",
@@ -168,7 +168,12 @@ class BulkFieldActionProcessor[TAction: BaseBulkFieldAction[Any, Any], TResult]:
         lookup_result = await self._owner_lookup.run(action.to_owner_lookup_action())
         owners = lookup_result.owners
         if not owners:
-            raise EntityNotFoundError("No field row matches the given ids")
+            field_id = action.field_ids()[0]
+            raise FieldNotFoundError(
+                "No field row matches the given ids",
+                field_type=field_id.field_type(),
+                operation=action.operation_type(),
+            )
 
         started_at = datetime.now(UTC)
         action_id = uuid.uuid4()
@@ -281,7 +286,12 @@ class PartialBulkFieldActionProcessor[TAction: BasePartialBulkFieldAction[Any, A
         lookup_result = await self._owner_lookup.run(action.to_owner_lookup_action())
         owners = lookup_result.owners
         if not owners:
-            raise EntityNotFoundError("No field row matches the given ids")
+            field_id = action.field_ids()[0]
+            raise FieldNotFoundError(
+                "No field row matches the given ids",
+                field_type=field_id.field_type(),
+                operation=action.operation_type(),
+            )
 
         started_at = datetime.now(UTC)
         action_id = uuid.uuid4()

--- a/src/ai/backend/manager/actions/v2/lookup/processor.py
+++ b/src/ai/backend/manager/actions/v2/lookup/processor.py
@@ -19,9 +19,9 @@ from ai.backend.manager.actions.v2.lookup.validator import (
 )
 from ai.backend.manager.actions.v2.single_entity.trigger import SingleEntityActionTriggerMeta
 from ai.backend.manager.actions.v2.single_entity.validator import SingleEntityActionValidator
+from ai.backend.manager.errors.base.not_found import NotFoundError
 from ai.backend.manager.errors.common import GenericBadRequest
 from ai.backend.manager.errors.permission import NotEnoughPermission
-from ai.backend.manager.errors.repository import EntityNotFoundError
 
 __all__ = ("LookupActionProcessor",)
 
@@ -122,7 +122,7 @@ class LookupActionProcessor[TAction: BaseLookupAction, TResult: BaseLookupAction
                 raise
             try:
                 result = await self._func(action)
-            except EntityNotFoundError as e:
+            except NotFoundError as e:
                 run_status = ActionRunStatus.of_failure(e, during_validation=False)
                 if not self._post_validators:
                     raise

--- a/src/ai/backend/manager/api/adapters/base.py
+++ b/src/ai/backend/manager/api/adapters/base.py
@@ -14,7 +14,7 @@ from ai.backend.manager.api.adapter_options.pagination.pagination import (
     PaginationSpec,
     build_pagination,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.not_found import NotFoundError
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
 from ai.backend.manager.models.entity_label.conditions import (
@@ -143,7 +143,7 @@ class BaseAdapter(BaseFilterAdapter):
         """
         try:
             result: BulkFieldOpsResult[TData] = await processor.run(action)
-        except EntityNotFoundError:
+        except NotFoundError:
             return [None for _ in field_ids]
         return [
             to_node(result.successes[field_id])
@@ -159,7 +159,7 @@ class BaseAdapter(BaseFilterAdapter):
         awaiting it, so a caller is never told a row is missing when it is one they may
         not read.
         """
-        if error is None or isinstance(error, EntityNotFoundError):
+        if error is None or isinstance(error, NotFoundError):
             return None
         return error
 

--- a/src/ai/backend/manager/api/adapters/rbac/adapter.py
+++ b/src/ai/backend/manager/api/adapters/rbac/adapter.py
@@ -169,11 +169,12 @@ from ai.backend.manager.data.permission.role import (
 )
 from ai.backend.manager.data.permission.status import RoleStatus as InternalRoleStatus
 from ai.backend.manager.data.permission.types import RoleSource as InternalRoleSource
+from ai.backend.manager.errors.base.not_found import NotFoundError
 from ai.backend.manager.errors.permission import (
     PermissionAlreadyGranted,
     ReplaceRolePermissionRoleIdMismatch,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError, RepositoryIntegrityError
+from ai.backend.manager.errors.repository import RepositoryIntegrityError
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
 from ai.backend.manager.models.rbac.exceptions import InvalidScope
@@ -1035,7 +1036,7 @@ class RBACAdapter(BaseAdapter):
                     permission_ids=[PermissionID(pid) for pid in input.permission_ids]
                 )
             )
-        except EntityNotFoundError:
+        except NotFoundError:
             return BulkRemoveRolePermissionsPayload(items=[], failed=[])
         return BulkRemoveRolePermissionsPayload(
             items=[self._permission_data_to_node(item) for item in result.successes.values()],
@@ -1045,7 +1046,7 @@ class RBACAdapter(BaseAdapter):
                     message=str(exception),
                 )
                 for permission_id, exception in result.errors.items()
-                if not isinstance(exception, EntityNotFoundError)
+                if not isinstance(exception, NotFoundError)
             ],
         )
 

--- a/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
+++ b/src/ai/backend/manager/api/adapters/resource_preset/adapter.py
@@ -32,7 +32,7 @@ from ai.backend.common.types import BinarySize, ResourceSlot
 from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.resource_preset.types import ResourcePresetData
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.not_found import NotFoundError
 from ai.backend.manager.errors.resource import ResourcePresetNotFound
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.condition_utils import combine_conditions_or, negate_conditions
@@ -127,7 +127,7 @@ class ResourcePresetAdapter(BaseAdapter):
             result = await self._resource_preset.get_preset.run(
                 GetResourcePresetAction(preset_id=ResourcePresetID(preset_id))
             )
-        except EntityNotFoundError as e:
+        except NotFoundError as e:
             # The generic repository names no domain; the route answered with the
             # preset's own error before and keeps doing so.
             raise ResourcePresetNotFound() from e

--- a/src/ai/backend/manager/api/gql/resource_slot/types.py
+++ b/src/ai/backend/manager/api/gql/resource_slot/types.py
@@ -201,13 +201,13 @@ class ResourceSlotTypeGQL(PydanticNodeMixin[Any]):
         node_ids: Iterable[str],
         required: bool = False,
     ) -> Iterable[Self | None]:
-        from ai.backend.manager.errors.repository import EntityNotFoundError
+        from ai.backend.manager.errors.base.not_found import NotFoundError
 
         results: list[Self | None] = []
         for slot_name in node_ids:
             try:
                 node = await load_resource_slot_type_node(info, slot_name)
-            except EntityNotFoundError:
+            except NotFoundError:
                 if required:
                     raise
                 results.append(None)

--- a/src/ai/backend/manager/errors/AGENTS.md
+++ b/src/ai/backend/manager/errors/AGENTS.md
@@ -1,10 +1,27 @@
 # Errors
 
-`errors/{domain}.py` holds this component's `BackendAIError` subclasses (e.g. `user.py`, `session.py`). The "inherit from `BackendAIError`, never raise built-ins" rule lives in the root `AGENTS.md`.
+`errors/{domain}.py` holds this component's `BackendAIError` subclasses (e.g. `user.py`, `session.py`); `errors/base/` holds the two bases they build on. The "inherit from `BackendAIError`, never raise built-ins" rule lives in the root `AGENTS.md`.
+
+## Rules
+
+1. An error about an entity inherits `EntityError` (`errors/base/entity.py`); one about a field row inherits `FieldError` (`errors/base/field.py`). Their `ErrorCode.domain` comes from the row's type; do not pick an `ErrorDomain` for them.
+2. An error class is defined under `manager/errors/` and nowhere else. `exceptions.py` modules in `sokovan`, `plugin`, `dependencies`, `models` are to be moved here, not extended.
+3. Error modules are split per domain (`errors/{domain}.py`, later `errors/{domain}/`).
+4. One meaning, one class. Before defining, search for an existing class with the same name or the same code.
+
+Three bases, drawn by what the error is about:
+
+| The error is about | Base | `ErrorCode.domain` |
+|---|---|---|
+| An entity (user, session, vfolder, ...) | `EntityError` | `EntityType` of that entity |
+| A field row (kernel, keypair, replica, ...) | `FieldError` | `{owner entity}-{field row}`; a dangling kind (`DanglingFieldType`, e.g. audit_log) reports its own alone |
+| The system (api, auth, database, bgtask, plugin, leader-election, message-queue, event, watcher, health-check, metric, storage-proxy, appproxy, external-system) | `BackendAIError` | `ErrorDomain` |
+
+The row types come from the identifiers: `EntityIdentifier.entity_type()`, `FieldIdentifier.field_type()`. A field type answers its own owner, so nothing beside it declares one. A spec that names a row by key declares the type on itself (`DataLookup.entity_type()`, `FieldKeyLookup.field_type()`).
 
 ## Base and enums
 
-`ai.backend.common.exception` defines `BackendAIError` and the enums `ErrorDomain` / `ErrorOperation` / `ErrorDetail` / `ErrorCode`. Other components mirror this layout: `{agent,storage,appproxy/*}/errors/{domain}.py`.
+`ai.backend.common.exception` defines `BackendAIError` and the enums `ErrorDomain` / `ErrorOperation` / `ErrorDetail` / `ErrorCode`. `ErrorCode.domain` is an open `str`: an `ErrorDomain` value for a system error, the row's type for an entity or field error. `str(ErrorCode)` stays `{domain}_{operation}_{detail}` and splits on `_`, so **no part carries an underscore**. A type spells itself in snake_case for the database and the graph; the error bases hyphenate it on the way into the domain and nothing else rewrites it. Other components mirror this layout: `{agent,storage,appproxy/*}/errors/{domain}.py`.
 
 ## Find an existing error before defining a new one
 
@@ -15,7 +32,34 @@ grep -rn "class .*BackendAIError" src/ai/backend                  # all componen
 
 ## Define
 
-Subclass `BackendAIError` plus the matching aiohttp HTTP type, and implement `error_code()`:
+An entity or field error subclasses `EntityError` / `FieldError` plus the matching aiohttp
+HTTP type, and **answers with its triple instead of declaring it in fields** — the way
+every error answers with its code. `operation` is an `ActionOperationType`, not an
+`ErrorOperation`: a row is acted on with the action vocabulary, and the base maps it to
+the code's operation.
+
+```python
+class AgentAlreadyExited(EntityError, web.HTTPConflict):
+    error_type = "https://api.backend.ai/probs/agent-already-exited"
+    error_title = "Agent has already exited."
+
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            AgentEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
+        )
+
+raise EntityNotFoundError(msg, entity_type=entity_id.entity_type(), operation=ActionOperationType.PURGE)
+raise FieldNotFoundError(msg, field_type=field_id.field_type())
+```
+
+A root that still owes its code cannot be constructed: `ErrorMeta` refuses it, because
+`Exception.__new__` skips the check `ABCMeta` records for an ordinary abstract class.
+
+`EntityNotFoundError` and `FieldNotFoundError` share `NotFoundError`, so a caller that
+answers the same way for a missing entity and a missing field row catches that one name.
+
+A system error subclasses `BackendAIError` plus the matching aiohttp HTTP type, and implements `error_code()`:
 
 - A concrete exception **MUST inherit an HTTP status type (`web.HTTP*`) at definition
   time** — there is no telling when it will surface externally, and a status-less
@@ -35,4 +79,4 @@ class UserNotFound(BackendAIError, web.HTTPNotFound):
         )
 ```
 
-Pick `domain` / `operation` / `error_detail` from the enums in `common/exception.py`; add a new enum value there if none fits.
+Pick `domain` / `operation` / `error_detail` from the enums in `common/exception.py`; add a new enum value there if none fits. Do not add an entity name to `ErrorDomain`: that is what `EntityError` is for.

--- a/src/ai/backend/manager/errors/agent.py
+++ b/src/ai/backend/manager/errors/agent.py
@@ -8,7 +8,7 @@ from typing import override
 
 from aiohttp import web
 
-from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.agent import AgentEntityType, AgentUUID
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -17,6 +17,8 @@ from ai.backend.common.exception import (
     ErrorOperation,
 )
 from ai.backend.common.types import AgentId
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 
 
 class AgentConnectionUnavailable(BackendAIError, web.HTTPServiceUnavailable):
@@ -39,23 +41,21 @@ class AgentConnectionUnavailable(BackendAIError, web.HTTPServiceUnavailable):
         )
 
 
-class AgentAlreadyExited(BackendAIError, web.HTTPConflict):
+class AgentAlreadyExited(EntityError, web.HTTPConflict):
     """Raised when an exit is recorded for an agent already in a terminal status."""
 
     error_type = "https://api.backend.ai/probs/agent-already-exited"
     error_title = "Agent has already exited."
+
+    agent_uuid: AgentUUID
 
     def __init__(self, agent_uuid: AgentUUID) -> None:
         self.agent_uuid = agent_uuid
         super().__init__(f"Agent {agent_uuid} is already in a terminal status.")
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(AgentEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT)
 
 
 class AgentHasConflictingSessions(BackendAIError, web.HTTPConflict):

--- a/src/ai/backend/manager/errors/base/__init__.py
+++ b/src/ai/backend/manager/errors/base/__init__.py
@@ -1,0 +1,1 @@
+"""Bases of the manager's entity and field errors: ``entity.py``, ``field.py``."""

--- a/src/ai/backend/manager/errors/base/entity.py
+++ b/src/ai/backend/manager/errors/base/entity.py
@@ -1,0 +1,80 @@
+"""Base of the manager's entity errors."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import override
+
+from aiohttp import web
+
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+)
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.not_found import NotFoundError
+
+
+@dataclass(frozen=True)
+class EntityErrorCode:
+    """What an entity error answers with: the row's type, what was being done to it,
+    and what went wrong. The entity axis of :class:`ErrorCode`."""
+
+    entity_type: EntityType
+    operation: ActionOperationType
+    detail: ErrorDetail
+
+    def to_error_code(self) -> ErrorCode:
+        """The wire form. The type keeps its underscores; the domain hyphenates them,
+        because no part of a code may carry an underscore."""
+        return ErrorCode(
+            domain=self.entity_type.replace("_", "-"),
+            operation=self.operation.to_error_operation(),
+            error_detail=self.detail,
+        )
+
+
+class EntityError(BackendAIError):
+    """An error about one entity, reporting that entity's type as the code's domain.
+
+    A subclass answers with the triple rather than declaring it in fields, the way
+    every error answers with its code. Carries no ``web.HTTP*`` mixin; a concrete
+    subclass adds its own.
+    """
+
+    @abstractmethod
+    def entity_error_code(self) -> EntityErrorCode:
+        """Return the entity, the operation and the detail this error reports."""
+        raise NotImplementedError
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return self.entity_error_code().to_error_code()
+
+
+class EntityNotFoundError(EntityError, NotFoundError, web.HTTPNotFound):
+    """Raised when an operation names an entity row that does not exist."""
+
+    error_type = "https://api.backend.ai/probs/entity-not-found"
+    error_title = "Entity not found."
+
+    _entity_type: EntityType
+    _operation: ActionOperationType
+
+    def __init__(
+        self,
+        extra_msg: str | None = None,
+        *,
+        entity_type: EntityType,
+        operation: ActionOperationType = ActionOperationType.GET,
+    ) -> None:
+        self._entity_type = entity_type
+        self._operation = operation
+        super().__init__(extra_msg)
+
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(self._entity_type, self._operation, ErrorDetail.NOT_FOUND)

--- a/src/ai/backend/manager/errors/base/field.py
+++ b/src/ai/backend/manager/errors/base/field.py
@@ -1,0 +1,88 @@
+"""Base of the manager's field row errors."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import override
+
+from aiohttp import web
+
+from ai.backend.common.data.entity.types import FieldType
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+)
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.not_found import NotFoundError
+
+
+@dataclass(frozen=True)
+class FieldErrorCode:
+    """What a field error answers with: the row's type, what was being done to it,
+    and what went wrong. The owning entity comes from the type, not from here."""
+
+    field_type: FieldType
+    operation: ActionOperationType
+    detail: ErrorDetail
+
+    def domain(self) -> str:
+        """The owning entity and the field row as one domain. A dangling kind has no
+        owner and reports its own type alone. No part carries an underscore."""
+        field = self.field_type.replace("_", "-")
+        owner = self.field_type.owner_type()
+        if owner is None:
+            return field
+        return f"{owner.name().replace('_', '-')}-{field}"
+
+    def to_error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=self.domain(),
+            operation=self.operation.to_error_operation(),
+            error_detail=self.detail,
+        )
+
+
+class FieldError(BackendAIError):
+    """An error about one field row, reporting its owner and its own type as the
+    code's domain.
+
+    A subclass answers with the triple rather than declaring it in fields, the way
+    every error answers with its code. Carries no ``web.HTTP*`` mixin; a concrete
+    subclass adds its own.
+    """
+
+    @abstractmethod
+    def field_error_code(self) -> FieldErrorCode:
+        """Return the field row, the operation and the detail this error reports."""
+        raise NotImplementedError
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return self.field_error_code().to_error_code()
+
+
+class FieldNotFoundError(FieldError, NotFoundError, web.HTTPNotFound):
+    """Raised when an operation names a field row that does not exist."""
+
+    error_type = "https://api.backend.ai/probs/field-not-found"
+    error_title = "Field row not found."
+
+    _field_type: FieldType
+    _operation: ActionOperationType
+
+    def __init__(
+        self,
+        extra_msg: str | None = None,
+        *,
+        field_type: FieldType,
+        operation: ActionOperationType = ActionOperationType.GET,
+    ) -> None:
+        self._field_type = field_type
+        self._operation = operation
+        super().__init__(extra_msg)
+
+    @override
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(self._field_type, self._operation, ErrorDetail.NOT_FOUND)

--- a/src/ai/backend/manager/errors/base/not_found.py
+++ b/src/ai/backend/manager/errors/base/not_found.py
@@ -1,0 +1,14 @@
+"""Shared root of the errors reporting that a named row does not exist."""
+
+from __future__ import annotations
+
+from ai.backend.common.exception import BackendAIError
+
+
+class NotFoundError(BackendAIError):
+    """Raised when an operation names a row that does not exist.
+
+    Declares nothing of its own, so it still owes the error code and cannot be
+    constructed. It exists to be caught: a caller that answers the same way for a
+    missing entity and a missing field row names this instead of both.
+    """

--- a/src/ai/backend/manager/errors/repository.py
+++ b/src/ai/backend/manager/errors/repository.py
@@ -82,28 +82,8 @@ class EmptyOperationScopeError(RepositoryError, web.HTTPBadRequest):
     def error_code(self) -> ErrorCode:
         return ErrorCode(
             domain=ErrorDomain.DATABASE,
-            operation=ErrorOperation.LIST,
+            operation=ErrorOperation.SEARCH,
             error_detail=ErrorDetail.INVALID_PARAMETERS,
-        )
-
-
-class EntityNotFoundError(RepositoryError, web.HTTPNotFound):
-    """Raised when an ops-backed operation names a row that does not exist.
-
-    The generic repository has no domain to name a more specific error from, so the
-    entity type travels in the message instead. A domain that wants its own error
-    keeps a hand-written repository method.
-    """
-
-    error_type = "https://api.backend.ai/probs/entity-not-found"
-    error_title = "Entity not found."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DATABASE,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.NOT_FOUND,
         )
 
 

--- a/src/ai/backend/manager/errors/role_preset.py
+++ b/src/ai/backend/manager/errors/role_preset.py
@@ -6,6 +6,7 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -13,6 +14,8 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 
 from .common import ObjectNotFound
 
@@ -42,17 +45,13 @@ class InvalidRoleNameTemplate(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class SystemRoleNotEditable(BackendAIError, web.HTTPForbidden):
+class SystemRoleNotEditable(EntityError, web.HTTPForbidden):
     error_type = "https://api.backend.ai/probs/system-role-not-editable"
     error_title = "A SYSTEM role cannot be purged; edit the role preset instead."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROLE,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.FORBIDDEN,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(RoleEntityType(), ActionOperationType.PURGE, ErrorDetail.FORBIDDEN)
 
 
 class RolePermissionPresetConflict(BackendAIError, web.HTTPConflict):

--- a/src/ai/backend/manager/errors/storage.py
+++ b/src/ai/backend/manager/errors/storage.py
@@ -9,6 +9,7 @@ from typing import Any, override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -16,6 +17,8 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 
 from .common import ObjectNotFound
 
@@ -155,16 +158,14 @@ class VFolderOperationFailed(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class VFolderFilterStatusFailed(BackendAIError, web.HTTPBadRequest):
+class VFolderFilterStatusFailed(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/vfolder-filter-status-failed"
     error_title = "Virtual folder status filtering has failed."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.VFOLDER,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.BAD_REQUEST,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            VFolderEntityType(), ActionOperationType.GET, ErrorDetail.BAD_REQUEST
         )
 
 

--- a/src/ai/backend/manager/models/agent/lookups.py
+++ b/src/ai/backend/manager/models/agent/lookups.py
@@ -9,7 +9,8 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.agent import AgentUUID
+from ai.backend.common.data.entity.agent import AgentEntityType, AgentUUID
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.types import AgentId
 from ai.backend.manager.models.agent.row import AgentRow
 from ai.backend.manager.models.clauses import QueryCondition
@@ -28,6 +29,10 @@ class AgentNameLookup(DataLookup[AgentRow, AgentUUID]):
     @override
     def row_class(self) -> type[AgentRow]:
         return AgentRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return AgentEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/app_config_allow_list/updaters.py
+++ b/src/ai/backend/manager/models/app_config_allow_list/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -40,7 +39,7 @@ class AppConfigAllowListUpdater(DataUpdater[AppConfigAllowListRow, AppConfigAllo
         return AppConfigAllowListRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> AppConfigAllowListID:
         return self.allow_list_id
 
     @property

--- a/src/ai/backend/manager/models/artifact/updaters.py
+++ b/src/ai/backend/manager/models/artifact/updaters.py
@@ -46,7 +46,7 @@ class ArtifactUpdater(GuardedDataUpdater[ArtifactRow, ArtifactData]):
         return ArtifactRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ArtifactID:
         return self.artifact_id
 
     @property
@@ -97,7 +97,7 @@ class ArtifactScanUpdater(DataUpdater[ArtifactRow, ArtifactData]):
         return ArtifactRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ArtifactID:
         return self.artifact_id
 
     @property

--- a/src/ai/backend/manager/models/artifact_registries/lookups.py
+++ b/src/ai/backend/manager/models/artifact_registries/lookups.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.artifact_registry import ArtifactRegistryID
+from ai.backend.common.data.entity.artifact_registry import (
+    ArtifactRegistryEntityType,
+    ArtifactRegistryID,
+)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.artifact_registries.row import ArtifactRegistryRow
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.specs.lookup import DataLookup
@@ -21,6 +25,10 @@ class ArtifactRegistryNameLookup(DataLookup[ArtifactRegistryRow, ArtifactRegistr
     @override
     def row_class(self) -> type[ArtifactRegistryRow]:
         return ArtifactRegistryRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return ArtifactRegistryEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/artifact_registries/updaters.py
+++ b/src/ai/backend/manager/models/artifact_registries/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -34,7 +33,7 @@ class ArtifactRegistryMetaUpdater(DataUpdater[ArtifactRegistryRow, ArtifactRegis
         return ArtifactRegistryRow.registry_id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ArtifactRegistryID:
         return self.registry_id
 
     @property

--- a/src/ai/backend/manager/models/artifact_revision/updaters.py
+++ b/src/ai/backend/manager/models/artifact_revision/updaters.py
@@ -6,7 +6,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -44,7 +43,7 @@ class ArtifactRevisionScanUpdater(DataUpdater[ArtifactRevisionRow, ArtifactRevis
         return ArtifactRevisionRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ArtifactRevisionID:
         return self.revision_id
 
     @property

--- a/src/ai/backend/manager/models/deployment_policy/purgers.py
+++ b/src/ai/backend/manager/models/deployment_policy/purgers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -31,7 +30,7 @@ class DeploymentPolicyPurger(FieldPurger[DeploymentPolicyRow, DeploymentPolicyDa
         return DeploymentPolicyRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DeploymentPolicyID:
         return self.policy_id
 
     @override

--- a/src/ai/backend/manager/models/deployment_revision_preset/updaters.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/updaters.py
@@ -4,7 +4,6 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -71,7 +70,7 @@ class DeploymentPresetUpdater(
         return DeploymentRevisionPresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DeploymentPresetID:
         return self.preset_id
 
     @property

--- a/src/ai/backend/manager/models/domain/lookups.py
+++ b/src/ai/backend/manager/models/domain/lookups.py
@@ -9,7 +9,8 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.domain import DomainID, DomainName
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID, DomainName
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
@@ -24,6 +25,10 @@ class DomainNameLookup(DataLookup[DomainRow, DomainID]):
     @override
     def row_class(self) -> type[DomainRow]:
         return DomainRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return DomainEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/domain/updaters.py
+++ b/src/ai/backend/manager/models/domain/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -48,7 +47,7 @@ class DomainUpdater(GuardedDataUpdater[DomainRow, DomainData]):
         return DomainRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DomainID:
         return self.domain_id
 
     @override
@@ -101,7 +100,7 @@ class DomainDotfilesUpdater(DataUpdater[DomainRow, DomainData]):
         return DomainRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DomainID:
         return self.domain_id
 
     @override
@@ -134,7 +133,7 @@ class DomainSoftDeleteUpdater(GuardedDataUpdater[DomainRow, DomainData]):
         return DomainRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DomainID:
         return self.domain_id
 
     @override
@@ -177,7 +176,7 @@ class DomainRestoreUpdater(GuardedDataUpdater[DomainRow, DomainData]):
         return DomainRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DomainID:
         return self.domain_id
 
     @override

--- a/src/ai/backend/manager/models/endpoint/lookups.py
+++ b/src/ai/backend/manager/models/endpoint/lookups.py
@@ -9,8 +9,10 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.auto_scaling_rule import AutoScalingRuleID
 from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
+from ai.backend.common.data.entity.types import FieldType
 from ai.backend.manager.models.endpoint.row import EndpointAutoScalingRuleRow, EndpointTokenRow
 from ai.backend.manager.models.specs.lookup import FieldOwnerKeyLookup, FieldOwnerLookup
 
@@ -20,6 +22,10 @@ class AutoScalingRuleDeploymentLookup(FieldOwnerKeyLookup[DeploymentID]):
     """Reads the deployment an auto-scaling rule belongs to."""
 
     rule_id: UUID
+
+    @override
+    def field_type(self) -> FieldType:
+        return AutoScalingRuleID.field_type()
 
     @override
     def build_query(self) -> sa.sql.Select[Any]:

--- a/src/ai/backend/manager/models/endpoint/updaters.py
+++ b/src/ai/backend/manager/models/endpoint/updaters.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.data.endpoint.types import ScalingState
+from ai.backend.common.data.entity.auto_scaling_rule import AutoScalingRuleID
 from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.replica_group import ReplicaGroupID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
@@ -62,7 +63,7 @@ class DeploymentUpdater(DataUpdater[EndpointRow, DeploymentInfo]):
         return EndpointRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DeploymentID:
         return self.deployment_id
 
     @property
@@ -114,7 +115,7 @@ class EndpointReplicaGroupUpdater(DataUpdater[EndpointRow, DeploymentInfo]):
         return EndpointRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DeploymentID:
         return self.deployment_id
 
     @property
@@ -174,7 +175,7 @@ class LegacyEndpointUpdater(DataUpdater[EndpointRow, DeploymentInfo]):
         return EndpointRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> DeploymentID:
         return self.deployment_id
 
     @property
@@ -286,8 +287,8 @@ class AutoScalingRuleUpdater(DataUpdater[EndpointAutoScalingRuleRow, EndpointAut
         return EndpointAutoScalingRuleRow.id
 
     @override
-    def target_id_value(self) -> UUID:
-        return self.rule_id
+    def target_id_value(self) -> AutoScalingRuleID:
+        return AutoScalingRuleID(self.rule_id)
 
     @property
     @override

--- a/src/ai/backend/manager/models/entity_label/purgers.py
+++ b/src/ai/backend/manager/models/entity_label/purgers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -37,7 +36,7 @@ class EntityLabelPurger(FieldPurger[EntityLabelRow, EntityLabelData]):
         return EntityLabelRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> EntityLabelID:
         return self.label_id
 
     @override

--- a/src/ai/backend/manager/models/entity_share/updaters.py
+++ b/src/ai/backend/manager/models/entity_share/updaters.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
@@ -65,7 +64,7 @@ class _RecipientInvitationUpdater(GuardedDataUpdater[EntityShareRow, EntityShare
         return EntityShareRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> EntityShareID:
         return self.share_id
 
     def addressed_to_scope(self) -> QueryCondition:
@@ -214,7 +213,7 @@ class EntityShareRevokeUpdater(GuardedDataUpdater[EntityShareRow, EntityShareDat
         return EntityShareRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> EntityShareID:
         return self.share_id
 
     @override
@@ -263,7 +262,7 @@ class EntityShareCancelUpdater(GuardedDataUpdater[EntityShareRow, EntityShareDat
         return EntityShareRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> EntityShareID:
         return self.share_id
 
     @override

--- a/src/ai/backend/manager/models/error_log/updaters.py
+++ b/src/ai/backend/manager/models/error_log/updaters.py
@@ -6,10 +6,10 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
+from ai.backend.common.data.entity.error_log import ErrorLogID
 from ai.backend.manager.data.error_log.types import ErrorLogData
 from ai.backend.manager.models.error_log.row import ErrorLogRow
 from ai.backend.manager.models.specs.types import IntegrityErrorCheck
@@ -36,8 +36,8 @@ class ErrorLogSoftDeleteUpdater(DataUpdater[ErrorLogRow, ErrorLogData]):
         return ErrorLogRow.id
 
     @override
-    def target_id_value(self) -> UUID:
-        return self.log_id
+    def target_id_value(self) -> ErrorLogID:
+        return ErrorLogID(self.log_id)
 
     @override
     def build_values(self) -> dict[str, Any]:

--- a/src/ai/backend/manager/models/huggingface_registry/updaters.py
+++ b/src/ai/backend/manager/models/huggingface_registry/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -35,7 +34,7 @@ class HuggingFaceRegistryUpdater(DataUpdater[HuggingFaceRegistryRow, HuggingFace
         return HuggingFaceRegistryRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ArtifactRegistryID:
         return self.registry_id
 
     @property

--- a/src/ai/backend/manager/models/kernel/lookups.py
+++ b/src/ai/backend/manager/models/kernel/lookups.py
@@ -11,6 +11,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.kernel import KernelID
 from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.types import FieldType
 from ai.backend.manager.models.kernel.row import KernelRow
 from ai.backend.manager.models.specs.lookup import FieldOwnerKeyLookup, FieldOwnerLookup
 
@@ -24,6 +25,10 @@ class KernelSessionLookup(FieldOwnerKeyLookup[SessionID]):
     """
 
     kernel_id: KernelID
+
+    @override
+    def field_type(self) -> FieldType:
+        return KernelID.field_type()
 
     @override
     def build_query(self) -> sa.sql.Select[Any]:

--- a/src/ai/backend/manager/models/keypair/lookups.py
+++ b/src/ai/backend/manager/models/keypair/lookups.py
@@ -10,7 +10,8 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.keypair import KeyPairID
-from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.entity.types import EntityType, FieldType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.keypair.row import KeyPairRow
@@ -42,6 +43,10 @@ class KeypairAccessKeyOwnerLookup(FieldOwnerKeyLookup[UserID]):
     access_key: AccessKey
 
     @override
+    def field_type(self) -> FieldType:
+        return KeyPairID.field_type()
+
+    @override
     def build_query(self) -> sa.sql.Select[Any]:
         return sa.select(KeyPairRow.user).where(KeyPairRow.access_key == self.access_key)
 
@@ -55,6 +60,10 @@ class KeypairAccessKeyLookup(FieldKeyLookup[KeyPairID, UserID]):
     """Reads the keypair an access key names, and the user that owns it."""
 
     access_key: AccessKey
+
+    @override
+    def field_type(self) -> FieldType:
+        return KeyPairID.field_type()
 
     @override
     def build_query(self) -> sa.sql.Select[Any]:
@@ -80,6 +89,10 @@ class KeypairAccessKeyUserLookup(DataLookup[KeyPairRow, UserID]):
     @override
     def row_class(self) -> type[KeyPairRow]:
         return KeyPairRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return UserEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/keypair/purgers.py
+++ b/src/ai/backend/manager/models/keypair/purgers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -37,7 +36,7 @@ class NonDefaultKeypairPurger(GuardedFieldPurger[KeyPairRow, KeyPairData]):
         return KeyPairRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> KeyPairID:
         return self.keypair_id
 
     @override

--- a/src/ai/backend/manager/models/keypair/updaters.py
+++ b/src/ai/backend/manager/models/keypair/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -38,7 +37,7 @@ class KeypairDotfilesUpdater(DataUpdater[KeyPairRow, KeyPairData]):
         return KeyPairRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> KeyPairID:
         return self.keypair_id
 
     @override
@@ -72,7 +71,7 @@ class KeypairBootstrapScriptUpdater(DataUpdater[KeyPairRow, KeyPairData]):
         return KeyPairRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> KeyPairID:
         return self.keypair_id
 
     @override
@@ -115,7 +114,7 @@ class KeypairUpdater(GuardedDataUpdater[KeyPairRow, KeyPairData]):
         return KeyPairRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> KeyPairID:
         return self.keypair_id
 
     @override

--- a/src/ai/backend/manager/models/login_client_type/updaters.py
+++ b/src/ai/backend/manager/models/login_client_type/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -33,7 +32,7 @@ class LoginClientTypeUpdater(DataUpdater[LoginClientTypeRow, LoginClientTypeData
         return LoginClientTypeRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> LoginClientTypeID:
         return self.login_client_type_id
 
     @property

--- a/src/ai/backend/manager/models/model_card/updaters.py
+++ b/src/ai/backend/manager/models/model_card/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -51,7 +50,7 @@ class ModelCardUpdater(DataUpdater[ModelCardRow, ModelCardData]):
         return ModelCardRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ModelCardID:
         return self.card_id
 
     @property

--- a/src/ai/backend/manager/models/notification/updaters.py
+++ b/src/ai/backend/manager/models/notification/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -48,7 +47,7 @@ class NotificationChannelUpdater(DataUpdater[NotificationChannelRow, Notificatio
         return NotificationChannelRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> NotificationChannelID:
         return self.channel_id
 
     @property
@@ -92,7 +91,7 @@ class NotificationRuleUpdater(DataUpdater[NotificationRuleRow, NotificationRuleD
         return NotificationRuleRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> NotificationRuleID:
         return self.rule_id
 
     @property

--- a/src/ai/backend/manager/models/object_storage/updaters.py
+++ b/src/ai/backend/manager/models/object_storage/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -37,7 +36,7 @@ class ObjectStorageUpdater(DataUpdater[ObjectStorageRow, ObjectStorageData]):
         return ObjectStorageRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ObjectStorageID:
         return self.storage_id
 
     @property

--- a/src/ai/backend/manager/models/project/lookups.py
+++ b/src/ai/backend/manager/models/project/lookups.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DomainName
-from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.data.project.types import ProjectType
 from ai.backend.manager.models.clauses import QueryCondition
@@ -28,6 +29,10 @@ class ProjectNameInDomainLookup(DataLookup[ProjectRow, ProjectID]):
     @override
     def row_class(self) -> type[ProjectRow]:
         return ProjectRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return ProjectEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:
@@ -54,6 +59,10 @@ class PersonalProjectOfUserLookup(DataLookup[ProjectRow, ProjectID]):
     @override
     def row_class(self) -> type[ProjectRow]:
         return ProjectRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return ProjectEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/project/updaters.py
+++ b/src/ai/backend/manager/models/project/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -56,7 +55,7 @@ class ProjectUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
         return ProjectRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ProjectID:
         return self.project_id
 
     @override
@@ -111,7 +110,7 @@ class ProjectDotfilesUpdater(DataUpdater[ProjectRow, ProjectData]):
         return ProjectRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ProjectID:
         return self.project_id
 
     @override
@@ -145,7 +144,7 @@ class ProjectSoftDeleteUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
         return ProjectRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ProjectID:
         return self.project_id
 
     @override
@@ -196,7 +195,7 @@ class ProjectRestoreUpdater(GuardedDataUpdater[ProjectRow, ProjectData]):
         return ProjectRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ProjectID:
         return self.project_id
 
     @override

--- a/src/ai/backend/manager/models/prometheus_query_preset/updaters.py
+++ b/src/ai/backend/manager/models/prometheus_query_preset/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
@@ -56,7 +55,7 @@ class PrometheusQueryPresetUpdater(
         return PrometheusQueryPresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> PrometheusQueryPresetID:
         return self.preset_id
 
     @property

--- a/src/ai/backend/manager/models/rbac_models/permission/purgers.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/purgers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -30,7 +29,7 @@ class RolePermissionPurger(FieldPurger[PermissionRow, PermissionData]):
         return PermissionRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> PermissionID:
         return self.permission_id
 
     @override

--- a/src/ai/backend/manager/models/rbac_models/permission/updaters.py
+++ b/src/ai/backend/manager/models/rbac_models/permission/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -36,7 +35,7 @@ class RolePermissionUpdater(DataUpdater[PermissionRow, PermissionData]):
         return PermissionRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> PermissionID:
         return self.permission_id
 
     @override

--- a/src/ai/backend/manager/models/rbac_models/role/updaters.py
+++ b/src/ai/backend/manager/models/rbac_models/role/updaters.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
@@ -48,7 +47,7 @@ class RoleUpdater(GuardedDataUpdater[RoleRow, RoleData]):
         return RoleRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RoleID:
         return self.role_id
 
     @override
@@ -97,7 +96,7 @@ class RoleSoftDeleteUpdater(GuardedDataUpdater[RoleRow, RoleData]):
         return RoleRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RoleID:
         return self.role_id
 
     @override
@@ -139,7 +138,7 @@ class RoleRestoreUpdater(DataUpdater[RoleRow, RoleData]):
         return RoleRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RoleID:
         return self.role_id
 
     @property

--- a/src/ai/backend/manager/models/rbac_models/role_permission_preset/purgers.py
+++ b/src/ai/backend/manager/models/rbac_models/role_permission_preset/purgers.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -31,7 +30,7 @@ class RolePermissionPresetPurger(FieldPurger[RolePermissionPresetRow, RolePermis
         return RolePermissionPresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RolePermissionPresetID:
         return self.permission_preset_id
 
     @override

--- a/src/ai/backend/manager/models/rbac_models/role_preset/updaters.py
+++ b/src/ai/backend/manager/models/rbac_models/role_preset/updaters.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -42,7 +41,7 @@ class RolePresetUpdater(DataUpdater[RolePresetRow, RolePresetData]):
         return RolePresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RolePresetID:
         return self.preset_id
 
     @property
@@ -80,7 +79,7 @@ class RolePresetSoftDeleteUpdater(DataUpdater[RolePresetRow, RolePresetData]):
         return RolePresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RolePresetID:
         return self.preset_id
 
     @property
@@ -113,7 +112,7 @@ class RolePresetRestoreUpdater(DataUpdater[RolePresetRow, RolePresetData]):
         return RolePresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RolePresetID:
         return self.preset_id
 
     @property

--- a/src/ai/backend/manager/models/replica_group/updaters.py
+++ b/src/ai/backend/manager/models/replica_group/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
@@ -47,7 +46,7 @@ class ReplicaGroupDeployUpdater(DataUpdater[ReplicaGroupRow, ReplicaGroupData]):
         return ReplicaGroupRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ReplicaGroupID:
         return self.replica_group_id
 
     @property
@@ -90,7 +89,7 @@ class ReplicaGroupScalingUpdater(DataUpdater[ReplicaGroupRow, ReplicaGroupData])
         return ReplicaGroupRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ReplicaGroupID:
         return self.replica_group_id
 
     @property
@@ -137,7 +136,7 @@ class ReplicaGroupLifecycleUpdater(DataUpdater[ReplicaGroupRow, ReplicaGroupData
         return ReplicaGroupRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ReplicaGroupID:
         return self.replica_group_id
 
     @property

--- a/src/ai/backend/manager/models/reservoir_registry/updaters.py
+++ b/src/ai/backend/manager/models/reservoir_registry/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -37,7 +36,7 @@ class ReservoirRegistryUpdater(DataUpdater[ReservoirRegistryRow, ReservoirRegist
         return ReservoirRegistryRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ArtifactRegistryID:
         return self.registry_id
 
     @property

--- a/src/ai/backend/manager/models/resource_group/lookups.py
+++ b/src/ai/backend/manager/models/resource_group/lookups.py
@@ -9,7 +9,12 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.resource_group import ResourceGroupID, ResourceGroupName
+from ai.backend.common.data.entity.resource_group import (
+    ResourceGroupEntityType,
+    ResourceGroupID,
+    ResourceGroupName,
+)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.resource_group.row import ResourceGroupRow
 from ai.backend.manager.models.specs.lookup import BulkDataLookup, DataLookup
@@ -24,6 +29,10 @@ class ResourceGroupNameLookup(DataLookup[ResourceGroupRow, ResourceGroupID]):
     @override
     def row_class(self) -> type[ResourceGroupRow]:
         return ResourceGroupRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return ResourceGroupEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/resource_policy/lookups.py
+++ b/src/ai/backend/manager/models/resource_policy/lookups.py
@@ -7,10 +7,14 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.resource_policy import (
+    KeyPairResourcePolicyEntityType,
     KeyPairResourcePolicyUUID,
+    ProjectResourcePolicyEntityType,
     ProjectResourcePolicyUUID,
+    UserResourcePolicyEntityType,
     UserResourcePolicyUUID,
 )
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.resource_policy.row import (
     KeyPairResourcePolicyRow,
@@ -31,6 +35,10 @@ class KeypairResourcePolicyNameLookup(
     @override
     def row_class(self) -> type[KeyPairResourcePolicyRow]:
         return KeyPairResourcePolicyRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return KeyPairResourcePolicyEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:
@@ -54,6 +62,10 @@ class ProjectResourcePolicyNameLookup(
         return ProjectResourcePolicyRow
 
     @override
+    def entity_type(self) -> EntityType:
+        return ProjectResourcePolicyEntityType()
+
+    @override
     def conditions(self) -> Sequence[QueryCondition]:
         return [lambda: ProjectResourcePolicyRow.name == self.name]
 
@@ -71,6 +83,10 @@ class UserResourcePolicyNameLookup(DataLookup[UserResourcePolicyRow, UserResourc
     @override
     def row_class(self) -> type[UserResourcePolicyRow]:
         return UserResourcePolicyRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return UserResourcePolicyEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/resource_policy/updaters.py
+++ b/src/ai/backend/manager/models/resource_policy/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -60,7 +59,7 @@ class KeyPairResourcePolicyUpdater(
         return KeyPairResourcePolicyRow.uuid
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> KeyPairResourcePolicyUUID:
         return self.policy_id
 
     @property
@@ -115,7 +114,7 @@ class UserResourcePolicyUpdater(DataUpdater[UserResourcePolicyRow, UserResourceP
         return UserResourcePolicyRow.uuid
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> UserResourcePolicyUUID:
         return self.policy_id
 
     @property
@@ -160,7 +159,7 @@ class ProjectResourcePolicyUpdater(
         return ProjectResourcePolicyRow.uuid
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ProjectResourcePolicyUUID:
         return self.policy_id
 
     @property

--- a/src/ai/backend/manager/models/resource_preset/lookups.py
+++ b/src/ai/backend/manager/models/resource_preset/lookups.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_preset import ResourcePresetID
+from ai.backend.common.data.entity.resource_preset import (
+    ResourcePresetEntityType,
+    ResourcePresetID,
+)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.resource_preset.row import ResourcePresetRow
 from ai.backend.manager.models.specs.lookup import DataLookup
@@ -22,6 +26,10 @@ class ResourcePresetNameLookup(DataLookup[ResourcePresetRow, ResourcePresetID]):
     @override
     def row_class(self) -> type[ResourcePresetRow]:
         return ResourcePresetRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return ResourcePresetEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/resource_preset/updaters.py
+++ b/src/ai/backend/manager/models/resource_preset/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -38,7 +37,7 @@ class ResourcePresetUpdater(DataUpdater[ResourcePresetRow, ResourcePresetData]):
         return ResourcePresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ResourcePresetID:
         return self.preset_id
 
     @property

--- a/src/ai/backend/manager/models/resource_slot/lookups.py
+++ b/src/ai/backend/manager/models/resource_slot/lookups.py
@@ -11,7 +11,11 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.agent_resource import AgentResourceID
-from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeUUID
+from ai.backend.common.data.entity.resource_slot import (
+    ResourceSlotTypeEntityType,
+    ResourceSlotTypeUUID,
+)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.agent.row import AgentRow
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.resource_slot.row import AgentResourceRow, ResourceSlotTypeRow
@@ -27,6 +31,10 @@ class ResourceSlotTypeLookup(DataLookup[ResourceSlotTypeRow, ResourceSlotTypeUUI
     @override
     def row_class(self) -> type[ResourceSlotTypeRow]:
         return ResourceSlotTypeRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return ResourceSlotTypeEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/resource_slot/updaters.py
+++ b/src/ai/backend/manager/models/resource_slot/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -49,7 +48,7 @@ class ResourceSlotTypeUpdater(DataUpdater[ResourceSlotTypeRow, ResourceSlotTypeD
         return ResourceSlotTypeRow.uuid
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ResourceSlotTypeUUID:
         return self.slot_type_id
 
     @property

--- a/src/ai/backend/manager/models/retention/updaters.py
+++ b/src/ai/backend/manager/models/retention/updaters.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -36,7 +35,7 @@ class RetentionPolicyUpdater(DataUpdater[RetentionPolicyRow, RetentionPolicyData
         return RetentionPolicyRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RetentionPolicyID:
         return self.policy_id
 
     @property
@@ -74,7 +73,7 @@ class LastSweptAtUpdater(DataUpdater[RetentionPolicyRow, RetentionPolicyData]):
         return RetentionPolicyRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RetentionPolicyID:
         return self.policy_id
 
     @property

--- a/src/ai/backend/manager/models/routing/updaters.py
+++ b/src/ai/backend/manager/models/routing/updaters.py
@@ -52,7 +52,7 @@ class ReplicaUpdater(DataUpdater[RoutingRow, RoutingData]):
         return RoutingRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> ReplicaID:
         return self.replica_id
 
     @property

--- a/src/ai/backend/manager/models/runtime_variant/lookups.py
+++ b/src/ai/backend/manager/models/runtime_variant/lookups.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
+from ai.backend.common.data.entity.runtime_variant import (
+    RuntimeVariantEntityType,
+    RuntimeVariantID,
+)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.runtime_variant.row import RuntimeVariantRow
 from ai.backend.manager.models.specs.lookup import DataLookup
@@ -25,6 +29,10 @@ class RuntimeVariantLookup(DataLookup[RuntimeVariantRow, RuntimeVariantID]):
     @override
     def row_class(self) -> type[RuntimeVariantRow]:
         return RuntimeVariantRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return RuntimeVariantEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/runtime_variant/updaters.py
+++ b/src/ai/backend/manager/models/runtime_variant/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -33,7 +32,7 @@ class RuntimeVariantUpdater(DataUpdater[RuntimeVariantRow, RuntimeVariantData]):
         return RuntimeVariantRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RuntimeVariantID:
         return self.variant_id
 
     @property

--- a/src/ai/backend/manager/models/runtime_variant_preset/updaters.py
+++ b/src/ai/backend/manager/models/runtime_variant_preset/updaters.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -51,7 +50,7 @@ class RuntimeVariantPresetUpdater(DataUpdater[RuntimeVariantPresetRow, RuntimeVa
         return RuntimeVariantPresetRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> RuntimeVariantPresetID:
         return self.preset_id
 
     @property

--- a/src/ai/backend/manager/models/session/lookups.py
+++ b/src/ai/backend/manager/models/session/lookups.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from typing import override
 from uuid import UUID
 
-from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.data.session.types import SessionStatus
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.session.row import SessionRow
@@ -29,6 +30,10 @@ class SessionNameOfUserLookup(DataLookup[SessionRow, SessionID]):
     @override
     def row_class(self) -> type[SessionRow]:
         return SessionRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return SessionEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/session/updaters.py
+++ b/src/ai/backend/manager/models/session/updaters.py
@@ -4,7 +4,6 @@ from collections.abc import Collection, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -42,7 +41,7 @@ class SessionUpdater(DataUpdater[SessionRow, SessionData]):
         return SessionRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> SessionID:
         return self.session_id
 
     @property

--- a/src/ai/backend/manager/models/specs/lookup.py
+++ b/src/ai/backend/manager/models/specs/lookup.py
@@ -13,6 +13,7 @@ from ai.backend.common.data.entity.types import (
     EntityIdentifier,
     EntityType,
     FieldIdentifier,
+    FieldType,
     RuntimeEntityID,
 )
 from ai.backend.manager.models.base import Base
@@ -60,6 +61,11 @@ class DataLookup[TRow: Base, TEntityID: EntityIdentifier](ABC):
     @abstractmethod
     def row_class(self) -> type[TRow]:
         """Return the ORM class the key resolves within."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def entity_type(self) -> EntityType:
+        """Return the type of the entity the key resolves."""
         raise NotImplementedError
 
     @abstractmethod
@@ -182,6 +188,11 @@ class FieldOwnerKeyLookup[TOwnerID: EntityIdentifier](ABC):
     """
 
     @abstractmethod
+    def field_type(self) -> FieldType:
+        """Return the type of field row the key names."""
+        raise NotImplementedError
+
+    @abstractmethod
     def build_query(self) -> sa.sql.Select[Any]:
         """Build the query selecting the owning entity's id for the key this carries."""
         raise NotImplementedError
@@ -203,6 +214,11 @@ class FieldKeyLookup[TFieldID: FieldIdentifier, TOwnerID: EntityIdentifier](ABC)
     A query rather than conditions, for the same reason :class:`FieldOwnerKeyLookup` is
     one: an owner reached through a join is expressible.
     """
+
+    @abstractmethod
+    def field_type(self) -> FieldType:
+        """Return the type of field row the key names."""
+        raise NotImplementedError
 
     @abstractmethod
     def build_query(self) -> sa.sql.Select[Any]:

--- a/src/ai/backend/manager/models/specs/purger.py
+++ b/src/ai/backend/manager/models/specs/purger.py
@@ -11,12 +11,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any, final, override
-from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
-from ai.backend.common.data.entity.types import EntityIdentifier, FieldData
+from ai.backend.common.data.entity.types import EntityIdentifier, FieldData, FieldIdentifier
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.types import ConflictCheck, GuardCheck
 
@@ -96,7 +95,7 @@ class GuardedFieldPurger[TRow: Base, TData: FieldData](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> FieldIdentifier:
         """Return the id of the field row to delete."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/models/specs/updater.py
+++ b/src/ai/backend/manager/models/specs/updater.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Any, final, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
+from ai.backend.common.data.entity.types import EntityIdentifier, FieldIdentifier
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.specs.types import GuardCheck, IntegrityErrorCheck
@@ -48,8 +48,8 @@ class GuardedDataUpdater[TRow: Base, TData](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def target_id_value(self) -> UUID:
-        """Return the id of the row to write."""
+    def target_id_value(self) -> EntityIdentifier | FieldIdentifier:
+        """Return the id of the row to write: the entity's, or the field row's own."""
         raise NotImplementedError
 
     @abstractmethod

--- a/src/ai/backend/manager/models/storage_namespace/lookups.py
+++ b/src/ai/backend/manager/models/storage_namespace/lookups.py
@@ -7,7 +7,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.storage_namespace import StorageNamespaceID
+from ai.backend.common.data.entity.storage_namespace import (
+    StorageNamespaceEntityType,
+    StorageNamespaceID,
+)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.storage_namespace import StorageNamespaceRow
@@ -27,6 +31,10 @@ class StorageNamespaceLookup(DataLookup[StorageNamespaceRow, StorageNamespaceID]
     @override
     def row_class(self) -> type[StorageNamespaceRow]:
         return StorageNamespaceRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return StorageNamespaceEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/user/lookups.py
+++ b/src/ai/backend/manager/models/user/lookups.py
@@ -6,7 +6,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.user import UserID
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.user.row import UserRow
@@ -21,6 +22,10 @@ class UserEmailLookup(DataLookup[UserRow, UserID]):
     @override
     def row_class(self) -> type[UserRow]:
         return UserRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return UserEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/user/updaters.py
+++ b/src/ai/backend/manager/models/user/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -56,7 +55,7 @@ class UserUpdater(DataUpdater[UserRow, UserData]):
         return UserRow.uuid
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> UserID:
         return self.user_id
 
     @override

--- a/src/ai/backend/manager/models/vfolder/lookups.py
+++ b/src/ai/backend/manager/models/vfolder/lookups.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from ai.backend.common.data.entity.types import FieldType
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
 from ai.backend.manager.models.specs.lookup import FieldKeyLookup
@@ -27,6 +28,10 @@ class VFolderMountPermissionLookup(FieldKeyLookup[VFolderPermissionID, VFolderUU
 
     vfolder_id: VFolderUUID
     user_id: uuid.UUID
+
+    @override
+    def field_type(self) -> FieldType:
+        return VFolderPermissionID.field_type()
 
     @override
     def build_query(self) -> sa.sql.Select[Any]:

--- a/src/ai/backend/manager/models/vfs_storage/lookups.py
+++ b/src/ai/backend/manager/models/vfs_storage/lookups.py
@@ -6,7 +6,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.vfs_storage import VFSStorageID
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.entity.vfs_storage import VFSStorageEntityType, VFSStorageID
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.specs.lookup import DataLookup
 from ai.backend.manager.models.vfs_storage.row import VFSStorageRow
@@ -21,6 +22,10 @@ class VFSStorageLookup(DataLookup[VFSStorageRow, VFSStorageID]):
     @override
     def row_class(self) -> type[VFSStorageRow]:
         return VFSStorageRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return VFSStorageEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/src/ai/backend/manager/models/vfs_storage/updaters.py
+++ b/src/ai/backend/manager/models/vfs_storage/updaters.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
-from uuid import UUID
 
 from sqlalchemy.orm import InstrumentedAttribute
 
@@ -34,7 +33,7 @@ class VFSStorageUpdater(DataUpdater[VFSStorageRow, VFSStorageData]):
         return VFSStorageRow.id
 
     @override
-    def target_id_value(self) -> UUID:
+    def target_id_value(self) -> VFSStorageID:
         return self.storage_id
 
     @property

--- a/src/ai/backend/manager/repositories/KNOWLEDGE.md
+++ b/src/ai/backend/manager/repositories/KNOWLEDGE.md
@@ -48,8 +48,9 @@ pass-through would remain.
   scoped spec cannot flow through a registration-free path.
 - There is no `delete`: which column marks a row deleted is domain knowledge, so a
   delete action carries a `DataUpdater` and runs the update path.
-- `OpsRepository` turns a missing row into `EntityNotFoundError` rather than `None` —
-  that seam is the only thing it adds over ops.
+- `OpsRepository` turns a missing row into `EntityNotFoundError` / `FieldNotFoundError`
+  rather than `None` — that seam is the only thing it adds over ops. The error's domain
+  is read off the identifier the spec carries, or off the lookup for a row named by key.
 
 ## Gradual migration to the ops provider
 

--- a/src/ai/backend/manager/repositories/ops/repository.py
+++ b/src/ai/backend/manager/repositories/ops/repository.py
@@ -16,8 +16,11 @@ from ai.backend.common.data.entity.types import (
     FieldIdentifier,
     RuntimeEntityID,
 )
+from ai.backend.common.exception import BackendAIError
+from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.models.scopes import OperationScope
 from ai.backend.manager.models.specs.creator import (
     DanglingFieldCreator,
@@ -78,8 +81,11 @@ class OpsRepository[TData]:
         async with self._ops.read_ops() as r:
             data = await r.query_data(querier)
             if data is None:
+                entity_id = querier.entity_id_value()
                 raise EntityNotFoundError(
-                    f"{querier.row_class().__name__} {querier.entity_id_value()} not found"
+                    entity_type=entity_id.entity_type(),
+                    operation=ActionOperationType.GET,
+                    extra_msg=f"{querier.row_class().__name__} {entity_id} not found",
                 )
             return data
 
@@ -101,8 +107,10 @@ class OpsRepository[TData]:
         async with self._ops.read_ops() as r:
             data = await r.query_field_data(querier)
             if data is None:
-                raise EntityNotFoundError(
-                    f"{querier.row_class().__name__} {querier.target_id_value()} not found"
+                field_id = querier.target_id_value()
+                raise FieldNotFoundError(
+                    f"{querier.row_class().__name__} {field_id} not found",
+                    field_type=field_id.field_type(),
                 )
             return data
 
@@ -117,7 +125,11 @@ class OpsRepository[TData]:
         async with self._ops.read_ops() as r:
             entity_id = await r.lookup_entity_id(lookup)
             if entity_id is None:
-                raise EntityNotFoundError(f"No {lookup.row_class().__name__} matches the given key")
+                raise EntityNotFoundError(
+                    f"No {lookup.row_class().__name__} matches the given key",
+                    entity_type=lookup.entity_type(),
+                    operation=ActionOperationType.LOOKUP,
+                )
             return entity_id
 
     async def bulk_lookup[TKey, TEntityID: EntityIdentifier](
@@ -161,7 +173,11 @@ class OpsRepository[TData]:
         owners = await self.field_owners(lookup, [field_id])
         owner = owners.get(field_id)
         if owner is None:
-            raise EntityNotFoundError("No field row matches the given id")
+            raise FieldNotFoundError(
+                "No field row matches the given id",
+                field_type=field_id.field_type(),
+                operation=ActionOperationType.LOOKUP,
+            )
         return owner
 
     async def runtime_field_owners(
@@ -178,7 +194,11 @@ class OpsRepository[TData]:
         owners = await self.runtime_field_owners(lookup, [field_id])
         owner = owners.get(field_id)
         if owner is None:
-            raise EntityNotFoundError("No field row matches the given id")
+            raise FieldNotFoundError(
+                "No field row matches the given id",
+                field_type=field_id.field_type(),
+                operation=ActionOperationType.LOOKUP,
+            )
         return owner
 
     async def field_owner_by_key[TOwnerID: EntityIdentifier](
@@ -192,7 +212,11 @@ class OpsRepository[TData]:
         async with self._ops.read_ops() as r:
             owner = await r.lookup_field_owner_by_key(lookup)
         if owner is None:
-            raise EntityNotFoundError("No field row matches the given key")
+            raise FieldNotFoundError(
+                "No field row matches the given key",
+                field_type=lookup.field_type(),
+                operation=ActionOperationType.LOOKUP,
+            )
         return owner
 
     async def field_by_key[TFieldID: FieldIdentifier, TOwnerID: EntityIdentifier](
@@ -206,7 +230,11 @@ class OpsRepository[TData]:
         async with self._ops.read_ops() as r:
             resolved = await r.lookup_field_by_key(lookup)
         if resolved is None:
-            raise EntityNotFoundError("No field row matches the given key")
+            raise FieldNotFoundError(
+                "No field row matches the given key",
+                field_type=lookup.field_type(),
+                operation=ActionOperationType.LOOKUP,
+            )
         return resolved
 
     async def search_in_scopes(
@@ -385,8 +413,11 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             data = await w.purge_entity(purger)
             if data is None:
+                entity_id = purger.entity_id()
                 raise EntityNotFoundError(
-                    f"{purger.row_class().__name__} {purger.entity_id()} not found"
+                    entity_type=entity_id.entity_type(),
+                    operation=ActionOperationType.PURGE,
+                    extra_msg=f"{purger.row_class().__name__} {entity_id} not found",
                 )
             return data
 
@@ -398,8 +429,11 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             data = await w.purge_field_entity(purger)
             if data is None:
-                raise EntityNotFoundError(
-                    f"{purger.row_class().__name__} {purger.target_id_value()} not found"
+                field_id = purger.target_id_value()
+                raise FieldNotFoundError(
+                    f"{purger.row_class().__name__} {field_id} not found",
+                    field_type=field_id.field_type(),
+                    operation=ActionOperationType.PURGE,
                 )
             return data
 
@@ -456,10 +490,22 @@ class OpsRepository[TData]:
         async with self._ops.write_ops() as w:
             data = await w.update_data(updater)
             if data is None:
-                raise EntityNotFoundError(
-                    f"{updater.row_class.__name__} {updater.target_id_value()} not found"
-                )
+                raise self._missing_target(updater)
             return data
+
+    def _missing_target(self, updater: GuardedDataUpdater[Any, Any]) -> BackendAIError:
+        """The not-found error for the row an updater names, typed by the id it carries."""
+        target = updater.target_id_value()
+        msg = f"{updater.row_class.__name__} {target} not found"
+        if isinstance(target, FieldIdentifier):
+            return FieldNotFoundError(
+                msg,
+                field_type=target.field_type(),
+                operation=ActionOperationType.UPDATE,
+            )
+        return EntityNotFoundError(
+            msg, entity_type=target.entity_type(), operation=ActionOperationType.UPDATE
+        )
 
     async def partial_bulk_update(
         self, updaters: Mapping[EntityIdentifier, GuardedDataUpdater[Any, TData]]

--- a/src/ai/backend/manager/repositories/ops/v2/entity_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/entity_write.py
@@ -32,6 +32,7 @@ from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import RBACTypeConversionError
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import (
@@ -42,7 +43,7 @@ from ai.backend.manager.data.permission.types import (
 from ai.backend.manager.data.permission.types import (
     ScopeType as LegacyScopeType,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.errors.role_preset import InvalidRoleNameTemplate
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -221,7 +222,9 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
                     data = await self.purge_entity(purger)
                     if data is None:
                         raise EntityNotFoundError(
-                            f"{purger.row_class().__name__} {purger.entity_id()} not found"
+                            entity_type=entity_id.entity_type(),
+                            operation=ActionOperationType.PURGE,
+                            extra_msg=f"{purger.row_class().__name__} {entity_id} not found",
                         )
                     successes[entity_id] = data
             except Exception as e:

--- a/src/ai/backend/manager/repositories/ops/v2/field_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/field_write.py
@@ -8,8 +8,9 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ai.backend.common.data.entity.types import EntityIdentifier, FieldData, FieldIdentifier
+from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.creator import (
     FieldCreator,
@@ -140,7 +141,7 @@ class V2FieldWriteOps(V2WriteOpsBase):
         self, purgers: Mapping[FieldIdentifier, GuardedFieldPurger[TRow, TData]]
     ) -> BulkFieldOpsResult[TData]:
         """Delete each named field row independently in its own savepoint; a
-        missing row is answered with :class:`EntityNotFoundError` rather than
+        missing row is answered with :class:`FieldNotFoundError` rather than
         skipped. Authorized through the owner, like the single field purge."""
         successes: dict[FieldIdentifier, TData] = {}
         errors: dict[FieldIdentifier, Exception] = {}
@@ -149,8 +150,10 @@ class V2FieldWriteOps(V2WriteOpsBase):
                 async with self._sess.begin_nested():
                     data = await self.purge_field_entity(purger)
                     if data is None:
-                        raise EntityNotFoundError(
-                            f"{purger.row_class().__name__} {purger.target_id_value()} not found"
+                        raise FieldNotFoundError(
+                            f"{purger.row_class().__name__} {field_id} not found",
+                            field_type=field_id.field_type(),
+                            operation=ActionOperationType.PURGE,
                         )
                     successes[field_id] = data
             except Exception as e:

--- a/src/ai/backend/manager/repositories/ops/v2/update_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/update_write.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ai.backend.common.data.entity.types import EntityIdentifier
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.models.base import Base
 from ai.backend.manager.models.specs.types import BulkResultWithFailures
 from ai.backend.manager.models.specs.updater import GuardedDataUpdater
@@ -62,7 +63,9 @@ class V2UpdateWriteOps(V2WriteOpsBase):
                     )
                     if row is None:
                         raise EntityNotFoundError(
-                            f"{updater.row_class.__name__} {updater.target_id_value()} not found"
+                            entity_type=entity_id.entity_type(),
+                            operation=ActionOperationType.UPDATE,
+                            extra_msg=f"{updater.row_class.__name__} {entity_id} not found",
                         )
                     successes[entity_id] = updater.to_data(row)
             except Exception as e:

--- a/src/ai/backend/manager/repositories/role_preset/repository.py
+++ b/src/ai/backend/manager/repositories/role_preset/repository.py
@@ -11,12 +11,13 @@ from collections.abc import Mapping, Sequence
 from ai.backend.common.data.entity.role_permission_preset import RolePermissionPresetID
 from ai.backend.common.data.entity.role_preset import RolePresetID
 from ai.backend.common.data.entity.types import FieldIdentifier
+from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
 from ai.backend.manager.data.role_preset.types import (
     RolePermissionPresetData,
     RolePresetData,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.models.rbac_models.role_permission_preset.creators import (
     RolePermissionPresetCreator,
 )
@@ -42,7 +43,11 @@ class RolePresetRepository:
         async with self._ops.write_ops() as w:
             data = await w.update_data(updater)
             if data is None:
-                raise EntityNotFoundError(f"RolePresetRow {updater.preset_id} not found")
+                raise EntityNotFoundError(
+                    entity_type=updater.preset_id.entity_type(),
+                    operation=ActionOperationType.UPDATE,
+                    extra_msg=f"RolePresetRow {updater.preset_id} not found",
+                )
             await w.sync_preset_roles(updater.preset_id)
             return data
 

--- a/src/ai/backend/manager/services/idle_checker/KNOWLEDGE.md
+++ b/src/ai/backend/manager/services/idle_checker/KNOWLEDGE.md
@@ -69,5 +69,5 @@ the entity type, shape, operation, gate and backing.
 
 - An update or purge naming no row raises `EntityNotFoundError`, not
   `IdleCheckerNotFound`.
-- ops knows no domain, so the entity type travels in the message. Both are 404 and
-  only the `error_type` string differs.
+- ops reads the entity type off the identifier, so the code's domain is the same
+  `idle_checker`; both are 404 and only the `error_type` string differs.

--- a/src/ai/backend/manager/services/ops/service.py
+++ b/src/ai/backend/manager/services/ops/service.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from ai.backend.common.data.entity.types import EntityData, FieldData
 from ai.backend.manager.actions.run_status import ActionRunStatus
-from ai.backend.manager.actions.types import OperationStatus
+from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
 from ai.backend.manager.actions.v2.bulk.result import (
     PartialBulkEntityResult,
     PartialBulkResult,
@@ -88,7 +88,8 @@ from ai.backend.manager.actions.v2.ops.result import (
     ScopedBatchOpsResult,
     ScopedFieldsOpsResult,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.models.specs.types import BulkResultWithFailures
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 
@@ -222,7 +223,11 @@ class PartialBulkGetService[TData]:
                 if entity_id in found
                 else PartialBulkEntityResult[TData].failed(
                     entity_id,
-                    EntityNotFoundError(f"{querier.row_class().__name__} {entity_id} not found"),
+                    EntityNotFoundError(
+                        entity_type=entity_id.entity_type(),
+                        operation=ActionOperationType.GET,
+                        extra_msg=f"{querier.row_class().__name__} {entity_id} not found",
+                    ),
                 )
                 for entity_id in entity_ids
             ]
@@ -729,8 +734,9 @@ class FieldPartialBulkGetService[TData: FieldData]:
         return BulkFieldOpsResult(
             successes={field_id: found[field_id] for field_id in field_ids if field_id in found},
             errors={
-                field_id: EntityNotFoundError(
-                    f"{querier.row_class().__name__} {field_id} not found"
+                field_id: FieldNotFoundError(
+                    f"{querier.row_class().__name__} {field_id} not found",
+                    field_type=field_id.field_type(),
                 )
                 for field_id in field_ids
                 if field_id not in found

--- a/tests/unit/common/test_exception.py
+++ b/tests/unit/common/test_exception.py
@@ -120,9 +120,9 @@ class TestPassthroughErrorFromHttpStatus:
         err = PassthroughError.from_http_status(
             403,
             domain=ErrorDomain.CONTAINER_REGISTRY,
-            operation=ErrorOperation.LIST,
+            operation=ErrorOperation.SEARCH,
         )
-        assert str(err.error_code()) == "container-registry_list-query_forbidden"
+        assert str(err.error_code()) == "container-registry_search_forbidden"
 
     def test_maps_server_error_status(self) -> None:
         # The mapping covers server-error statuses too, not just 4xx.

--- a/tests/unit/manager/actions/test_action_types.py
+++ b/tests/unit/manager/actions/test_action_types.py
@@ -1,6 +1,9 @@
 """Tests for the action type system: ActionOperationType, EntityType, and enum enforcement."""
 
+import pytest
+
 from ai.backend.common.data.permission.types import EntityType, OperationType, Permission
+from ai.backend.common.exception import ErrorOperation
 from ai.backend.manager.actions.action.base import BaseAction
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.permission_contoller.actions.get_role_detail import (
@@ -46,6 +49,25 @@ class TestActionOperationType:
             "lookup",
         }
         assert {v.value for v in values} == expected
+
+    @pytest.mark.parametrize(
+        ("operation", "expected"),
+        [
+            (ActionOperationType.GET, ErrorOperation.READ),
+            (ActionOperationType.SEARCH, ErrorOperation.SEARCH),
+            (ActionOperationType.LOOKUP, ErrorOperation.READ),
+            (ActionOperationType.CREATE, ErrorOperation.CREATE),
+            (ActionOperationType.UPSERT, ErrorOperation.UPSERT),
+            (ActionOperationType.UPDATE, ErrorOperation.UPDATE),
+            (ActionOperationType.RESTORE, ErrorOperation.RESTORE),
+            (ActionOperationType.DELETE, ErrorOperation.SOFT_DELETE),
+            (ActionOperationType.PURGE, ErrorOperation.HARD_DELETE),
+        ],
+    )
+    def test_to_error_operation_mapping(
+        self, operation: ActionOperationType, expected: ErrorOperation
+    ) -> None:
+        assert operation.to_error_operation() is expected
 
     def test_to_permission_operation_mapping(self) -> None:
         assert ActionOperationType.GET.to_permission_operation() == OperationType.READ

--- a/tests/unit/manager/actions/test_lookup_permission_gate.py
+++ b/tests/unit/manager/actions/test_lookup_permission_gate.py
@@ -42,9 +42,10 @@ from ai.backend.manager.actions.v2.lookup.result import LookupActionProcessResul
 from ai.backend.manager.actions.v2.single_entity.trigger import SingleEntityActionTriggerMeta
 from ai.backend.manager.actions.v2.single_entity.validator import SingleEntityActionValidator
 from ai.backend.manager.actions.v2.validators import ActionValidators
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.errors.common import GenericBadRequest
 from ai.backend.manager.errors.permission import NotEnoughPermission
-from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 from ai.backend.manager.services.deployment.actions.lookup_owner import (
     LookupAutoScalingRuleDeploymentAction,
@@ -155,7 +156,7 @@ def action() -> _Action:
 
 
 async def _missing(_: _Action) -> _Result:
-    raise EntityNotFoundError("No Row matches the given key")
+    raise EntityNotFoundError("No Row matches the given key", entity_type=EntityType("row"))
 
 
 async def _resolved(_: _Action) -> _Result:
@@ -296,7 +297,10 @@ async def test_a_key_owner_lookup_merges_both_failures(
     denied_monitor = _RecordingMonitor()
 
     async def missing(*_: Any) -> EntityIdentifier:
-        raise EntityNotFoundError("No field row matches the given key")
+        raise FieldNotFoundError(
+            "No field row matches the given key",
+            field_type=KeyPairID.field_type(),
+        )
 
     async def found(*_: Any) -> EntityIdentifier:
         return owner_id
@@ -335,7 +339,10 @@ async def test_a_key_field_lookup_merges_both_failures(
     denied_monitor = _RecordingMonitor()
 
     async def missing(*_: Any) -> tuple[KeyPairID, UserID]:
-        raise EntityNotFoundError("No field row matches the given key")
+        raise FieldNotFoundError(
+            "No field row matches the given key",
+            field_type=KeyPairID.field_type(),
+        )
 
     async def found(*_: Any) -> tuple[KeyPairID, UserID]:
         return field_id, owner_id

--- a/tests/unit/manager/actions/test_partial_bulk_get_processor.py
+++ b/tests/unit/manager/actions/test_partial_bulk_get_processor.py
@@ -33,9 +33,9 @@ from ai.backend.manager.actions.v2.bulk.result import (
 )
 from ai.backend.manager.actions.v2.bulk.trigger import BulkActionTriggerMeta
 from ai.backend.manager.actions.v2.bulk.validator.base import PartialBulkActionValidator
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.errors.common import ServerMisconfiguredError
 from ai.backend.manager.errors.permission import NotEnoughPermission
-from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.errors.user import UserNotFound
 
 _STORAGE_ENTITY_TYPE = ObjectStorageEntityType()
@@ -121,7 +121,9 @@ class _Reader:
             items=[
                 PartialBulkEntityResult[str].succeeded(entity_id, f"data:{entity_id}")
                 if entity_id in self._present
-                else PartialBulkEntityResult[str].failed(entity_id, EntityNotFoundError("gone"))
+                else PartialBulkEntityResult[str].failed(
+                    entity_id, EntityNotFoundError(entity_type=_STORAGE_ENTITY_TYPE)
+                )
                 for entity_id in entity_ids
             ]
         )

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -56,8 +56,8 @@ from ai.backend.manager.data.deployment.types import (
     ResourceConfigData,
 )
 from ai.backend.manager.errors.auth import InsufficientPrivilege
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.errors.common import GenericForbidden
-from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.repositories.ops.repository import OpsRepository
 from ai.backend.manager.services.deployment.actions.scoped_search import (
     ScopedSearchDeploymentsActionResult,
@@ -314,7 +314,9 @@ class TestFieldBatchLoads:
     ) -> None:
         deployment_adapter, processors = adapter
         processors.deployment.bulk_get_access_tokens.run = AsyncMock(
-            side_effect=EntityNotFoundError("No field row matches the given ids")
+            side_effect=FieldNotFoundError(
+                field_type=DeploymentRevisionID.field_type(),
+            )
         )
 
         assert await deployment_adapter.batch_load_access_tokens_by_ids([

--- a/tests/unit/manager/api/adapters/test_scheduling_history_adapter.py
+++ b/tests/unit/manager/api/adapters/test_scheduling_history_adapter.py
@@ -16,8 +16,8 @@ from ai.backend.manager.actions.v2.ops.result import BulkFieldOpsResult
 from ai.backend.manager.api.adapters.scheduling_history.adapter import SchedulingHistoryAdapter
 from ai.backend.manager.data.kernel.types import KernelSchedulingHistoryData
 from ai.backend.manager.data.session.types import SchedulingResult, SessionSchedulingHistoryData
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.errors.common import GenericForbidden
-from ai.backend.manager.errors.repository import EntityNotFoundError
 
 READABLE = SessionSchedulingHistoryID(uuid.uuid4())
 DENIED = SessionSchedulingHistoryID(uuid.uuid4())
@@ -54,7 +54,9 @@ def processors(readable: SessionSchedulingHistoryData, denial: GenericForbidden)
         return_value=BulkFieldOpsResult(successes={READABLE: readable}, errors={DENIED: denial})
     )
     processors.scheduling_history.bulk_get_kernel_histories.run = AsyncMock(
-        side_effect=EntityNotFoundError("No field row matches the given ids")
+        side_effect=FieldNotFoundError(
+            field_type=KernelSchedulingHistoryID.field_type(),
+        )
     )
     return processors
 

--- a/tests/unit/manager/errors/test_entity_error.py
+++ b/tests/unit/manager/errors/test_entity_error.py
@@ -1,0 +1,168 @@
+"""The entity and field error bases: what they answer with, and that the roots
+cannot be constructed."""
+
+from __future__ import annotations
+
+import uuid
+from typing import override
+
+import pytest
+from aiohttp import web
+
+from ai.backend.common.data.entity.agent import AgentEntityType, AgentUUID
+from ai.backend.common.data.entity.audit_log import AuditLogFieldType, AuditLogID
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.kernel import KernelID
+from ai.backend.common.data.entity.replica import ReplicaFieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.exception import (
+    BackendAIError,
+    ErrorCode,
+    ErrorDetail,
+    ErrorDomain,
+    ErrorOperation,
+    InvalidErrorCode,
+)
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.agent import AgentAlreadyExited
+from ai.backend.manager.errors.base.entity import (
+    EntityError,
+    EntityErrorCode,
+    EntityNotFoundError,
+)
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode, FieldNotFoundError
+from ai.backend.manager.errors.base.not_found import NotFoundError
+
+
+class _Refused(EntityError, web.HTTPForbidden):
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.UPDATE, ErrorDetail.FORBIDDEN
+        )
+
+
+class _SessionRefused(EntityError, web.HTTPForbidden):
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(SessionEntityType(), ActionOperationType.GET, ErrorDetail.FORBIDDEN)
+
+
+class _Purged(EntityError, web.HTTPForbidden):
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.PURGE, ErrorDetail.FORBIDDEN
+        )
+
+
+class _KernelStuck(FieldError, web.HTTPConflict):
+    @override
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            KernelID.field_type(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
+        )
+
+
+class _ReplicaStuck(FieldError, web.HTTPConflict):
+    @override
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(ReplicaFieldType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT)
+
+
+class _DanglingRecord(FieldError, web.HTTPConflict):
+    @override
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(AuditLogFieldType(), ActionOperationType.GET, ErrorDetail.CONFLICT)
+
+
+class TestAbstractRootsAreNotConstructible:
+    """``Exception.__new__`` skips the abstract check, so the metaclass makes it."""
+
+    @pytest.mark.parametrize("cls", [BackendAIError, NotFoundError, EntityError, FieldError])
+    def test_a_root_that_owes_its_code_is_refused(self, cls: type[BackendAIError]) -> None:
+        with pytest.raises(TypeError, match="abstract error"):
+            cls()
+
+    def test_a_concrete_error_is_built(self) -> None:
+        assert _Refused().status_code == 403
+
+
+class TestEntityError:
+    def test_the_answered_triple_forms_the_code(self) -> None:
+        assert str(_Refused().error_code()) == "deployment_update_forbidden"
+
+    def test_the_body_carries_the_code_and_the_message(self) -> None:
+        err = _SessionRefused("why")
+        assert err.body_dict["error_code"] == "session_read_forbidden"
+        assert err.body_dict["msg"] == "why"
+
+    def test_the_action_operation_is_mapped(self) -> None:
+        assert _Purged().error_code().operation is ErrorOperation.HARD_DELETE
+        assert str(_Purged().error_code()) == "deployment_purge_forbidden"
+
+    def test_a_hand_written_error_keeps_its_code(self) -> None:
+        err = AgentAlreadyExited(AgentUUID(uuid.uuid4()))
+        assert str(err.error_code()) == "agent_update_conflict"
+
+    def test_not_found_takes_the_entity_type(self) -> None:
+        err = EntityNotFoundError(
+            entity_type=AgentEntityType(), operation=ActionOperationType.PURGE
+        )
+        assert str(err.error_code()) == "agent_purge_not-found"
+        assert err.status_code == 404
+        assert isinstance(err, NotFoundError)
+
+
+class TestFieldError:
+    def test_the_owner_and_the_row_form_the_domain(self) -> None:
+        assert str(_KernelStuck().error_code()) == "session-kernel_update_conflict"
+        assert str(_ReplicaStuck().error_code()) == "deployment-replica_update_conflict"
+
+    def test_a_dangling_row_reports_its_own_type_alone(self) -> None:
+        assert str(_DanglingRecord().error_code()) == "audit-log_read_conflict"
+
+    def test_not_found_takes_the_field_type(self) -> None:
+        err = FieldNotFoundError(field_type=KernelID.field_type())
+        assert str(err.error_code()) == "session-kernel_read_not-found"
+        assert err.status_code == 404
+        assert isinstance(err, NotFoundError)
+
+    def test_a_dangling_id_answers_the_same_way(self) -> None:
+        err = FieldNotFoundError(field_type=AuditLogID.field_type())
+        assert str(err.error_code()) == "audit-log_read_not-found"
+
+
+class TestErrorCodeRoundTrip:
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "user_read_not-found",
+            "model-deployment_update_forbidden",
+            "session-kernel_read_not-found",
+            "storage-proxy_request_internal-error",
+        ],
+    )
+    def test_from_str_reverses_str(self, code: str) -> None:
+        assert str(ErrorCode.from_str(code)) == code
+
+    def test_a_parsed_domain_compares_with_the_enum(self) -> None:
+        assert ErrorCode.from_str("agent_update_conflict").domain == ErrorDomain.AGENT
+
+    def test_a_hyphenated_domain_is_kept_whole(self) -> None:
+        parsed = ErrorCode.from_str("model-deployment_update_forbidden")
+        assert parsed.domain == "model-deployment"
+        assert parsed.operation is ErrorOperation.UPDATE
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "read_not-found",
+            "user_nope_not-found",
+            "model_deployment_update_forbidden",
+        ],
+    )
+    def test_malformed_codes_are_rejected(self, code: str) -> None:
+        """The last one is a domain that failed to hyphenate its compound word."""
+        with pytest.raises(InvalidErrorCode):
+            ErrorCode.from_str(code)

--- a/tests/unit/manager/models/resource_slot/test_agent_resource_field_specs.py
+++ b/tests/unit/manager/models/resource_slot/test_agent_resource_field_specs.py
@@ -38,20 +38,29 @@ async def agent_uuid(
         db_sess.add(ResourceSlotTypeRow(slot_name="cpu", slot_type="count", rank=40))
         db_sess.add(ResourceSlotTypeRow(slot_name="mem", slot_type="bytes", rank=10))
         await db_sess.flush()
+        found = await db_sess.scalar(sa.select(AgentRow.uuid).where(AgentRow.id == agent_id))
+        assert found is not None
+        owner = AgentUUID(found)
         db_sess.add(
             AgentResourceRow(
-                agent_id=agent_id, slot_name="cpu", capacity=Decimal(4), used=Decimal(1)
+                agent_id=agent_id,
+                agent_uuid=owner,
+                slot_name="cpu",
+                capacity=Decimal(4),
+                used=Decimal(1),
             )
         )
         db_sess.add(
             AgentResourceRow(
-                agent_id=agent_id, slot_name="mem", capacity=Decimal(1024), used=Decimal(512)
+                agent_id=agent_id,
+                agent_uuid=owner,
+                slot_name="mem",
+                capacity=Decimal(1024),
+                used=Decimal(512),
             )
         )
         await db_sess.flush()
-        found = await db_sess.scalar(sa.select(AgentRow.uuid).where(AgentRow.id == agent_id))
-        assert found is not None
-        return AgentUUID(found)
+        return owner
 
 
 @pytest.fixture

--- a/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_allow_list/test_repository.py
@@ -16,10 +16,8 @@ from ai.backend.manager.data.app_config.types import (
     AppConfigDefinitionData,
 )
 from ai.backend.manager.errors.app_config import AppConfigDefinitionNotFound
-from ai.backend.manager.errors.repository import (
-    EntityNotFoundError,
-    UniqueConstraintViolationError,
-)
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
+from ai.backend.manager.errors.repository import UniqueConstraintViolationError
 from ai.backend.manager.models.app_config_allow_list.conditions import (
     AppConfigAllowListConditions,
 )

--- a/tests/unit/manager/repositories/app_config_definition/test_repository.py
+++ b/tests/unit/manager/repositories/app_config_definition/test_repository.py
@@ -10,7 +10,7 @@ import pytest
 from ai.backend.common.data.entity.app_config_definition import AppConfigDefinitionID
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.data.app_config.types import AppConfigDefinitionData
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.models.app_config_definition.conditions import (
     AppConfigDefinitionConditions,
 )

--- a/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
+++ b/tests/unit/manager/repositories/artifact_revision/test_artifact_revision_repository.py
@@ -20,7 +20,7 @@ from ai.backend.manager.data.artifact.types import (
     ArtifactStatus,
     ArtifactType,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.artifact import ArtifactRow
 from ai.backend.manager.models.artifact_revision import ArtifactRevisionRow
@@ -393,7 +393,7 @@ class TestArtifactRevisionRepository:
         revision_ops: OpsRepository[ArtifactRevisionData],
     ) -> None:
         """Test retrieving non-existent artifact revision raises error"""
-        with pytest.raises(EntityNotFoundError):
+        with pytest.raises(FieldNotFoundError):
             await revision_ops.get_field(
                 ArtifactRevisionQuerier(revision_id=ArtifactRevisionID(uuid.uuid4()))
             )

--- a/tests/unit/manager/repositories/idle_checker/test_crud.py
+++ b/tests/unit/manager/repositories/idle_checker/test_crud.py
@@ -18,7 +18,7 @@ from ai.backend.common.data.idle_checker.types import (
 )
 from ai.backend.common.types import SessionTypes
 from ai.backend.manager.data.idle_checker.types import IdleCheckerData
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.models.entity_label.row import EntityLabelRow
 from ai.backend.manager.models.idle_checker.conditions import IdleCheckerConditions
 from ai.backend.manager.models.idle_checker.creators import IdleCheckerCreator

--- a/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
+++ b/tests/unit/manager/repositories/keypair_resource_policy/test_keypair_resource_policy.py
@@ -16,7 +16,7 @@ from ai.backend.common.types import (
     VFolderHostPermission,
 )
 from ai.backend.manager.data.resource.types import KeyPairResourcePolicyData
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.deployment_auto_scaling_policy import DeploymentAutoScalingPolicyRow

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -42,11 +42,8 @@ from ai.backend.manager.actions.v2.ops.base import SearchOpsAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.data.role_preset.types import RolePresetData
-from ai.backend.manager.errors.repository import (
-    AmbiguousEntityKeyError,
-    EmptyOperationScopeError,
-    EntityNotFoundError,
-)
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
+from ai.backend.manager.errors.repository import AmbiguousEntityKeyError, EmptyOperationScopeError
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.entity_label.row import EntityLabelRow
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -206,8 +203,8 @@ class _PresetFieldType(FieldType):
 
     @override
     @classmethod
-    def owner_type(cls) -> type[EntityType] | None:
-        return None
+    def owner_type(cls) -> type[EntityType]:
+        return RolePresetEntityType
 
 
 class _PresetFieldID(FieldIdentifier):
@@ -330,6 +327,10 @@ class _PresetByName(DataLookup[RolePresetRow, RolePresetID]):
     @override
     def row_class(self) -> type[RolePresetRow]:
         return RolePresetRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return RolePresetEntityType()
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:

--- a/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
+++ b/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
@@ -54,11 +54,9 @@ from ai.backend.manager.data.permission.types import (
 from ai.backend.manager.data.permission.types import (
     ScopeType as LegacyScopeType,
 )
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.errors.permission import VirtualEntityNotFound
-from ai.backend.manager.errors.repository import (
-    EntityNotFoundError,
-    RepositoryIntegrityError,
-)
+from ai.backend.manager.errors.repository import RepositoryIntegrityError
 from ai.backend.manager.models.base import GUID, Base
 from ai.backend.manager.models.entity_label.row import EntityLabelRow
 from ai.backend.manager.models.rbac_models.permission.permission import PermissionRow
@@ -955,12 +953,12 @@ _SIDECAR_FIELD_TYPE = _SidecarFieldType()
 
 
 class _SidecarID(FieldIdentifier):
+    """The id of a row that rides beside the graph."""
+
     @override
     @classmethod
     def field_type(cls) -> FieldType:
         return _SIDECAR_FIELD_TYPE
-
-    """The id of a row that rides beside the graph."""
 
 
 @dataclass(frozen=True)

--- a/tests/unit/manager/repositories/ops/v2/test_guarded_update.py
+++ b/tests/unit/manager/repositories/ops/v2/test_guarded_update.py
@@ -26,7 +26,15 @@ import sqlalchemy as sa
 from aiohttp import web
 from sqlalchemy.orm import InstrumentedAttribute, Mapped, mapped_column
 
-from ai.backend.common.data.entity.types import FieldData
+from ai.backend.common.data.entity.types import (
+    DanglingFieldType,
+    EntityIdentifier,
+    EntityType,
+    FieldData,
+    FieldIdentifier,
+    FieldType,
+    RuntimeEntityID,
+)
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -85,6 +93,37 @@ _TERMINAL = "terminal"
 _PINNED_NOTE = "pinned"
 
 
+class _RowEntityType(EntityType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "guarded_row"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "A row the guarded write tests operate on."
+
+
+class _RowFieldType(DanglingFieldType):
+    @override
+    @classmethod
+    def name(cls) -> str:
+        return "guarded_row_field"
+
+    @override
+    @classmethod
+    def description(cls) -> str:
+        return "The same row reached as a field row."
+
+
+class _RowFieldID(FieldIdentifier):
+    @override
+    @classmethod
+    def field_type(cls) -> FieldType:
+        return _RowFieldType()
+
+
 @dataclass
 class _StatusUpdater(GuardedDataUpdater[GuardedUpdateTestRow, _RowData]):
     """Writes a row's status unless it already reached the terminal one, or is pinned."""
@@ -103,8 +142,8 @@ class _StatusUpdater(GuardedDataUpdater[GuardedUpdateTestRow, _RowData]):
         return GuardedUpdateTestRow.id
 
     @override
-    def target_id_value(self) -> UUID:
-        return self.row_id
+    def target_id_value(self) -> EntityIdentifier:
+        return RuntimeEntityID(_RowEntityType(), self.row_id)
 
     @override
     def guard_checks(self) -> Sequence[GuardCheck]:
@@ -151,8 +190,8 @@ class _NonTerminalPurger(GuardedFieldPurger[GuardedUpdateTestRow, _RowData]):
         return GuardedUpdateTestRow.id
 
     @override
-    def target_id_value(self) -> UUID:
-        return self.row_id
+    def target_id_value(self) -> FieldIdentifier:
+        return _RowFieldID(self.row_id)
 
     @override
     def guard_checks(self) -> Sequence[GuardCheck]:

--- a/tests/unit/manager/repositories/permission_controller/test_role_permission_write.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_permission_write.py
@@ -16,8 +16,8 @@ from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.manager.data.permission.permission import PermissionData
 from ai.backend.manager.data.permission.status import RoleStatus
 from ai.backend.manager.data.permission.types import Permission, RoleSource
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.errors.permission import PermissionAlreadyGranted
-from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.rbac_models.permission.creators import RolePermissionCreator
 from ai.backend.manager.models.rbac_models.permission.lookups import RolePermissionOwnerLookup
@@ -110,4 +110,4 @@ class TestRolePermissionWrite:
         })
 
         assert set(result.successes) == {created.id}
-        assert isinstance(result.errors[unknown], EntityNotFoundError)
+        assert isinstance(result.errors[unknown], FieldNotFoundError)

--- a/tests/unit/manager/repositories/permission_controller/test_role_write.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_write.py
@@ -14,8 +14,8 @@ from ai.backend.common.data.entity.role import RoleEntityType, RoleID
 from ai.backend.common.data.permission.types import RoleSource
 from ai.backend.manager.data.permission.role import RoleData
 from ai.backend.manager.data.permission.status import RoleStatus
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.errors.permission import VirtualEntityNotFound
-from ai.backend.manager.errors.repository import EntityNotFoundError
 from ai.backend.manager.errors.role_preset import SystemRoleNotEditable
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.entity_label.row import EntityLabelRow

--- a/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_repository.py
+++ b/tests/unit/manager/repositories/prometheus_query_preset/test_prometheus_query_preset_repository.py
@@ -23,7 +23,7 @@ from ai.backend.manager.clients.prometheus.client import PrometheusClient
 from ai.backend.manager.data.prometheus_query_preset import (
     PrometheusQueryPresetData,
 )
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.entity import EntityNotFoundError
 from ai.backend.manager.models.entity_label.row import EntityLabelRow
 from ai.backend.manager.models.prometheus_query_preset import PrometheusQueryPresetRow
 from ai.backend.manager.models.prometheus_query_preset.creators import (

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -82,7 +82,7 @@ from ai.backend.manager.actions.v2.scope.processor import ScopeActionProcessor
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
 from ai.backend.manager.actions.v2.single_entity.processor import SingleEntityActionProcessor
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
-from ai.backend.manager.errors.repository import EntityNotFoundError
+from ai.backend.manager.errors.base.field import FieldNotFoundError
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.rbac_models.role_preset.row import RolePresetRow
 from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
@@ -164,8 +164,8 @@ class _TestFieldType(FieldType):
 
     @override
     @classmethod
-    def owner_type(cls) -> type[EntityType] | None:
-        return None
+    def owner_type(cls) -> type[EntityType]:
+        return RolePresetEntityType
 
 
 _FIELD_TYPE = _TestFieldType()
@@ -301,8 +301,8 @@ class _PresetUpdater(DataUpdater[RolePresetRow, _PresetData]):
         return RolePresetRow.id
 
     @override
-    def target_id_value(self) -> uuid.UUID:
-        return self.target
+    def target_id_value(self) -> EntityIdentifier:
+        return _EntityID(self.target)
 
     @property
     @override
@@ -367,6 +367,10 @@ class _PresetByName(DataLookup[RolePresetRow, EntityIdentifier]):
     @override
     def row_class(self) -> type[RolePresetRow]:
         return RolePresetRow
+
+    @override
+    def entity_type(self) -> EntityType:
+        return _ENTITY_TYPE
 
     @override
     def conditions(self) -> Sequence[QueryCondition]:
@@ -532,8 +536,8 @@ class _PresetFieldPurger(FieldPurger[RolePresetRow, _PresetFieldData]):
         return RolePresetRow.id
 
     @override
-    def target_id_value(self) -> uuid.UUID:
-        return self.target
+    def target_id_value(self) -> FieldIdentifier:
+        return _FieldID(self.target)
 
     @override
     def conflict_checks(self) -> Sequence[ConflictCheck]:
@@ -1695,7 +1699,7 @@ async def test_field_partial_bulk_get_answers_for_every_named_row(
 
     assert result.successes == {field_stored.id: field_stored}
     assert list(result.errors) == [absent]
-    assert isinstance(result.errors[absent], EntityNotFoundError)
+    assert isinstance(result.errors[absent], FieldNotFoundError)
 
 
 async def test_field_upsert_forwards_owner_and_upserter(


### PR DESCRIPTION
## Summary

- `EntityError` and `FieldError` land under `manager/errors/base`. An entity error answers with its entity type, the action being performed and the detail; a field error answers with the field row's type, whose owner comes from the type itself. `ErrorCode.domain` widens to an open string so a row type can be the domain, and the bases hyphenate it on the way in, so a code keeps its three underscore-free parts.
- The identifiers and the specs supply those types. A lookup declares the type it resolves, and an updater's or a purger's target id narrows from a bare `UUID` to the identifier that knows its own type. `EntityNotFoundError` and `FieldNotFoundError` share `NotFoundError`, so a caller that answers the same way for a missing entity and a missing field row catches one name.
- `ErrorMeta` refuses to construct an error that still owes its code. `ABCMeta` records what is owed, but `Exception.__new__` never reads it, so the refusal runs in the metaclass instead.

### Breaking

Error code values change where the generic ops errors used to report under the `database` domain. A missing row now reports under the row's own type.

| Before | After |
|---|---|
| `database_access_not-found` | `agent_read_not-found`, `session-kernel_read_not-found`, ... |
| `database_list-query_invalid-parameters` | `database_search_invalid-parameters` |

`ErrorOperation` gains `upsert` and `restore` and renames `list-query` to `search`, so the action vocabulary maps onto it without collapsing two operations into one.

Checked against the consumers: the Python SDK and the v2 DTOs carry `error_code` as an opaque string and never branch on the domain, the single `ErrorCode.from_str` caller parses a storage-proxy response whose domain is a system one, and the two WebUI literal comparisons (`vfolder_create_already-exists`, `session_create_already-exists`) keep their values. Prometheus panels that group by the `domain` label will show the new values as new series.

## Test plan

- [x] `pants lint check --changed-since=HEAD~1 --changed-dependents=transitive`
- [x] `pants test --changed-since=HEAD~1 --changed-dependents=direct` — 200 targets pass
- [x] New tests fix the code each base answers with, that a dangling field row reports its own type alone, and that the abstract roots cannot be constructed
- [x] CI

### Also carried here

`tests/unit/manager/models/resource_slot/test_agent_resource_field_specs.py` was already failing on `main`. BA-7739 (#14453) made `agent_resources.agent_uuid` not-null without giving the fixture's seeded rows an owner, and CI selects tests by direct dependents, so the file stayed out of the run that introduced the column. This branch touches the same package, which pulled the file back into the selection and surfaced it, so the fixture fix rides along in its own commit.

Resolves BA-7769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01666RBp8GBZpxYVA1HiPUy5