### PR TITLE
refactor(BA-7818): move the session runtime errors onto EntityError

### DIFF
--- a/changes/14491.misc.md
+++ b/changes/14491.misc.md
@@ -1,0 +1,1 @@
+The session, kernel, agent and resource slot errors now report the row type as the error code domain; five errors nothing raised are removed.

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -84,6 +84,13 @@ one place per domain.
 | `AgentNotAllocated` | a kernel with no agent assigned yet, reported under an `access` no `ActionOperationType` maps to |
 | `InvalidUserUpdateMode`, `InvalidPresetQuery` | a request's own mode value, or a query naming neither id nor name |
 | `NoCurrentTaskContext`, `DatabaseConnectionUnavailable`, `ConfigurationLoadFailed`, `DataTransformationFailed`, `DBOperationFailed` | the asyncio context, the connection, the configuration load or the database call itself |
+| `BackendAgentError`, `KernelExecutionFailed`, `InvalidStreamMode` | they report `access` or `execute`, which no `ActionOperationType` maps to |
+| `AgentConnectionUnavailable` | reaching an agent, under that same `access` |
+| `InvalidSessionId`, `InvalidKernelConfig`, `IncompleteSessionSpec` | they refuse a request before it reaches a row; `IncompleteSessionSpec` is one of three `BackendAISchema.build_validation_error` overrides, a hook declared to return `BackendAIError` |
+| the three `IdleCheckerAssignment*` errors | the assignment row's id is a `NewType`, with no `EntityType` |
+| `IdlePolicyNotFound` | no idle-policy row type, and it is raised for absent config values rather than a row |
+| `QuotaExceeded` | a resource-policy limit reached, not a condition of one row |
+| `ConflictingSessionRescheduleNotSupported` | an unimplemented cleanup policy, not a condition of an agent row |
 
 ## The legacy neighbor is a different kind
 

--- a/src/ai/backend/manager/errors/agent.py
+++ b/src/ai/backend/manager/errors/agent.py
@@ -59,7 +59,7 @@ class AgentAlreadyExited(EntityError, web.HTTPConflict):
         return EntityErrorCode(AgentEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT)
 
 
-class AgentHasConflictingSessions(BackendAIError, web.HTTPConflict):
+class AgentHasConflictingSessions(EntityError, web.HTTPConflict):
     """
     Raised when an agent has sessions conflicting with its resource group and
     the caller did not request forced cleanup (the admin must drain first).
@@ -77,12 +77,8 @@ class AgentHasConflictingSessions(BackendAIError, web.HTTPConflict):
         )
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(AgentEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT)
 
 
 class ConflictingSessionRescheduleNotSupported(BackendAIError, web.HTTPNotImplemented):

--- a/src/ai/backend/manager/errors/idle_checker.py
+++ b/src/ai/backend/manager/errors/idle_checker.py
@@ -4,6 +4,7 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.idle_checker import IdleCheckerEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -11,6 +12,8 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 from ai.backend.manager.errors.common import ObjectNotFound
 
 __all__ = (
@@ -21,9 +24,15 @@ __all__ = (
 )
 
 
-class IdleCheckerNotFound(ObjectNotFound):
+class IdleCheckerNotFound(EntityError, ObjectNotFound):
     error_type = "https://api.backend.ai/probs/idle-checker-not-found"
     object_name = "idle checker"
+
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            IdleCheckerEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
+        )
 
 
 class IdleCheckerAssignmentNotFound(ObjectNotFound):

--- a/src/ai/backend/manager/errors/kernel.py
+++ b/src/ai/backend/manager/errors/kernel.py
@@ -9,6 +9,8 @@ from typing import Any, override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.kernel import KernelFieldType
+from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -17,84 +19,65 @@ from ai.backend.common.exception import (
     ErrorOperation,
 )
 from ai.backend.common.json import dump_json
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 from ai.backend.manager.exceptions import AgentError
 
 from .common import ObjectNotFound
 
 
-class KernelNotReady(BackendAIError, web.HTTPBadRequest):
+class KernelNotReady(FieldError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/kernel-not-ready"
     error_title = "Kernel not ready."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_READY,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(KernelFieldType(), ActionOperationType.GET, ErrorDetail.NOT_READY)
 
 
-class InvalidSessionId(BackendAIError, web.HTTPBadRequest):
+class InvalidSessionId(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-session-id"
     error_title = "Invalid session ID format."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            SessionEntityType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
         )
 
 
-class SessionNotFound(ObjectNotFound):
+class SessionNotFound(EntityError, ObjectNotFound):
     object_name = "session"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(SessionEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class MainKernelNotFound(ObjectNotFound):
+class MainKernelNotFound(FieldError, ObjectNotFound):
     object_name = "main kernel"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(KernelFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class KernelNotFound(ObjectNotFound):
+class KernelNotFound(FieldError, ObjectNotFound):
     object_name = "kernel"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(KernelFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class TooManySessionsMatched(BackendAIError, web.HTTPNotFound):
+class TooManySessionsMatched(EntityError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/too-many-sessions-matched"
     error_title = "Too many sessions matched."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(SessionEntityType(), ActionOperationType.GET, ErrorDetail.CONFLICT)
 
     def __init__(
         self,
@@ -116,29 +99,23 @@ class TooManySessionsMatched(BackendAIError, web.HTTPNotFound):
         super().__init__(extra_msg, extra_data, **kwargs)
 
 
-class TooManyKernelsFound(BackendAIError, web.HTTPNotFound):
+class TooManyKernelsFound(FieldError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/too-many-kernels"
     error_title = "There are two or more matching kernels."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(KernelFieldType(), ActionOperationType.GET, ErrorDetail.CONFLICT)
 
 
-class SessionAlreadyExists(BackendAIError, web.HTTPBadRequest):
+class SessionAlreadyExists(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/session-already-exists"
     error_title = "The session already exists but you requested not to reuse existing one."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.ALREADY_EXISTS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            SessionEntityType(), ActionOperationType.CREATE, ErrorDetail.ALREADY_EXISTS
         )
 
 
@@ -241,45 +218,6 @@ class BackendAgentError(BackendAIError):
         return (type(self), (self.agent_error_type, self.agent_details))
 
 
-class KernelCreationFailed(BackendAgentError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/kernel-creation-failed"
-    error_title = "Kernel creation has failed."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class KernelDestructionFailed(BackendAgentError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/kernel-destruction-failed"
-    error_title = "Kernel destruction has failed."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.SOFT_DELETE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class KernelRestartFailed(BackendAgentError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/kernel-restart-failed"
-    error_title = "Kernel restart has failed."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.START,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
 class KernelExecutionFailed(BackendAgentError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/kernel-execution-failed"
     error_title = "Executing user code in the kernel has failed."
@@ -306,55 +244,36 @@ class InvalidStreamMode(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class InvalidSessionData(BackendAIError, web.HTTPInternalServerError):
+class InvalidSessionData(EntityError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/invalid-session-data"
     error_title = "Session data has an invalid type or format."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            SessionEntityType(), ActionOperationType.GET, ErrorDetail.INVALID_DATA_FORMAT
         )
 
 
-class InvalidKernelData(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/invalid-kernel-data"
-    error_title = "Kernel data has an invalid type or format."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
-        )
-
-
-class InvalidKernelConfig(BackendAIError, web.HTTPBadRequest):
+class InvalidKernelConfig(FieldError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-kernel-config"
     error_title = "Invalid kernel configuration."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            KernelFieldType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
         )
 
 
-class IncompleteSessionSpec(BackendAIError, web.HTTPBadRequest):
+class IncompleteSessionSpec(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/incomplete-session-spec"
     error_title = "Session spec has unresolved required fields."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            SessionEntityType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
         )
 
 
@@ -367,17 +286,4 @@ class IdlePolicyNotFound(ObjectNotFound):
             domain=ErrorDomain.SESSION,
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class InvalidKernelStatus(BackendAIError, web.HTTPConflict):
-    error_type = "https://api.backend.ai/probs/invalid-kernel-status"
-    error_title = "Invalid kernel status for this operation."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
         )

--- a/src/ai/backend/manager/errors/kernel.py
+++ b/src/ai/backend/manager/errors/kernel.py
@@ -36,14 +36,16 @@ class KernelNotReady(FieldError, web.HTTPBadRequest):
         return FieldErrorCode(KernelFieldType(), ActionOperationType.GET, ErrorDetail.NOT_READY)
 
 
-class InvalidSessionId(EntityError, web.HTTPBadRequest):
+class InvalidSessionId(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-session-id"
     error_title = "Invalid session ID format."
 
     @override
-    def entity_error_code(self) -> EntityErrorCode:
-        return EntityErrorCode(
-            SessionEntityType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SESSION,
+            operation=ErrorOperation.READ,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
 
 
@@ -255,25 +257,29 @@ class InvalidSessionData(EntityError, web.HTTPInternalServerError):
         )
 
 
-class InvalidKernelConfig(FieldError, web.HTTPBadRequest):
+class InvalidKernelConfig(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-kernel-config"
     error_title = "Invalid kernel configuration."
 
     @override
-    def field_error_code(self) -> FieldErrorCode:
-        return FieldErrorCode(
-            KernelFieldType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.KERNEL,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class IncompleteSessionSpec(EntityError, web.HTTPBadRequest):
+class IncompleteSessionSpec(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/incomplete-session-spec"
     error_title = "Session spec has unresolved required fields."
 
     @override
-    def entity_error_code(self) -> EntityErrorCode:
-        return EntityErrorCode(
-            SessionEntityType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.SESSION,
+            operation=ErrorOperation.CREATE,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
 
 

--- a/src/ai/backend/manager/errors/resource_slot.py
+++ b/src/ai/backend/manager/errors/resource_slot.py
@@ -8,100 +8,88 @@ from typing import override
 
 from aiohttp import web
 
-from ai.backend.common.exception import (
-    BackendAIError,
-    ErrorCode,
-    ErrorDetail,
-    ErrorDomain,
-    ErrorOperation,
-)
+from ai.backend.common.data.entity.agent_resource import AgentResourceFieldType
+from ai.backend.common.data.entity.resource_allocation import ResourceAllocationFieldType
+from ai.backend.common.data.entity.resource_slot import ResourceSlotTypeEntityType
+from ai.backend.common.exception import ErrorDetail
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 
 
-class ResourceSlotTypeNotFound(BackendAIError, web.HTTPNotFound):
+class ResourceSlotTypeNotFound(EntityError, web.HTTPNotFound):
     """Raised when a requested resource slot type does not exist."""
 
     error_type = "https://api.backend.ai/probs/resource-slot-type-not-found"
     error_title = "Resource slot type not found."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RESOURCE_PRESET,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceSlotTypeEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class ResourceSlotTypeAlreadyExists(BackendAIError, web.HTTPConflict):
+class ResourceSlotTypeAlreadyExists(EntityError, web.HTTPConflict):
     """Raised when creating a resource slot type whose slot name is already registered."""
 
     error_type = "https://api.backend.ai/probs/resource-slot-type-already-exists"
     error_title = "Resource slot type already exists."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RESOURCE_PRESET,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.ALREADY_EXISTS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceSlotTypeEntityType(), ActionOperationType.CREATE, ErrorDetail.ALREADY_EXISTS
         )
 
 
-class ResourceSlotTypeInUse(BackendAIError, web.HTTPConflict):
+class ResourceSlotTypeInUse(EntityError, web.HTTPConflict):
     """Raised when deleting a resource slot type that is still referenced elsewhere."""
 
     error_type = "https://api.backend.ai/probs/resource-slot-type-in-use"
     error_title = "Resource slot type is still referenced."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RESOURCE_PRESET,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceSlotTypeEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT
         )
 
 
-class AgentResourceNotFound(BackendAIError, web.HTTPNotFound):
+class AgentResourceNotFound(FieldError, web.HTTPNotFound):
     """Raised when an agent resource entry for a given agent+slot is not found."""
 
     error_type = "https://api.backend.ai/probs/agent-resource-not-found"
     error_title = "Agent resource not found."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            AgentResourceFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class ResourceAllocationNotFound(BackendAIError, web.HTTPNotFound):
+class ResourceAllocationNotFound(FieldError, web.HTTPNotFound):
     """Raised when a resource allocation entry for a given kernel+slot is not found."""
 
     error_type = "https://api.backend.ai/probs/resource-allocation-not-found"
     error_title = "Resource allocation not found."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.KERNEL,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            ResourceAllocationFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class AgentResourceCapacityExceeded(BackendAIError, web.HTTPConflict):
+class AgentResourceCapacityExceeded(FieldError, web.HTTPConflict):
     """Raised when an agent resource update would exceed the slot capacity."""
 
     error_type = "https://api.backend.ai/probs/agent-resource-capacity-exceeded"
     error_title = "Agent resource capacity exceeded."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            AgentResourceFieldType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
         )


### PR DESCRIPTION
## Summary
- Sixteen errors naming a session, a kernel, an agent, an agent resource, a resource allocation, a resource slot type or an idle checker now inherit `EntityError` or `FieldError` and report the row's type as the code domain. `KernelFieldType.owner_type()` is `SessionEntityType`, so kernels are field rows and report `session-kernel`; agent resources and resource allocations follow the same shape.
- Deleted five errors nothing raised, all orphaned when the session lifecycle moved to sokovan (#11250): `KernelCreationFailed`, `KernelDestructionFailed`, `KernelRestartFailed`, `InvalidKernelData`, `InvalidKernelStatus`.
- Thirteen errors stay on `BackendAIError`; `errors/KNOWLEDGE.md` lists them with the reason.

### Outward code changes

| Error | Before | After |
|---|---|---|
| `KernelNotReady` | `kernel_read_not-ready` | `session-kernel_read_not-ready` |
| `KernelNotFound`, `MainKernelNotFound` | `kernel_read_not-found` | `session-kernel_read_not-found` |
| `TooManyKernelsFound` | `kernel_read_conflict` | `session-kernel_read_conflict` |
| `ResourceSlotTypeNotFound` | `resource-preset_read_not-found` | `resource-slot-type_read_not-found` |
| `ResourceSlotTypeAlreadyExists` | `resource-preset_create_already-exists` | `resource-slot-type_create_already-exists` |
| `ResourceSlotTypeInUse` | `resource-preset_purge_conflict` | `resource-slot-type_purge_conflict` |
| `AgentResourceNotFound` | `agent_read_not-found` | `agent-agent-resource_read_not-found` |
| `AgentResourceCapacityExceeded` | `agent_update_conflict` | `agent-agent-resource_update_conflict` |
| `ResourceAllocationNotFound` | `kernel_read_not-found` | `session-resource-allocation_read_not-found` |
| `IdleCheckerNotFound` | `backendai_read_not-found` | `idle-checker_read_not-found` |

The four session codes (`SessionNotFound`, `TooManySessionsMatched`, `SessionAlreadyExists`, `InvalidSessionData`) and `AgentHasConflictingSessions` keep their codes. HTTP statuses, `error_type` URLs and `error_title` are unchanged throughout.

### Errors left on `BackendAIError`

`EntityErrorCode` and `FieldErrorCode` take an `ActionOperationType`, which has no value for `access`, `start` or `execute` — an error reporting one of those cannot move without also changing its operation.

| Error | Why |
|---|---|
| `BackendAgentError`, `KernelExecutionFailed`, `InvalidStreamMode`, `AgentConnectionUnavailable` | report `access` or `execute`, which no `ActionOperationType` maps to |
| `InvalidSessionId`, `InvalidKernelConfig`, `IncompleteSessionSpec` | refuse a request before it reaches a row. `IncompleteSessionSpec` is one of three `BackendAISchema.build_validation_error` overrides, a hook declared to return `BackendAIError`, so moving it alone took one member of that family off the family's base |
| the three `IdleCheckerAssignment*` errors | the assignment row's id is a `NewType`, with no `EntityType` |
| `IdlePolicyNotFound` | no idle-policy row type, and it is raised for absent config values rather than a row |
| `QuotaExceeded` | a resource-policy limit reached, not a condition of one row |
| `ConflictingSessionRescheduleNotSupported` | an unimplemented cleanup policy, not a condition of an agent row |

## Test plan
- [x] `pants lint` / `check` / `test` in CI
- [x] Constructed every moved and every untouched error and asserted its code, HTTP status and title
- [x] Confirmed the deleted five have no reference anywhere in the repo, and that `git log -S` puts their last raise sites in the sokovan lifecycle refactor
- [x] Checked WebUI: it branches on `error_code` in five places, all naming `vfolder_*`, `session_create_already-exists` or `storage_access_forbidden`, none of which change here. `agent_read_not-found` and `kernel_create_internal-error` appear only in app-launcher test fixtures as arbitrary non-matching codes, and `backendai_read_not-found` there is the generic `ObjectNotFound` on the app-launch path, not `IdleCheckerNotFound`

Resolves BA-7818

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128bKAiecc6WfVK9VBRjxBv
