### PR TITLE
feat(BA-7810): cap GraphQL query depth and alias count (#14483)

### DIFF
--- a/changes/14483.feature.md
+++ b/changes/14483.feature.md
@@ -1,0 +1,1 @@
+Limit the depth and the alias count of a GraphQL query so that a single request cannot exhaust the manager.

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -953,62 +953,6 @@ schema = CustomizedSchema(
     subscription=Subscription,
     config=StrawberryConfig(auto_camel_case=True),
     federation_version="2.7",
-<<<<<<< HEAD
-=======
-    # Federation stubs bridging legacy graphene Node types into the Strawberry-owned
-    # node(id:) resolver. Listed explicitly so they are part of the schema (and the Node
-    # interface's possible types) even when no V2 field references them.
-    types=[
-        _SessionStub,
-        _DomainStub,
-        _ProjectStub,
-        _ImageStub,
-        _VFolderStub,
-        _UserStub,
-        _ResourceGroupStub,
-        _AgentNodeStub,
-        _NetworkNodeStub,
-        _ModelCardStub,
-        _ContainerRegistryNodeStub,
-    ],
-    extensions=[
-        GQLLoggingExtension,
-        GQLMetricExtension,
-        GQLValidationExtension,
-        QueryDepthLimiter(max_depth=MAX_QUERY_DEPTH),
-        MaxAliasesLimiter(max_alias_count=MAX_ALIAS_COUNT),
-        GQLExceptionHandlerExtension,
-    ],
-)
-
-
-@gql_root_field(BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Returns 'pong'"))  # type: ignore[misc]
-async def ping() -> str:
-    return "pong"
-
-
-@strawberry.type(name="Query")
-class PublicQueries:
-    """Query root of the ``public`` subgraph, served without authentication at
-    ``POST /admin/gql/strawberry/public``.
-
-    Contains ONLY fields that are safe to expose without authentication; private fields are
-    physically absent, so they cannot be queried (no runtime gate needed). A public field belongs
-    here and nowhere else: declaring it on ``Query`` as well would let the router resolve it
-    against the authenticated subgraph, which answers 401 to an anonymous caller.
-    """
-
-    ping = ping
-    public_app_configs = public_app_configs
-
-
-# A subgraph of the same supergraph as `schema`, kept separate only so that its routing URL
-# carries no auth middleware: anonymous queries compose against this subgraph alone.
-public_schema = Schema(
-    query=PublicQueries,
-    config=StrawberryConfig(auto_camel_case=True),
-    federation_version="2.7",
->>>>>>> efe4d151 (feat(BA-7810): cap GraphQL query depth and alias count (#14483))
     extensions=[
         GQLLoggingExtension,
         GQLMetricExtension,

--- a/src/ai/backend/manager/api/gql/schema.py
+++ b/src/ai/backend/manager/api/gql/schema.py
@@ -3,6 +3,7 @@ from typing import override
 import strawberry
 from graphql import GraphQLError
 from graphql.pyutils.undefined import Undefined as GraphQLUndefined
+from strawberry.extensions import MaxAliasesLimiter, QueryDepthLimiter
 from strawberry.federation import Schema
 from strawberry.schema.config import StrawberryConfig
 from strawberry.types import ExecutionContext
@@ -912,6 +913,11 @@ class Subscription:
     background_task_events = background_task_events
 
 
+# Per-request cost ceilings applied to every schema below.
+MAX_QUERY_DEPTH = 20
+MAX_ALIAS_COUNT = 20
+
+
 class CustomizedSchema(Schema):
     @override
     def process_errors(
@@ -947,10 +953,68 @@ schema = CustomizedSchema(
     subscription=Subscription,
     config=StrawberryConfig(auto_camel_case=True),
     federation_version="2.7",
+<<<<<<< HEAD
+=======
+    # Federation stubs bridging legacy graphene Node types into the Strawberry-owned
+    # node(id:) resolver. Listed explicitly so they are part of the schema (and the Node
+    # interface's possible types) even when no V2 field references them.
+    types=[
+        _SessionStub,
+        _DomainStub,
+        _ProjectStub,
+        _ImageStub,
+        _VFolderStub,
+        _UserStub,
+        _ResourceGroupStub,
+        _AgentNodeStub,
+        _NetworkNodeStub,
+        _ModelCardStub,
+        _ContainerRegistryNodeStub,
+    ],
     extensions=[
         GQLLoggingExtension,
         GQLMetricExtension,
         GQLValidationExtension,
+        QueryDepthLimiter(max_depth=MAX_QUERY_DEPTH),
+        MaxAliasesLimiter(max_alias_count=MAX_ALIAS_COUNT),
+        GQLExceptionHandlerExtension,
+    ],
+)
+
+
+@gql_root_field(BackendAIGQLMeta(added_version=NEXT_RELEASE_VERSION, description="Returns 'pong'"))  # type: ignore[misc]
+async def ping() -> str:
+    return "pong"
+
+
+@strawberry.type(name="Query")
+class PublicQueries:
+    """Query root of the ``public`` subgraph, served without authentication at
+    ``POST /admin/gql/strawberry/public``.
+
+    Contains ONLY fields that are safe to expose without authentication; private fields are
+    physically absent, so they cannot be queried (no runtime gate needed). A public field belongs
+    here and nowhere else: declaring it on ``Query`` as well would let the router resolve it
+    against the authenticated subgraph, which answers 401 to an anonymous caller.
+    """
+
+    ping = ping
+    public_app_configs = public_app_configs
+
+
+# A subgraph of the same supergraph as `schema`, kept separate only so that its routing URL
+# carries no auth middleware: anonymous queries compose against this subgraph alone.
+public_schema = Schema(
+    query=PublicQueries,
+    config=StrawberryConfig(auto_camel_case=True),
+    federation_version="2.7",
+>>>>>>> efe4d151 (feat(BA-7810): cap GraphQL query depth and alias count (#14483))
+    extensions=[
+        GQLLoggingExtension,
+        GQLMetricExtension,
+        GQLValidationExtension,
+        QueryDepthLimiter(max_depth=MAX_QUERY_DEPTH),
+        MaxAliasesLimiter(max_alias_count=MAX_ALIAS_COUNT),
         GQLExceptionHandlerExtension,
     ],
 )


### PR DESCRIPTION
This is an auto-generated backport of #14483 to the 26.4 release.