### PR TITLE
refactor(BA-7797): unify the scope and entity identifier types

### DIFF
--- a/changes/14476.misc.md
+++ b/changes/14476.misc.md
@@ -1,0 +1,1 @@
+Identify a scope by the entity identifier it already is, removing `EntityRef`, `ScopeRef`, `ScopeType`, `ScopeID` and the transparent `EntityID` alias

--- a/docs/manager/rest-reference/openapi.json
+++ b/docs/manager/rest-reference/openapi.json
@@ -17052,36 +17052,36 @@
         "title": "UnassignUsersFromProjectInput",
         "type": "object"
       },
-      "EntityID": {
-        "format": "uuid",
-        "type": "string"
-      },
       "EntityShareRecipientInput": {
         "description": "Who an offer goes to, named exactly one of three ways.\n\nA project takes it directly, a person takes it into the project that is theirs\nalone, and an address reaches someone who may have no account yet.",
         "properties": {
           "project_id": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/EntityID"
+                "format": "uuid",
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "default": null,
-            "description": "Project the offer goes to"
+            "description": "Project the offer goes to",
+            "title": "Project Id"
           },
           "user_id": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/EntityID"
+                "format": "uuid",
+                "type": "string"
               },
               {
                 "type": "null"
               }
             ],
             "default": null,
-            "description": "Person the offer goes to; it lands in their own project"
+            "description": "Person the offer goes to; it lands in their own project",
+            "title": "User Id"
           },
           "email": {
             "anyOf": [
@@ -17121,8 +17121,10 @@
             "type": "string"
           },
           "target_entity_id": {
-            "$ref": "#/components/schemas/EntityID",
-            "description": "Id of the entity being offered"
+            "description": "Id of the entity being offered",
+            "format": "uuid",
+            "title": "Target Entity Id",
+            "type": "string"
           },
           "recipient": {
             "$ref": "#/components/schemas/EntityShareRecipientInput",
@@ -17465,8 +17467,10 @@
             "type": "string"
           },
           "entity_id": {
-            "$ref": "#/components/schemas/EntityID",
-            "description": "Id of the entity being offered"
+            "description": "Id of the entity being offered",
+            "format": "uuid",
+            "title": "Entity Id",
+            "type": "string"
           }
         },
         "required": [

--- a/src/ai/backend/common/data/entity/container_registry.py
+++ b/src/ai/backend/common/data/entity/container_registry.py
@@ -1,10 +1,9 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
     "ContainerRegistryEntityType",
-    "CONTAINER_REGISTRY_SCOPE_TYPE",
     "ContainerRegistryID",
 )
 
@@ -19,9 +18,6 @@ class ContainerRegistryEntityType(EntityType):
     @classmethod
     def description(cls) -> str:
         return "A registry that container images are pulled from, with the credentials to reach it."
-
-
-CONTAINER_REGISTRY_SCOPE_TYPE = ScopeType(ContainerRegistryEntityType())
 
 
 class ContainerRegistryID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/deployment.py
+++ b/src/ai/backend/common/data/entity/deployment.py
@@ -1,10 +1,10 @@
-"""Entity type, scope type and id of the deployments table."""
+"""Entity type and id of the deployments table."""
 
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
-__all__ = ("DeploymentEntityType", "DEPLOYMENT_SCOPE_TYPE", "DeploymentID")
+__all__ = ("DeploymentEntityType", "DeploymentID")
 
 
 class DeploymentEntityType(EntityType):
@@ -17,9 +17,6 @@ class DeploymentEntityType(EntityType):
     @classmethod
     def description(cls) -> str:
         return "A model service holding the replica count to keep and the replica group serving it."
-
-
-DEPLOYMENT_SCOPE_TYPE = ScopeType(DeploymentEntityType())
 
 
 class DeploymentID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/domain.py
+++ b/src/ai/backend/common/data/entity/domain.py
@@ -1,15 +1,9 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    NaturalKey,
-    ScopeType,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, NaturalKey
 
 __all__ = (
     "DomainEntityType",
-    "DOMAIN_SCOPE_TYPE",
     "DomainID",
     "DomainName",
 )
@@ -25,9 +19,6 @@ class DomainEntityType(EntityType):
     @classmethod
     def description(cls) -> str:
         return "The top-level tenant holding projects and users."
-
-
-DOMAIN_SCOPE_TYPE = ScopeType(DomainEntityType())
 
 
 class DomainID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/project.py
+++ b/src/ai/backend/common/data/entity/project.py
@@ -1,10 +1,9 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
     "ProjectEntityType",
-    "PROJECT_SCOPE_TYPE",
     "ProjectID",
 )
 
@@ -19,9 +18,6 @@ class ProjectEntityType(EntityType):
     @classmethod
     def description(cls) -> str:
         return "A group of users inside a domain that owns sessions and vfolders."
-
-
-PROJECT_SCOPE_TYPE = ScopeType(ProjectEntityType())
 
 
 class ProjectID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/resource_group.py
+++ b/src/ai/backend/common/data/entity/resource_group.py
@@ -1,10 +1,9 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, NaturalKey, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, NaturalKey
 
 __all__ = (
     "ResourceGroupEntityType",
-    "RESOURCE_GROUP_SCOPE_TYPE",
     "ResourceGroupID",
     "ResourceGroupName",
 )
@@ -23,9 +22,6 @@ class ResourceGroupEntityType(EntityType):
             "A pool of agents with its own scheduler, opened to the domains, projects and"
             " keypairs allowed to use it."
         )
-
-
-RESOURCE_GROUP_SCOPE_TYPE = ScopeType(ResourceGroupEntityType())
 
 
 class ResourceGroupID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/session.py
+++ b/src/ai/backend/common/data/entity/session.py
@@ -1,10 +1,9 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
     "SessionEntityType",
-    "SESSION_SCOPE_TYPE",
     "SessionID",
 )
 
@@ -19,9 +18,6 @@ class SessionEntityType(EntityType):
     @classmethod
     def description(cls) -> str:
         return "A compute session made of one or more kernels."
-
-
-SESSION_SCOPE_TYPE = ScopeType(SessionEntityType())
 
 
 class SessionID(EntityIdentifier):

--- a/src/ai/backend/common/data/entity/types.py
+++ b/src/ai/backend/common/data/entity/types.py
@@ -12,9 +12,6 @@ from pydantic_core import CoreSchema, core_schema
 # An entity's identifier. Polymorphic across entity kinds; the concrete kind is
 # discriminated by the accompanying entity_type.
 type EntityID = uuid.UUID
-# A scope's identifier. Every scope doubles as an entity, so this is an alias of
-# EntityID: the subset relation is visible in the type.
-type ScopeID = EntityID
 
 
 class EntityType(str):

--- a/src/ai/backend/common/data/entity/types.py
+++ b/src/ai/backend/common/data/entity/types.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import Any, Self, override
@@ -8,10 +7,6 @@ from uuid import UUID
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
-
-# An entity's identifier. Polymorphic across entity kinds; the concrete kind is
-# discriminated by the accompanying entity_type.
-type EntityID = uuid.UUID
 
 
 class EntityType(str):
@@ -264,7 +259,7 @@ class EntityData(ABC):
 
     An abstract method rather than an ``id`` field: several domains key on a name
     (``domains.name``, ``scaling_groups.name``, ``keypairs.access_key``) and map it to
-    an ``EntityID`` themselves.
+    an ``EntityIdentifier`` themselves.
 
     MUST carry the columns of its own domain's row and nothing else: no relationship,
     no joined value. Rationale: ``manager/data/KNOWLEDGE.md``.

--- a/src/ai/backend/common/data/entity/types.py
+++ b/src/ai/backend/common/data/entity/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import Any, NewType, Self, override
+from typing import Any, Self, override
 from uuid import UUID
 
 from pydantic import GetCoreSchemaHandler
@@ -75,11 +75,6 @@ class EntityType(str):
         return core_schema.no_info_after_validator_function(
             lambda _: cls(), core_schema.literal_schema([cls.name()])
         )
-
-
-# Every entity doubles as a scope, so a scope type IS an entity type; the
-# reverse direction stays an explicit declaration (`ScopeType(<entity type>)`).
-ScopeType = NewType("ScopeType", EntityType)
 
 
 class GlobalEntityType(EntityType):

--- a/src/ai/backend/common/data/entity/types.py
+++ b/src/ai/backend/common/data/entity/types.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from dataclasses import dataclass
 from typing import Any, NewType, Self, override
 from uuid import UUID
 
@@ -175,41 +174,6 @@ class NaturalKey(str):
         return core_schema.no_info_after_validator_function(cls, core_schema.str_schema())
 
 
-@dataclass(frozen=True, slots=True)
-class EntityRef:
-    """An entity identified by its (open) type and id.
-
-    Deprecated: use :class:`EntityIdentifier` — BA-7204. This pair stays only where a
-    row's type is read at run time.
-
-    Both are values read at run time — the graph layer reads them off a row — so the id
-    is a bare one. Where the entity is known statically, pass an
-    :class:`EntityIdentifier`, which needs no separate type beside it.
-    """
-
-    entity_type: EntityType
-    entity_id: EntityID
-
-
-@dataclass(frozen=True, slots=True)
-class ScopeRef:
-    """A scope identified by its (open) type and id.
-
-    Deprecated: use :class:`EntityIdentifier` — BA-7204. This pair stays only where a
-    row's type is read at run time.
-
-    ``scope_type`` is a free-form string (NewType), not a fixed enum: the virtual
-    scope layer accepts any owner type without extending a hard-coded scope enum.
-    """
-
-    scope_type: ScopeType
-    scope_id: ScopeID
-
-    def to_entity_ref(self) -> EntityRef:
-        """An entity's scope identity is its entity identity: one pair serves both."""
-        return EntityRef(entity_type=self.scope_type, entity_id=self.scope_id)
-
-
 class EntityIdentifier(UUID):
     """An entity's id, which knows the type it is an id of.
 
@@ -248,9 +212,6 @@ class EntityIdentifier(UUID):
         """
         raise NotImplementedError
 
-    def entity_ref(self) -> EntityRef:
-        return EntityRef(entity_type=self.entity_type(), entity_id=self)
-
     @classmethod
     def __get_pydantic_core_schema__(cls, source: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
         """Validated as the uuid it is; pydantic builds no schema for a `UUID`
@@ -279,7 +240,7 @@ class RuntimeEntityID(EntityIdentifier):
 class FieldIdentifier(UUID):
     """A field row's id.
 
-    No `entity_ref()`: a field row carries no membership of its own, so what it belongs
+    Names no entity: a field row carries no membership of its own, so what it belongs
     to is only knowable through the entity that owns it. Which entity that is comes from
     the owner lookup, not from this class: an owner may be another field row, and some
     kinds have none at all.

--- a/src/ai/backend/common/data/entity/user.py
+++ b/src/ai/backend/common/data/entity/user.py
@@ -1,10 +1,9 @@
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 
 __all__ = (
     "UserEntityType",
-    "USER_SCOPE_TYPE",
     "UserID",
 )
 
@@ -19,9 +18,6 @@ class UserEntityType(EntityType):
     @classmethod
     def description(cls) -> str:
         return "An account inside a domain."
-
-
-USER_SCOPE_TYPE = ScopeType(UserEntityType())
 
 
 class UserID(EntityIdentifier):

--- a/src/ai/backend/common/data/permission/virtual_entity.py
+++ b/src/ai/backend/common/data/permission/virtual_entity.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import Permission
 
@@ -17,7 +18,7 @@ __all__ = (
 class VirtualEntityData:
     id: VirtualEntityID
     entity_type: EntityType
-    entity_id: EntityID
+    entity_id: UUID
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/common/dto/manager/rbac/request.py
+++ b/src/ai/backend/common/dto/manager/rbac/request.py
@@ -10,14 +10,18 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import SENTINEL, BaseRequestModel, Sentinel
-from ai.backend.common.data.entity.types import ScopeType
-from ai.backend.common.data.permission.types import ScopeType as LegacyScopeType
+from ai.backend.common.data.entity.types import EntityType
+from ai.backend.common.data.permission.types import (
+    EntityType as LegacyEntityType,
+)
+from ai.backend.common.data.permission.types import (
+    ScopeType as LegacyScopeType,
+)
 from ai.backend.common.dto.manager.defs import DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT
 from ai.backend.common.dto.manager.query import StringFilter
 
 from .types import (
     AssignedUserOrderField,
-    EntityType,
     OperationType,
     OrderDirection,
     PermissionStatus,
@@ -52,7 +56,7 @@ class CreateRoleRequest(BaseRequestModel):
     """Request to create a role."""
 
     name: str = Field(description="Role name")
-    scope_type: ScopeType = Field(description="Type of the scope the role belongs to")
+    scope_type: EntityType = Field(description="Type of the scope the role belongs to")
     scope_id: UUID = Field(description="ID of the scope the role belongs to")
     status: RoleStatus | None = Field(default=None, description="Role status; active if omitted")
     description: str | None = Field(default=None, description="Role description")
@@ -156,7 +160,7 @@ class CreatePermissionRequest(BaseRequestModel):
     role_id: UUID = Field(description="Role ID for the permission")
     scope_type: LegacyScopeType = Field(description="Scope type for the permission")
     scope_id: str = Field(description="Scope ID for the permission")
-    entity_type: EntityType = Field(description="Entity type for the permission")
+    entity_type: LegacyEntityType = Field(description="Entity type for the permission")
     operation: OperationType = Field(description="Operation type for the permission")
 
 
@@ -164,7 +168,7 @@ class CreateObjectPermissionRequest(BaseRequestModel):
     """Request to create an object permission for a role."""
 
     role_id: UUID = Field(description="Role ID to add the object permission to")
-    entity_type: EntityType = Field(description="Entity type for the object permission")
+    entity_type: LegacyEntityType = Field(description="Entity type for the object permission")
     entity_id: str = Field(description="Entity ID (e.g., project_id, user_id)")
     operation: OperationType = Field(description="Operation type for the object permission")
     status: PermissionStatus = Field(

--- a/src/ai/backend/common/dto/manager/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/rbac/response.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.permission.types import ScopeType as LegacyScopeType
 from ai.backend.common.dto.manager.pagination import PaginationInfo
 from ai.backend.common.types import BackendAISchema
@@ -52,7 +52,7 @@ class RoleDTO(BackendAISchema):
     id: UUID = Field(description="Role ID")
     name: str = Field(description="Role name")
     scope_type: EntityType = Field(description="Type of the scope the role belongs to")
-    scope_id: EntityID = Field(description="ID of the scope the role belongs to")
+    scope_id: UUID = Field(description="ID of the scope the role belongs to")
     source: RoleSource = Field(description="Role source")
     status: RoleStatus = Field(description="Role status")
     created_at: datetime = Field(description="Creation timestamp")

--- a/src/ai/backend/common/dto/manager/v2/entity_share/request.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_share/request.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from pydantic import Field, model_validator
 
 from ai.backend.common.api_handlers import BaseRequestModel
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.dto.manager.query import StringFilter, UUIDFilter
 from ai.backend.common.dto.manager.v2.common import OrderDirection
 from ai.backend.common.dto.manager.v2.entity_share.types import (
@@ -34,8 +36,8 @@ class EntityShareRecipientInput(BaseRequestModel):
     alone, and an address reaches someone who may have no account yet.
     """
 
-    project_id: EntityID | None = Field(default=None, description="Project the offer goes to")
-    user_id: EntityID | None = Field(
+    project_id: UUID | None = Field(default=None, description="Project the offer goes to")
+    user_id: UUID | None = Field(
         default=None, description="Person the offer goes to; it lands in their own project"
     )
     email: str | None = Field(default=None, description="Address the offer goes to")
@@ -56,7 +58,7 @@ class CreateEntityShareInput(BaseRequestModel):
     """
 
     target_entity_type: EntityType = Field(description="Type of the entity being offered")
-    target_entity_id: EntityID = Field(description="Id of the entity being offered")
+    target_entity_id: UUID = Field(description="Id of the entity being offered")
     recipient: EntityShareRecipientInput = Field(description="Who the offer goes to")
     permissions: list[PermissionBitDTO] = Field(
         default_factory=list,
@@ -92,7 +94,7 @@ class EntityShareTargetScope(BaseRequestModel):
     """
 
     entity_type: EntityType = Field(description="Type of the entity being offered")
-    entity_id: EntityID = Field(description="Id of the entity being offered")
+    entity_id: UUID = Field(description="Id of the entity being offered")
 
 
 class EntityShareScope(BaseRequestModel):

--- a/src/ai/backend/common/dto/manager/v2/entity_share/response.py
+++ b/src/ai/backend/common/dto/manager/v2/entity_share/response.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
 from ai.backend.common.data.entity.entity_share import EntityShareID
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.dto.manager.v2.entity_share.types import EntityShareStatusDTO
 from ai.backend.common.dto.manager.v2.rbac.types import PermissionBitDTO
@@ -28,14 +29,14 @@ class EntityShareNode(BaseResponseModel):
     recipient_entity_type: EntityType | None = Field(
         default=None, description="Type of the scope the offer goes to, once it names one"
     )
-    recipient_entity_id: EntityID | None = Field(
+    recipient_entity_id: UUID | None = Field(
         default=None, description="Id of the scope the offer goes to, once it names one"
     )
     recipient_email: str | None = Field(
         default=None, description="Address the offer goes to, when it names one"
     )
     target_entity_type: EntityType = Field(description="Type of the entity being offered")
-    target_entity_id: EntityID = Field(description="Id of the entity being offered")
+    target_entity_id: UUID = Field(description="Id of the entity being offered")
     permissions: list[PermissionBitDTO] = Field(
         description="Permissions the offer caps at; empty for no ceiling"
     )

--- a/src/ai/backend/common/dto/manager/v2/rbac/response.py
+++ b/src/ai/backend/common/dto/manager/v2/rbac/response.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from pydantic import Field
 
 from ai.backend.common.api_handlers import BaseResponseModel
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 
 from .types import (
     OperationTypeDTO,
@@ -71,7 +71,7 @@ class RoleNode(BaseResponseModel):
     updated_at: datetime = Field(description="Last update timestamp")
     deleted_at: datetime | None = Field(default=None, description="Deletion timestamp")
     scope_type: EntityType = Field(description="Type of the scope the role belongs to")
-    scope_id: EntityID = Field(description="ID of the scope the role belongs to")
+    scope_id: UUID = Field(description="ID of the scope the role belongs to")
 
 
 class CreateRolePayload(BaseResponseModel):

--- a/src/ai/backend/manager/actions/types.py
+++ b/src/ai/backend/manager/actions/types.py
@@ -2,7 +2,7 @@ import enum
 from dataclasses import dataclass
 from typing import Final
 
-from ai.backend.common.data.entity.types import EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.permission.types import OperationType, Permission
 from ai.backend.common.exception import ErrorOperation
 
@@ -200,5 +200,5 @@ class ActionSpec:
 
 @dataclass(frozen=True)
 class Scope:
-    type: ScopeType
+    type: EntityType
     id: str

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -223,7 +223,7 @@ class ScopeItem(ABC):
     """
 
     @abstractmethod
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         """The scope the read is answered for."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/v2/ops/base.py
+++ b/src/ai/backend/manager/actions/v2/ops/base.py
@@ -2,12 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import Any, override
 
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    FieldData,
-    FieldIdentifier,
-    ScopeRef,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, FieldData, FieldIdentifier
 from ai.backend.common.data.entity.types import EntityIdentifier as OwnerEntityID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.bulk.base import BaseBulkAction, BasePartialBulkAction
@@ -228,7 +223,7 @@ class ScopeItem(ABC):
     """
 
     @abstractmethod
-    def scope_ref(self) -> ScopeRef:
+    def scope_ref(self) -> EntityIdentifier:
         """The scope the read is answered for."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/v2/relation/base.py
+++ b/src/ai/backend/manager/actions/v2/relation/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 
 __all__ = ("BaseRelationAction",)
@@ -37,7 +37,7 @@ class BaseRelationAction(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         """Return the scopes this run links or unlinks.
 
         Every one of them has to permit the run: you must be able to touch both to put

--- a/src/ai/backend/manager/actions/v2/relation/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/audit_log.py
@@ -78,7 +78,7 @@ class RelationActionAuditLogMonitor(RelationActionMonitor):
         await self._repository.atomic_create_dangling_fields_with_nested(
             [creator],
             [
-                AuditLogScopeCreator(scope_type=str(scope.scope_type), scope_id=scope.scope_id)
+                AuditLogScopeCreator(scope_type=str(scope.entity_type()), scope_id=scope)
                 for scope in meta.scope_targets
             ],
         )

--- a/src/ai/backend/manager/actions/v2/relation/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/v2/relation/monitor/reporter.py
@@ -4,7 +4,6 @@ from typing import override
 
 from ai.backend.common.contexts.request_id import current_request_id
 from ai.backend.common.contexts.user import current_user, triggered_user
-from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.actions.types import BLANK_ID
 from ai.backend.manager.actions.v2.relation.monitor.base import RelationActionMonitor
 from ai.backend.manager.actions.v2.relation.result import RelationActionProcessResult
@@ -40,8 +39,8 @@ class RelationActionReporterMonitor(RelationActionMonitor):
                 StartedActionMessage(
                     action_id=meta.action_id,
                     action_type=meta.action_name,
-                    entity_id=scope.scope_id,
-                    entity_type=EntityType(scope.scope_type),
+                    entity_id=scope,
+                    entity_type=scope.entity_type(),
                     request_id=request_id,
                     triggered_by=str(trigger.user_id) if trigger else None,
                     acted_as=acting.user_id if acting else None,
@@ -62,11 +61,11 @@ class RelationActionReporterMonitor(RelationActionMonitor):
                 FinishedActionMessage(
                     action_id=meta.action_id,
                     action_type=meta.action_name,
-                    entity_id=scope.scope_id,
+                    entity_id=scope,
                     request_id=request_id,
                     triggered_by=str(trigger.user_id) if trigger else None,
                     acted_as=acting.user_id if acting else None,
-                    entity_type=EntityType(scope.scope_type),
+                    entity_type=scope.entity_type(),
                     operation_type=meta.operation_type,
                     status=result.meta.status,
                     description=result.meta.description,

--- a/src/ai/backend/manager/actions/v2/relation/trigger.py
+++ b/src/ai/backend/manager/actions/v2/relation/trigger.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from ai.backend.common.data.entity.action import ActionID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 
 __all__ = ("RelationActionTriggerMeta",)
@@ -15,6 +15,6 @@ class RelationActionTriggerMeta:
 
     action_id: ActionID
     started_at: datetime
-    scope_targets: Sequence[ScopeRef]
+    scope_targets: Sequence[EntityIdentifier]
     operation_type: ActionOperationType
     action_name: str

--- a/src/ai/backend/manager/actions/v2/relation/validator/rbac.py
+++ b/src/ai/backend/manager/actions/v2/relation/validator/rbac.py
@@ -1,7 +1,6 @@
 from typing import override
 
 from ai.backend.common.contexts.user import current_user
-from ai.backend.common.data.entity.types import EntityIdentifier, RuntimeEntityID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.exception import UnreachableError
@@ -47,10 +46,10 @@ class VirtualEntityRelationActionRBACValidator(RelationActionValidator):
         if user.is_superadmin:
             return
 
-        entities: list[EntityIdentifier] = [
-            RuntimeEntityID(scope.scope_type, scope.scope_id) for scope in meta.scope_targets
+        keys = [
+            OwnCheckKey(user_id=UserID(user.user_id), entity=entity)
+            for entity in meta.scope_targets
         ]
-        keys = [OwnCheckKey(user_id=UserID(user.user_id), entity=entity) for entity in entities]
         permission = meta.operation_type.to_permission()
         owned = await self._repository.owned_permissions(keys)
         denied = [

--- a/src/ai/backend/manager/actions/v2/scope/base.py
+++ b/src/ai/backend/manager/actions/v2/scope/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 
 
@@ -9,7 +9,7 @@ class BaseScopeAction(ABC):
     """Base for actions that target entities by scope rather than by identity."""
 
     @abstractmethod
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         """Return the Sequence of scopes that this action applies to."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/v2/scope/monitor/audit_log.py
+++ b/src/ai/backend/manager/actions/v2/scope/monitor/audit_log.py
@@ -59,7 +59,7 @@ class ScopeActionAuditLogMonitor(ScopeActionMonitor):
         if not self._policy.should_record(action.operation_type(), meta.status):
             return
         nested = [
-            AuditLogScopeCreator(scope_type=str(s.scope_type), scope_id=s.scope_id)
+            AuditLogScopeCreator(scope_type=str(s.entity_type()), scope_id=s)
             for s in meta.scope_targets
         ]
         client_ip = await self._client_ip_masking.mask(

--- a/src/ai/backend/manager/actions/v2/scope/monitor/reporter.py
+++ b/src/ai/backend/manager/actions/v2/scope/monitor/reporter.py
@@ -40,7 +40,7 @@ class ScopeActionReporterMonitor(ScopeActionMonitor):
             message = StartedActionMessage(
                 action_id=meta.action_id,
                 action_type=action.action_name(),
-                entity_id=scope.scope_id,
+                entity_id=scope,
                 entity_type=action.entity_type(),
                 request_id=request_id,
                 triggered_by=str(trigger.user_id) if trigger else None,
@@ -60,7 +60,7 @@ class ScopeActionReporterMonitor(ScopeActionMonitor):
             message = FinishedActionMessage(
                 action_id=meta.action_id,
                 action_type=action.action_name(),
-                entity_id=scope.scope_id,
+                entity_id=scope,
                 request_id=request_id,
                 triggered_by=str(trigger.user_id) if trigger else None,
                 acted_as=acting.user_id if acting else None,

--- a/src/ai/backend/manager/actions/v2/scope/result.py
+++ b/src/ai/backend/manager/actions/v2/scope/result.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 from ai.backend.common.data.entity.action import ActionID
-from ai.backend.common.data.entity.types import EntityIdentifier, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.exception import ErrorCode
 from ai.backend.manager.actions.types import OperationStatus
 
@@ -36,7 +36,7 @@ class ScopeActionResultMeta:
     """
 
     action_id: ActionID
-    scope_targets: Sequence[ScopeRef]
+    scope_targets: Sequence[EntityIdentifier]
     entity_ids: Sequence[EntityIdentifier]
     status: OperationStatus
     description: str

--- a/src/ai/backend/manager/actions/v2/scope/target.py
+++ b/src/ai/backend/manager/actions/v2/scope/target.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.models.scopes import OperationScope
 
 
@@ -16,7 +16,7 @@ class SearchableScopeTarget(ABC):
     """
 
     @abstractmethod
-    def to_scope_ref(self) -> ScopeRef:
+    def to_scope_ref(self) -> EntityIdentifier:
         """Return the scope the read is answered for."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/actions/v2/scope/target.py
+++ b/src/ai/backend/manager/actions/v2/scope/target.py
@@ -16,7 +16,7 @@ class SearchableScopeTarget(ABC):
     """
 
     @abstractmethod
-    def to_scope_ref(self) -> EntityIdentifier:
+    def to_scope_id(self) -> EntityIdentifier:
         """Return the scope the read is answered for."""
         raise NotImplementedError
 

--- a/src/ai/backend/manager/api/gql_legacy/group.py
+++ b/src/ai/backend/manager/api/gql_legacy/group.py
@@ -18,7 +18,7 @@ from graphql import Undefined
 from sqlalchemy.engine.row import Row
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import (
     GroupNotFound,
@@ -225,7 +225,7 @@ class GroupNode(graphene.ObjectType):  # type: ignore[misc]
             last=last,
         )
         # Project membership comes from the virtual-entity chain (PROJECT/USER).
-        membership_filter = user_scope_membership_exists(PROJECT_SCOPE_TYPE, self.id, UserRow.uuid)
+        membership_filter = user_scope_membership_exists(ProjectEntityType(), self.id, UserRow.uuid)
         user_query = query.where(membership_filter)
         cnt_query = sa.select(sa.func.count()).select_from(UserRow).where(membership_filter)
         for cond in conditions:
@@ -506,7 +506,7 @@ class Group(graphene.ObjectType):  # type: ignore[misc]
             _type = [ProjectType.GENERAL]
         else:
             _type = type
-        ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+        ms = user_scope_membership_query(ProjectEntityType()).subquery()
         j = sa.join(groups, ms, groups.c.id == ms.c.scope_id)
         query = (
             sa.select(groups, ms.c.user_id)
@@ -532,7 +532,7 @@ class Group(graphene.ObjectType):  # type: ignore[misc]
         user_id: uuid.UUID,
     ) -> Sequence[Group]:
         query = sa.select(groups).where(
-            user_scope_membership_exists(PROJECT_SCOPE_TYPE, groups.c.id, user_id)
+            user_scope_membership_exists(ProjectEntityType(), groups.c.id, user_id)
         )
         async with graph_ctx.db.begin_readonly() as conn:
             return [

--- a/src/ai/backend/manager/api/gql_legacy/keypair.py
+++ b/src/ai/backend/manager/api/gql_legacy/keypair.py
@@ -315,12 +315,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
         is_active: bool | None = None,
         filter: str | None = None,
     ) -> int:
-        from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+        from ai.backend.common.data.entity.project import ProjectEntityType
         from ai.backend.manager.models.project.row import groups
         from ai.backend.manager.models.user.row import users
         from ai.backend.manager.models.virtual_entity.queries import user_scope_membership_query
 
-        ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+        ms = user_scope_membership_query(ProjectEntityType()).subquery()
         j = (
             sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
             .outerjoin(ms, users.c.uuid == ms.c.user_id)
@@ -353,12 +353,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
         filter: str | None = None,
         order: str | None = None,
     ) -> Sequence[KeyPair]:
-        from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+        from ai.backend.common.data.entity.project import ProjectEntityType
         from ai.backend.manager.models.project.row import groups
         from ai.backend.manager.models.user.row import users
         from ai.backend.manager.models.virtual_entity.queries import user_scope_membership_query
 
-        ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+        ms = user_scope_membership_query(ProjectEntityType()).subquery()
         j = (
             sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
             .outerjoin(ms, users.c.uuid == ms.c.user_id)
@@ -406,12 +406,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
         domain_name: str | None = None,
         is_active: bool | None = None,
     ) -> Sequence[Sequence[KeyPair | None]]:
-        from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+        from ai.backend.common.data.entity.project import ProjectEntityType
         from ai.backend.manager.models.project.row import groups
         from ai.backend.manager.models.user.row import users
         from ai.backend.manager.models.virtual_entity.queries import user_scope_membership_query
 
-        ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+        ms = user_scope_membership_query(ProjectEntityType()).subquery()
         j = (
             sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
             .join(ms, users.c.uuid == ms.c.user_id)
@@ -450,12 +450,12 @@ class KeyPair(graphene.ObjectType):  # type: ignore[misc]
         *,
         domain_name: str | None = None,
     ) -> Sequence[KeyPair | None]:
-        from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+        from ai.backend.common.data.entity.project import ProjectEntityType
         from ai.backend.manager.models.project.row import groups
         from ai.backend.manager.models.user.row import users
         from ai.backend.manager.models.virtual_entity.queries import user_scope_membership_query
 
-        ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+        ms = user_scope_membership_query(ProjectEntityType()).subquery()
         j = (
             sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
             .join(ms, users.c.uuid == ms.c.user_id)

--- a/src/ai/backend/manager/api/gql_legacy/user.py
+++ b/src/ai/backend/manager/api/gql_legacy/user.py
@@ -19,7 +19,7 @@ from graphql import Undefined
 from sqlalchemy.engine.row import Row
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import UserNotFound
 from ai.backend.common.meta.meta import NEXT_RELEASE_VERSION
@@ -107,7 +107,7 @@ __all__ = (
 
 def _project_membership_join(base_table: sa.Table | sa.sql.Join) -> sa.sql.Join:
     """Join the base users selectable to groups via the virtual-entity membership pairs."""
-    ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+    ms = user_scope_membership_query(ProjectEntityType()).subquery()
     return sa.join(
         base_table,
         ms,
@@ -482,7 +482,9 @@ class UserNode(graphene.ObjectType):  # type: ignore[misc]
             before=before,
             last=last,
         )
-        membership_filter = user_scope_membership_exists(PROJECT_SCOPE_TYPE, ProjectRow.id, self.id)
+        membership_filter = user_scope_membership_exists(
+            ProjectEntityType(), ProjectRow.id, self.id
+        )
         prj_query = query.where(membership_filter)
         cnt_query = cnt_query.where(membership_filter)
         result: list[GroupNode] = []
@@ -521,7 +523,7 @@ class UserGroup(graphene.ObjectType):  # type: ignore[misc]
         cls, ctx: GraphQueryContext, user_ids: Sequence[UUID]
     ) -> Sequence[Sequence[UserGroup]]:
         async with ctx.db.begin() as conn:
-            ms = user_scope_membership_query(PROJECT_SCOPE_TYPE).subquery()
+            ms = user_scope_membership_query(ProjectEntityType()).subquery()
             j = groups.join(ms, groups.c.id == ms.c.scope_id)
             query = (
                 sa.select(
@@ -674,7 +676,7 @@ class User(graphene.ObjectType):  # type: ignore[misc]
         )
         if group_id is not None:
             query = query.where(
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, group_id, users.c.uuid)
+                user_scope_membership_exists(ProjectEntityType(), group_id, users.c.uuid)
             )
         if ctx.user["role"] != UserRole.SUPERADMIN:
             query = query.where(users.c.domain_name == ctx.user["domain_name"])
@@ -746,7 +748,7 @@ class User(graphene.ObjectType):  # type: ignore[misc]
         query = sa.select(sa.func.count()).select_from(users)
         if group_id is not None:
             query = query.where(
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, group_id, users.c.uuid)
+                user_scope_membership_exists(ProjectEntityType(), group_id, users.c.uuid)
             )
         if domain_name is not None:
             query = query.where(users.c.domain_name == domain_name)
@@ -784,7 +786,7 @@ class User(graphene.ObjectType):  # type: ignore[misc]
         )
         if group_id is not None:
             query = query.where(
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, group_id, users.c.uuid)
+                user_scope_membership_exists(ProjectEntityType(), group_id, users.c.uuid)
             )
         if domain_name is not None:
             query = query.where(users.c.domain_name == domain_name)

--- a/src/ai/backend/manager/api/gql_legacy/vfolder.py
+++ b/src/ai/backend/manager/api/gql_legacy/vfolder.py
@@ -25,7 +25,7 @@ from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import joinedload, selectinload
 
 from ai.backend.common.config import ModelDefinition, ModelMetadata
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.exception import ModelDefinitionValidationError, VFolderNotFound
 from ai.backend.common.types import (
@@ -1217,7 +1217,7 @@ class VirtualFolder(graphene.ObjectType):  # type: ignore[misc]
     ) -> int:
         from ai.backend.manager.models.project import groups
 
-        membership_query = user_scope_membership_query(PROJECT_SCOPE_TYPE, user_id)
+        membership_query = user_scope_membership_query(ProjectEntityType(), user_id)
 
         async with graph_ctx.db.begin_readonly() as conn:
             membership_result = await conn.execute(membership_query)
@@ -1258,7 +1258,7 @@ class VirtualFolder(graphene.ObjectType):  # type: ignore[misc]
     ) -> list[VirtualFolder]:
         from ai.backend.manager.models.project import groups
 
-        membership_query = user_scope_membership_query(PROJECT_SCOPE_TYPE, user_id)
+        membership_query = user_scope_membership_query(ProjectEntityType(), user_id)
         async with graph_ctx.db.begin_readonly() as conn:
             membership_result = await conn.execute(membership_query)
         grps = membership_result.fetchall()

--- a/src/ai/backend/manager/api/rest/vfolder/handler.py
+++ b/src/ai/backend/manager/api/rest/vfolder/handler.py
@@ -14,9 +14,9 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Final
 
 from ai.backend.common.api_handlers import APIResponse, BodyParam, QueryParam
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationID
 from ai.backend.common.dto.manager.field import (
@@ -352,10 +352,9 @@ class VFolderHandler:
         )
         owner_user_uuid = user_scope.owner_uuid
         group_id = params.group_id
-        if group_id is not None:
-            scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=group_id)
-        else:
-            scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=owner_user_uuid)
+        scope: EntityIdentifier = (
+            ProjectID(group_id) if group_id is not None else UserID(owner_user_uuid)
+        )
         result = await self._vfolder.list_vfolder.run(
             ListVFolderAction(
                 user_uuid=owner_user_uuid,

--- a/src/ai/backend/manager/data/permission/role.py
+++ b/src/ai/backend/manager/data/permission/role.py
@@ -7,12 +7,7 @@ from typing import override
 
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.role_preset import RolePresetID
-from ai.backend.common.data.entity.types import (
-    EntityData,
-    EntityID,
-    EntityIdentifier,
-    EntityType,
-)
+from ai.backend.common.data.entity.types import EntityData, EntityIdentifier, EntityType
 from ai.backend.manager.data.common.types import SearchResult
 
 from .id import ObjectId, ScopeId
@@ -48,7 +43,7 @@ class RoleData(EntityData):
     deleted_at: datetime | None
     # The one scope the role belongs to.
     scope_type: EntityType
-    scope_id: EntityID
+    scope_id: uuid.UUID
     auto_assign: bool = False
     description: str | None = None
     role_preset_id: RolePresetID | None = None
@@ -87,7 +82,7 @@ class RoleDetailData:
     updated_at: datetime
     deleted_at: datetime | None
     scope_type: EntityType
-    scope_id: EntityID
+    scope_id: uuid.UUID
     auto_assign: bool = False
     description: str | None = None
     role_preset_id: RolePresetID | None = None

--- a/src/ai/backend/manager/data/permission/scope_template.py
+++ b/src/ai/backend/manager/data/permission/scope_template.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 
 
 @dataclass(frozen=True)
 class ScopeTemplateValue:
     """Scope attributes exposed to templates as ``{{ scope.* }}``."""
 
-    id: ScopeID
+    id: EntityID
     name: str
     type: str

--- a/src/ai/backend/manager/data/permission/scope_template.py
+++ b/src/ai/backend/manager/data/permission/scope_template.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-from ai.backend.common.data.entity.types import EntityID
+from uuid import UUID
 
 
 @dataclass(frozen=True)
 class ScopeTemplateValue:
     """Scope attributes exposed to templates as ``{{ scope.* }}``."""
 
-    id: EntityID
+    id: UUID
     name: str
     type: str

--- a/src/ai/backend/manager/data/permission/virtual_entity.py
+++ b/src/ai/backend/manager/data/permission/virtual_entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserID
 
 
@@ -22,5 +22,5 @@ class GovernCheckKey:
     scope's virtual entity (itself included)."""
 
     user_id: UserID
-    scope: ScopeRef
+    scope: EntityIdentifier
     entity_type: EntityType

--- a/src/ai/backend/manager/data/resource/types.py
+++ b/src/ai/backend/manager/data/resource/types.py
@@ -21,7 +21,7 @@ from ai.backend.common.types import (
 
 @dataclass
 class UserResourcePolicyData(EntityData):
-    """One user resource policy. Keyed by ``name``; ``uuid`` is its ``EntityID``."""
+    """One user resource policy. Keyed by ``name``; ``uuid`` is its ``EntityIdentifier``."""
 
     uuid: UserResourcePolicyUUID
     name: str
@@ -39,7 +39,7 @@ class UserResourcePolicyData(EntityData):
 
 @dataclass
 class ProjectResourcePolicyData(EntityData):
-    """One project resource policy. Keyed by ``name``; ``uuid`` is its ``EntityID``."""
+    """One project resource policy. Keyed by ``name``; ``uuid`` is its ``EntityIdentifier``."""
 
     uuid: ProjectResourcePolicyUUID
     name: str
@@ -55,7 +55,7 @@ class ProjectResourcePolicyData(EntityData):
 
 @dataclass
 class KeyPairResourcePolicyData(EntityData):
-    """One keypair resource policy. Keyed by ``name``; ``uuid`` is its ``EntityID``."""
+    """One keypair resource policy. Keyed by ``name``; ``uuid`` is its ``EntityIdentifier``."""
 
     uuid: KeyPairResourcePolicyUUID
     name: str

--- a/src/ai/backend/manager/data/resource_slot/types.py
+++ b/src/ai/backend/manager/data/resource_slot/types.py
@@ -43,7 +43,7 @@ class ResourceSlotTypeData(EntityData):
     """One registered resource slot type.
 
     ``slot_name`` is the primary key and the five referencing tables' FK target;
-    ``uuid`` is the unique alternate key that gives the entity its ``EntityID``.
+    ``uuid`` is the unique alternate key that gives the entity its ``EntityIdentifier``.
     """
 
     uuid: ResourceSlotTypeUUID

--- a/src/ai/backend/manager/models/app_config_fragment/conditions.py
+++ b/src/ai/backend/manager/models/app_config_fragment/conditions.py
@@ -13,8 +13,8 @@ from ai.backend.common.data.entity.app_config_fragment import (
     AppConfigFragmentEntityType,
     AppConfigFragmentID,
 )
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
 from ai.backend.manager.models.clauses import QueryCondition
@@ -166,7 +166,7 @@ class AppConfigFragmentConditions:
                     AppConfigFragmentRow.scope_id == domain_id,
                 ),
                 scope_membership_exists(
-                    DOMAIN_SCOPE_TYPE,
+                    DomainEntityType(),
                     domain_id,
                     AppConfigFragmentEntityType(),
                     AppConfigFragmentRow.id,
@@ -187,7 +187,7 @@ class AppConfigFragmentConditions:
                     AppConfigFragmentRow.scope_id == user_id,
                 ),
                 scope_membership_exists(
-                    USER_SCOPE_TYPE,
+                    UserEntityType(),
                     user_id,
                     AppConfigFragmentEntityType(),
                     AppConfigFragmentRow.id,

--- a/src/ai/backend/manager/models/audit_log/creators.py
+++ b/src/ai/backend/manager/models/audit_log/creators.py
@@ -11,7 +11,7 @@ from typing import override
 
 from ai.backend.common.data.entity.action import ActionID
 from ai.backend.common.data.entity.audit_log import AuditLogID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType, ScopeID
+from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionKind, OperationStatus
 from ai.backend.manager.data.audit_log.types import AuditLogData, AuditLogScopeData
 from ai.backend.manager.models.audit_log.row import AuditLogRow
@@ -257,7 +257,7 @@ class AuditLogScopeCreator(NestedFieldCreator[AuditLogID, AuditLogScopeRow, Audi
     """A scope the audited run covered, owned by the audit row it is written under."""
 
     scope_type: str
-    scope_id: ScopeID
+    scope_id: EntityID
 
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:

--- a/src/ai/backend/manager/models/audit_log/creators.py
+++ b/src/ai/backend/manager/models/audit_log/creators.py
@@ -11,7 +11,7 @@ from typing import override
 
 from ai.backend.common.data.entity.action import ActionID
 from ai.backend.common.data.entity.audit_log import AuditLogID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionKind, OperationStatus
 from ai.backend.manager.data.audit_log.types import AuditLogData, AuditLogScopeData
 from ai.backend.manager.models.audit_log.row import AuditLogRow
@@ -78,7 +78,7 @@ class BaseAuditLogFields:
         self,
         *,
         entity_type: str | None,
-        entity_id: EntityID | str | None = None,
+        entity_id: uuid.UUID | str | None = None,
         lookup_kind: str | None = None,
         lookup_key: str | None = None,
     ) -> AuditLogRow:
@@ -257,7 +257,7 @@ class AuditLogScopeCreator(NestedFieldCreator[AuditLogID, AuditLogScopeRow, Audi
     """A scope the audited run covered, owned by the audit row it is written under."""
 
     scope_type: str
-    scope_id: EntityID
+    scope_id: uuid.UUID
 
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:

--- a/src/ai/backend/manager/models/container_registry/row.py
+++ b/src/ai/backend/manager/models/container_registry/row.py
@@ -17,7 +17,6 @@ from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.entity.container_registry import ContainerRegistryID
-from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.exception import UnknownImageRegistry
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.container_registry.types import ContainerRegistryData
@@ -253,7 +252,7 @@ class ContainerRegistryRow(Base):
         return result
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[ContainerRegistryID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/container_registry/row.py
+++ b/src/ai/backend/manager/models/container_registry/row.py
@@ -17,7 +17,7 @@ from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.entity.container_registry import ContainerRegistryID
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.exception import UnknownImageRegistry
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.container_registry.types import ContainerRegistryData
@@ -253,7 +253,7 @@ class ContainerRegistryRow(Base):
         return result
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/domain/creators.py
+++ b/src/ai/backend/manager/models/domain/creators.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import ClassVar, override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
@@ -46,7 +46,7 @@ class DomainCreator(RoleManagedGlobalEntityCreator[DomainRow, DomainData]):
 
     @override
     def template_value(self, row: DomainRow) -> ScopeTemplateValue:
-        return ScopeTemplateValue(id=row.id, name=row.name, type=DOMAIN_SCOPE_TYPE)
+        return ScopeTemplateValue(id=row.id, name=row.name, type=DomainEntityType())
 
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -21,7 +21,7 @@ from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common import msgpack
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.domain.types import DomainData, DomainStatus
@@ -127,7 +127,7 @@ class DomainRow(LifecycleTimestampsMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/domain/row.py
+++ b/src/ai/backend/manager/models/domain/row.py
@@ -21,7 +21,6 @@ from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common import msgpack
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.domain.types import DomainData, DomainStatus
@@ -127,7 +126,7 @@ class DomainRow(LifecycleTimestampsMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[DomainID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/domain/scopes.py
+++ b/src/ai/backend/manager/models/domain/scopes.py
@@ -9,10 +9,7 @@ from typing import Any, override
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainEntityType
-from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
-    ResourceGroupID,
-)
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType, ResourceGroupID
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.domain.row import DomainRow
 from ai.backend.manager.models.resource_group.row import ResourceGroupForDomainRow
@@ -41,7 +38,7 @@ class ResourceGroupDomainOperationScope(OperationScope):
                     )
                 ),
                 scope_membership_exists(
-                    RESOURCE_GROUP_SCOPE_TYPE,
+                    ResourceGroupEntityType(),
                     resource_group_id,
                     DomainEntityType(),
                     DomainRow.id,

--- a/src/ai/backend/manager/models/endpoint/scopes.py
+++ b/src/ai/backend/manager/models/endpoint/scopes.py
@@ -10,8 +10,8 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.errors.resource import ProjectNotFound
 from ai.backend.manager.errors.user import UserNotFound
 from ai.backend.manager.models.clauses import QueryCondition
@@ -40,7 +40,7 @@ class ProjectDeploymentOperationScope(OperationScope):
             return sa.or_(
                 EndpointRow.project == project_id,
                 scope_membership_exists(
-                    PROJECT_SCOPE_TYPE, project_id, DeploymentEntityType(), EndpointRow.id
+                    ProjectEntityType(), project_id, DeploymentEntityType(), EndpointRow.id
                 ),
             )
 
@@ -73,7 +73,7 @@ class UserDeploymentOperationScope(OperationScope):
             return sa.or_(
                 EndpointRow.created_user == user_id,
                 scope_membership_exists(
-                    USER_SCOPE_TYPE, user_id, DeploymentEntityType(), EndpointRow.id
+                    UserEntityType(), user_id, DeploymentEntityType(), EndpointRow.id
                 ),
             )
 

--- a/src/ai/backend/manager/models/entity_label/row.py
+++ b/src/ai/backend/manager/models/entity_label/row.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.entity_label import EntityLabelID, EntityLabelKey
-from ai.backend.common.data.entity.types import EntityID, EntityType, RuntimeEntityID
+from ai.backend.common.data.entity.types import EntityType, RuntimeEntityID
 from ai.backend.manager.data.entity_label.types import EntityLabelData
 from ai.backend.manager.models.base import GUID, Base
 from ai.backend.manager.models.mixins.timestamp import LifecycleTimestampsMixin
@@ -39,7 +41,7 @@ class EntityLabelRow(LifecycleTimestampsMixin, Base):
     entity_type: Mapped[EntityType] = mapped_column(
         "entity_type", sa.String(length=32), nullable=False
     )
-    entity_id: Mapped[EntityID] = mapped_column("entity_id", GUID(), nullable=False)
+    entity_id: Mapped[UUID] = mapped_column("entity_id", GUID(), nullable=False)
     key: Mapped[EntityLabelKey] = mapped_column("key", sa.String(length=255), nullable=False)
     value: Mapped[str] = mapped_column("value", sa.String(length=255), nullable=False)
 

--- a/src/ai/backend/manager/models/entity_label/scopes.py
+++ b/src/ai/backend/manager/models/entity_label/scopes.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
+from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.entity_label.row import EntityLabelRow
 from ai.backend.manager.models.scopes import ExistenceCheck, OperationScope
@@ -27,7 +28,7 @@ class EntityLabelOperationScope(OperationScope):
     """
 
     entity_type: EntityType
-    entity_id: EntityID
+    entity_id: UUID
 
     @override
     def to_condition(self) -> QueryCondition:

--- a/src/ai/backend/manager/models/entity_share/row.py
+++ b/src/ai/backend/manager/models/entity_share/row.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
 from ai.backend.common.data.entity.entity_share import EntityShareID
-from ai.backend.common.data.entity.types import EntityID, EntityType, RuntimeEntityID
+from ai.backend.common.data.entity.types import EntityType, RuntimeEntityID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.data.entity_share.types import (
@@ -113,7 +114,7 @@ class EntityShareRow(LifecycleTimestampsMixin, Base):
     recipient_entity_type: Mapped[EntityType | None] = mapped_column(
         "recipient_entity_type", sa.String(length=32), nullable=True
     )
-    recipient_entity_id: Mapped[EntityID | None] = mapped_column(
+    recipient_entity_id: Mapped[UUID | None] = mapped_column(
         "recipient_entity_id", GUID(), nullable=True
     )
     recipient_email: Mapped[str | None] = mapped_column(
@@ -122,7 +123,7 @@ class EntityShareRow(LifecycleTimestampsMixin, Base):
     target_entity_type: Mapped[EntityType] = mapped_column(
         "target_entity_type", sa.String(length=32), nullable=False
     )
-    target_entity_id: Mapped[EntityID] = mapped_column("target_entity_id", GUID(), nullable=False)
+    target_entity_id: Mapped[UUID] = mapped_column("target_entity_id", GUID(), nullable=False)
     permission_cap: Mapped[Permission | None] = mapped_column(
         "permission_cap", IntFlagType(Permission), nullable=True
     )

--- a/src/ai/backend/manager/models/image/row.py
+++ b/src/ai/backend/manager/models/image/row.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import (
 from sqlalchemy.sql.expression import true
 
 from ai.backend.common.data.entity.image_alias import ImageAliasID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.docker import ImageRef
 from ai.backend.common.exception import UnknownImageReference
@@ -1214,7 +1214,7 @@ class ImagePermissionContextBuilder(
         scope: UserScope,
     ) -> list[ProjectScope]:
         project_ids_stmt = sa.select(ProjectRow.id).where(
-            user_scope_membership_exists(PROJECT_SCOPE_TYPE, ProjectRow.id, scope.user_id)
+            user_scope_membership_exists(ProjectEntityType(), ProjectRow.id, scope.user_id)
         )
         project_ids = await self.db_session.scalars(project_ids_stmt)
 

--- a/src/ai/backend/manager/models/model_card/scopes.py
+++ b/src/ai/backend/manager/models/model_card/scopes.py
@@ -10,7 +10,7 @@ from uuid import UUID
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.model_card import ModelCardEntityType, ModelCardID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.manager.errors.resource import ProjectNotFound
 from ai.backend.manager.models.clauses import QueryCondition
@@ -63,7 +63,7 @@ class ProjectModelCardOperationScope(OperationScope):
             return sa.or_(
                 ModelCardRow.project == project_id,
                 scope_membership_exists(
-                    PROJECT_SCOPE_TYPE, project_id, ModelCardEntityType(), ModelCardRow.id
+                    ProjectEntityType(), project_id, ModelCardEntityType(), ModelCardRow.id
                 ),
             )
 

--- a/src/ai/backend/manager/models/project/conditions.py
+++ b/src/ai/backend/manager/models/project/conditions.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.filter_specs import StringMatchSpec, UUIDEqualMatchSpec, UUIDInMatchSpec
 from ai.backend.manager.data.project.types import ProjectStatus, ProjectType
@@ -42,7 +42,7 @@ class ProjectConditions:
             return sa.or_(
                 ProjectRow.domain_name == domain_name,
                 scope_membership_exists(
-                    DOMAIN_SCOPE_TYPE, domain_id, ProjectEntityType(), ProjectRow.id
+                    DomainEntityType(), domain_id, ProjectEntityType(), ProjectRow.id
                 ),
             )
 

--- a/src/ai/backend/manager/models/project/creators.py
+++ b/src/ai/backend/manager/models/project/creators.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import InvalidAPIParameters
@@ -79,7 +79,7 @@ class ProjectCreator(RoleManagedEntityCreator[ProjectRow, ProjectData]):
 
     @override
     def template_value(self, row: ProjectRow) -> ScopeTemplateValue:
-        return ScopeTemplateValue(id=row.id, name=row.name, type=PROJECT_SCOPE_TYPE)
+        return ScopeTemplateValue(id=row.id, name=row.name, type=ProjectEntityType())
 
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:

--- a/src/ai/backend/manager/models/project/row.py
+++ b/src/ai/backend/manager/models/project/row.py
@@ -33,7 +33,6 @@ from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common import msgpack
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
@@ -239,7 +238,7 @@ class ProjectRow(LifecycleTimestampsMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[ProjectID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/project/row.py
+++ b/src/ai/backend/manager/models/project/row.py
@@ -33,7 +33,7 @@ from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common import msgpack
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import ResourceSlot, VFolderHostPermissionMap
 from ai.backend.logging import BraceStyleAdapter
@@ -239,7 +239,7 @@ class ProjectRow(LifecycleTimestampsMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/project/scopes.py
+++ b/src/ai/backend/manager/models/project/scopes.py
@@ -8,12 +8,9 @@ from typing import Any, override
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectEntityType
-from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
-    ResourceGroupID,
-)
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType, ResourceGroupID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.errors.resource import DomainNotFound
 from ai.backend.manager.models.clauses import QueryCondition
@@ -58,7 +55,7 @@ class DomainProjectOperationScope(OperationScope):
                 ProjectRow.domain_name
                 == sa.select(DomainRow.name).where(DomainRow.id == domain_id).scalar_subquery(),
                 scope_membership_exists(
-                    DOMAIN_SCOPE_TYPE, domain_id, ProjectEntityType(), ProjectRow.id
+                    DomainEntityType(), domain_id, ProjectEntityType(), ProjectRow.id
                 ),
             )
 
@@ -95,7 +92,7 @@ class UserProjectOperationScope(OperationScope):
         user_id = self.user_id
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return user_scope_membership_exists(PROJECT_SCOPE_TYPE, ProjectRow.id, user_id)
+            return user_scope_membership_exists(ProjectEntityType(), ProjectRow.id, user_id)
 
         return inner
 
@@ -128,7 +125,7 @@ class ResourceGroupProjectOperationScope(OperationScope):
                     )
                 ),
                 scope_membership_exists(
-                    RESOURCE_GROUP_SCOPE_TYPE,
+                    ResourceGroupEntityType(),
                     resource_group_id,
                     ProjectEntityType(),
                     ProjectRow.id,

--- a/src/ai/backend/manager/models/rbac_models/role/row.py
+++ b/src/ai/backend/manager/models/rbac_models/role/row.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import (
     TYPE_CHECKING,
 )
+from uuid import UUID
 
 import sqlalchemy as sa
 from sqlalchemy.orm import (
@@ -15,12 +16,7 @@ from sqlalchemy.orm import (
 
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.role_preset import RolePresetID
-from ai.backend.common.data.entity.types import (
-    EntityID,
-    EntityIdentifier,
-    EntityType,
-    RuntimeEntityID,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, RuntimeEntityID
 from ai.backend.manager.data.permission.role import (
     RoleData,
     RoleDetailData,
@@ -110,7 +106,7 @@ class RoleRow(LifecycleTimestampsMixin, Base):
     scope_type: Mapped[EntityType] = mapped_column(
         "scope_type", sa.String(length=32), nullable=False
     )
-    scope_id: Mapped[EntityID] = mapped_column("scope_id", GUID(), nullable=False)
+    scope_id: Mapped[UUID] = mapped_column("scope_id", GUID(), nullable=False)
     # The preset this role was instantiated from; NULL for roles made by hand or
     # before presets were recorded. `use_alter` keeps the FK out of the CREATE TABLE
     # so table subsets that omit ``role_presets`` still build.

--- a/src/ai/backend/manager/models/resource_group/creators.py
+++ b/src/ai/backend/manager/models/resource_group/creators.py
@@ -8,7 +8,7 @@ from typing import Any, override
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE, ResourceGroupID
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType, ResourceGroupID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import ResourceGroupConflict
@@ -59,7 +59,7 @@ class ResourceGroupCreator(RoleManagedGlobalEntityCreator[ResourceGroupRow, Reso
 
     @override
     def template_value(self, row: ResourceGroupRow) -> ScopeTemplateValue:
-        return ScopeTemplateValue(id=row.id, name=row.name, type=RESOURCE_GROUP_SCOPE_TYPE)
+        return ScopeTemplateValue(id=row.id, name=row.name, type=ResourceGroupEntityType())
 
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:

--- a/src/ai/backend/manager/models/resource_group/row.py
+++ b/src/ai/backend/manager/models/resource_group/row.py
@@ -32,7 +32,6 @@ from sqlalchemy.sql.expression import SQLColumnExpression, false, true
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.schema.resource_group import PreemptionConfig
 from ai.backend.common.types import (
     AgentSelectionStrategy,
@@ -313,7 +312,7 @@ class ResourceGroupRow(CreatedAtMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[ResourceGroupID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/resource_group/row.py
+++ b/src/ai/backend/manager/models/resource_group/row.py
@@ -32,7 +32,7 @@ from sqlalchemy.sql.expression import SQLColumnExpression, false, true
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.schema.resource_group import PreemptionConfig
 from ai.backend.common.types import (
     AgentSelectionStrategy,
@@ -313,7 +313,7 @@ class ResourceGroupRow(CreatedAtMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
         return cls.id
 
     @classmethod

--- a/src/ai/backend/manager/models/resource_group/scopes.py
+++ b/src/ai/backend/manager/models/resource_group/scopes.py
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.models.clauses import QueryCondition
 from ai.backend.manager.models.keypair.row import KeyPairRow
@@ -58,7 +58,7 @@ class DomainResourceGroupOperationScope(OperationScope):
                     )
                 ),
                 scope_membership_exists(
-                    RESOURCE_GROUP_SCOPE_TYPE,
+                    ResourceGroupEntityType(),
                     ResourceGroupRow.id,
                     DomainEntityType(),
                     domain_id,
@@ -92,7 +92,7 @@ class ProjectResourceGroupOperationScope(OperationScope):
                     )
                 ),
                 scope_membership_exists(
-                    RESOURCE_GROUP_SCOPE_TYPE,
+                    ResourceGroupEntityType(),
                     ResourceGroupRow.id,
                     ProjectEntityType(),
                     project_id,
@@ -132,7 +132,7 @@ class UserResourceGroupOperationScope(OperationScope):
                     )
                 ),
                 scope_membership_exists(
-                    RESOURCE_GROUP_SCOPE_TYPE,
+                    ResourceGroupEntityType(),
                     ResourceGroupRow.id,
                     UserEntityType(),
                     user_id,

--- a/src/ai/backend/manager/models/scope_source.py
+++ b/src/ai/backend/manager/models/scope_source.py
@@ -14,7 +14,7 @@ class ScopeSource(Protocol):
 
     @classmethod
     def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
-        """Column whose value is used as ``ScopeRef.scope_id``."""
+        """Column carrying the scope's id."""
         ...
 
     @classmethod

--- a/src/ai/backend/manager/models/scope_source.py
+++ b/src/ai/backend/manager/models/scope_source.py
@@ -6,14 +6,14 @@ from typing import Protocol
 
 from sqlalchemy.sql.expression import SQLColumnExpression
 
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 
 
 class ScopeSource(Protocol):
     """A Row queryable as an RBAC scope: its scope-id and display-name expressions."""
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
         """Column carrying the scope's id."""
         ...
 

--- a/src/ai/backend/manager/models/scope_source.py
+++ b/src/ai/backend/manager/models/scope_source.py
@@ -6,14 +6,14 @@ from typing import Protocol
 
 from sqlalchemy.sql.expression import SQLColumnExpression
 
-from ai.backend.common.data.entity.types import EntityID
+from ai.backend.common.data.entity.types import EntityIdentifier
 
 
 class ScopeSource(Protocol):
     """A Row queryable as an RBAC scope: its scope-id and display-name expressions."""
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityIdentifier]:
         """Column carrying the scope's id."""
         ...
 

--- a/src/ai/backend/manager/models/session/scopes.py
+++ b/src/ai/backend/manager/models/session/scopes.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.manager.errors.resource import ProjectNotFound
 from ai.backend.manager.models.clauses import QueryCondition
@@ -41,7 +41,7 @@ class ProjectSessionOperationScope(OperationScope):
             return sa.or_(
                 SessionRow.group_id == project_id,
                 scope_membership_exists(
-                    PROJECT_SCOPE_TYPE, project_id, SessionEntityType(), SessionRow.id
+                    ProjectEntityType(), project_id, SessionEntityType(), SessionRow.id
                 ),
             )
 

--- a/src/ai/backend/manager/models/user/creators.py
+++ b/src/ai/backend/manager/models/user/creators.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.types import EntityIdentifier
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.data.user.types import UserData, UserStatus
 from ai.backend.manager.errors.repository import (
@@ -62,7 +62,7 @@ class UserCreator(RoleManagedEntityCreator[UserRow, UserData]):
 
     @override
     def template_value(self, row: UserRow) -> ScopeTemplateValue:
-        return ScopeTemplateValue(id=row.uuid, name=row.username, type=USER_SCOPE_TYPE)
+        return ScopeTemplateValue(id=row.uuid, name=row.username, type=UserEntityType())
 
     @override
     def integrity_error_checks(self) -> Sequence[IntegrityErrorCheck]:

--- a/src/ai/backend/manager/models/user/row.py
+++ b/src/ai/backend/manager/models/user/row.py
@@ -25,7 +25,6 @@ from sqlalchemy.orm.strategy_options import _AbstractLoad
 from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.types import ReadableCIDR
@@ -207,7 +206,7 @@ class UserRow(LifecycleTimestampsMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[UserID]:
         return cls.uuid
 
     @classmethod

--- a/src/ai/backend/manager/models/user/row.py
+++ b/src/ai/backend/manager/models/user/row.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm.strategy_options import _AbstractLoad
 from sqlalchemy.sql.expression import SQLColumnExpression
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.types import ScopeID
+from ai.backend.common.data.entity.types import EntityID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.user.types import UserRole
 from ai.backend.common.types import ReadableCIDR
@@ -207,7 +207,7 @@ class UserRow(LifecycleTimestampsMixin, Base):
     )
 
     @classmethod
-    def scope_id_expr(cls) -> SQLColumnExpression[ScopeID]:
+    def scope_id_expr(cls) -> SQLColumnExpression[EntityID]:
         return cls.uuid
 
     @classmethod

--- a/src/ai/backend/manager/models/user/scopes.py
+++ b/src/ai/backend/manager/models/user/scopes.py
@@ -8,8 +8,8 @@ from typing import override
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.manager.errors.permission import RoleNotFound
 from ai.backend.manager.errors.resource import DomainNotFound, ProjectNotFound
@@ -45,7 +45,7 @@ class DomainUserOperationScope(OperationScope):
         domain_id = self.domain_id
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return user_scope_membership_exists(DOMAIN_SCOPE_TYPE, domain_id, UserRow.uuid)
+            return user_scope_membership_exists(DomainEntityType(), domain_id, UserRow.uuid)
 
         return inner
 
@@ -80,7 +80,7 @@ class ProjectUserOperationScope(OperationScope):
         project_id = self.project_id
 
         def inner() -> sa.sql.expression.ColumnElement[bool]:
-            return user_scope_membership_exists(PROJECT_SCOPE_TYPE, project_id, UserRow.uuid)
+            return user_scope_membership_exists(ProjectEntityType(), project_id, UserRow.uuid)
 
         return inner
 

--- a/src/ai/backend/manager/models/vfolder/creators.py
+++ b/src/ai/backend/manager/models/vfolder/creators.py
@@ -10,9 +10,9 @@ from typing import Any, override
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityIdentifier, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.entity.vfolder_invitation import VFolderInvitationID
 from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
@@ -81,7 +81,7 @@ class VFolderBaseCreator(GuardedEntityCreator[VFolderRow, VFolderData]):
     status: VFolderOperationStatus = VFolderOperationStatus.CREATING
 
     @abstractmethod
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         """The scope the creation is authorized against.
 
         The project for a folder that project owns, the person's own scope for a folder
@@ -203,8 +203,8 @@ class PersonalVFolderCreator(VFolderBaseCreator):
     user: UserID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user,)
 
     @override
     def build_row(self) -> VFolderRow:
@@ -244,8 +244,8 @@ class ProjectVFolderCreator(VFolderBaseCreator):
     project: ProjectID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project,)
 
     @override
     def precondition_checks(self) -> Sequence[PreconditionCheck]:

--- a/src/ai/backend/manager/models/vfolder/row.py
+++ b/src/ai/backend/manager/models/vfolder/row.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import Mapped, foreign, load_only, mapped_column, relationship, selectinload
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.defs import (
@@ -705,7 +705,7 @@ async def query_accessible_vfolders(
             grps = result.fetchall()
             group_ids = [g.id for g in grps]
         else:
-            query = user_scope_membership_query(PROJECT_SCOPE_TYPE, user_uuid)
+            query = user_scope_membership_query(ProjectEntityType(), user_uuid)
             result = await conn.execute(query)
             grps = result.fetchall()
             group_ids = [g.scope_id for g in grps]
@@ -842,7 +842,7 @@ async def get_allowed_vfolder_hosts_by_user(
         result_hosts: VFolderHostPermissionMap = allowed_hosts | values
         allowed_hosts = result_hosts
     # User's Groups' allowed_vfolder_hosts.
-    membership_cond = user_scope_membership_exists(PROJECT_SCOPE_TYPE, groups.c.id, user_uuid)
+    membership_cond = user_scope_membership_exists(ProjectEntityType(), groups.c.id, user_uuid)
     if group_id is not None:
         membership_cond = sa.and_(membership_cond, groups.c.id == group_id)
     query = sa.select(groups.c.allowed_vfolder_hosts).where(
@@ -1054,7 +1054,7 @@ async def ensure_quota_scope_accessible_by_user(
             case _:
                 membership_query = sa.select(
                     user_scope_membership_exists(
-                        PROJECT_SCOPE_TYPE, quota_scope_group.id, user["uuid"]
+                        ProjectEntityType(), quota_scope_group.id, user["uuid"]
                     )
                 )
                 if await conn.scalar(membership_query):
@@ -1354,7 +1354,7 @@ class VFolderPermissionContextBuilder(
             sa.select(ProjectRow)
             .where(
                 ProjectRow.domain_name == domain_name,
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, ProjectRow.id, ctx.user_id),
+                user_scope_membership_exists(ProjectEntityType(), ProjectRow.id, ctx.user_id),
             )
             .options(load_only(ProjectRow.id))
         )

--- a/src/ai/backend/manager/models/vfolder/scopes.py
+++ b/src/ai/backend/manager/models/vfolder/scopes.py
@@ -9,8 +9,8 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.manager.data.project.types import ProjectType
 from ai.backend.manager.errors.resource import ProjectNotFound
@@ -48,7 +48,7 @@ class ProjectVFolderOperationScope(OperationScope):
             return sa.or_(
                 VFolderRow.group == project_id,
                 scope_membership_exists(
-                    PROJECT_SCOPE_TYPE, project_id, VFolderEntityType(), VFolderRow.id
+                    ProjectEntityType(), project_id, VFolderEntityType(), VFolderRow.id
                 ),
             )
 
@@ -104,10 +104,10 @@ class UserVFolderOperationScope(OperationScope):
                 VFolderRow.user == user_id,
                 VFolderRow.id.in_(permitted_vfolder_ids),
                 scope_membership_exists(
-                    PROJECT_SCOPE_TYPE, personal_project_id, VFolderEntityType(), VFolderRow.id
+                    ProjectEntityType(), personal_project_id, VFolderEntityType(), VFolderRow.id
                 ),
                 scope_membership_exists(
-                    USER_SCOPE_TYPE, user_id, VFolderEntityType(), VFolderRow.id
+                    UserEntityType(), user_id, VFolderEntityType(), VFolderRow.id
                 ),
             )
 

--- a/src/ai/backend/manager/models/virtual_entity/queries.py
+++ b/src/ai/backend/manager/models/virtual_entity/queries.py
@@ -14,7 +14,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
-from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeType
+from ai.backend.common.data.entity.types import EntityID, EntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
@@ -32,7 +32,7 @@ type _UuidExpr = uuid.UUID | sa.ColumnElement[Any] | InstrumentedAttribute[Any]
 
 
 def user_scope_membership_query(
-    scope_type: ScopeType, user_id: _UuidExpr | None = None
+    scope_type: EntityType, user_id: _UuidExpr | None = None
 ) -> sa.Select[tuple[EntityID, EntityID]]:
     """(``user_id``, ``scope_id``) pairs of the users enrolled in scopes of
     ``scope_type``, narrowed to one user when ``user_id`` is given. The scope side is
@@ -58,7 +58,7 @@ def user_scope_membership_query(
 
 
 def scope_membership_exists(
-    scope_type: ScopeType,
+    scope_type: EntityType,
     scope_id: _UuidExpr,
     member_type: EntityType,
     member_id: _UuidExpr,
@@ -87,7 +87,7 @@ def scope_membership_exists(
 
 
 def user_scope_membership_exists(
-    scope_type: ScopeType,
+    scope_type: EntityType,
     scope_id: _UuidExpr,
     user_id: _UuidExpr,
 ) -> sa.ColumnElement[bool]:

--- a/src/ai/backend/manager/models/virtual_entity/queries.py
+++ b/src/ai/backend/manager/models/virtual_entity/queries.py
@@ -14,7 +14,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
-from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeID, ScopeType
+from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
@@ -33,7 +33,7 @@ type _UuidExpr = uuid.UUID | sa.ColumnElement[Any] | InstrumentedAttribute[Any]
 
 def user_scope_membership_query(
     scope_type: ScopeType, user_id: _UuidExpr | None = None
-) -> sa.Select[tuple[EntityID, ScopeID]]:
+) -> sa.Select[tuple[EntityID, EntityID]]:
     """(``user_id``, ``scope_id``) pairs of the users enrolled in scopes of
     ``scope_type``, narrowed to one user when ``user_id`` is given. The scope side is
     ``VirtualEntityRow``, so callers may filter on its columns; both selected columns

--- a/src/ai/backend/manager/models/virtual_entity/queries.py
+++ b/src/ai/backend/manager/models/virtual_entity/queries.py
@@ -14,7 +14,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.models.virtual_entity.entity_membership import EntityMembershipRow
 from ai.backend.manager.models.virtual_entity.virtual_entity import VirtualEntityRow
@@ -33,7 +33,7 @@ type _UuidExpr = uuid.UUID | sa.ColumnElement[Any] | InstrumentedAttribute[Any]
 
 def user_scope_membership_query(
     scope_type: EntityType, user_id: _UuidExpr | None = None
-) -> sa.Select[tuple[EntityID, EntityID]]:
+) -> sa.Select[tuple[uuid.UUID, uuid.UUID]]:
     """(``user_id``, ``scope_id``) pairs of the users enrolled in scopes of
     ``scope_type``, narrowed to one user when ``user_id`` is given. The scope side is
     ``VirtualEntityRow``, so callers may filter on its columns; both selected columns

--- a/src/ai/backend/manager/models/virtual_entity/virtual_entity.py
+++ b/src/ai/backend/manager/models/virtual_entity/virtual_entity.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from uuid import UUID
+
 import sqlalchemy as sa
 from sqlalchemy.orm import Mapped, mapped_column
 
-from ai.backend.common.data.entity.types import EntityID, EntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.virtual_entity import VirtualEntityData
 from ai.backend.manager.models.base import (
@@ -31,7 +33,7 @@ class VirtualEntityRow(CreatedAtMixin, Base):
     entity_type: Mapped[EntityType] = mapped_column(
         "entity_type", sa.String(length=32), nullable=False
     )
-    entity_id: Mapped[EntityID] = mapped_column("entity_id", GUID(), nullable=False)
+    entity_id: Mapped[UUID] = mapped_column("entity_id", GUID(), nullable=False)
 
     def to_data(self) -> VirtualEntityData:
         return VirtualEntityData(

--- a/src/ai/backend/manager/repositories/auth/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/auth/db_source/db_source.py
@@ -14,7 +14,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pgsql
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.exception import BackendAIError, UserNotFound
@@ -125,7 +125,7 @@ class AuthDBSource:
     async def fetch_group_membership(self, group_id: UUID, user_id: UUID) -> GroupMembershipData:
         """Fetch group membership from database."""
         async with self._db.begin() as conn:
-            query = sa.select(user_scope_membership_exists(PROJECT_SCOPE_TYPE, group_id, user_id))
+            query = sa.select(user_scope_membership_exists(ProjectEntityType(), group_id, user_id))
             is_member = (await conn.execute(query)).scalar()
             if not is_member:
                 raise GroupMembershipNotFoundError(

--- a/src/ai/backend/manager/repositories/ops/v2/entity_write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/entity_write.py
@@ -24,10 +24,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.role_preset import RolePresetID
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    ScopeType,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.permission.types import RBACElementType
 from ai.backend.common.exception import RBACTypeConversionError
@@ -329,7 +326,7 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
 
     # -- Preset-derived roles (role-managed paths only) ---------------------------
 
-    def _scope_element_type(self, scope_type: ScopeType) -> RBACElementType:
+    def _scope_element_type(self, scope_type: EntityType) -> RBACElementType:
         try:
             return RBACElementType(scope_type)
         except ValueError as e:
@@ -389,8 +386,7 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
             await self._sess.scalars(
                 sa.select(RolePresetRow).where(
                     RolePresetRow.scope_type.in_({
-                        self._scope_element_type(ScopeType(e.entity_type())).to_scope_type()
-                        for e in entities
+                        self._scope_element_type(e.entity_type()).to_scope_type() for e in entities
                     }),
                     RolePresetRow.deleted.is_(False),
                 )
@@ -430,7 +426,7 @@ class V2EntityWriteOps(V2GraphWriteOpsBase):
             )
             for entity in entities
             for preset in presets_by_scope_type[
-                self._scope_element_type(ScopeType(entity.entity_type())).to_scope_type()
+                self._scope_element_type(entity.entity_type()).to_scope_type()
             ]
         ]
 

--- a/src/ai/backend/manager/repositories/ops/v2/graph_read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/graph_read.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.data.project.types import ProjectType
 from ai.backend.manager.models.project.row import ProjectRow
@@ -30,7 +30,7 @@ class V2GraphReadOpsBase(V2OpsBase):
 
     async def scopes_owning(
         self, scope_type: EntityType, entity: EntityIdentifier
-    ) -> Sequence[EntityID]:
+    ) -> Sequence[uuid.UUID]:
         """The scopes of ``scope_type`` that own the entity, uncapped — a share is not
         own. Empty where no such scope holds it."""
         return (await self._sess.scalars(self._scopes_owning_query(scope_type, entity))).all()

--- a/src/ai/backend/manager/repositories/ops/v2/graph_read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/graph_read.py
@@ -16,7 +16,7 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, ScopeType
+from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.data.project.types import ProjectType
 from ai.backend.manager.models.project.row import ProjectRow
@@ -29,7 +29,7 @@ class V2GraphReadOpsBase(V2OpsBase):
     """What the graph answers about who holds what."""
 
     async def scopes_owning(
-        self, scope_type: ScopeType, entity: EntityIdentifier
+        self, scope_type: EntityType, entity: EntityIdentifier
     ) -> Sequence[EntityID]:
         """The scopes of ``scope_type`` that own the entity, uncapped — a share is not
         own. Empty where no such scope holds it."""
@@ -53,7 +53,7 @@ class V2GraphReadOpsBase(V2OpsBase):
         return {row.creator_id: row.id for row in rows}
 
     def _scopes_owning_query(
-        self, scope_type: ScopeType, entity: EntityIdentifier
+        self, scope_type: EntityType, entity: EntityIdentifier
     ) -> sa.Select[tuple[uuid.UUID]]:
         membership = EntityMembershipRow.__table__
         scope = VirtualEntityRow.__table__.alias("owning_scope_node")

--- a/src/ai/backend/manager/repositories/ops/v2/permission/read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/permission/read.py
@@ -152,16 +152,16 @@ class PermissionReadOps(V2ReadOps):
             groups[
                 _GroupKey(
                     user_id=key.user_id,
-                    entity_type=EntityType(key.scope.scope_type),
+                    entity_type=key.scope.entity_type(),
                     subject_entity_type=key.entity_type,
                 )
             ].append(key)
 
         result: dict[GovernCheckKey, Permission] = {}
         for group_key, members in groups.items():
-            granted = await self._resolve_group(group_key, [k.scope.scope_id for k in members])
+            granted = await self._resolve_group(group_key, [k.scope for k in members])
             for key in members:
-                result[key] = granted.get(key.scope.scope_id, Permission.NONE)
+                result[key] = granted.get(key.scope, Permission.NONE)
         return result
 
     async def _resolve_group(

--- a/src/ai/backend/manager/repositories/ops/v2/permission/read.py
+++ b/src/ai/backend/manager/repositories/ops/v2/permission/read.py
@@ -15,10 +15,7 @@ from dataclasses import dataclass
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.role import RoleID
-from ai.backend.common.data.entity.types import (
-    EntityID,
-    EntityType,
-)
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.permission.id import FieldPath
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -165,14 +162,14 @@ class PermissionReadOps(V2ReadOps):
         return result
 
     async def _resolve_group(
-        self, group_key: _GroupKey, entity_ids: Sequence[EntityID]
-    ) -> Mapping[EntityID, Permission]:
+        self, group_key: _GroupKey, entity_ids: Sequence[uuid.UUID]
+    ) -> Mapping[uuid.UUID, Permission]:
         result = await self._sess.execute(self._owned_query(group_key, entity_ids))
         return {row.entity_id: Permission(row.granted) for row in result}
 
     def _owned_query(
-        self, group_key: _GroupKey, entity_ids: Sequence[EntityID]
-    ) -> sa.Select[tuple[EntityID, int]]:
+        self, group_key: _GroupKey, entity_ids: Sequence[uuid.UUID]
+    ) -> sa.Select[tuple[uuid.UUID, int]]:
         """Run the virtual-entity-chain query for a single ``(user_id, entity_type,
         subject_entity_type)`` group with N entity_ids.
 

--- a/src/ai/backend/manager/repositories/ops/v2/role_preset/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/role_preset/write.py
@@ -12,19 +12,14 @@ from typing import ClassVar
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.container_registry import CONTAINER_REGISTRY_SCOPE_TYPE
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE
+from ai.backend.common.data.entity.container_registry import ContainerRegistryEntityType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.role_preset import RolePresetID
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    RuntimeEntityID,
-    ScopeType,
-)
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, RuntimeEntityID
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
@@ -49,12 +44,12 @@ _SYNC_CHUNK_SIZE = 200
 class RolePresetWriteOps(PermissionWriteOps):
     """The permission write ops plus the sync of a preset's derived roles."""
 
-    _scope_rows: ClassVar[Mapping[ScopeType, type[ScopeSource]]] = {
-        CONTAINER_REGISTRY_SCOPE_TYPE: ContainerRegistryRow,
-        DOMAIN_SCOPE_TYPE: DomainRow,
-        PROJECT_SCOPE_TYPE: ProjectRow,
-        RESOURCE_GROUP_SCOPE_TYPE: ResourceGroupRow,
-        USER_SCOPE_TYPE: UserRow,
+    _scope_rows: ClassVar[Mapping[EntityType, type[ScopeSource]]] = {
+        ContainerRegistryEntityType(): ContainerRegistryRow,
+        DomainEntityType(): DomainRow,
+        ProjectEntityType(): ProjectRow,
+        ResourceGroupEntityType(): ResourceGroupRow,
+        UserEntityType(): UserRow,
     }
 
     async def sync_preset_roles(self, preset_id: RolePresetID) -> None:
@@ -68,7 +63,7 @@ class RolePresetWriteOps(PermissionWriteOps):
         preset = await self._sess.get(RolePresetRow, preset_id)
         if preset is None:
             return
-        scope_type = ScopeType(EntityType(preset.scope_type.to_element().value))
+        scope_type = EntityType(EntityType(preset.scope_type.to_element().value))
         granted = await self._preset_grants(preset_id)
         roles = await self._derived_roles(preset_id, scope_type)
         for start in range(0, len(roles), _SYNC_CHUNK_SIZE):
@@ -79,7 +74,7 @@ class RolePresetWriteOps(PermissionWriteOps):
     async def _sync_roles(
         self,
         preset: RolePresetRow,
-        scope_type: ScopeType,
+        scope_type: EntityType,
         granted: Mapping[EntityType, Permission],
         entities: Mapping[RoleID, EntityIdentifier],
     ) -> None:
@@ -125,7 +120,7 @@ class RolePresetWriteOps(PermissionWriteOps):
         return granted
 
     async def _derived_roles(
-        self, preset_id: RolePresetID, scope_type: ScopeType
+        self, preset_id: RolePresetID, scope_type: EntityType
     ) -> list[tuple[RoleID, EntityIdentifier]]:
         """Each role the preset instantiated with the scope of ``scope_type`` it sits in."""
         rows = (
@@ -160,7 +155,7 @@ class RolePresetWriteOps(PermissionWriteOps):
     async def _rendered_names(
         self,
         preset: RolePresetRow,
-        scope_type: ScopeType,
+        scope_type: EntityType,
         entities: Mapping[RoleID, EntityIdentifier],
     ) -> dict[RoleID, str]:
         """The name the preset's rule now yields per role; a templated preset whose
@@ -178,7 +173,7 @@ class RolePresetWriteOps(PermissionWriteOps):
         }
 
     async def _scope_template_values(
-        self, scope_type: ScopeType, scopes: Collection[EntityIdentifier]
+        self, scope_type: EntityType, scopes: Collection[EntityIdentifier]
     ) -> dict[EntityIdentifier, ScopeTemplateValue]:
         row_cls = self._scope_rows.get(scope_type)
         if row_cls is None:

--- a/src/ai/backend/manager/repositories/ops/v2/roster/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/roster/write.py
@@ -17,7 +17,7 @@ from typing import ClassVar
 
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.permission.types import Permission
@@ -111,7 +111,7 @@ class V2RosterWriteOps(V2WriteOps, V2CapOps):
             await self._sess.scalars(
                 sa.select(UserRow).where(
                     UserRow.uuid.in_(requested),
-                    user_scope_membership_exists(PROJECT_SCOPE_TYPE, project_id, UserRow.uuid),
+                    user_scope_membership_exists(ProjectEntityType(), project_id, UserRow.uuid),
                 )
             )
         ).all()
@@ -148,7 +148,9 @@ class V2RosterWriteOps(V2WriteOps, V2CapOps):
                     sa.select(UserRow).where(
                         UserRow.uuid.in_(user_ids),
                         UserRow.domain_name == project_domain,
-                        ~user_scope_membership_exists(PROJECT_SCOPE_TYPE, project_id, UserRow.uuid),
+                        ~user_scope_membership_exists(
+                            ProjectEntityType(), project_id, UserRow.uuid
+                        ),
                     )
                 )
             ).all()
@@ -176,7 +178,7 @@ class V2RosterWriteOps(V2WriteOps, V2CapOps):
         """Unmap the user from every role of the project — the reverse of what joining
         granted, read the same way."""
         project_role_ids = sa.select(RoleRow.id).where(
-            RoleRow.scope_type == PROJECT_SCOPE_TYPE,
+            RoleRow.scope_type == ProjectEntityType(),
             RoleRow.scope_id == project_id,
         )
         await self._sess.execute(

--- a/src/ai/backend/manager/repositories/ops/v2/user/write.py
+++ b/src/ai/backend/manager/repositories/ops/v2/user/write.py
@@ -19,7 +19,7 @@ from typing import ClassVar
 import sqlalchemy as sa
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.data.keypair.types import KeyPairData, KeyPairSecrets
 from ai.backend.manager.data.project.types import ProjectData
@@ -227,7 +227,7 @@ class V2UserWriteOps(V2RosterWriteOps):
 
     async def _joined_project_ids(self, user_id: UserID) -> set[ProjectID]:
         """The projects the user is on the roster of, personal ones left out."""
-        stmt = user_scope_membership_query(PROJECT_SCOPE_TYPE, user_id).where(
+        stmt = user_scope_membership_query(ProjectEntityType(), user_id).where(
             VirtualEntityRow.entity_id.not_in(
                 sa.select(ProjectRow.id).where(ProjectRow.type == ProjectType.PERSONAL)
             )

--- a/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/permission_controller/db_source/db_source.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from sqlalchemy.orm import contains_eager, selectinload
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.permission.types import (
@@ -224,7 +224,7 @@ class PermissionDBSource:
             # take the user off the project's roster.
             project_subq = sa.select(RoleRow.scope_id).where(
                 RoleRow.id == data.role_id,
-                RoleRow.scope_type == PROJECT_SCOPE_TYPE,
+                RoleRow.scope_type == ProjectEntityType(),
             )
             rows = (
                 await db_session.execute(
@@ -234,7 +234,7 @@ class PermissionDBSource:
                         (UserRoleRow.role_id == RoleRow.id) & (UserRoleRow.user_id == data.user_id),
                     )
                     .where(
-                        RoleRow.scope_type == PROJECT_SCOPE_TYPE,
+                        RoleRow.scope_type == ProjectEntityType(),
                         RoleRow.scope_id.in_(project_subq),
                     )
                     .group_by(RoleRow.scope_id)

--- a/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/resource_preset/db_source/db_source.py
@@ -11,7 +11,7 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.resource_preset import ResourcePresetID
 from ai.backend.common.types import (
     AccessKey,
@@ -267,7 +267,7 @@ class ResourcePresetDBSource:
         :raises ProjectNotFound: If the group does not exist or the user is not a member
         """
         query = sa.select(groups.c.id, groups.c.total_resource_slots).where(
-            user_scope_membership_exists(PROJECT_SCOPE_TYPE, groups.c.id, user_id)
+            user_scope_membership_exists(ProjectEntityType(), groups.c.id, user_id)
             & (groups.c.name == group_name)
             & (groups.c.domain_name == domain_name),
         )

--- a/src/ai/backend/manager/repositories/vfolder/repository.py
+++ b/src/ai/backend/manager/repositories/vfolder/repository.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import contains_eager, selectinload
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
 from ai.backend.common.contexts.user import current_user
 from ai.backend.common.data.entity.model_card import ModelCardID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.entity.vfolder_permission import VFolderPermissionID
@@ -1835,7 +1835,9 @@ class VfolderRepository:
                 raise VFolderInvalidParameter("Only group vfolders can be shared with users.")
             users_table = UserRow.__table__
             db_query = sa.select(users_table.c.uuid, users_table.c.email).where(
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, vfolder_group, users_table.c.uuid),
+                user_scope_membership_exists(
+                    ProjectEntityType(), vfolder_group, users_table.c.uuid
+                ),
                 users_table.c.email.in_(emails),
                 users_table.c.email != requester_email,
                 users_table.c.status.in_(ACTIVE_USER_STATUSES),
@@ -1949,7 +1951,7 @@ class VfolderRepository:
                         vf_table.c.user == requester_id,
                         vf_table.c.creator_id == requester_id,
                         user_scope_membership_exists(
-                            PROJECT_SCOPE_TYPE, vf_table.c.group, requester_id
+                            ProjectEntityType(), vf_table.c.group, requester_id
                         ),
                     )
                 )

--- a/src/ai/backend/manager/services/app_config/actions/fragment/bulk_upsert.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/bulk_upsert.py
@@ -5,12 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    ScopeRef,
-    ScopeType,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import AtomicUpsertEntityOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
@@ -41,8 +36,8 @@ class BulkUpsertAppConfigFragmentsAction(
         return "bulk_upsert_app_config_fragments"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=ScopeType(self.owner.entity_type()), scope_id=self.owner),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.owner,)
 
     @override
     def to_upserters(self) -> Sequence[AppConfigFragmentUpserter]:

--- a/src/ai/backend/manager/services/app_config/actions/fragment/scoped_search.py
+++ b/src/ai/backend/manager/services/app_config/actions/fragment/scoped_search.py
@@ -7,12 +7,7 @@ from typing import override
 from ai.backend.common.data.app_config.types import AppConfigScopeType
 from ai.backend.common.data.entity.app_config import AppConfigScopeID
 from ai.backend.common.data.entity.app_config_fragment import AppConfigFragmentEntityType
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    ScopeRef,
-    ScopeType,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.app_config.types import AppConfigFragmentData
 from ai.backend.manager.models.app_config_fragment.row import AppConfigFragmentRow
@@ -47,11 +42,11 @@ class ScopedSearchAppConfigFragmentAction(
         return "search_app_config_fragments"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         owner = self.owner
         if owner is None:
             return ()
-        return (ScopeRef(scope_type=ScopeType(owner.entity_type()), scope_id=owner),)
+        return (owner,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/app_config/actions/search.py
+++ b/src/ai/backend/manager/services/app_config/actions/search.py
@@ -6,8 +6,8 @@ from typing import override
 
 from ai.backend.common.data.entity.app_config import AppConfigEntityType
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
 from ai.backend.manager.data.app_config.types import AppConfigData, AppConfigFragmentData
@@ -50,8 +50,8 @@ class SearchAppConfigsAction(
         return "search_app_configs"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:
@@ -90,7 +90,7 @@ class AnonymousSearchAppConfigsAction(
         return "anonymous_search_app_configs"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return ()
 
     @override

--- a/src/ai/backend/manager/services/artifact/actions/get_revisions.py
+++ b/src/ai/backend/manager/services/artifact/actions/get_revisions.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.artifact import ArtifactEntityType, ArtifactID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.artifact.types import ArtifactRevisionData
 from ai.backend.manager.models.artifact_revision.row import ArtifactRevisionRow
@@ -37,8 +37,8 @@ class GetArtifactRevisionsAction(
         return "get_artifact_revisions"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=ScopeType(ArtifactEntityType()), scope_id=self.artifact_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.artifact_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/auth/actions/search_login_history.py
+++ b/src/ai/backend/manager/services/auth/actions/search_login_history.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.ops.base import (
     OperationScopeOpsAction,
     SearchGlobalOpsAction,
@@ -49,8 +49,8 @@ class SearchLoginHistoryAction(OperationScopeOpsAction[LoginHistoryRow, LoginHis
         return UserEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/auth/actions/search_login_sessions.py
+++ b/src/ai/backend/manager/services/auth/actions/search_login_sessions.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.ops.base import (
     OperationScopeOpsAction,
     SearchGlobalOpsAction,
@@ -49,8 +49,8 @@ class SearchLoginSessionsAction(OperationScopeOpsAction[LoginSessionRow, LoginSe
         return UserEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/deployment/actions/access_token/search_access_tokens.py
+++ b/src/ai/backend/manager/services/deployment/actions/access_token/search_access_tokens.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelDeploymentAccessTokenData
 from ai.backend.manager.models.endpoint.row import EndpointTokenRow
@@ -38,10 +38,8 @@ class SearchAccessTokensAction(
         return "search_access_tokens"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (
-            ScopeRef(scope_type=ScopeType(DeploymentEntityType()), scope_id=self.deployment_id),
-        )
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.deployment_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/deployment/actions/create_deployment.py
+++ b/src/ai/backend/manager/services/deployment/actions/create_deployment.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.creator import NewDeploymentCreator
 from ai.backend.manager.data.deployment.types import ModelDeploymentData
@@ -25,8 +25,8 @@ class CreateDeploymentAction(DeploymentScopeAction):
     auto_activate: bool
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment/actions/create_legacy_deployment.py
+++ b/src/ai/backend/manager/services/deployment/actions/create_legacy_deployment.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.deployment.creator import DeploymentCreationDraft
 from ai.backend.manager.data.deployment.types import DeploymentInfo
@@ -24,8 +24,8 @@ class CreateLegacyDeploymentAction(DeploymentScopeAction):
     draft: DeploymentCreationDraft
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/deployment/actions/model_revision/search_revisions.py
+++ b/src/ai/backend/manager/services/deployment/actions/model_revision/search_revisions.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelRevisionData
 from ai.backend.manager.models.deployment_revision.row import DeploymentRevisionRow
@@ -38,10 +38,8 @@ class SearchRevisionsAction(OperationScopeOpsAction[DeploymentRevisionRow, Model
         return "search_revisions"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (
-            ScopeRef(scope_type=ScopeType(DeploymentEntityType()), scope_id=self.deployment_id),
-        )
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.deployment_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/deployment/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/deployment/actions/scoped_search.py
@@ -7,9 +7,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.ops.base import ScopeItem
 from ai.backend.manager.data.deployment.types import ModelDeploymentData
@@ -44,8 +44,8 @@ class ProjectDeploymentScopeItem(DeploymentScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.project_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -59,8 +59,8 @@ class UserDeploymentScopeItem(DeploymentScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -79,7 +79,7 @@ class ScopedSearchDeploymentsAction(DeploymentScopeAction):
     querier: BatchQuerier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/deployment/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/deployment/actions/scoped_search.py
@@ -44,7 +44,7 @@ class ProjectDeploymentScopeItem(DeploymentScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.project_id
 
     @override
@@ -59,7 +59,7 @@ class UserDeploymentScopeItem(DeploymentScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -80,7 +80,7 @@ class ScopedSearchDeploymentsAction(DeploymentScopeAction):
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     def operation_scopes(self) -> Sequence[OperationScope]:
         return [item.operation_scope() for item in self.items]

--- a/src/ai/backend/manager/services/deployment/actions/search_replicas.py
+++ b/src/ai/backend/manager/services/deployment/actions/search_replicas.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.deployment import DeploymentEntityType, DeploymentID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment.types import ModelReplicaData
 from ai.backend.manager.models.routing.row import RoutingRow
@@ -36,10 +36,8 @@ class SearchReplicasAction(OperationScopeOpsAction[RoutingRow, ModelReplicaData]
         return "search_replicas"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (
-            ScopeRef(scope_type=ScopeType(DeploymentEntityType()), scope_id=self.deployment_id),
-        )
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.deployment_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/deployment_revision_preset/actions/search_resource_slots.py
+++ b/src/ai/backend/manager/services/deployment_revision_preset/actions/search_resource_slots.py
@@ -8,7 +8,7 @@ from ai.backend.common.data.entity.deployment_preset import (
     DeploymentPresetEntityType,
     DeploymentPresetID,
 )
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.deployment_preset.types import PresetResourceSlotData
 from ai.backend.manager.models.deployment_revision_preset.scopes import (
@@ -40,10 +40,8 @@ class SearchPresetResourceSlotsAction(
         return DeploymentPresetEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (
-            ScopeRef(scope_type=ScopeType(DeploymentPresetEntityType()), scope_id=self.preset_id),
-        )
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.preset_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/domain/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/domain/actions/scoped_search.py
@@ -9,10 +9,9 @@ from typing import override
 
 from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
 )
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.domain.types import DomainData
 from ai.backend.manager.models.domain.row import DomainRow
@@ -32,8 +31,8 @@ class ResourceGroupDomainScopeItem(DomainScopeItem):
     resource_group_id: ResourceGroupID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.resource_group_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -62,7 +61,7 @@ class ScopedSearchDomainsAction(OperationScopeOpsAction[DomainRow, DomainData]):
         return "scoped_search_domains"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/domain/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/domain/actions/scoped_search.py
@@ -31,7 +31,7 @@ class ResourceGroupDomainScopeItem(DomainScopeItem):
     resource_group_id: ResourceGroupID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.resource_group_id
 
     @override
@@ -62,7 +62,7 @@ class ScopedSearchDomainsAction(OperationScopeOpsAction[DomainRow, DomainData]):
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/entity_share/actions/answer.py
+++ b/src/ai/backend/manager/services/entity_share/actions/answer.py
@@ -10,7 +10,7 @@ from ai.backend.common.data.entity.entity_share import (
     EntityShareEntityType,
     EntityShareID,
 )
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -53,9 +53,9 @@ class _RecipientAnswerAction(BaseScopeAction):
         return ActionOperationType.UPDATE
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         scope = self.answering_scope
-        return (ScopeRef(scope_type=ScopeType(scope.entity_type()), scope_id=scope),)
+        return (scope,)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/entity_share/actions/create.py
+++ b/src/ai/backend/manager/services/entity_share/actions/create.py
@@ -7,12 +7,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.entity_share import EntityShareEntityType
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    ScopeRef,
-    ScopeType,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -52,9 +47,9 @@ class CreateEntityShareAction(BaseScopeAction):
         return "create_entity_share"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         target = self.creator.target
-        return (ScopeRef(scope_type=ScopeType(target.entity_type()), scope_id=target),)
+        return (target,)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/entity_share/actions/search.py
+++ b/src/ai/backend/manager/services/entity_share/actions/search.py
@@ -8,14 +8,9 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.entity_share import EntityShareEntityType
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    ScopeRef,
-    ScopeType,
-)
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.entity_share.types import EntityShareData
 from ai.backend.manager.models.entity_share.row import EntityShareRow
@@ -49,8 +44,8 @@ class EntityShareRecipientScopeItem(EntityShareScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -64,8 +59,8 @@ class EntityShareSharerScopeItem(EntityShareScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -79,8 +74,8 @@ class EntityShareRecipientProjectScopeItem(EntityShareScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.project_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -94,8 +89,8 @@ class EntityShareTargetScopeItem(EntityShareScopeItem):
     target: EntityIdentifier
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=ScopeType(self.target.entity_type()), scope_id=self.target)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.target
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -124,7 +119,7 @@ class SearchEntitySharesAction(OperationScopeOpsAction[EntityShareRow, EntitySha
         return "search_entity_shares"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/entity_share/actions/search.py
+++ b/src/ai/backend/manager/services/entity_share/actions/search.py
@@ -44,7 +44,7 @@ class EntityShareRecipientScopeItem(EntityShareScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -59,7 +59,7 @@ class EntityShareSharerScopeItem(EntityShareScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -74,7 +74,7 @@ class EntityShareRecipientProjectScopeItem(EntityShareScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.project_id
 
     @override
@@ -89,7 +89,7 @@ class EntityShareTargetScopeItem(EntityShareScopeItem):
     target: EntityIdentifier
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.target
 
     @override
@@ -120,7 +120,7 @@ class SearchEntitySharesAction(OperationScopeOpsAction[EntityShareRow, EntitySha
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/export/actions/base.py
+++ b/src/ai/backend/manager/services/export/actions/base.py
@@ -6,11 +6,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.export import ExportEntityType
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -38,8 +38,8 @@ class ExportUserScopeAction(BaseScopeAction):
         return ExportEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_uuid),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_uuid,)
 
 
 @dataclass
@@ -54,8 +54,8 @@ class ExportProjectScopeAction(BaseScopeAction):
         return ExportEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
 
 @dataclass
@@ -71,8 +71,8 @@ class ExportDomainScopeAction(BaseScopeAction):
         return ExportEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.domain_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.domain_id,)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/fair_share/actions.py
+++ b/src/ai/backend/manager/services/fair_share/actions.py
@@ -14,15 +14,9 @@ from decimal import Decimal
 from typing import override
 
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
 )
-from ai.backend.common.data.entity.types import (
-    EntityIdentifier,
-    EntityType,
-    GlobalEntityType,
-    ScopeRef,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, GlobalEntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -63,8 +57,8 @@ class DomainFairShareAction(BaseScopeAction):
         return GlobalEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.resource_group_id,)
 
 
 @dataclass(frozen=True)
@@ -210,8 +204,8 @@ class ProjectFairShareAction(BaseScopeAction):
         return GlobalEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.resource_group_id,)
 
 
 @dataclass(frozen=True)
@@ -359,8 +353,8 @@ class UserFairShareAction(BaseScopeAction):
         return GlobalEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.resource_group_id,)
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/idle_checker_assignment/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/idle_checker_assignment/actions/scoped_search.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -44,11 +44,8 @@ class ScopedSearchIdleCheckerAssignmentsAction(BaseScopeAction):
         return "scoped_search_idle_checker_assignments"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return [
-            ScopeRef(scope_type=ScopeType(scope.entity_type()), scope_id=scope)
-            for scope in self.scopes
-        ]
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return [scope for scope in self.scopes]
 
     def operation_scopes(self) -> Sequence[OperationScope]:
         return [IdleCheckerAssignmentOperationScope(scope=scope) for scope in self.scopes]

--- a/src/ai/backend/manager/services/keypair_resource_policy/actions/search_keypair_resource_policies.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/actions/search_keypair_resource_policies.py
@@ -7,8 +7,8 @@ from typing import override
 from ai.backend.common.data.entity.resource_policy import (
     KeyPairResourcePolicyEntityType,
 )
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.resource.types import KeyPairResourcePolicyData
 from ai.backend.manager.models.resource_policy.row import KeyPairResourcePolicyRow
@@ -26,8 +26,8 @@ class KeypairResourcePolicyScopeItem(ScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -53,7 +53,7 @@ class SearchKeypairResourcePoliciesAction(
         return KeyPairResourcePolicyEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/keypair_resource_policy/actions/search_keypair_resource_policies.py
+++ b/src/ai/backend/manager/services/keypair_resource_policy/actions/search_keypair_resource_policies.py
@@ -26,7 +26,7 @@ class KeypairResourcePolicyScopeItem(ScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -54,7 +54,7 @@ class SearchKeypairResourcePoliciesAction(
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/model_card/actions/create.py
+++ b/src/ai/backend/manager/services/model_card/actions/create.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.model_card import ModelCardEntityType
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateEntityWithFieldsOpsAction
 from ai.backend.manager.data.model_card.types import (
     ModelCardData,
@@ -41,10 +41,8 @@ class CreateModelCardAction(
         return ModelCardEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (
-            ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(self.creator.project_id)),
-        )
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (ProjectID(self.creator.project_id),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/model_card/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/model_card/actions/scoped_search.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.model_card import ModelCardEntityType
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.model_card.types import ModelCardData
 from ai.backend.manager.models.model_card.row import ModelCardRow
@@ -27,8 +27,8 @@ class ModelCardScopeItem(ScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.project_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -53,7 +53,7 @@ class ScopedSearchModelCardsAction(OperationScopeOpsAction[ModelCardRow, ModelCa
         return "scoped_search_model_cards"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/model_card/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/model_card/actions/scoped_search.py
@@ -27,7 +27,7 @@ class ModelCardScopeItem(ScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.project_id
 
     @override
@@ -54,7 +54,7 @@ class ScopedSearchModelCardsAction(OperationScopeOpsAction[ModelCardRow, ModelCa
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/model_serving/actions/dry_run_model_service.py
+++ b/src/ai/backend/manager/services/model_serving/actions/dry_run_model_service.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, override
 
 from pydantic import AnyUrl
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.types import ClusterMode, RuntimeVariant
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.model_serving.types import ModelServicePrepareCtx, ServiceConfig
@@ -48,8 +48,8 @@ class DryRunModelServiceAction(ModelServiceScopeAction):
     model_service_prepare_ctx: ModelServicePrepareCtx
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/model_serving/actions/list_model_service.py
+++ b/src/ai/backend/manager/services/model_serving/actions/list_model_service.py
@@ -3,8 +3,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.model_serving.types import CompactServiceInfo
 from ai.backend.manager.services.model_serving.actions.base import (
@@ -18,8 +18,8 @@ class ListModelServiceAction(ModelServiceScopeAction):
     session_owener_id: uuid.UUID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.session_owener_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.session_owener_id),)
 
     name: str | None
 

--- a/src/ai/backend/manager/services/model_serving/actions/search_services.py
+++ b/src/ai/backend/manager/services/model_serving/actions/search_services.py
@@ -3,8 +3,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.model_serving.types import ServiceSearchItem
 from ai.backend.manager.models.clauses import QueryCondition
@@ -19,8 +19,8 @@ class SearchServicesAction(ModelServiceScopeAction):
     session_owner_id: uuid.UUID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.session_owner_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.session_owner_id),)
 
     conditions: list[QueryCondition] = field(default_factory=list)
     offset: int = 0

--- a/src/ai/backend/manager/services/model_serving/actions/validate_model_service.py
+++ b/src/ai/backend/manager/services/model_serving/actions/validate_model_service.py
@@ -3,8 +3,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.types import AccessKey, RuntimeVariant, VFolderMount
 from ai.backend.manager.actions.types import ActionOperationType
@@ -33,8 +33,8 @@ class ValidateModelServiceAction(ModelServiceScopeAction):
     owner_access_key_override: AccessKey | None
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.requester_uuid),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.requester_uuid),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/permission_contoller/actions/create_role.py
+++ b/src/ai/backend/manager/services/permission_contoller/actions/create_role.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.role import RoleEntityType
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateEntityOpsAction
 from ai.backend.manager.data.permission.role import RoleData
 from ai.backend.manager.models.rbac_models.role.creators import RoleCreator
@@ -22,9 +22,9 @@ class CreateRoleAction(CreateEntityOpsAction[RoleRow, RoleData]):
         return RoleEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         scope = self.creator.scope
-        return (ScopeRef(scope_type=ScopeType(scope.entity_type()), scope_id=scope),)
+        return (scope,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project/actions/create_project.py
+++ b/src/ai/backend/manager/services/project/actions/create_project.py
@@ -2,9 +2,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import CreateRoleManagedEntityOpsAction
 from ai.backend.manager.data.project.types import ProjectData
 from ai.backend.manager.models.project.creators import ProjectCreator
@@ -24,8 +24,8 @@ class CreateProjectAction(CreateRoleManagedEntityOpsAction[ProjectRow, ProjectDa
         return ProjectEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.domain_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.domain_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/project/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/project/actions/scoped_search.py
@@ -7,14 +7,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
 )
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.project.types import ProjectData
 from ai.backend.manager.models.project.row import ProjectRow
@@ -46,8 +45,8 @@ class DomainProjectScopeItem(ProjectScopeItem):
     domain_id: DomainID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.domain_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.domain_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -61,8 +60,8 @@ class UserProjectScopeItem(ProjectScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -76,8 +75,8 @@ class ResourceGroupProjectScopeItem(ProjectScopeItem):
     resource_group_id: ResourceGroupID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.resource_group_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -106,7 +105,7 @@ class ScopedSearchProjectsAction(OperationScopeOpsAction[ProjectRow, ProjectData
         return "scoped_search_projects"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/project/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/project/actions/scoped_search.py
@@ -45,7 +45,7 @@ class DomainProjectScopeItem(ProjectScopeItem):
     domain_id: DomainID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.domain_id
 
     @override
@@ -60,7 +60,7 @@ class UserProjectScopeItem(ProjectScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -75,7 +75,7 @@ class ResourceGroupProjectScopeItem(ProjectScopeItem):
     resource_group_id: ResourceGroupID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.resource_group_id
 
     @override
@@ -106,7 +106,7 @@ class ScopedSearchProjectsAction(OperationScopeOpsAction[ProjectRow, ProjectData
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/rbac/actions/relation/base.py
+++ b/src/ai/backend/manager/services/rbac/actions/relation/base.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.v2.relation.base import BaseRelationAction
 
 __all__ = (
@@ -62,13 +62,7 @@ class BaseEntityRelationAction[TScope: EntityIdentifier, TTarget: EntityIdentifi
     pairs: Sequence[RelationPair[TScope, TTarget]]
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         """Every entity the run names, each once and in the order first named."""
-        seen: dict[tuple[ScopeType, EntityIdentifier], ScopeRef] = {}
-        for pair in self.pairs:
-            for entity in (pair.scope, pair.target):
-                scope_type = ScopeType(entity.entity_type())
-                seen.setdefault(
-                    (scope_type, entity), ScopeRef(scope_type=scope_type, scope_id=entity)
-                )
-        return list(seen.values())
+        seen = dict.fromkeys(entity for pair in self.pairs for entity in (pair.scope, pair.target))
+        return list(seen)

--- a/src/ai/backend/manager/services/rbac/actions/roster/base.py
+++ b/src/ai/backend/manager/services/rbac/actions/roster/base.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 
@@ -23,8 +23,8 @@ class ProjectRosterAction(BaseScopeAction):
     user_ids: list[UserID]
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return [ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id)]
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return [self.project_id]
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_group/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/resource_group/actions/scoped_search.py
@@ -7,11 +7,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.resource_group.types import ResourceGroupData
 from ai.backend.manager.models.resource_group.row import ResourceGroupRow
@@ -39,8 +39,8 @@ class DomainResourceGroupScopeItem(ResourceGroupScopeItem):
     domain_id: DomainID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.domain_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.domain_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -54,8 +54,8 @@ class ProjectResourceGroupScopeItem(ResourceGroupScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.project_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -69,8 +69,8 @@ class UserResourceGroupScopeItem(ResourceGroupScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -101,7 +101,7 @@ class ScopedSearchResourceGroupsAction(
         return "scoped_search_resource_groups"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/resource_group/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/resource_group/actions/scoped_search.py
@@ -39,7 +39,7 @@ class DomainResourceGroupScopeItem(ResourceGroupScopeItem):
     domain_id: DomainID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.domain_id
 
     @override
@@ -54,7 +54,7 @@ class ProjectResourceGroupScopeItem(ResourceGroupScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.project_id
 
     @override
@@ -69,7 +69,7 @@ class UserResourceGroupScopeItem(ResourceGroupScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -102,7 +102,7 @@ class ScopedSearchResourceGroupsAction(
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/resource_slot/actions/get_domain_resource_overview.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/get_domain_resource_overview.py
@@ -4,9 +4,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.session import SessionEntityType
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -30,8 +30,8 @@ class GetDomainResourceOverviewAction(BaseScopeAction):
         return SessionEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.domain_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.domain_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_slot/actions/get_project_resource_overview.py
+++ b/src/ai/backend/manager/services/resource_slot/actions/get_project_resource_overview.py
@@ -4,9 +4,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.session import SessionEntityType
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -25,8 +25,8 @@ class GetProjectResourceOverviewAction(BaseScopeAction):
         return SessionEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/resource_usage/actions/scope_items.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/scope_items.py
@@ -7,8 +7,8 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE, ResourceGroupID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.v2.ops.base import ScopeItem
 from ai.backend.manager.models.resource_usage_history.scopes import (
     DomainUsageBucketOperationScope,
@@ -34,8 +34,8 @@ class UsageBucketScopeItem(ScopeItem, ABC):
     resource_group_id: ResourceGroupID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=self.resource_group_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.resource_group_id
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/resource_usage/actions/scope_items.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/scope_items.py
@@ -34,7 +34,7 @@ class UsageBucketScopeItem(ScopeItem, ABC):
     resource_group_id: ResourceGroupID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.resource_group_id
 
 

--- a/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.domain import DomainEntityType
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import DomainUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import DomainUsageBucketRow
@@ -38,7 +38,7 @@ class SearchDomainUsageBucketsAction(
         return "search_domain_usage_buckets"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_domain_usage_buckets.py
@@ -39,7 +39,7 @@ class SearchDomainUsageBucketsAction(
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.project import ProjectEntityType
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import ProjectUsageBucketData
 from ai.backend.manager.models.resource_usage_history.row import ProjectUsageBucketRow
@@ -38,7 +38,7 @@ class SearchProjectUsageBucketsAction(
         return "search_project_usage_buckets"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_project_usage_buckets.py
@@ -39,7 +39,7 @@ class SearchProjectUsageBucketsAction(
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
@@ -39,7 +39,7 @@ class SearchUserUsageBucketsAction(
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
+++ b/src/ai/backend/manager/services/resource_usage/actions/search_user_usage_buckets.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.resource_usage_history.types import UserUsageBucketData
@@ -38,7 +38,7 @@ class SearchUserUsageBucketsAction(
         return "search_user_usage_buckets"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/role_preset/actions/search_permission_presets.py
+++ b/src/ai/backend/manager/services/role_preset/actions/search_permission_presets.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.role_preset.types import RolePermissionPresetData
 from ai.backend.manager.models.rbac_models.role_permission_preset.row import (
@@ -39,8 +39,8 @@ class SearchRolePermissionPresetsAction(
         return RolePresetEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=ScopeType(RolePresetEntityType()), scope_id=self.preset_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.preset_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/scheduling_history/actions/base.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/base.py
@@ -6,9 +6,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_SCOPE_TYPE, DeploymentID
-from ai.backend.common.data.entity.session import SESSION_SCOPE_TYPE, SessionID
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.deployment import DeploymentID
+from ai.backend.common.data.entity.session import SessionID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -26,8 +26,8 @@ class SessionSchedulingHistoryAction(BaseScopeAction):
     session_id: SessionID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=SESSION_SCOPE_TYPE, scope_id=self.session_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.session_id,)
 
 
 @dataclass
@@ -37,8 +37,8 @@ class DeploymentSchedulingHistoryAction(BaseScopeAction):
     deployment_id: DeploymentID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=DEPLOYMENT_SCOPE_TYPE, scope_id=self.deployment_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.deployment_id,)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/scheduling_history/actions/scoped_search_replica_group_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/scoped_search_replica_group_history.py
@@ -5,11 +5,10 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.deployment import (
-    DEPLOYMENT_SCOPE_TYPE,
     DeploymentEntityType,
     DeploymentID,
 )
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
@@ -42,8 +41,8 @@ class DeploymentReplicaGroupHistoryTarget(ReplicaGroupHistoryTarget):
         return DeploymentReplicaGroupHistoryOperationScope(deployment_id=self.deployment_id)
 
     @override
-    def to_scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=DEPLOYMENT_SCOPE_TYPE, scope_id=self.deployment_id)
+    def to_scope_ref(self) -> EntityIdentifier:
+        return self.deployment_id
 
 
 @dataclass
@@ -57,7 +56,7 @@ class ScopedSearchReplicaGroupHistoryAction(BaseScopeAction):
     querier: BatchQuerier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.target.to_scope_ref(),)
 
     @override

--- a/src/ai/backend/manager/services/scheduling_history/actions/scoped_search_replica_group_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/scoped_search_replica_group_history.py
@@ -41,7 +41,7 @@ class DeploymentReplicaGroupHistoryTarget(ReplicaGroupHistoryTarget):
         return DeploymentReplicaGroupHistoryOperationScope(deployment_id=self.deployment_id)
 
     @override
-    def to_scope_ref(self) -> EntityIdentifier:
+    def to_scope_id(self) -> EntityIdentifier:
         return self.deployment_id
 
 
@@ -57,7 +57,7 @@ class ScopedSearchReplicaGroupHistoryAction(BaseScopeAction):
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return (self.target.to_scope_ref(),)
+        return (self.target.to_scope_id(),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -5,11 +5,10 @@ from dataclasses import dataclass
 from typing import override
 
 from ai.backend.common.data.entity.session import (
-    SESSION_SCOPE_TYPE,
     SessionEntityType,
     SessionID,
 )
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
@@ -51,8 +50,8 @@ class KernelKernelHistoryTarget(KernelHistoryTarget):
         return KernelKernelHistoryOperationScope(kernel_id=self.kernel_id)
 
     @override
-    def to_scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=SESSION_SCOPE_TYPE, scope_id=SessionID(self.kernel_id))
+    def to_scope_ref(self) -> EntityIdentifier:
+        return SessionID(self.kernel_id)
 
 
 @dataclass(frozen=True)
@@ -66,8 +65,8 @@ class SessionKernelHistoryTarget(KernelHistoryTarget):
         return SessionKernelHistoryOperationScope(session_id=self.session_id)
 
     @override
-    def to_scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=SESSION_SCOPE_TYPE, scope_id=SessionID(self.session_id))
+    def to_scope_ref(self) -> EntityIdentifier:
+        return SessionID(self.session_id)
 
 
 @dataclass
@@ -81,7 +80,7 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
     querier: BatchQuerier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.target.to_scope_ref(),)
 
     @override

--- a/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
+++ b/src/ai/backend/manager/services/scheduling_history/actions/search_kernel_scoped_history.py
@@ -50,7 +50,7 @@ class KernelKernelHistoryTarget(KernelHistoryTarget):
         return KernelKernelHistoryOperationScope(kernel_id=self.kernel_id)
 
     @override
-    def to_scope_ref(self) -> EntityIdentifier:
+    def to_scope_id(self) -> EntityIdentifier:
         return SessionID(self.kernel_id)
 
 
@@ -65,7 +65,7 @@ class SessionKernelHistoryTarget(KernelHistoryTarget):
         return SessionKernelHistoryOperationScope(session_id=self.session_id)
 
     @override
-    def to_scope_ref(self) -> EntityIdentifier:
+    def to_scope_id(self) -> EntityIdentifier:
         return SessionID(self.session_id)
 
 
@@ -81,7 +81,7 @@ class SearchKernelScopedHistoryAction(BaseScopeAction):
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return (self.target.to_scope_ref(),)
+        return (self.target.to_scope_id(),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/create_cluster.py
+++ b/src/ai/backend/manager/services/session/actions/create_cluster.py
@@ -3,8 +3,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.types import AccessKey, SessionTypes
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.user import UserRole
@@ -40,8 +40,8 @@ class CreateClusterAction(SessionScopeAction):
     max_wait_seconds: int
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/create_from_params.py
+++ b/src/ai/backend/manager/services/session/actions/create_from_params.py
@@ -6,8 +6,8 @@ from typing import Any, override
 
 import yarl
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.defs.session import JOB_PRIORITY_DEFAULT
 from ai.backend.common.types import AccessKey, ClusterMode, SessionTypes
 from ai.backend.manager.actions.types import ActionOperationType
@@ -64,8 +64,8 @@ class CreateFromParamsAction(SessionScopeAction):
     keypair_resource_policy: dict[str, Any] | None
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/create_from_template.py
+++ b/src/ai/backend/manager/services/session/actions/create_from_template.py
@@ -6,8 +6,8 @@ from typing import Any, override
 
 import yarl
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.defs.session import JOB_PRIORITY_DEFAULT
 from ai.backend.common.types import AccessKey, ClusterMode, SessionTypes
 from ai.backend.manager.actions.types import ActionOperationType
@@ -67,8 +67,8 @@ class CreateFromTemplateAction(SessionScopeAction):
     keypair_resource_policy: dict[str, Any] | None
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/enqueue_session.py
+++ b/src/ai/backend/manager/services/session/actions/enqueue_session.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.defs.session import JOB_PRIORITY_DEFAULT
 from ai.backend.common.types import AccessKey, ClusterMode, MountInfoEntry, SessionTypes
 from ai.backend.manager.actions.types import ActionOperationType
@@ -109,8 +109,8 @@ class EnqueueSessionAction(SessionScopeAction):
     """
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/match_sessions.py
+++ b/src/ai/backend/manager/services/session/actions/match_sessions.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.session.base import (
@@ -26,8 +26,8 @@ class MatchSessionsAction(SessionScopeAction):
     user_id: UserID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/search.py
+++ b/src/ai/backend/manager/services/session/actions/search.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
 from ai.backend.manager.repositories.base import BatchQuerier
@@ -27,8 +27,8 @@ class SearchSessionsAction(SessionScopeAction):
     user_id: UserID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/search_in_project.py
+++ b/src/ai/backend/manager/services/session/actions/search_in_project.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.session.types import SessionData
 from ai.backend.manager.models.session.scopes import ProjectSessionOperationScope
@@ -28,8 +28,8 @@ class SearchSessionsInProjectAction(SessionScopeAction):
     querier: BatchQuerier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ProjectID(self.scope.project_id)),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (ProjectID(self.scope.project_id),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/actions/search_kernel.py
+++ b/src/ai/backend/manager/services/session/actions/search_kernel.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.kernel.types import KernelInfo
 from ai.backend.manager.repositories.base import BatchQuerier
@@ -27,8 +27,8 @@ class SearchKernelsAction(SessionScopeAction):
     user_id: UserID
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/resource_allocation/actions/check_preset_availability.py
+++ b/src/ai/backend/manager/services/session/resource_allocation/actions/check_preset_availability.py
@@ -4,9 +4,9 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.types import ActionOperationType
@@ -36,8 +36,8 @@ class CheckPresetAvailabilityAction(BaseScopeAction):
         return ResourcePresetEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/session/resource_allocation/actions/get_effective_allocation.py
+++ b/src/ai/backend/manager/services/session/resource_allocation/actions/get_effective_allocation.py
@@ -4,9 +4,9 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.session import SessionEntityType
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.types import ActionOperationType
@@ -35,8 +35,8 @@ class GetEffectiveAllocationAction(BaseScopeAction):
         return SessionEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.project_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/template/actions/base.py
+++ b/src/ai/backend/manager/services/template/actions/base.py
@@ -4,13 +4,13 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.session_template import (
     SessionTemplateEntityType,
     SessionTemplateID,
 )
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.scope.base import BaseScopeAction
 from ai.backend.manager.actions.v2.scope.result import BaseScopeActionResult
 from ai.backend.manager.actions.v2.single_entity.base import BaseSingleEntityAction
@@ -40,8 +40,8 @@ class TemplateProjectScopeAction(BaseScopeAction):
         return SessionTemplateEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.requesting_project),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.requesting_project,)
 
 
 @dataclass
@@ -56,8 +56,8 @@ class TemplateUserScopeAction(BaseScopeAction):
         return SessionTemplateEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_uuid),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_uuid,)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/user/actions/create_user.py
+++ b/src/ai/backend/manager/services/user/actions/create_user.py
@@ -4,8 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.global_scope.base import BaseGlobalAction
@@ -37,8 +36,8 @@ class CreateUserAction(BaseScopeAction):
         return UserEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.creator.domain_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.creator.domain_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/keypair_ops.py
+++ b/src/ai/backend/manager/services/user/actions/keypair_ops.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass, field
 from typing import override
 
 from ai.backend.common.data.entity.keypair import KeyPairID
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.actions.v2.field.base import BaseSingleFieldAction
@@ -184,8 +184,8 @@ class SearchMyKeypairsAction(BaseScopeAction):
         return UserEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/user/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/user/actions/scoped_search.py
@@ -40,7 +40,7 @@ class DomainUserScopeItem(UserScopeItem):
     domain_id: DomainID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.domain_id
 
     @override
@@ -55,7 +55,7 @@ class ProjectUserScopeItem(UserScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.project_id
 
     @override
@@ -86,7 +86,7 @@ class ScopedSearchUsersAction(OperationScopeOpsAction[UserRow, UserData]):
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/user/actions/scoped_search.py
+++ b/src/ai/backend/manager/services/user/actions/scoped_search.py
@@ -7,9 +7,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.user.types import UserData
@@ -40,8 +40,8 @@ class DomainUserScopeItem(UserScopeItem):
     domain_id: DomainID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=self.domain_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.domain_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -55,8 +55,8 @@ class ProjectUserScopeItem(UserScopeItem):
     project_id: ProjectID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.project_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.project_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -85,7 +85,7 @@ class ScopedSearchUsersAction(OperationScopeOpsAction[UserRow, UserData]):
         return "scoped_search_users"
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/user/error_log/actions/search.py
+++ b/src/ai/backend/manager/services/user/error_log/actions/search.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserEntityType, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction
 from ai.backend.manager.data.error_log.types import ErrorLogData
 from ai.backend.manager.models.error_log.row import ErrorLogRow
@@ -27,8 +27,8 @@ class SearchErrorLogsAction(OperationScopeOpsAction[ErrorLogRow, ErrorLogData]):
         return UserEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (self.user_id,)
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/user_resource_policy/actions/search_user_resource_policies.py
+++ b/src/ai/backend/manager/services/user_resource_policy/actions/search_user_resource_policies.py
@@ -7,8 +7,8 @@ from typing import override
 from ai.backend.common.data.entity.resource_policy import (
     UserResourcePolicyEntityType,
 )
-from ai.backend.common.data.entity.types import EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.v2.ops.base import OperationScopeOpsAction, ScopeItem
 from ai.backend.manager.data.resource.types import UserResourcePolicyData
 from ai.backend.manager.models.resource_policy.row import UserResourcePolicyRow
@@ -26,8 +26,8 @@ class UserResourcePolicyScopeItem(ScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> ScopeRef:
-        return ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id)
+    def scope_ref(self) -> EntityIdentifier:
+        return self.user_id
 
     @override
     def operation_scope(self) -> OperationScope:
@@ -53,7 +53,7 @@ class SearchUserResourcePoliciesAction(
         return UserResourcePolicyEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return [item.scope_ref() for item in self.items]
 
     @override

--- a/src/ai/backend/manager/services/user_resource_policy/actions/search_user_resource_policies.py
+++ b/src/ai/backend/manager/services/user_resource_policy/actions/search_user_resource_policies.py
@@ -26,7 +26,7 @@ class UserResourcePolicyScopeItem(ScopeItem):
     user_id: UserID
 
     @override
-    def scope_ref(self) -> EntityIdentifier:
+    def scope_id(self) -> EntityIdentifier:
         return self.user_id
 
     @override
@@ -54,7 +54,7 @@ class SearchUserResourcePoliciesAction(
 
     @override
     def scope_targets(self) -> Sequence[EntityIdentifier]:
-        return [item.scope_ref() for item in self.items]
+        return [item.scope_id() for item in self.items]
 
     @override
     def operation_scopes(self) -> Sequence[OperationScope]:

--- a/src/ai/backend/manager/services/vfolder/actions/base.py
+++ b/src/ai/backend/manager/services/vfolder/actions/base.py
@@ -3,8 +3,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.types import (
     AccessKey,
@@ -164,10 +164,10 @@ class GetVFolderActionResult:
 @dataclass
 class ListVFolderAction(VFolderScopeAction):
     user_uuid: uuid.UUID
-    scope: ScopeRef
+    scope: EntityIdentifier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @override
@@ -359,8 +359,8 @@ class GetTaskLogsAction(VFolderScopeAction):
     request: Any
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.user_id),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfolder/actions/create.py
+++ b/src/ai/backend/manager/services/vfolder/actions/create.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.vfolder.types import VFolderData
 from ai.backend.manager.models.vfolder.creators import VFolderBaseCreator
@@ -26,7 +26,7 @@ class CreateVFolderAction(VFolderScopeAction):
     creator: VFolderBaseCreator
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return self.creator.scope_targets()
 
     @override

--- a/src/ai/backend/manager/services/vfolder/actions/invite.py
+++ b/src/ai/backend/manager/services/vfolder/actions/invite.py
@@ -6,8 +6,8 @@ from typing import (
     override,
 )
 
-from ai.backend.common.data.entity.types import EntityIdentifier, EntityType, ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder_invitation import (
     VFolderInvitationEntityType,
     VFolderInvitationID,
@@ -50,8 +50,8 @@ class VFolderInvitationScopeAction(BaseScopeAction):
         return VFolderInvitationEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_uuid),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.user_uuid),)
 
 
 @dataclass

--- a/src/ai/backend/manager/services/vfolder/actions/search_in_project.py
+++ b/src/ai/backend/manager/services/vfolder/actions/search_in_project.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.vfolder.types import VFolderData
 from ai.backend.manager.models.vfolder.scopes import ProjectVFolderOperationScope
@@ -29,8 +29,8 @@ class SearchVFoldersInProjectAction(VFolderScopeAction):
     querier: BatchQuerier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.scope.project_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (ProjectID(self.scope.project_id),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfolder/actions/search_storage_host_permissions.py
+++ b/src/ai/backend/manager/services/vfolder/actions/search_storage_host_permissions.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import VFolderHostPermission
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.services.vfolder.actions.base import (
@@ -31,8 +31,8 @@ class SearchStorageHostPermissionsAction(VFolderScopeAction):
     domain_name: str
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_uuid),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.user_uuid),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfolder/actions/search_user_vfolders.py
+++ b/src/ai/backend/manager/services/vfolder/actions/search_user_vfolders.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import override
 
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.data.vfolder.types import VFolderData
 from ai.backend.manager.models.vfolder.scopes import UserVFolderOperationScope
@@ -29,8 +29,8 @@ class SearchUserVFoldersAction(VFolderScopeAction):
     querier: BatchQuerier
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.scope.user_id),)
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
+        return (UserID(self.scope.user_id),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/services/vfolder/actions/storage_ops.py
+++ b/src/ai/backend/manager/services/vfolder/actions/storage_ops.py
@@ -5,9 +5,9 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, override
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.models.user import UserRole
 
@@ -148,11 +148,11 @@ class SearchHostsAction(VFolderScopeAction):
     resource_policy: Mapping[str, Any]
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         """A project folder is bounded by the project, a user folder by its owner."""
         if self.group_id is not None:
-            return (ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=self.group_id),)
-        return (ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=self.user_uuid),)
+            return (ProjectID(self.group_id),)
+        return (UserID(self.user_uuid),)
 
     @override
     @classmethod

--- a/src/ai/backend/manager/utils.py
+++ b/src/ai/backend/manager/utils.py
@@ -5,7 +5,7 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.types import AccessKey
 
 from .data.user.types import SessionOwnerContext
@@ -214,7 +214,7 @@ async def query_userinfo(
             sa.select(groups.c.id)
             .select_from(groups)
             .where(
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, groups.c.id, owner_uuid)
+                user_scope_membership_exists(ProjectEntityType(), groups.c.id, owner_uuid)
                 & (groups.c.domain_name == owner_domain)
                 & (group_match_query)
                 & (groups.c.is_active),
@@ -368,7 +368,7 @@ async def query_userinfo_from_session(
             sa.select(groups.c.id)
             .select_from(groups)
             .where(
-                user_scope_membership_exists(PROJECT_SCOPE_TYPE, groups.c.id, owner_uuid)
+                user_scope_membership_exists(ProjectEntityType(), groups.c.id, owner_uuid)
                 & (groups.c.domain_name == owner_domain)
                 & (group_match_query)
                 & (groups.c.is_active),

--- a/tests/component/rbac/conftest.py
+++ b/tests/component/rbac/conftest.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.dto.manager.rbac.request import (
@@ -125,7 +125,7 @@ async def role_factory(
         unique = secrets.token_hex(4)
         params: dict[str, Any] = {
             "name": f"test-role-{unique}",
-            "scope_type": PROJECT_SCOPE_TYPE,
+            "scope_type": ProjectEntityType(),
             "scope_id": group_fixture,
             "description": f"Test role {unique}",
         }

--- a/tests/component/rbac/test_rbac.py
+++ b/tests/component/rbac/test_rbac.py
@@ -9,7 +9,7 @@ import pytest
 
 from ai.backend.client.v2.exceptions import NotFoundError, PermissionDeniedError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.rbac.request import (
     AssignRoleRequest,
@@ -89,7 +89,7 @@ class TestRoleCreate:
             await user_registry.rbac.create_role(
                 CreateRoleRequest(
                     name=f"denied-role-{unique}",
-                    scope_type=PROJECT_SCOPE_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=group_fixture,
                     description="Should be denied",
                 )

--- a/tests/component/rbac/test_rbac_permission.py
+++ b/tests/component/rbac/test_rbac_permission.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.permission import PermissionID
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.types import EntityType
@@ -247,7 +247,7 @@ class TestCheckPermissionInScope:
         domain_fixture: DomainFixtureData,
     ) -> None:
         """S-SCOPE-1: User has permission in target scope → True."""
-        role = await role_factory(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_fixture.domain_id)
+        role = await role_factory(scope_type=DomainEntityType(), scope_id=domain_fixture.domain_id)
         role_id = role.role.id
         user_id: uuid.UUID = admin_user_fixture.user_uuid
 

--- a/tests/component/rbac/test_rbac_role.py
+++ b/tests/component/rbac/test_rbac_role.py
@@ -8,7 +8,7 @@ import pytest
 
 from ai.backend.client.v2.exceptions import ConflictError, NotFoundError, PermissionDeniedError
 from ai.backend.client.v2.registry import BackendAIClientRegistry
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.rbac.request import (
     AssignRoleRequest,
@@ -486,7 +486,7 @@ class TestRolePermissions:
             await user_registry.rbac.create_role(
                 CreateRoleRequest(
                     name=f"denied-role-{unique}",
-                    scope_type=PROJECT_SCOPE_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=group_fixture,
                     description="Should be denied",
                 )

--- a/tests/component/rbac/test_rbac_scoped_role_search.py
+++ b/tests/component/rbac/test_rbac_scoped_role_search.py
@@ -13,7 +13,7 @@ import yarl
 from ai.backend.client.v2.auth import HMACAuth
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.dto.manager.v2.rbac.request import SearchRolesInput
 from ai.backend.common.dto.manager.v2.rbac.response import AdminSearchRolesPayload
@@ -165,7 +165,7 @@ class TestScopedRoleSearch:
         """Roles of another scope should NOT appear in project search."""
         not_in_project = await role_factory(
             name=f"not-in-proj-{uuid.uuid4().hex[:8]}",
-            scope_type=DOMAIN_SCOPE_TYPE,
+            scope_type=DomainEntityType(),
             scope_id=domain_fixture.domain_id,
         )
 

--- a/tests/component/vfolder/test_vfolder_clone.py
+++ b/tests/component/vfolder/test_vfolder_clone.py
@@ -24,7 +24,7 @@ from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.registry import BackendAIClientRegistry
 from ai.backend.client.v2.v2_registry import V2ClientRegistry
 from ai.backend.common.bgtask.types import TaskID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.dto.manager.v2.vfolder.request import CloneVFolderInput
 from ai.backend.common.dto.manager.vfolder import CloneVFolderReq
@@ -196,7 +196,7 @@ async def _fetch_scope_graph(
                 .where(
                     members.c.entity_type == VFolderEntityType(),
                     members.c.entity_id == vfolder_id,
-                    scopes.c.entity_type == PROJECT_SCOPE_TYPE,
+                    scopes.c.entity_type == ProjectEntityType(),
                     scopes.c.entity_id == owner_project_id,
                 )
             )

--- a/tests/unit/client_v2/test_rbac.py
+++ b/tests/unit/client_v2/test_rbac.py
@@ -11,7 +11,7 @@ from yarl import URL
 from ai.backend.client.v2.base_client import BackendAIAuthClient
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.domains.rbac import RBACClient
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.dto.manager.query import StringFilter
 from ai.backend.common.dto.manager.rbac.request import (
     AssignRoleRequest,
@@ -104,7 +104,7 @@ class TestRoleCreate:
 
         result = await rc.create_role(
             CreateRoleRequest(
-                scope_type=PROJECT_SCOPE_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=uuid.uuid4(),
                 name="test-role",
                 description="A test role",

--- a/tests/unit/client_v2/test_rbac_client.py
+++ b/tests/unit/client_v2/test_rbac_client.py
@@ -7,7 +7,7 @@ from yarl import URL
 from ai.backend.client.v2.base_client import BackendAIAuthClient
 from ai.backend.client.v2.config import ClientConfig
 from ai.backend.client.v2.domains.rbac import RBACClient
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.dto.manager.rbac.request import (
     AssignRoleRequest,
     CreateRoleRequest,
@@ -92,7 +92,7 @@ class TestRBACClient:
         rbac = RBACClient(client)
 
         request = CreateRoleRequest(
-            scope_type=PROJECT_SCOPE_TYPE,
+            scope_type=ProjectEntityType(),
             scope_id=uuid.uuid4(),
             name="admin",
             description="Admin role",

--- a/tests/unit/manager/actions/test_denied_recording.py
+++ b/tests/unit/manager/actions/test_denied_recording.py
@@ -12,7 +12,7 @@ from typing import override
 
 import pytest
 
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.exception import PermissionDeniedError
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
@@ -28,7 +28,7 @@ from ai.backend.manager.actions.v2.single_entity.validator.base import (
 )
 from ai.backend.manager.errors.common import InternalServerError
 
-_ENTITY_ID: EntityID = uuid.uuid4()
+_ENTITY_ID: uuid.UUID = uuid.uuid4()
 
 
 class _StubEntityID(EntityIdentifier):

--- a/tests/unit/manager/actions/test_relation_processor.py
+++ b/tests/unit/manager/actions/test_relation_processor.py
@@ -17,9 +17,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.domain import DomainEntityType
-from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
-from ai.backend.common.data.entity.types import ScopeRef, ScopeType
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.resource_group import ResourceGroupID
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.common.exception import PermissionDeniedError
@@ -35,19 +35,16 @@ from ai.backend.manager.actions.v2.relation.validator.rbac import (
 )
 from ai.backend.manager.errors.permission import NotEnoughPermission
 
-_RESOURCE_GROUP = ScopeType(ResourceGroupEntityType())
-_DOMAIN = ScopeType(DomainEntityType())
-
-_RG_ID = uuid.uuid5(uuid.NAMESPACE_OID, "rg")
-_DOMAIN_ID = uuid.uuid5(uuid.NAMESPACE_OID, "domain")
+_RG_ID = ResourceGroupID(uuid.uuid5(uuid.NAMESPACE_OID, "rg"))
+_DOMAIN_ID = DomainID(uuid.uuid5(uuid.NAMESPACE_OID, "domain"))
 
 
 @dataclass
 class _LinkAction(BaseRelationAction):
-    scopes: list[ScopeRef]
+    scopes: list[EntityIdentifier]
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return self.scopes
 
     @classmethod
@@ -61,16 +58,16 @@ class _LinkAction(BaseRelationAction):
         return "link_resource_group_to_domain"
 
 
-def _action(*scopes: ScopeRef) -> _LinkAction:
+def _action(*scopes: EntityIdentifier) -> _LinkAction:
     return _LinkAction(scopes=list(scopes))
 
 
-def _rg() -> ScopeRef:
-    return ScopeRef(scope_type=_RESOURCE_GROUP, scope_id=_RG_ID)
+def _rg() -> EntityIdentifier:
+    return _RG_ID
 
 
-def _domain() -> ScopeRef:
-    return ScopeRef(scope_type=_DOMAIN, scope_id=_DOMAIN_ID)
+def _domain() -> EntityIdentifier:
+    return _DOMAIN_ID
 
 
 class _RecordingMonitor(RelationActionMonitor):
@@ -109,10 +106,7 @@ class TestRelationActionProcessor:
         )
 
         (meta, result) = monitor.done_calls[0]
-        assert [(s.scope_type, s.scope_id) for s in meta.scope_targets] == [
-            (_RESOURCE_GROUP, _RG_ID),
-            (_DOMAIN, _DOMAIN_ID),
-        ]
+        assert list(meta.scope_targets) == [_RG_ID, _DOMAIN_ID]
         assert result.meta.status is OperationStatus.SUCCESS
 
     async def test_the_action_carries_no_entity_type(self) -> None:

--- a/tests/unit/manager/actions/test_scoped_read_gate_wiring.py
+++ b/tests/unit/manager/actions/test_scoped_read_gate_wiring.py
@@ -16,10 +16,8 @@ import pytest
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
 )
-from ai.backend.common.data.entity.types import ScopeRef
 from ai.backend.common.data.user.types import UserData, UserRole
 from ai.backend.manager.actions.action import BaseActionTriggerMeta
 from ai.backend.manager.actions.monitors import ActionMonitors
@@ -93,6 +91,4 @@ async def test_rg_domain_search_is_answered_for_the_resource_group(
     with with_user(regular_user), pytest.raises(NotEnoughPermission):
         await processors.scoped_search.run(action)
 
-    assert [seen.scope_targets() for seen in denying_scope.seen] == [
-        [ScopeRef(scope_type=RESOURCE_GROUP_SCOPE_TYPE, scope_id=resource_group_id)]
-    ]
+    assert [seen.scope_targets() for seen in denying_scope.seen] == [[resource_group_id]]

--- a/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
@@ -22,15 +22,13 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession as SASession
 
 from ai.backend.common.contexts.user import with_user
-from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.types import (
     EntityID,
     EntityIdentifier,
     EntityType,
     ScopeID,
-    ScopeRef,
-    ScopeType,
 )
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
@@ -130,9 +128,9 @@ class _StubEntityID(EntityIdentifier):
 class _ProjectCreateScopeAction(BaseScopeAction):
     """PROJECT:CREATE at domain scopes — subject type differs from the scope type."""
 
-    _scopes: Sequence[ScopeRef]
+    _scopes: Sequence[EntityIdentifier]
 
-    def __init__(self, scopes: Sequence[ScopeRef]) -> None:
+    def __init__(self, scopes: Sequence[EntityIdentifier]) -> None:
         self._scopes = scopes
 
     @classmethod
@@ -141,7 +139,7 @@ class _ProjectCreateScopeAction(BaseScopeAction):
         return ProjectEntityType()
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return self._scopes
 
     @classmethod
@@ -237,8 +235,8 @@ class _VfolderID(EntityIdentifier):
         return VFolderEntityType()
 
 
-def _domain_scope(scope_id: ScopeID) -> ScopeRef:
-    return ScopeRef(scope_type=ScopeType(DomainEntityType()), scope_id=scope_id)
+def _domain_scope(scope_id: ScopeID) -> EntityIdentifier:
+    return DomainID(scope_id)
 
 
 def _make_user_data(user_id: uuid.UUID, *, is_superadmin: bool) -> UserData:

--- a/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
@@ -28,7 +28,6 @@ from ai.backend.common.data.entity.types import (
     EntityID,
     EntityIdentifier,
     EntityType,
-    ScopeID,
 )
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
@@ -110,9 +109,9 @@ _ORM_CLUSTER = (
     ResourceGroupForDomainRow,
 )
 
-_DOMAIN_ID: ScopeID = uuid.uuid4()
-_OTHER_DOMAIN_ID: ScopeID = uuid.uuid4()
-_PROJECT_ID: ScopeID = uuid.uuid4()
+_DOMAIN_ID: EntityID = uuid.uuid4()
+_OTHER_DOMAIN_ID: EntityID = uuid.uuid4()
+_PROJECT_ID: EntityID = uuid.uuid4()
 _VFOLDER_ID: EntityID = uuid.uuid4()
 _BULK_VF_GRANTED: EntityID = uuid.uuid4()
 _BULK_VF_DENIED: EntityID = uuid.uuid4()
@@ -235,7 +234,7 @@ class _VfolderID(EntityIdentifier):
         return VFolderEntityType()
 
 
-def _domain_scope(scope_id: ScopeID) -> EntityIdentifier:
+def _domain_scope(scope_id: EntityID) -> EntityIdentifier:
     return DomainID(scope_id)
 
 

--- a/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
+++ b/tests/unit/manager/actions/validators/test_virtual_entity_rbac_validators.py
@@ -24,11 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession as SASession
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType
-from ai.backend.common.data.entity.types import (
-    EntityID,
-    EntityIdentifier,
-    EntityType,
-)
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import (
@@ -109,12 +105,12 @@ _ORM_CLUSTER = (
     ResourceGroupForDomainRow,
 )
 
-_DOMAIN_ID: EntityID = uuid.uuid4()
-_OTHER_DOMAIN_ID: EntityID = uuid.uuid4()
-_PROJECT_ID: EntityID = uuid.uuid4()
-_VFOLDER_ID: EntityID = uuid.uuid4()
-_BULK_VF_GRANTED: EntityID = uuid.uuid4()
-_BULK_VF_DENIED: EntityID = uuid.uuid4()
+_DOMAIN_ID: uuid.UUID = uuid.uuid4()
+_OTHER_DOMAIN_ID: uuid.UUID = uuid.uuid4()
+_PROJECT_ID: uuid.UUID = uuid.uuid4()
+_VFOLDER_ID: uuid.UUID = uuid.uuid4()
+_BULK_VF_GRANTED: uuid.UUID = uuid.uuid4()
+_BULK_VF_DENIED: uuid.UUID = uuid.uuid4()
 
 
 class _StubEntityID(EntityIdentifier):
@@ -156,7 +152,7 @@ class _ProjectCreateScopeAction(BaseScopeAction):
 class _VfolderUpdateAction(BaseSingleEntityAction):
     """VFOLDER:UPDATE on a single vfolder — exercises the single-entity path."""
 
-    vfolder_id: EntityID = field(default_factory=lambda: _VFOLDER_ID)
+    vfolder_id: uuid.UUID = field(default_factory=lambda: _VFOLDER_ID)
 
     @classmethod
     @override
@@ -177,7 +173,7 @@ class _VfolderUpdateAction(BaseSingleEntityAction):
 class _VfolderUpsertAction(BaseSingleEntityAction):
     """VFOLDER:UPSERT on a single vfolder — requires the ``CREATE | UPDATE`` mask."""
 
-    vfolder_id: EntityID = field(default_factory=lambda: _VFOLDER_ID)
+    vfolder_id: uuid.UUID = field(default_factory=lambda: _VFOLDER_ID)
 
     @classmethod
     @override
@@ -198,7 +194,7 @@ class _VfolderUpsertAction(BaseSingleEntityAction):
 class _BulkVfolderUpdateAction(BaseBulkAction):
     """VFOLDER:UPDATE on multiple vfolders — exercises the bulk validator path."""
 
-    ids: list[EntityID]
+    ids: list[uuid.UUID]
 
     @classmethod
     @override
@@ -234,7 +230,7 @@ class _VfolderID(EntityIdentifier):
         return VFolderEntityType()
 
 
-def _domain_scope(scope_id: EntityID) -> EntityIdentifier:
+def _domain_scope(scope_id: uuid.UUID) -> EntityIdentifier:
     return DomainID(scope_id)
 
 

--- a/tests/unit/manager/api/adapters/test_deployment_adapter.py
+++ b/tests/unit/manager/api/adapters/test_deployment_adapter.py
@@ -19,10 +19,8 @@ from ai.backend.common.data.entity.deployment_revision import DeploymentRevision
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.image import ImageID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE
+from ai.backend.common.data.entity.types import EntityIdentifier
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
 from ai.backend.common.data.user.types import UserData, UserRole
@@ -159,7 +157,7 @@ class _RecordingScopeValidator(ScopeActionValidator):
     """Lets every scoped read through and keeps the scopes it was asked about."""
 
     def __init__(self) -> None:
-        self.seen: list[Sequence[ScopeRef]] = []
+        self.seen: list[Sequence[EntityIdentifier]] = []
 
     @override
     async def validate(self, action: BaseScopeAction, meta: BaseActionTriggerMeta) -> None:
@@ -224,9 +222,7 @@ class TestDeploymentSearchGates:
             payload = await adapter.my_search(AdminSearchDeploymentsInput(limit=10, offset=0))
 
         assert payload.total_count == 0
-        assert scope_gate.seen == [
-            [ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=regular_user.user_id)]
-        ]
+        assert scope_gate.seen == [[regular_user.user_id]]
 
     async def test_project_search_is_answered_for_the_project_scope(
         self,
@@ -241,7 +237,7 @@ class TestDeploymentSearchGates:
             )
 
         assert payload.total_count == 0
-        assert scope_gate.seen == [[ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id)]]
+        assert scope_gate.seen == [[project_id]]
 
     async def test_admin_search_keeps_the_superadmin_gate(
         self,

--- a/tests/unit/manager/models/virtual_entity/test_queries.py
+++ b/tests/unit/manager/models/virtual_entity/test_queries.py
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
-from ai.backend.common.data.entity.types import EntityType, ScopeType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.types import EntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
@@ -47,7 +47,7 @@ class TestScopeMembershipExists:
     async def _holds(
         self,
         db: ExtendedAsyncSAEngine,
-        scope_type: ScopeType,
+        scope_type: EntityType,
         scope_id: uuid.UUID,
         member_type: EntityType,
         member_id: uuid.UUID,
@@ -62,7 +62,7 @@ class TestScopeMembershipExists:
     async def test_belonging_edge_is_held(self, db_with_cleanup: ExtendedAsyncSAEngine) -> None:
         project_id, vfolder_id = uuid.uuid4(), uuid.uuid4()
         async with db_with_cleanup.begin_session() as sess:
-            project = await self._node(sess, PROJECT_SCOPE_TYPE, project_id)
+            project = await self._node(sess, ProjectEntityType(), project_id)
             vfolder = await self._node(sess, VFolderEntityType(), vfolder_id)
             sess.add(
                 EntityMembershipRow(
@@ -70,14 +70,14 @@ class TestScopeMembershipExists:
                 )
             )
         assert await self._holds(
-            db_with_cleanup, PROJECT_SCOPE_TYPE, project_id, VFolderEntityType(), vfolder_id
+            db_with_cleanup, ProjectEntityType(), project_id, VFolderEntityType(), vfolder_id
         )
 
     async def test_capped_edge_is_held(self, db_with_cleanup: ExtendedAsyncSAEngine) -> None:
         """A share is what the scope holds under a cap, so a read still finds it."""
         project_id, vfolder_id = uuid.uuid4(), uuid.uuid4()
         async with db_with_cleanup.begin_session() as sess:
-            project = await self._node(sess, PROJECT_SCOPE_TYPE, project_id)
+            project = await self._node(sess, ProjectEntityType(), project_id)
             vfolder = await self._node(sess, VFolderEntityType(), vfolder_id)
             sess.add(
                 EntityMembershipRow(
@@ -85,7 +85,7 @@ class TestScopeMembershipExists:
                 )
             )
         assert await self._holds(
-            db_with_cleanup, PROJECT_SCOPE_TYPE, project_id, VFolderEntityType(), vfolder_id
+            db_with_cleanup, ProjectEntityType(), project_id, VFolderEntityType(), vfolder_id
         )
 
     async def test_another_scope_does_not_hold_it(
@@ -93,8 +93,8 @@ class TestScopeMembershipExists:
     ) -> None:
         holder_id, other_id, vfolder_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         async with db_with_cleanup.begin_session() as sess:
-            holder = await self._node(sess, PROJECT_SCOPE_TYPE, holder_id)
-            await self._node(sess, PROJECT_SCOPE_TYPE, other_id)
+            holder = await self._node(sess, ProjectEntityType(), holder_id)
+            await self._node(sess, ProjectEntityType(), other_id)
             vfolder = await self._node(sess, VFolderEntityType(), vfolder_id)
             sess.add(
                 EntityMembershipRow(
@@ -102,7 +102,7 @@ class TestScopeMembershipExists:
                 )
             )
         assert not await self._holds(
-            db_with_cleanup, PROJECT_SCOPE_TYPE, other_id, VFolderEntityType(), vfolder_id
+            db_with_cleanup, ProjectEntityType(), other_id, VFolderEntityType(), vfolder_id
         )
 
     async def test_member_type_narrows_the_answer(
@@ -111,7 +111,7 @@ class TestScopeMembershipExists:
         """Two entities may share an id across types; the type tells them apart."""
         project_id, shared_id = uuid.uuid4(), uuid.uuid4()
         async with db_with_cleanup.begin_session() as sess:
-            project = await self._node(sess, PROJECT_SCOPE_TYPE, project_id)
+            project = await self._node(sess, ProjectEntityType(), project_id)
             vfolder = await self._node(sess, VFolderEntityType(), shared_id)
             await self._node(sess, UserEntityType(), shared_id)
             sess.add(
@@ -120,10 +120,10 @@ class TestScopeMembershipExists:
                 )
             )
         assert await self._holds(
-            db_with_cleanup, PROJECT_SCOPE_TYPE, project_id, VFolderEntityType(), shared_id
+            db_with_cleanup, ProjectEntityType(), project_id, VFolderEntityType(), shared_id
         )
         assert not await self._holds(
-            db_with_cleanup, PROJECT_SCOPE_TYPE, project_id, UserEntityType(), shared_id
+            db_with_cleanup, ProjectEntityType(), project_id, UserEntityType(), shared_id
         )
 
     async def test_correlates_with_the_outer_row(
@@ -132,7 +132,7 @@ class TestScopeMembershipExists:
         """The member id may be a column, which is how an operation scope uses it."""
         project_id, held_id, loose_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
         async with db_with_cleanup.begin_session() as sess:
-            project = await self._node(sess, PROJECT_SCOPE_TYPE, project_id)
+            project = await self._node(sess, ProjectEntityType(), project_id)
             held = await self._node(sess, VFolderEntityType(), held_id)
             await self._node(sess, VFolderEntityType(), loose_id)
             sess.add(
@@ -145,7 +145,7 @@ class TestScopeMembershipExists:
                     sa.select(vfolders.entity_id).where(
                         vfolders.entity_type == VFolderEntityType(),
                         scope_membership_exists(
-                            PROJECT_SCOPE_TYPE,
+                            ProjectEntityType(),
                             project_id,
                             VFolderEntityType(),
                             vfolders.entity_id,

--- a/tests/unit/manager/repositories/image/test_customized_image_creator.py
+++ b/tests/unit/manager/repositories/image/test_customized_image_creator.py
@@ -22,11 +22,7 @@ from ai.backend.common.data.entity.container_registry import (
 )
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.image import ImageID
-from ai.backend.common.data.entity.project import (
-    PROJECT_SCOPE_TYPE,
-    ProjectEntityType,
-    ProjectID,
-)
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.docker import LabelName
 from ai.backend.common.types import ResourceSlot
@@ -306,7 +302,7 @@ class TestImageOwnershipGraph:
 
     async def _owning_projects(self, db: ExtendedAsyncSAEngine, image_id: ImageID) -> list[UUID]:
         async with V2DBOpsProvider(db).read_ops() as r:
-            return list(await r.scopes_owning(PROJECT_SCOPE_TYPE, image_id))
+            return list(await r.scopes_owning(ProjectEntityType(), image_id))
 
     async def _commit_rescan(
         self,

--- a/tests/unit/manager/repositories/ops/test_ops_repository.py
+++ b/tests/unit/manager/repositories/ops/test_ops_repository.py
@@ -21,7 +21,7 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute
 
-from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.role_preset import (
     RolePresetEntityType,
     RolePresetID,
@@ -33,8 +33,6 @@ from ai.backend.common.data.entity.types import (
     FieldData,
     FieldIdentifier,
     FieldType,
-    ScopeRef,
-    ScopeType,
 )
 from ai.backend.common.data.permission.types import ScopeType as RBACScopeType
 from ai.backend.manager.actions.types import ActionOperationType
@@ -720,7 +718,7 @@ class _NamedScope(OperationScope):
 class _SearchPresetsAction(BaseScopeAction, SearchOpsAction[RolePresetRow, _PresetView]):
     """The only file a pass-through domain still writes: the action."""
 
-    scope: ScopeRef
+    scope: EntityIdentifier
     scopes: tuple[OperationScope, ...] = ()
 
     @override
@@ -732,7 +730,7 @@ class _SearchPresetsAction(BaseScopeAction, SearchOpsAction[RolePresetRow, _Pres
         return self.scopes
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -801,7 +799,7 @@ class TestFullStack:
             service.execute
         )
         action = _SearchPresetsAction(
-            scope=ScopeRef(scope_type=ScopeType(DomainEntityType()), scope_id=uuid.uuid4()),
+            scope=DomainID(uuid.uuid4()),
             scopes=(_NamedScope(name="default"),),
         )
 

--- a/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
+++ b/tests/unit/manager/repositories/ops/v2/test_entity_lifecycle.py
@@ -31,8 +31,8 @@ import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import InstrumentedAttribute, Mapped, aliased, mapped_column
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.data.entity.types import (
     EntityIdentifier,
@@ -40,7 +40,6 @@ from ai.backend.common.data.entity.types import (
     FieldData,
     FieldIdentifier,
     FieldType,
-    ScopeType,
 )
 from ai.backend.manager.data.permission.scope_template import ScopeTemplateValue
 from ai.backend.manager.data.permission.status import RoleStatus
@@ -115,8 +114,8 @@ class _EntityData:
     note: str | None
 
 
-_SCOPE_TYPE = PROJECT_SCOPE_TYPE
-_PARENT_SCOPE_TYPE = DOMAIN_SCOPE_TYPE
+_SCOPE_TYPE = ProjectEntityType()
+_PARENT_SCOPE_TYPE = DomainEntityType()
 
 
 # A scope type outside every permission-layer enum — the chain accepts it as-is.
@@ -132,7 +131,7 @@ class _OpenEntityType(EntityType):
         return "A kind outside every permission-layer enum."
 
 
-_OPEN_SCOPE_TYPE = ScopeType(_OpenEntityType())
+_OPEN_SCOPE_TYPE = _OpenEntityType()
 
 
 class _EntityID(EntityIdentifier):
@@ -427,7 +426,7 @@ async def _preset_id(database: ExtendedAsyncSAEngine, name: str) -> UUID:
 
 
 async def _virtual_entity_id(
-    database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: ScopeType = _SCOPE_TYPE
+    database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: EntityType = _SCOPE_TYPE
 ) -> UUID | None:
     async with database.begin_readonly_session() as sess:
         result = await sess.execute(
@@ -439,7 +438,7 @@ async def _virtual_entity_id(
         return result.scalar_one_or_none()
 
 
-def _node_id(scope_type: ScopeType, scope_id: UUID) -> sa.ScalarSelect[Any]:
+def _node_id(scope_type: EntityType, scope_id: UUID) -> sa.ScalarSelect[Any]:
     return (
         sa.select(VirtualEntityRow.id)
         .where(
@@ -451,7 +450,7 @@ def _node_id(scope_type: ScopeType, scope_id: UUID) -> sa.ScalarSelect[Any]:
 
 
 async def _self_membership_exists(
-    database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: ScopeType = _SCOPE_TYPE
+    database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: EntityType = _SCOPE_TYPE
 ) -> bool:
     async with database.begin_readonly_session() as sess:
         node = _node_id(scope_type, scope_id)
@@ -465,7 +464,7 @@ async def _self_membership_exists(
 
 
 async def _self_binding_exists(
-    database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: ScopeType = _SCOPE_TYPE
+    database: ExtendedAsyncSAEngine, scope_id: UUID, scope_type: EntityType = _SCOPE_TYPE
 ) -> bool:
     async with database.begin_readonly_session() as sess:
         node = _node_id(scope_type, scope_id)
@@ -570,7 +569,7 @@ async def _scope_governs_role(
     async with database.begin_readonly_session() as sess:
         row = await sess.scalar(
             sa.select(ScopeBindingRow.scope_entity_id).where(
-                ScopeBindingRow.virtual_entity_id == _node_id(ScopeType(RoleEntityType()), role_id),
+                ScopeBindingRow.virtual_entity_id == _node_id(RoleEntityType(), role_id),
                 ScopeBindingRow.scope_entity_id == _node_id(_SCOPE_TYPE, scope_id),
             )
         )

--- a/tests/unit/manager/repositories/ops/v2/user/test_create_user.py
+++ b/tests/unit/manager/repositories/ops/v2/user/test_create_user.py
@@ -10,11 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy import Table
 
 from ai.backend.common.data.entity.domain import DomainEntityType, DomainID, DomainName
-from ai.backend.common.data.entity.project import (
-    PROJECT_SCOPE_TYPE,
-    ProjectEntityType,
-    ProjectID,
-)
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.role import RoleEntityType, RoleID
 from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
@@ -503,7 +499,7 @@ async def _enrol_auto_assign_role(db: ExtendedAsyncSAEngine, project_id: Project
                 name=f"role-{role_id.hex[:8]}",
                 status=RoleStatus.ACTIVE,
                 auto_assign=True,
-                scope_type=PROJECT_SCOPE_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=project_id,
             )
         )
@@ -512,7 +508,7 @@ async def _enrol_auto_assign_role(db: ExtendedAsyncSAEngine, project_id: Project
         await session.flush()
         project_node_id = await session.scalar(
             sa.select(VirtualEntityRow.id).where(
-                VirtualEntityRow.entity_type == PROJECT_SCOPE_TYPE,
+                VirtualEntityRow.entity_type == ProjectEntityType(),
                 VirtualEntityRow.entity_id == project_id,
             )
         )

--- a/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
@@ -20,7 +20,7 @@ from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.session import SessionEntityType, SessionID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
@@ -106,7 +106,7 @@ class VSChainFixture:
     bound_scope_node_id: VirtualEntityID = field(
         default_factory=lambda: VirtualEntityID(uuid.uuid4())
     )
-    entity_id: EntityID = field(default_factory=uuid.uuid4)
+    entity_id: uuid.UUID = field(default_factory=uuid.uuid4)
     entity_node_id: VirtualEntityID = field(default_factory=lambda: VirtualEntityID(uuid.uuid4()))
 
 

--- a/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
@@ -20,7 +20,7 @@ from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectEnt
 from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.session import SessionEntityType, SessionID
-from ai.backend.common.data.entity.types import EntityID, EntityType, ScopeRef, ScopeType
+from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType, ScopeType
 from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
@@ -101,7 +101,7 @@ class VSChainFixture:
     virtual_entity_id: VirtualEntityID = field(
         default_factory=lambda: VirtualEntityID(uuid.uuid4())
     )
-    owner_scope_id: uuid.UUID = field(default_factory=uuid.uuid4)
+    owner_scope_id: ProjectID = field(default_factory=lambda: ProjectID(uuid.uuid4()))
     bound_scope_id: uuid.UUID = field(default_factory=uuid.uuid4)
     bound_scope_node_id: VirtualEntityID = field(
         default_factory=lambda: VirtualEntityID(uuid.uuid4())
@@ -665,7 +665,7 @@ class TestUserRosterEnrollment:
         self,
         db: ExtendedAsyncSAEngine,
         ids: VSChainFixture,
-        project_id: uuid.UUID,
+        project_id: ProjectID,
         entity_type: PermEntityType = PermEntityType.VFOLDER,
         operation: OperationType = OperationType.READ,
         permission: Permission = Permission.READ,
@@ -723,7 +723,7 @@ class TestUserRosterEnrollment:
             )
             await self._provision_scope(
                 db_sess,
-                ScopeRef(scope_type=ScopeType(EntityType("project")), scope_id=project_id),
+                project_id,
             )
             db_sess.add(
                 RoleRow(
@@ -807,28 +807,28 @@ class TestUserRosterEnrollment:
         self,
         db: ExtendedAsyncSAEngine,
         roster_provider: RosterOpsProvider,
-        project_scope: ScopeRef,
-        user_scope: ScopeRef,
+        project_scope: EntityIdentifier,
+        user_scope: EntityIdentifier,
         user_id: UserID,
     ) -> None:
         async with db.begin_session() as db_sess:
             for scope in (project_scope, user_scope):
                 await self._provision_scope(db_sess, scope)
         async with roster_provider.write_ops() as roster:
-            await roster.join_member(ProjectID(project_scope.scope_id), user_id)
+            await roster.join_member(ProjectID(project_scope), user_id)
 
-    async def _provision_scope(self, db_sess: AsyncSession, scope: ScopeRef) -> None:
+    async def _provision_scope(self, db_sess: AsyncSession, scope: EntityIdentifier) -> None:
         """The node a scope stands as, with the self membership and self binding an
         entity creation writes for it. Idempotent."""
         node_id = await db_sess.scalar(
             sa.select(VirtualEntityRow.id).where(
-                VirtualEntityRow.entity_type == scope.scope_type,
-                VirtualEntityRow.entity_id == scope.scope_id,
+                VirtualEntityRow.entity_type == scope.entity_type(),
+                VirtualEntityRow.entity_id == scope,
             )
         )
         if node_id is not None:
             return
-        node = VirtualEntityRow(entity_type=scope.scope_type, entity_id=scope.scope_id)
+        node = VirtualEntityRow(entity_type=scope.entity_type(), entity_id=scope)
         db_sess.add(node)
         await db_sess.flush()
         db_sess.add(
@@ -848,8 +848,8 @@ class TestUserRosterEnrollment:
     ) -> None:
         """A project-scope grant must not resolve onto a vfolder enrolled only in the
         member user's own virtual entity: no row binds that scope into the project."""
-        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
-        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        project_scope = ids.owner_scope_id
+        user_scope = ids.user_id
         await self._grant_on_project(db_with_rbac_tables, ids, ids.owner_scope_id)
 
         await self._enroll_user_in_project(
@@ -877,8 +877,8 @@ class TestUserRosterEnrollment:
     ) -> None:
         """The same grant does reach a session enrolled in the project's virtual entity,
         so the check above fails for the intended reason and not by accident."""
-        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
-        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        project_scope = ids.owner_scope_id
+        user_scope = ids.user_id
         session_id = uuid.uuid4()
         await self._grant_on_project(
             db_with_rbac_tables,
@@ -908,8 +908,8 @@ class TestUserRosterEnrollment:
     async def _put_vfolder_in_project_vs(
         self,
         db: ExtendedAsyncSAEngine,
-        project_id: uuid.UUID,
-        vfolder_id: uuid.UUID,
+        project_id: ProjectID,
+        vfolder_id: VFolderUUID,
         cap: Permission | None,
     ) -> None:
         """Put a vfolder into the project's virtual entity: shared under ``cap``, or
@@ -947,9 +947,9 @@ class TestUserRosterEnrollment:
         """A project role holding session READ reaches sessions under a vfolder the
         project owns, and not under one merely shared into it: a share answers for
         the shared entity's own type only."""
-        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
-        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
-        vfolder_id = uuid.uuid4()
+        project_scope = ids.owner_scope_id
+        user_scope = ids.user_id
+        vfolder_id = VFolderUUID(uuid.uuid4())
         await self._grant_on_project(
             db_with_rbac_tables,
             ids,
@@ -965,7 +965,7 @@ class TestUserRosterEnrollment:
 
         key = GovernCheckKey(
             user_id=ids.user_id,
-            scope=ScopeRef(scope_type=ScopeType(VFolderEntityType()), scope_id=vfolder_id),
+            scope=vfolder_id,
             entity_type=SessionEntityType(),
         )
         result = await repository.governed_permissions([key])
@@ -1031,8 +1031,8 @@ class TestUserRosterEnrollment:
         """A project governing a resource group under READ reaches what the resource
         group owns, and not what was merely shared to the resource group: a share
         answers to the resource group's own scope only."""
-        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
-        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        project_scope = ids.owner_scope_id
+        user_scope = ids.user_id
         other_project_id = uuid.uuid4()
         await self._grant_on_project(
             db_with_rbac_tables,
@@ -1064,8 +1064,8 @@ class TestUserRosterEnrollment:
     ) -> None:
         """A project role holding user UPDATE resolves to READ over the member user:
         the roster enrollment caps every project-to-user row to read."""
-        project_scope = ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=ids.owner_scope_id)
-        user_scope = ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=ids.user_id)
+        project_scope = ids.owner_scope_id
+        user_scope = ids.user_id
         await self._grant_on_project(
             db_with_rbac_tables,
             ids,

--- a/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_and_govern_checks.py
@@ -16,12 +16,12 @@ import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.session import SessionEntityType, SessionID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType, ScopeType
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.entity.virtual_entity import VirtualEntityID
 from ai.backend.common.data.permission.types import Permission
@@ -238,7 +238,7 @@ class TestCheckPermissionViaVirtualEntity:
     def _chain_nodes(
         self,
         ids: VSChainFixture,
-        scope_type: ScopeType,
+        scope_type: EntityType,
         entity_type: EntityType,
     ) -> list[VirtualEntityRow]:
         """The nodes a chain names beyond the bound scope, which is made with the role:
@@ -270,9 +270,7 @@ class TestCheckPermissionViaVirtualEntity:
             db_sess.add(
                 DomainRow(id=domain_id, name=domain_name, total_resource_slots=ResourceSlot())
             )
-            db_sess.add_all(
-                self._chain_nodes(ids, ScopeType(ProjectEntityType()), _TARGET_ENTITY_TYPE)
-            )
+            db_sess.add_all(self._chain_nodes(ids, ProjectEntityType(), _TARGET_ENTITY_TYPE))
             await db_sess.flush()
 
             db_sess.add(
@@ -535,9 +533,7 @@ class TestCheckPermissionViaVirtualEntity:
         """The chain of :meth:`_build_chain`, over an entity type the legacy enum
         does not name."""
         async with db.begin_session() as db_sess:
-            db_sess.add_all(
-                self._chain_nodes(ids, ScopeType(ProjectEntityType()), _UNMAPPED_ENTITY_TYPE)
-            )
+            db_sess.add_all(self._chain_nodes(ids, ProjectEntityType(), _UNMAPPED_ENTITY_TYPE))
             await db_sess.flush()
             db_sess.add(
                 ScopeBindingRow(
@@ -755,7 +751,7 @@ class TestUserRosterEnrollment:
         async with db.begin_session() as db_sess:
             user_vs_id = await db_sess.scalar(
                 sa.select(VirtualEntityRow.id).where(
-                    VirtualEntityRow.entity_type == USER_SCOPE_TYPE,
+                    VirtualEntityRow.entity_type == UserEntityType(),
                     VirtualEntityRow.entity_id == ids.user_id,
                 )
             )
@@ -787,7 +783,7 @@ class TestUserRosterEnrollment:
         async with db.begin_session() as db_sess:
             project_ve_id = await db_sess.scalar(
                 sa.select(VirtualEntityRow.id).where(
-                    VirtualEntityRow.entity_type == PROJECT_SCOPE_TYPE,
+                    VirtualEntityRow.entity_type == ProjectEntityType(),
                     VirtualEntityRow.entity_id == project_id,
                 )
             )
@@ -917,7 +913,7 @@ class TestUserRosterEnrollment:
         async with db.begin_session() as db_sess:
             project_ve_id = await db_sess.scalar(
                 sa.select(VirtualEntityRow.id).where(
-                    VirtualEntityRow.entity_type == PROJECT_SCOPE_TYPE,
+                    VirtualEntityRow.entity_type == ProjectEntityType(),
                     VirtualEntityRow.entity_id == project_id,
                 )
             )
@@ -983,7 +979,7 @@ class TestUserRosterEnrollment:
         async with db.begin_session() as db_sess:
             project_ve_id = await db_sess.scalar(
                 sa.select(VirtualEntityRow.id).where(
-                    VirtualEntityRow.entity_type == PROJECT_SCOPE_TYPE,
+                    VirtualEntityRow.entity_type == ProjectEntityType(),
                     VirtualEntityRow.entity_id == project_id,
                 )
             )

--- a/tests/unit/manager/repositories/permission_controller/test_own_check_query.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_check_query.py
@@ -29,7 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.session import SessionEntityType, SessionID
-from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
+from ai.backend.common.data.entity.types import EntityIdentifier, EntityType
 from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.permission.types import Permission
@@ -76,7 +76,7 @@ class _Seed:
 
 
 type _Plant = Callable[[AsyncSession], Awaitable[_Seed]]
-type _Run = Callable[[], Awaitable[Mapping[EntityID, Permission]]]
+type _Run = Callable[[], Awaitable[Mapping[uuid.UUID, Permission]]]
 
 
 @pytest.fixture
@@ -305,12 +305,12 @@ async def _previous_query(
     user_id: UserID,
     entity_type: EntityType,
     entity_ids: Sequence[EntityIdentifier],
-) -> Mapping[EntityID, Permission]:
+) -> Mapping[uuid.UUID, Permission]:
     """The own check as it stood before the ``held`` CTE and the SQL-side OR: one row
     per path and bit, clipped and combined in Python."""
     query = _previous_statement(user_id, entity_type, entity_ids)
     full_cap = Permission.full()
-    granted: defaultdict[EntityID, Permission] = defaultdict(lambda: Permission.NONE)
+    granted: defaultdict[uuid.UUID, Permission] = defaultdict(lambda: Permission.NONE)
     for row in await sess.execute(query):
         scope_cap = row.scope_cap if row.scope_cap is not None else full_cap
         granted[row.entity_id] |= row.permission & scope_cap
@@ -412,12 +412,12 @@ def _runs(database: ExtendedAsyncSAEngine, seed: _Seed) -> tuple[_Run, _Run]:
     keys = [OwnCheckKey(user_id=seed.user_id, entity=e) for e in seed.entity_ids]
     provider = PermissionOpsProvider(database)
 
-    async def current() -> Mapping[EntityID, Permission]:
+    async def current() -> Mapping[uuid.UUID, Permission]:
         async with provider.read_ops() as r:
             answered = await r.owned_permissions(keys)
         return {key.entity: bits for key, bits in answered.items()}
 
-    async def previous() -> Mapping[EntityID, Permission]:
+    async def previous() -> Mapping[uuid.UUID, Permission]:
         async with database.begin_readonly_session() as sess:
             return dict(
                 await _previous_query(sess, seed.user_id, seed.entity_type, seed.entity_ids)
@@ -774,14 +774,14 @@ async def test_benchmark_at_scale(database: ExtendedAsyncSAEngine) -> None:
     for name, (entity_type, entity_ids) in cases.items():
         keys = [OwnCheckKey(user_id=seed.user_id, entity=e) for e in entity_ids]
 
-        async def current() -> Mapping[EntityID, Permission]:
+        async def current() -> Mapping[uuid.UUID, Permission]:
             async with provider.read_ops() as r:
                 answered = await r.owned_permissions(keys)
             # The previous query left unreached entities out; the current one maps
             # them to NONE. Compare what is reached.
             return {key.entity: bits for key, bits in answered.items() if bits}
 
-        async def previous() -> Mapping[EntityID, Permission]:
+        async def previous() -> Mapping[uuid.UUID, Permission]:
             async with database.begin_readonly_session() as sess:
                 return dict(await _previous_query(sess, seed.user_id, entity_type, entity_ids))
 

--- a/tests/unit/manager/repositories/permission_controller/test_own_check_query.py
+++ b/tests/unit/manager/repositories/permission_controller/test_own_check_query.py
@@ -30,7 +30,7 @@ from ai.backend.common.data.entity.domain import DomainEntityType, DomainID
 from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.data.entity.types import EntityID, EntityIdentifier, EntityType
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import ResourceSlot
@@ -203,7 +203,7 @@ async def _user_in_domain(sess: AsyncSession) -> tuple[UserID, DomainID, uuid.UU
     )
     await sess.flush()
     domain_node = await _node(sess, _DOMAIN, domain_id)
-    user_node = await _node(sess, USER_SCOPE_TYPE, user_id)
+    user_node = await _node(sess, UserEntityType(), user_id)
     await _govern(sess, domain_node, user_node)
     return user_id, domain_id, user_node, domain_node
 
@@ -212,7 +212,7 @@ async def _role(sess: AsyncSession, user_id: UserID, rows: Sequence[PermissionRo
     role = RoleRow(
         name=f"role-{uuid.uuid4().hex[:8]}",
         status=RoleStatus.ACTIVE,
-        scope_type=USER_SCOPE_TYPE,
+        scope_type=UserEntityType(),
         scope_id=user_id,
     )
     sess.add(role)
@@ -264,7 +264,7 @@ async def seed_shares(sess: AsyncSession, count: int) -> _Seed:
         user_id,
         _permission_rows(
             uuid.uuid4(),
-            USER_SCOPE_TYPE,
+            UserEntityType(),
             user_id,
             VFolderEntityType(),
             Permission.READ | Permission.UPDATE,
@@ -520,7 +520,7 @@ async def seed_at_scale(database: ExtendedAsyncSAEngine, scale: _Scale) -> _Scal
         for kind, ids in (
             (str(_DOMAIN), domain_ids),
             (str(ProjectEntityType()), project_ids),
-            (str(USER_SCOPE_TYPE), user_ids),
+            (str(UserEntityType()), user_ids),
             (str(SessionEntityType()), session_ids),
             (str(VFolderEntityType()), vfolder_ids),
         ):
@@ -617,7 +617,7 @@ async def seed_at_scale(database: ExtendedAsyncSAEngine, scale: _Scale) -> _Scal
         for bit in (Permission.READ, Permission.UPDATE):
             yield (
                 vfolder_role,
-                str(USER_SCOPE_TYPE),
+                str(UserEntityType()),
                 str(measured),
                 str(VFolderEntityType()),
                 int(bit),

--- a/tests/unit/manager/repositories/permission_controller/test_role_write.py
+++ b/tests/unit/manager/repositories/permission_controller/test_role_write.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 import sqlalchemy as sa
 
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.role import RoleEntityType, RoleID
 from ai.backend.common.data.permission.types import RoleSource
 from ai.backend.manager.data.permission.role import RoleData
@@ -78,7 +78,7 @@ class TestRoleWrite:
         role_id = RoleID(uuid.uuid4())
         project_id = ProjectID(uuid.uuid4())
         async with db.begin_session() as db_sess:
-            db_sess.add(VirtualEntityRow(entity_type=PROJECT_SCOPE_TYPE, entity_id=project_id))
+            db_sess.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=project_id))
             await db_sess.flush()
             await db_sess.execute(
                 sa.insert(RoleRow).values(
@@ -86,7 +86,7 @@ class TestRoleWrite:
                     name=f"role-{source.value}",
                     source=source,
                     status=RoleStatus.ACTIVE,
-                    scope_type=PROJECT_SCOPE_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=project_id,
                 )
             )
@@ -162,7 +162,7 @@ class TestRoleCreate:
     async def project_id(self, db_with_tables: ExtendedAsyncSAEngine) -> ProjectID:
         project_id = ProjectID(uuid.uuid4())
         async with db_with_tables.begin_session() as db_sess:
-            db_sess.add(VirtualEntityRow(entity_type=PROJECT_SCOPE_TYPE, entity_id=project_id))
+            db_sess.add(VirtualEntityRow(entity_type=ProjectEntityType(), entity_id=project_id))
         return project_id
 
     async def _owning_scope_ids(self, db: ExtendedAsyncSAEngine, role_id: RoleID) -> set[uuid.UUID]:
@@ -195,7 +195,7 @@ class TestRoleCreate:
 
         assert data.name == "reader"
         assert data.source == RoleSource.CUSTOM
-        assert (data.scope_type, data.scope_id) == (PROJECT_SCOPE_TYPE, project_id)
+        assert (data.scope_type, data.scope_id) == (ProjectEntityType(), project_id)
         assert await self._owning_scope_ids(db_with_tables, data.id) == {data.id, project_id}
 
     async def test_create_in_a_scope_without_a_node_fails(

--- a/tests/unit/manager/repositories/permission_controller/test_search_users_assigned_to_role.py
+++ b/tests/unit/manager/repositories/permission_controller/test_search_users_assigned_to_role.py
@@ -13,7 +13,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE
+from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.filter_specs import StringMatchSpec
 from ai.backend.manager.models.agent import AgentRow
 
@@ -128,7 +128,7 @@ class TestSearchUsersAssignedToRole:
             await db_sess.flush()
 
             role = RoleRow(
-                scope_type=PROJECT_SCOPE_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=uuid.uuid4(),
                 name="test-role",
                 description="Test role",
@@ -209,7 +209,7 @@ class TestSearchUsersAssignedToRole:
         """Searching with a different role_id should not return assignments from the test role."""
         async with db_with_tables.begin_session() as db_sess:
             other_role = RoleRow(
-                scope_type=PROJECT_SCOPE_TYPE,
+                scope_type=ProjectEntityType(),
                 scope_id=uuid.uuid4(),
                 name="other-role",
                 description="Other role",

--- a/tests/unit/manager/repositories/retention/test_retention_repository.py
+++ b/tests/unit/manager/repositories/retention/test_retention_repository.py
@@ -35,7 +35,7 @@ import sqlalchemy as sa
 from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenID
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.data.entity.session_group import SessionGroupID
 from ai.backend.common.data.entity.user import UserID
@@ -497,14 +497,14 @@ class TestTerminalStateFilter:
             db,
             [
                 RoleRow(
-                    scope_type=PROJECT_SCOPE_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=uuid.uuid4(),
                     name="deleted-old",
                     status=RoleStatus.DELETED,
                     deleted_at=_OLD,
                 ),
                 RoleRow(
-                    scope_type=PROJECT_SCOPE_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=uuid.uuid4(),
                     name="deleted-new",
                     status=RoleStatus.DELETED,
@@ -512,7 +512,7 @@ class TestTerminalStateFilter:
                 ),
                 # Active role: never deleted, deleted_at is NULL -> preserved.
                 RoleRow(
-                    scope_type=PROJECT_SCOPE_TYPE,
+                    scope_type=ProjectEntityType(),
                     scope_id=uuid.uuid4(),
                     name="active",
                     status=RoleStatus.ACTIVE,

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_ownership_transfer.py
@@ -17,8 +17,8 @@ import sqlalchemy as sa
 from sqlalchemy.orm import aliased
 
 from ai.backend.common.data.entity.domain import DomainID, DomainName
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.permission.types import Permission
 from ai.backend.common.types import (
@@ -116,7 +116,7 @@ async def _membership_cap(
                 )
                 .join(member, member.id == EntityMembershipRow.member_entity_id)
                 .where(
-                    VirtualEntityRow.entity_type == PROJECT_SCOPE_TYPE,
+                    VirtualEntityRow.entity_type == ProjectEntityType(),
                     VirtualEntityRow.entity_id == personal_project_id,
                     member.entity_type == VFolderEntityType(),
                     member.entity_id == vfolder_id,
@@ -366,7 +366,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
                 id=role_id,
                 name=f"user-role-{user_uuid.hex[:8]}",
                 source=RoleSource.SYSTEM,
-                scope_type=USER_SCOPE_TYPE,
+                scope_type=UserEntityType(),
                 scope_id=user_uuid,
             )
             db_sess.add(role_row)
@@ -395,7 +395,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
             db_sess.add(
                 VirtualEntityRow(
                     id=uuid.uuid4(),
-                    entity_type=USER_SCOPE_TYPE,
+                    entity_type=UserEntityType(),
                     entity_id=UserID(user_uuid),
                 )
             )
@@ -419,7 +419,7 @@ class TestVFolderOwnershipTransferRBACCleanup:
             db_sess.add(
                 VirtualEntityRow(
                     id=uuid.uuid4(),
-                    entity_type=PROJECT_SCOPE_TYPE,
+                    entity_type=ProjectEntityType(),
                     entity_id=ProjectID(personal_project_id),
                 )
             )

--- a/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
+++ b/tests/unit/manager/repositories/vfolder/test_vfolder_repository.py
@@ -17,8 +17,8 @@ from ai.backend.common.container_registry import ContainerRegistryType
 from ai.backend.common.data.endpoint.types import EndpointLifecycle
 from ai.backend.common.data.entity.container_registry import ContainerRegistryID
 from ai.backend.common.data.entity.domain import DomainID, DomainName
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
+from ai.backend.common.data.entity.user import UserEntityType, UserID
 from ai.backend.common.data.entity.vfolder import VFolderEntityType, VFolderUUID
 from ai.backend.common.types import (
     BinarySize,
@@ -300,7 +300,7 @@ class TestVfolderRepository:
                 id=role_id,
                 name=f"user-role-{user_uuid.hex[:8]}",
                 source=RoleSource.SYSTEM,
-                scope_type=USER_SCOPE_TYPE,
+                scope_type=UserEntityType(),
                 scope_id=user_uuid,
             )
             db_sess.add(role)
@@ -319,7 +319,7 @@ class TestVfolderRepository:
             db_sess.add(
                 VirtualEntityRow(
                     id=uuid.uuid4(),
-                    entity_type=USER_SCOPE_TYPE,
+                    entity_type=UserEntityType(),
                     entity_id=UserID(user_uuid),
                 )
             )
@@ -357,7 +357,7 @@ class TestVfolderRepository:
             db_sess.add(
                 VirtualEntityRow(
                     id=uuid.uuid4(),
-                    entity_type=PROJECT_SCOPE_TYPE,
+                    entity_type=ProjectEntityType(),
                     entity_id=ProjectID(group_uuid),
                 )
             )

--- a/tests/unit/manager/services/app_config/test_service.py
+++ b/tests/unit/manager/services/app_config/test_service.py
@@ -160,7 +160,7 @@ class TestAppConfigService:
         assert scopes == (
             VisibleAppConfigFragmentOperationScope(user_id=_USER_ID, domain_id=_DOMAIN_ID),
         )
-        assert [target.scope_id for target in action.scope_targets()] == [_USER_ID]
+        assert list(action.scope_targets()) == [_USER_ID]
 
     async def test_search_replaces_lists_wholesale(
         self,

--- a/tests/unit/manager/services/idle_checker_assignment/test_actions.py
+++ b/tests/unit/manager/services/idle_checker_assignment/test_actions.py
@@ -4,9 +4,8 @@ import uuid
 
 import pytest
 
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.domain import DomainID
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.manager.models.idle_checker.scopes import IdleCheckerAssignmentOperationScope
 from ai.backend.manager.models.idle_checker.searchers import IdleCheckerAssignmentSearcher
 from ai.backend.manager.models.specs.pagination import NoPagination
@@ -40,8 +39,8 @@ class TestScopedSearchIdleCheckerAssignmentsAction:
         project_id: ProjectID,
     ) -> None:
         assert action.scope_targets() == [
-            ScopeRef(scope_type=DOMAIN_SCOPE_TYPE, scope_id=domain_id),
-            ScopeRef(scope_type=PROJECT_SCOPE_TYPE, scope_id=project_id),
+            domain_id,
+            project_id,
         ]
 
     def test_operation_scopes_restrict_the_read_to_the_same_scopes(

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -34,7 +34,6 @@ from ai.backend.common.data.entity.types import (
     FieldData,
     FieldIdentifier,
     FieldType,
-    ScopeType,
 )
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.data.user.types import UserData, UserRole
@@ -147,7 +146,7 @@ from ai.backend.manager.services.ops.service import (
 )
 
 _ENTITY_TYPE = RolePresetEntityType()
-_SCOPE_TYPE = ScopeType(_ENTITY_TYPE)
+_SCOPE_TYPE = EntityType(_ENTITY_TYPE)
 
 
 class _TestFieldType(FieldType):

--- a/tests/unit/manager/services/ops/test_generic_services.py
+++ b/tests/unit/manager/services/ops/test_generic_services.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 
 from ai.backend.common.contexts.user import with_user
 from ai.backend.common.data.entity.domain import DomainID
-from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.role_preset import RolePresetEntityType, RolePresetID
 from ai.backend.common.data.entity.types import (
     EntityData,
@@ -34,7 +34,6 @@ from ai.backend.common.data.entity.types import (
     FieldData,
     FieldIdentifier,
     FieldType,
-    ScopeRef,
     ScopeType,
 )
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
@@ -692,7 +691,7 @@ class _DeleteAction(BaseSingleEntityAction, UpdateOpsAction[RolePresetRow, _Pres
 
 @dataclass
 class _CreateAction(BaseScopeAction, EntityCreateOpsAction[RolePresetRow, _PresetData]):
-    scope: ScopeRef
+    scope: EntityIdentifier
     creator: _PresetCreator
 
     @override
@@ -700,7 +699,7 @@ class _CreateAction(BaseScopeAction, EntityCreateOpsAction[RolePresetRow, _Prese
         return self.creator
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -911,7 +910,7 @@ class _BulkPurgeAction(BaseBulkAction, EntityPartialBulkPurgeOpsAction[RolePrese
 
 @dataclass
 class _BulkCreateAction(BaseScopeAction, EntityAtomicCreateOpsAction[RolePresetRow, _PresetData]):
-    scope: ScopeRef
+    scope: EntityIdentifier
     creators: list[_PresetCreator]
 
     @override
@@ -919,7 +918,7 @@ class _BulkCreateAction(BaseScopeAction, EntityAtomicCreateOpsAction[RolePresetR
         return self.creators
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -1135,7 +1134,7 @@ class _FieldUpsertAction(
 class _RoleManagedCreateAction(
     BaseScopeAction, RoleManagedEntityCreateOpsAction[RolePresetRow, _PresetData]
 ):
-    scope: ScopeRef
+    scope: EntityIdentifier
     creator: _PresetRoleManagedCreator
 
     @override
@@ -1143,7 +1142,7 @@ class _RoleManagedCreateAction(
         return self.creator
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -1166,7 +1165,7 @@ class _RoleManagedCreateAction(
 class _RoleManagedBulkCreateAction(
     BaseScopeAction, RoleManagedEntityAtomicCreateOpsAction[RolePresetRow, _PresetData]
 ):
-    scope: ScopeRef
+    scope: EntityIdentifier
     creators: list[_PresetRoleManagedCreator]
 
     @override
@@ -1174,7 +1173,7 @@ class _RoleManagedBulkCreateAction(
         return self.creators
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -1195,7 +1194,7 @@ class _RoleManagedBulkCreateAction(
 
 @dataclass
 class _BatchUpdateAction(BaseScopeAction, BatchUpdateOpsAction[RolePresetRow, _PresetData]):
-    scope: ScopeRef
+    scope: EntityIdentifier
     updater: _PresetBatchUpdater
     scopes: list[OperationScope] = field(default_factory=list)
 
@@ -1208,7 +1207,7 @@ class _BatchUpdateAction(BaseScopeAction, BatchUpdateOpsAction[RolePresetRow, _P
         return self.scopes
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -1229,7 +1228,7 @@ class _BatchUpdateAction(BaseScopeAction, BatchUpdateOpsAction[RolePresetRow, _P
 
 @dataclass
 class _BatchPurgeAction(BaseScopeAction, BatchPurgeOpsAction[RolePresetRow, _PresetData]):
-    scope: ScopeRef
+    scope: EntityIdentifier
     purger: _PresetBatchPurger
     scopes: list[OperationScope] = field(default_factory=list)
 
@@ -1242,7 +1241,7 @@ class _BatchPurgeAction(BaseScopeAction, BatchPurgeOpsAction[RolePresetRow, _Pre
         return self.scopes
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -1289,7 +1288,7 @@ class _GlobalSearchAction(BaseGlobalAction, GlobalSearchOpsAction[RolePresetRow,
 
 @dataclass
 class _SearchAction(BaseScopeAction, SearchOpsAction[RolePresetRow, _PresetData]):
-    scope: ScopeRef
+    scope: EntityIdentifier
     searcher: _PresetSearcher
     scopes: list[OperationScope] = field(default_factory=list)
 
@@ -1302,7 +1301,7 @@ class _SearchAction(BaseScopeAction, SearchOpsAction[RolePresetRow, _PresetData]
         return self.scopes
 
     @override
-    def scope_targets(self) -> Sequence[ScopeRef]:
+    def scope_targets(self) -> Sequence[EntityIdentifier]:
         return (self.scope,)
 
     @classmethod
@@ -1405,8 +1404,8 @@ def authenticated_user() -> UserData:
 
 
 @pytest.fixture
-def scope() -> ScopeRef:
-    return ScopeRef(scope_type=ScopeType(ProjectEntityType()), scope_id=uuid.uuid4())
+def scope() -> EntityIdentifier:
+    return ProjectID(uuid.uuid4())
 
 
 @pytest.fixture
@@ -1447,7 +1446,7 @@ async def test_delete_applies_the_action_s_updater(
 
 
 async def test_create_forwards_the_action_s_creator(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: EntityCreateService[_PresetData] = EntityCreateService(repository)
     creator = _PresetCreator()
@@ -1545,7 +1544,7 @@ async def test_lookup_runs_under_the_lookup_processor(
 
 
 async def test_atomic_create_forwards_every_creator(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: EntityAtomicCreateService[_PresetData] = EntityAtomicCreateService(repository)
     creators = [_PresetCreator(), _PresetCreator()]
@@ -1593,7 +1592,7 @@ async def test_partial_bulk_purge_answers_for_every_named_entity(
 
 
 async def test_role_managed_create_forwards_the_action_s_creator(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: RoleManagedEntityCreateService[_PresetData] = RoleManagedEntityCreateService(
         repository
@@ -1607,7 +1606,7 @@ async def test_role_managed_create_forwards_the_action_s_creator(
 
 
 async def test_role_managed_atomic_create_forwards_every_creator(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: RoleManagedEntityAtomicCreateService[_PresetData] = (
         RoleManagedEntityAtomicCreateService(repository)
@@ -1717,7 +1716,7 @@ async def test_field_upsert_forwards_owner_and_upserter(
 
 
 async def test_batch_update_names_what_it_wrote(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: BatchUpdateService[_PresetData] = BatchUpdateService(repository)
     updater = _PresetBatchUpdater()
@@ -1732,7 +1731,7 @@ async def test_batch_update_names_what_it_wrote(
 
 
 async def test_batch_purge_names_what_it_removed(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: BatchPurgeService[_PresetData] = BatchPurgeService(repository)
     purger = _PresetBatchPurger()
@@ -1749,7 +1748,7 @@ async def test_batch_purge_names_what_it_removed(
 async def test_search_forwards_the_searcher_and_its_scopes(
     repository: MagicMock,
     stored: _PresetData,
-    scope: ScopeRef,
+    scope: EntityIdentifier,
     searcher: _PresetSearcher,
 ) -> None:
     service: SearchService[_PresetData] = SearchService(repository)
@@ -1790,7 +1789,7 @@ async def test_global_search_takes_no_scopes_at_all(
 
 
 async def test_create_runs_under_the_scope_processor(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: EntityCreateService[_PresetData] = EntityCreateService(repository)
     processor: ScopeActionProcessor[_CreateAction, CreatedEntityOpsResult[_PresetData]] = (
@@ -1804,7 +1803,7 @@ async def test_create_runs_under_the_scope_processor(
 
 
 async def test_search_names_what_it_read_under_the_scope_processor(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef, searcher: _PresetSearcher
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier, searcher: _PresetSearcher
 ) -> None:
     service: SearchService[_PresetData] = SearchService(repository)
     processor: ScopeActionProcessor[_SearchAction, ScopedBatchOpsResult[_PresetData]] = (
@@ -1817,7 +1816,7 @@ async def test_search_names_what_it_read_under_the_scope_processor(
 
 
 async def test_batch_purge_runs_under_the_scope_processor(
-    repository: MagicMock, stored: _PresetData, scope: ScopeRef
+    repository: MagicMock, stored: _PresetData, scope: EntityIdentifier
 ) -> None:
     service: BatchPurgeService[_PresetData] = BatchPurgeService(repository)
     processor: ScopeActionProcessor[_BatchPurgeAction, EntitiesOpsResult[_PresetData]] = (

--- a/tests/unit/manager/services/rbac/test_relation_actions.py
+++ b/tests/unit/manager/services/rbac/test_relation_actions.py
@@ -18,14 +18,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ai.backend.common.data.entity.container_registry import (
-    CONTAINER_REGISTRY_SCOPE_TYPE,
+    ContainerRegistryEntityType,
     ContainerRegistryID,
 )
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.idle_checker import (
     IdleCheckerID,
 )
-from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
+from ai.backend.common.data.entity.project import ProjectEntityType, ProjectID
 from ai.backend.common.data.entity.resource_group import (
     ResourceGroupID,
 )
@@ -261,6 +261,6 @@ class TestARelationRunIsRecordedOnItsOwn:
         assert creators[0].entity_type is None
         assert creators[0].action_name == "create_relation"
         assert {(s.scope_type, s.scope_id) for s in scopes} == {
-            (str(PROJECT_SCOPE_TYPE), _PROJECT_ID),
-            (str(CONTAINER_REGISTRY_SCOPE_TYPE), _REGISTRY_ID),
+            (str(ProjectEntityType()), _PROJECT_ID),
+            (str(ContainerRegistryEntityType()), _REGISTRY_ID),
         }

--- a/tests/unit/manager/services/rbac/test_relation_actions.py
+++ b/tests/unit/manager/services/rbac/test_relation_actions.py
@@ -21,18 +21,16 @@ from ai.backend.common.data.entity.container_registry import (
     CONTAINER_REGISTRY_SCOPE_TYPE,
     ContainerRegistryID,
 )
-from ai.backend.common.data.entity.domain import DOMAIN_SCOPE_TYPE, DomainID
+from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.idle_checker import (
-    IdleCheckerEntityType,
     IdleCheckerID,
 )
 from ai.backend.common.data.entity.project import PROJECT_SCOPE_TYPE, ProjectID
 from ai.backend.common.data.entity.resource_group import (
-    RESOURCE_GROUP_SCOPE_TYPE,
     ResourceGroupID,
 )
-from ai.backend.common.data.entity.types import ScopeType
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.types import EntityIdentifier
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.manager.actions.audit_policy import AuditLogPolicy
 from ai.backend.manager.actions.types import ActionOperationType, OperationStatus
@@ -90,8 +88,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.CREATE,
                 [
-                    (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (CONTAINER_REGISTRY_SCOPE_TYPE, _REGISTRY_ID),
+                    _PROJECT_ID,
+                    _REGISTRY_ID,
                 ],
             ),
             (
@@ -101,8 +99,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.DELETE,
                 [
-                    (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (CONTAINER_REGISTRY_SCOPE_TYPE, _REGISTRY_ID),
+                    _PROJECT_ID,
+                    _REGISTRY_ID,
                 ],
             ),
             (
@@ -112,8 +110,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.CREATE,
                 [
-                    (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (RESOURCE_GROUP_SCOPE_TYPE, _RESOURCE_GROUP_ID),
+                    _PROJECT_ID,
+                    _RESOURCE_GROUP_ID,
                 ],
             ),
             (
@@ -123,8 +121,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.DELETE,
                 [
-                    (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (RESOURCE_GROUP_SCOPE_TYPE, _RESOURCE_GROUP_ID),
+                    _PROJECT_ID,
+                    _RESOURCE_GROUP_ID,
                 ],
             ),
             (
@@ -134,8 +132,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.CREATE,
                 [
-                    (DOMAIN_SCOPE_TYPE, _DOMAIN_ID),
-                    (RESOURCE_GROUP_SCOPE_TYPE, _RESOURCE_GROUP_ID),
+                    _DOMAIN_ID,
+                    _RESOURCE_GROUP_ID,
                 ],
             ),
             (
@@ -145,8 +143,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.DELETE,
                 [
-                    (DOMAIN_SCOPE_TYPE, _DOMAIN_ID),
-                    (RESOURCE_GROUP_SCOPE_TYPE, _RESOURCE_GROUP_ID),
+                    _DOMAIN_ID,
+                    _RESOURCE_GROUP_ID,
                 ],
             ),
             (
@@ -156,8 +154,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.CREATE,
                 [
-                    (USER_SCOPE_TYPE, _USER_ID),
-                    (RESOURCE_GROUP_SCOPE_TYPE, _RESOURCE_GROUP_ID),
+                    _USER_ID,
+                    _RESOURCE_GROUP_ID,
                 ],
             ),
             (
@@ -167,8 +165,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.DELETE,
                 [
-                    (USER_SCOPE_TYPE, _USER_ID),
-                    (RESOURCE_GROUP_SCOPE_TYPE, _RESOURCE_GROUP_ID),
+                    _USER_ID,
+                    _RESOURCE_GROUP_ID,
                 ],
             ),
             (
@@ -178,8 +176,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.DELETE,
                 [
-                    (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (ScopeType(IdleCheckerEntityType()), _IDLE_CHECKER_ID),
+                    _PROJECT_ID,
+                    _IDLE_CHECKER_ID,
                 ],
             ),
             (
@@ -189,8 +187,8 @@ class TestEveryPairBecomesTheRunsScopes:
                 ),
                 ActionOperationType.RESTORE,
                 [
-                    (PROJECT_SCOPE_TYPE, _PROJECT_ID),
-                    (ScopeType(IdleCheckerEntityType()), _IDLE_CHECKER_ID),
+                    _PROJECT_ID,
+                    _IDLE_CHECKER_ID,
                 ],
             ),
         ],
@@ -199,9 +197,9 @@ class TestEveryPairBecomesTheRunsScopes:
         self,
         action: BaseRelationAction,
         operation: ActionOperationType,
-        expected: list[tuple[str, uuid.UUID]],
+        expected: list[EntityIdentifier],
     ) -> None:
-        assert [(s.scope_type, s.scope_id) for s in action.scope_targets()] == expected
+        assert list(action.scope_targets()) == expected
         assert action.operation_type() is operation
 
     def test_a_run_over_several_pairs_names_every_entity_once(self) -> None:
@@ -213,11 +211,11 @@ class TestEveryPairBecomesTheRunsScopes:
             creator=ContainerRegistryProjectCreator(),
         )
 
-        assert [(s.scope_type, s.scope_id) for s in action.scope_targets()] == [
-            (PROJECT_SCOPE_TYPE, projects[0]),
-            (CONTAINER_REGISTRY_SCOPE_TYPE, _REGISTRY_ID),
-            (PROJECT_SCOPE_TYPE, projects[1]),
-            (PROJECT_SCOPE_TYPE, projects[2]),
+        assert list(action.scope_targets()) == [
+            projects[0],
+            _REGISTRY_ID,
+            projects[1],
+            projects[2],
         ]
 
 

--- a/tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py
+++ b/tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py
@@ -23,7 +23,7 @@ USER_UUID = uuid.uuid4()
 
 def test_domain_item_is_read_for_the_resource_group() -> None:
     item = DomainUsageBucketScopeItem(resource_group_id=RESOURCE_GROUP_ID, domain_name="default")
-    assert item.scope_ref() == RESOURCE_GROUP_ID
+    assert item.scope_id() == RESOURCE_GROUP_ID
     assert item.operation_scope() == DomainUsageBucketOperationScope(
         resource_group_id=RESOURCE_GROUP_ID, domain_name="default"
     )
@@ -33,7 +33,7 @@ def test_project_item_is_read_for_the_resource_group() -> None:
     item = ProjectUsageBucketScopeItem(
         resource_group_id=RESOURCE_GROUP_ID, domain_name="default", project_id=PROJECT_ID
     )
-    assert item.scope_ref() == RESOURCE_GROUP_ID
+    assert item.scope_id() == RESOURCE_GROUP_ID
     assert item.operation_scope() == ProjectUsageBucketOperationScope(
         resource_group_id=RESOURCE_GROUP_ID, domain_name="default", project_id=PROJECT_ID
     )
@@ -46,7 +46,7 @@ def test_user_item_is_read_for_the_resource_group() -> None:
         project_id=PROJECT_ID,
         user_uuid=USER_UUID,
     )
-    assert item.scope_ref() == RESOURCE_GROUP_ID
+    assert item.scope_id() == RESOURCE_GROUP_ID
     assert item.operation_scope() == UserUsageBucketOperationScope(
         resource_group_id=RESOURCE_GROUP_ID,
         domain_name="default",

--- a/tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py
+++ b/tests/unit/manager/services/resource_usage/test_usage_bucket_scope_items.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import uuid
 
-from ai.backend.common.data.entity.resource_group import RESOURCE_GROUP_SCOPE_TYPE, ResourceGroupID
+from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.manager.models.resource_usage_history.scopes import (
     DomainUsageBucketOperationScope,
     ProjectUsageBucketOperationScope,
@@ -23,9 +23,7 @@ USER_UUID = uuid.uuid4()
 
 def test_domain_item_is_read_for_the_resource_group() -> None:
     item = DomainUsageBucketScopeItem(resource_group_id=RESOURCE_GROUP_ID, domain_name="default")
-    ref = item.scope_ref()
-    assert ref.scope_type == RESOURCE_GROUP_SCOPE_TYPE
-    assert ref.scope_id == RESOURCE_GROUP_ID
+    assert item.scope_ref() == RESOURCE_GROUP_ID
     assert item.operation_scope() == DomainUsageBucketOperationScope(
         resource_group_id=RESOURCE_GROUP_ID, domain_name="default"
     )
@@ -35,9 +33,7 @@ def test_project_item_is_read_for_the_resource_group() -> None:
     item = ProjectUsageBucketScopeItem(
         resource_group_id=RESOURCE_GROUP_ID, domain_name="default", project_id=PROJECT_ID
     )
-    ref = item.scope_ref()
-    assert ref.scope_type == RESOURCE_GROUP_SCOPE_TYPE
-    assert ref.scope_id == RESOURCE_GROUP_ID
+    assert item.scope_ref() == RESOURCE_GROUP_ID
     assert item.operation_scope() == ProjectUsageBucketOperationScope(
         resource_group_id=RESOURCE_GROUP_ID, domain_name="default", project_id=PROJECT_ID
     )
@@ -50,9 +46,7 @@ def test_user_item_is_read_for_the_resource_group() -> None:
         project_id=PROJECT_ID,
         user_uuid=USER_UUID,
     )
-    ref = item.scope_ref()
-    assert ref.scope_type == RESOURCE_GROUP_SCOPE_TYPE
-    assert ref.scope_id == RESOURCE_GROUP_ID
+    assert item.scope_ref() == RESOURCE_GROUP_ID
     assert item.operation_scope() == UserUsageBucketOperationScope(
         resource_group_id=RESOURCE_GROUP_ID,
         domain_name="default",

--- a/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
+++ b/tests/unit/manager/services/scheduling_history/test_scheduling_history_service.py
@@ -12,13 +12,12 @@ from uuid import UUID, uuid4
 import pytest
 from dateutil.tz import tzutc
 
-from ai.backend.common.data.entity.deployment import DEPLOYMENT_SCOPE_TYPE, DeploymentID
+from ai.backend.common.data.entity.deployment import DeploymentID
 from ai.backend.common.data.entity.kernel_scheduling_history import KernelSchedulingHistoryID
 from ai.backend.common.data.entity.replica import ReplicaID
 from ai.backend.common.data.entity.replica_group import ReplicaGroupID
 from ai.backend.common.data.entity.replica_group_history import ReplicaGroupHistoryID
-from ai.backend.common.data.entity.session import SESSION_SCOPE_TYPE, SessionEntityType, SessionID
-from ai.backend.common.data.entity.types import ScopeRef
+from ai.backend.common.data.entity.session import SessionEntityType, SessionID
 from ai.backend.common.types import KernelId, SessionId
 from ai.backend.manager.data.deployment.types import (
     DeploymentHandlerCategory,
@@ -425,9 +424,7 @@ class TestSearchKernelScopedHistoryAction:
         assert result.items == [history_item]
         # Authorized via session read: kernel permission records are intentionally
         # empty, so the session is the scope the search is bounded by.
-        assert action.scope_targets() == (
-            ScopeRef(scope_type=SESSION_SCOPE_TYPE, scope_id=_SESSION_ID),
-        )
+        assert action.scope_targets() == (SessionID(_SESSION_ID),)
         assert action.entity_type() == SessionEntityType()
         mock_repository.search_kernel_scoped_history.assert_awaited_once_with(
             querier=querier,
@@ -485,9 +482,7 @@ class TestScopedSearchReplicaGroupHistoryAction:
 
         assert result.items == [replica_group_history]
         # A replica group is no scope of its own, so the deployment bounds the search.
-        assert action.scope_targets() == (
-            ScopeRef(scope_type=DEPLOYMENT_SCOPE_TYPE, scope_id=_DEPLOYMENT_ID),
-        )
+        assert action.scope_targets() == (_DEPLOYMENT_ID,)
         mock_repository.scoped_search_replica_group_history.assert_awaited_once_with(
             querier=querier,
             scopes=[DeploymentReplicaGroupHistoryOperationScope(deployment_id=_DEPLOYMENT_ID)],

--- a/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
+++ b/tests/unit/manager/services/vfolder/test_vfolder_crud_service.py
@@ -12,8 +12,7 @@ import aiohttp
 import pytest
 
 from ai.backend.common.data.entity.project import ProjectID
-from ai.backend.common.data.entity.types import ScopeRef
-from ai.backend.common.data.entity.user import USER_SCOPE_TYPE, UserID
+from ai.backend.common.data.entity.user import UserID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.types import (
     QuotaScopeID,
@@ -448,7 +447,7 @@ class TestListVFolderAction:
 
         action = ListVFolderAction(
             user_uuid=user_uuid,
-            scope=ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=user_uuid),
+            scope=UserID(user_uuid),
         )
 
         result = await vfolder_service.list(action)
@@ -484,7 +483,7 @@ class TestListVFolderAction:
 
         action = ListVFolderAction(
             user_uuid=user_uuid,
-            scope=ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=user_uuid),
+            scope=UserID(user_uuid),
         )
 
         result = await vfolder_service.list(action)
@@ -508,7 +507,7 @@ class TestListVFolderAction:
 
         action = ListVFolderAction(
             user_uuid=user_uuid,
-            scope=ScopeRef(scope_type=USER_SCOPE_TYPE, scope_id=user_uuid),
+            scope=UserID(user_uuid),
         )
 
         await vfolder_service.list(action)


### PR DESCRIPTION
## Summary

- A scope is an entity, so `ScopeRef`, `ScopeType` and `ScopeID` named nothing that an
  entity's id and type did not already name. All three are gone, together with
  `EntityRef` and the `to_entity_ref()` / `entity_ref()` helpers that converted between
  an id and itself.
- `ScopeItem.scope_id()` and every `scope_targets()` answer an `EntityIdentifier`. The
  validators, monitors and the govern check read the kind off the id instead of a second
  field, and the seven `*_SCOPE_TYPE` constants give way to the kind named directly.
- `EntityID` was a transparent alias of `uuid.UUID`, so it enforced nothing and had
  already been reached for where a declared id class belonged. A value is now an
  `EntityIdentifier` that knows its kind, or a bare uuid at a polymorphic column or the
  wire field mirroring it, with the kind put back on at the conversion.
- Types only. No behavior change and no schema change.

## Test plan

- [ ] `pants check` over the changed files and their transitive dependents
- [ ] `pants test` over the changed files and their direct dependents

Resolves BA-7797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DH4xDgAzJ8n7CepAxa3xc
