### PR TITLE
refactor(BA-7821): move the permission and share errors onto EntityError

### DIFF
--- a/changes/14490.misc.md
+++ b/changes/14490.misc.md
@@ -1,0 +1,1 @@
+The permission, entity share and role preset errors now report the row type as the error code domain; five errors nothing raised are removed.

--- a/src/ai/backend/common/data/entity/role_permission_preset.py
+++ b/src/ai/backend/common/data/entity/role_permission_preset.py
@@ -7,7 +7,10 @@ from ai.backend.common.data.entity.types import (
     FieldType,
 )
 
-__all__ = ("RolePermissionPresetID",)
+__all__ = (
+    "RolePermissionPresetFieldType",
+    "RolePermissionPresetID",
+)
 
 
 class RolePermissionPresetFieldType(FieldType):

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -1,9 +1,9 @@
 ---
 name: error-code-and-status-axes
 type: design-rationale
-description: The error-code triple and its no-underscore constraint, error code and HTTP status as independent axes, mixin-less base errors, GraphQL carrying only the code, absence of a central code registry, the separation from common/exception.py and the legacy manager/exceptions.py
+description: The error-code triple and its no-underscore constraint, error code and HTTP status as independent axes, mixin-less base errors, GraphQL carrying only the code, absence of a central code registry, the separation from common/exception.py and the legacy manager/exceptions.py, the permission and share errors that stay on BackendAIError for want of a declared row type
 scope: src/ai/backend/manager/errors
-keywords: [BackendAIError, ErrorCode, ErrorDomain, ErrorOperation, ErrorDetail, ObjectNotFound, problem+json, exceptions.py]
+keywords: [BackendAIError, ErrorCode, ErrorDomain, ErrorOperation, ErrorDetail, ObjectNotFound, EntityError, FieldError, problem+json, exceptions.py]
 sources:
   - src/ai/backend/common/exception.py
   - src/ai/backend/manager/api/rest/middleware/exception.py
@@ -43,6 +43,18 @@ one place per domain.
 
 - `ObjectNotFound` builds its title from `object_name`, and about 20 domain not-found errors inherit it setting only `object_name`.
 - When the meaning fits, extend an existing concrete error rather than deriving fresh from `BackendAIError`.
+
+## Some permission and share errors stay on `BackendAIError`
+
+These name no declared row type, so they keep an `ErrorDomain`. Declaring the
+type is what reopens the decision.
+
+| Error | Why it stays |
+|---|---|
+| `RoleAlreadyAssigned`, `RoleNotAssigned` | the `user_roles` row has no `EntityType` or `FieldType` |
+| `InvalidFieldPermission` | validates a requested field scope for both permission entries and entity shares, so it names no one row kind |
+| `VirtualEntityNotFound` | `data/entity/virtual_entity.py` declares an id alone, no `EntityType` |
+| `NotEnoughPermission` | an authorization denial about the caller, not about a row |
 
 ## The legacy neighbor is a different kind
 

--- a/src/ai/backend/manager/errors/entity_share.py
+++ b/src/ai/backend/manager/errors/entity_share.py
@@ -2,42 +2,35 @@ from typing import override
 
 from aiohttp import web
 
-from ai.backend.common.exception import (
-    BackendAIError,
-    ErrorCode,
-    ErrorDetail,
-    ErrorDomain,
-    ErrorOperation,
-)
+from ai.backend.common.data.entity.entity_share import EntityShareEntityType
+from ai.backend.common.exception import ErrorDetail
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 from ai.backend.manager.errors.common import ObjectNotFound
 
 
-class EntityShareNotFound(ObjectNotFound):
+class EntityShareNotFound(EntityError, ObjectNotFound):
     object_name = "entity-share"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENTITY_SHARE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            EntityShareEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class DuplicateEntityShareError(BackendAIError, web.HTTPConflict):
+class DuplicateEntityShareError(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-entity-share"
     error_title = "Duplicate entity share."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENTITY_SHARE,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            EntityShareEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )
 
 
-class ShareToAPersonalProject(BackendAIError, web.HTTPConflict):
+class ShareToAPersonalProject(EntityError, web.HTTPConflict):
     """A project that is one person's own is not offered to as a project.
 
     It is that person under another name, and naming them twice would stand two rows
@@ -48,15 +41,13 @@ class ShareToAPersonalProject(BackendAIError, web.HTTPConflict):
     error_title = "That project is one person's own."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENTITY_SHARE,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            EntityShareEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )
 
 
-class ShareToTheOwningScope(BackendAIError, web.HTTPConflict):
+class ShareToTheOwningScope(EntityError, web.HTTPConflict):
     """A scope that owns the entity cannot be offered it.
 
     Accepting one would lend back what is already held outright, and lending states
@@ -67,22 +58,7 @@ class ShareToTheOwningScope(BackendAIError, web.HTTPConflict):
     error_title = "The scope already owns the entity."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENTITY_SHARE,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
-
-
-class EntityShareInvalidStatus(BackendAIError, web.HTTPBadRequest):
-    error_type = "https://api.backend.ai/probs/entity-share-invalid-status"
-    error_title = "Invalid entity invitation status transition."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENTITY_SHARE,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            EntityShareEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )

--- a/src/ai/backend/manager/errors/permission.py
+++ b/src/ai/backend/manager/errors/permission.py
@@ -4,6 +4,8 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.permission import PermissionFieldType
+from ai.backend.common.data.entity.role import RoleEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -11,54 +13,30 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 
 __all__ = (
     "InvalidFieldPermission",
     "InvalidPermissionOperation",
     "NotEnoughPermission",
-    "ObjectPermissionNotFound",
     "PermissionAlreadyGranted",
-    "PermissionNotFound",
     "ReplaceRolePermissionRoleIdMismatch",
     "RoleAlreadyAssigned",
     "RoleNotAssigned",
     "RoleNotFound",
-    "UserSystemRoleNotProvisioned",
     "VirtualEntityNotFound",
 )
 
 
-class RoleNotFound(BackendAIError, web.HTTPNotFound):
+class RoleNotFound(EntityError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/role-not-found"
     error_title = "The role does not exist."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROLE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class UserSystemRoleNotProvisioned(BackendAIError, web.HTTPInternalServerError):
-    """Raised when a user is missing the SYSTEM role that should exist for every user.
-
-    This is a server-side data-integrity condition (e.g. legacy or externally
-    provisioned accounts) to be remediated via the superadmin ensure-system-role
-    API, not a client error.
-    """
-
-    error_type = "https://api.backend.ai/probs/user-system-role-not-provisioned"
-    error_title = "The user's SYSTEM role is not provisioned."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROLE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(RoleEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
 class RoleAlreadyAssigned(BackendAIError, web.HTTPConflict):
@@ -87,16 +65,14 @@ class RoleNotAssigned(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class PermissionAlreadyGranted(BackendAIError, web.HTTPConflict):
+class PermissionAlreadyGranted(FieldError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/permission-already-granted"
     error_title = "The role already holds the permission."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.PERMISSION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.ALREADY_EXISTS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            PermissionFieldType(), ActionOperationType.CREATE, ErrorDetail.ALREADY_EXISTS
         )
 
 
@@ -116,7 +92,7 @@ class InvalidFieldPermission(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class InvalidPermissionOperation(BackendAIError, web.HTTPBadRequest):
+class InvalidPermissionOperation(FieldError, web.HTTPBadRequest):
     """An operation with no permission bit — a grant operation — cannot be stored
     as a permission; sharing is judged from entity shares and scope CREATE."""
 
@@ -124,11 +100,9 @@ class InvalidPermissionOperation(BackendAIError, web.HTTPBadRequest):
     error_title = "The operation cannot be stored as a permission."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.PERMISSION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            PermissionFieldType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
         )
 
 
@@ -142,32 +116,6 @@ class NotEnoughPermission(BackendAIError, web.HTTPForbidden):
             domain=ErrorDomain.ROLE,
             operation=ErrorOperation.CREATE,
             error_detail=ErrorDetail.FORBIDDEN,
-        )
-
-
-class PermissionNotFound(BackendAIError, web.HTTPNotFound):
-    error_type = "https://api.backend.ai/probs/permission-not-found"
-    error_title = "The permission does not exist."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.PERMISSION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class ObjectPermissionNotFound(BackendAIError, web.HTTPNotFound):
-    error_type = "https://api.backend.ai/probs/object-permission-not-found"
-    error_title = "The object permission does not exist."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.PERMISSION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
         )
 
 
@@ -191,14 +139,12 @@ class VirtualEntityNotFound(BackendAIError, web.HTTPInternalServerError):
         )
 
 
-class ReplaceRolePermissionRoleIdMismatch(BackendAIError, web.HTTPBadRequest):
+class ReplaceRolePermissionRoleIdMismatch(FieldError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/replace-role-permission-role-id-mismatch"
     error_title = "Permission entry role_id does not match the request role_id."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.PERMISSION,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.MISMATCH,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            PermissionFieldType(), ActionOperationType.UPDATE, ErrorDetail.MISMATCH
         )

--- a/src/ai/backend/manager/errors/role_preset.py
+++ b/src/ai/backend/manager/errors/role_preset.py
@@ -7,41 +7,22 @@ from typing import override
 from aiohttp import web
 
 from ai.backend.common.data.entity.role import RoleEntityType
-from ai.backend.common.exception import (
-    BackendAIError,
-    ErrorCode,
-    ErrorDetail,
-    ErrorDomain,
-    ErrorOperation,
-)
+from ai.backend.common.data.entity.role_permission_preset import RolePermissionPresetFieldType
+from ai.backend.common.data.entity.role_preset import RolePresetEntityType
+from ai.backend.common.exception import ErrorDetail
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
-
-from .common import ObjectNotFound
-
-
-class RolePresetNotFound(ObjectNotFound):
-    object_name = "role_preset"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROLE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 
 
-class InvalidRoleNameTemplate(BackendAIError, web.HTTPBadRequest):
+class InvalidRoleNameTemplate(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-role-name-template"
     error_title = "Invalid role name template."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROLE,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            RolePresetEntityType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
         )
 
 
@@ -54,14 +35,12 @@ class SystemRoleNotEditable(EntityError, web.HTTPForbidden):
         return EntityErrorCode(RoleEntityType(), ActionOperationType.PURGE, ErrorDetail.FORBIDDEN)
 
 
-class RolePermissionPresetConflict(BackendAIError, web.HTTPConflict):
+class RolePermissionPresetConflict(FieldError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-role-permission-preset"
     error_title = "Duplicate role permission preset entry."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROLE,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            RolePermissionPresetFieldType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )


### PR DESCRIPTION
## Summary
- Eight errors naming a role, a role preset, an entity share or a permission row now inherit `EntityError` or `FieldError` and report the row's type as the code domain instead of an `ErrorDomain`. Permission and role-permission-preset rows are field rows, so those take `FieldError`.
- Deleted five errors nothing raised: `ObjectPermissionNotFound`, `PermissionNotFound`, `UserSystemRoleNotProvisioned`, `EntityShareInvalidStatus`, `RolePresetNotFound`.
- Six errors stay on `BackendAIError` because no row type is declared for what they are about; `errors/KNOWLEDGE.md` now lists them with the reason so the judgment is not redone.

### Outward code changes

| Error | Before | After |
|---|---|---|
| `PermissionAlreadyGranted` | `permission_create_already-exists` | `role-permission_create_already-exists` |
| `InvalidPermissionOperation` | `permission_create_invalid-parameters` | `role-permission_create_invalid-parameters` |
| `ReplaceRolePermissionRoleIdMismatch` | `permission_update_mismatch` | `role-permission_update_mismatch` |
| `InvalidRoleNameTemplate` | `role_create_invalid-parameters` | `role-preset_create_invalid-parameters` |
| `RolePermissionPresetConflict` | `role_create_conflict` | `role-preset-role-permission-preset_create_conflict` |
| `PermissionNotFound` | `permission_read_not-found` | deleted |

`RoleNotFound` and the four entity-share errors keep their codes. HTTP statuses, `error_type` URLs and `error_title` are unchanged throughout.

### Errors left on `BackendAIError`

| Error | Why |
|---|---|
| `RoleAlreadyAssigned`, `RoleNotAssigned` | the `user_roles` row has no `EntityType` or `FieldType` |
| `InvalidFieldPermission` | validates a requested field scope for both permission entries and entity shares, so it names no one row kind |
| `VirtualEntityNotFound` | `data/entity/virtual_entity.py` declares an id alone, no `EntityType` |
| `NotEnoughPermission` | an authorization denial about the caller, not about a row |

## Test plan
- [x] `pants lint` / `check` / `test` in CI
- [x] Constructed every remaining error and asserted its code, HTTP status and title
- [x] Confirmed no client branches on the changed codes — WebUI compares `error_code` only on `vfolder`, `session` and `storage` codes, and `useErrorMessageResolver` appends the code to the message rather than mapping it
- [x] No test or document in this repo compares the affected code strings

Resolves BA-7821

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128bKAiecc6WfVK9VBRjxBv