### PR TITLE
refactor(BA-7822): move the deployment and service errors onto EntityError

### DIFF
--- a/changes/14495.misc.md
+++ b/changes/14495.misc.md
@@ -1,0 +1,1 @@
+The deployment, model service and route errors now report the row type as the error code domain instead of a fixed error domain.

--- a/changes/14495.misc.md
+++ b/changes/14495.misc.md
@@ -1,1 +1,1 @@
-The deployment, model service and route errors now report the row type as the error code domain instead of a fixed error domain.
+The deployment, model service and route errors now report the row type as the error code domain instead of a fixed error domain; seven errors nothing raised are removed.

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -55,8 +55,7 @@ type is what reopens the decision.
 | `InvalidFieldPermission` | validates a requested field scope for both permission entries and entity shares, so it names no one row kind |
 | `VirtualEntityNotFound` | `data/entity/virtual_entity.py` declares an id alone, no `EntityType` |
 | `NotEnoughPermission` | an authorization denial about the caller, not about a row |
-| `DefinitionFileNotFound`, `DeploymentDefinitionFileReadError`, `ModelDefinitionNotFound` | a file inside a vfolder, which no row type declares |
-| `AutoScalingPolicyNotFound` | `deployment_auto_scaling_policies` has no `FieldType` |
+| `DeploymentDefinitionFileReadError` | a file inside a vfolder, which no row type declares |
 | `NoUpdatesToApply` | a modifier that changed nothing; the row is whichever one the caller was updating |
 | `AppServiceStartFailed` | an app started inside a session is no row, and `ActionOperationType` has no `start` |
 | `AppProxyConnectionError`, `AppProxyResponseError` | AppProxy is a system domain by the `AGENTS.md` table |

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -1,7 +1,7 @@
 ---
 name: error-code-and-status-axes
 type: design-rationale
-description: The error-code triple and its no-underscore constraint, error code and HTTP status as independent axes, mixin-less base errors, GraphQL carrying only the code, absence of a central code registry, the separation from common/exception.py and the legacy manager/exceptions.py, the permission and share errors that stay on BackendAIError for want of a declared row type
+description: The error-code triple and its no-underscore constraint, error code and HTTP status as independent axes, mixin-less base errors, GraphQL carrying only the code, absence of a central code registry, the separation from common/exception.py and the legacy manager/exceptions.py, the errors that stay on BackendAIError for want of a declared row type
 scope: src/ai/backend/manager/errors
 keywords: [BackendAIError, ErrorCode, ErrorDomain, ErrorOperation, ErrorDetail, ObjectNotFound, EntityError, FieldError, problem+json, exceptions.py]
 sources:
@@ -9,8 +9,8 @@ sources:
   - src/ai/backend/manager/api/rest/middleware/exception.py
   - src/ai/backend/manager/api/gql/extensions/exception_handler.py
 generated:
-  by: claude-code/fable-5
-  at: 2026-08-10
+  by: claude-code/opus-5
+  at: 2026-09-10
 status: stable
 ---
 
@@ -44,7 +44,7 @@ one place per domain.
 - `ObjectNotFound` builds its title from `object_name`, and about 20 domain not-found errors inherit it setting only `object_name`.
 - When the meaning fits, extend an existing concrete error rather than deriving fresh from `BackendAIError`.
 
-## Some permission and share errors stay on `BackendAIError`
+## Some errors stay on `BackendAIError`
 
 These name no declared row type, so they keep an `ErrorDomain`. Declaring the
 type is what reopens the decision.
@@ -55,6 +55,11 @@ type is what reopens the decision.
 | `InvalidFieldPermission` | validates a requested field scope for both permission entries and entity shares, so it names no one row kind |
 | `VirtualEntityNotFound` | `data/entity/virtual_entity.py` declares an id alone, no `EntityType` |
 | `NotEnoughPermission` | an authorization denial about the caller, not about a row |
+| `DefinitionFileNotFound`, `DeploymentDefinitionFileReadError`, `ModelDefinitionNotFound` | a file inside a vfolder, which no row type declares |
+| `AutoScalingPolicyNotFound` | `deployment_auto_scaling_policies` has no `FieldType` |
+| `NoUpdatesToApply` | a modifier that changed nothing; the row is whichever one the caller was updating |
+| `AppServiceStartFailed` | an app started inside a session is no row, and `ActionOperationType` has no `start` |
+| `AppProxyConnectionError`, `AppProxyResponseError` | AppProxy is a system domain by the `AGENTS.md` table |
 
 ## The legacy neighbor is a different kind
 

--- a/src/ai/backend/manager/errors/deployment.py
+++ b/src/ai/backend/manager/errors/deployment.py
@@ -2,6 +2,13 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyFieldType
+from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionFieldType
+from ai.backend.common.data.entity.keypair import KeyPairFieldType
+from ai.backend.common.data.entity.replica import ReplicaFieldType
+from ai.backend.common.data.entity.session import SessionEntityType
+from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.entity.vfolder import VFolderUUID
 from ai.backend.common.exception import (
     BackendAIError,
@@ -10,6 +17,9 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 from ai.backend.manager.errors.common import ObjectNotFound
 
 
@@ -47,68 +57,56 @@ class DeploymentDefinitionFileReadError(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class EndpointNotFound(ObjectNotFound):
+class EndpointNotFound(EntityError, ObjectNotFound):
     object_name = "endpoint"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class DeploymentRevisionNotFound(ObjectNotFound):
+class DeploymentRevisionNotFound(FieldError, ObjectNotFound):
     object_name = "deployment-revision"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentRevisionFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class UserNotFoundInDeployment(ObjectNotFound):
+class UserNotFoundInDeployment(EntityError, ObjectNotFound):
     object_name = "user in deployment"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(UserEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class NoActiveKeypairForDeployment(ObjectNotFound):
+class NoActiveKeypairForDeployment(FieldError, ObjectNotFound):
     object_name = "active keypair for deployment user"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_DEPLOYMENT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(KeyPairFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class DeploymentHasNoTargetRevision(BackendAIError, web.HTTPBadRequest):
+class DeploymentHasNoTargetRevision(FieldError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/deployment-has-no-target-revision"
     error_title = "Deployment has no target revision."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentRevisionFieldType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class RevisionMissingModelVFolder(BackendAIError, web.HTTPBadRequest):
+class RevisionMissingModelVFolder(FieldError, web.HTTPBadRequest):
     """A revision's model vfolder reference is null.
 
     Raised when the draft / session pipeline reads a
@@ -124,15 +122,15 @@ class RevisionMissingModelVFolder(BackendAIError, web.HTTPBadRequest):
     error_title = "Deployment revision has no model vfolder."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentRevisionFieldType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class RevisionNotDeployable(BackendAIError, web.HTTPConflict):
+class RevisionNotDeployable(FieldError, web.HTTPConflict):
     """A revision references resources that no longer exist.
 
     Raised when a ``DeploymentRevisionRow`` is converted to a
@@ -147,41 +145,37 @@ class RevisionNotDeployable(BackendAIError, web.HTTPConflict):
     error_title = "Deployment revision references deleted resources."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentRevisionFieldType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class InvalidDeploymentStrategy(BackendAIError, web.HTTPBadRequest):
+class InvalidDeploymentStrategy(FieldError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-deployment-strategy"
     error_title = "Unknown or invalid deployment strategy."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentPolicyFieldType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class RouteSessionNotFound(BackendAIError):
+class RouteSessionNotFound(EntityError):
     error_type = "https://api.backend.ai/probs/route-session-not-found"
     error_title = "No session associated with route."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(SessionEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class RouteSessionTerminated(BackendAIError):
+class RouteSessionTerminated(EntityError):
     error_type = "https://api.backend.ai/probs/route-session-terminated"
     error_title = "Route session is in terminal state."
 
@@ -190,35 +184,31 @@ class RouteSessionTerminated(BackendAIError):
         self.session_status = session_status
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            SessionEntityType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
         )
 
 
-class RouteUnhealthy(BackendAIError):
+class RouteUnhealthy(FieldError):
     error_type = "https://api.backend.ai/probs/route-unhealthy"
     error_title = "Route health check failed."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            ReplicaFieldType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
         )
 
 
-class IncompleteRevisionData(BackendAIError, web.HTTPInternalServerError):
+class IncompleteRevisionData(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/incomplete-revision-data"
     error_title = "Revision data is missing required fields."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentRevisionFieldType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )

--- a/src/ai/backend/manager/errors/deployment.py
+++ b/src/ai/backend/manager/errors/deployment.py
@@ -6,7 +6,6 @@ from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyFieldType
 from ai.backend.common.data.entity.deployment_revision import DeploymentRevisionFieldType
 from ai.backend.common.data.entity.keypair import KeyPairFieldType
-from ai.backend.common.data.entity.replica import ReplicaFieldType
 from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.common.data.entity.vfolder import VFolderUUID
@@ -21,18 +20,6 @@ from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 from ai.backend.manager.errors.common import ObjectNotFound
-
-
-class DefinitionFileNotFound(ObjectNotFound):
-    object_name = "definition-file"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
 
 
 class DeploymentDefinitionFileReadError(BackendAIError, web.HTTPBadRequest):
@@ -130,29 +117,6 @@ class RevisionMissingModelVFolder(FieldError, web.HTTPBadRequest):
         )
 
 
-class RevisionNotDeployable(FieldError, web.HTTPConflict):
-    """A revision references resources that no longer exist.
-
-    Raised when a ``DeploymentRevisionRow`` is converted to a
-    ``ModelRevisionSpec`` but one of its SET NULL-backed references —
-    ``image`` or ``model`` — has collapsed to NULL because the
-    underlying row was deleted. The revision is preserved for history
-    yet cannot be redeployed; the scheduler is expected to catch this
-    exception and transition the deployment to ``BLOCKED``.
-    """
-
-    error_type = "https://api.backend.ai/probs/revision-not-deployable"
-    error_title = "Deployment revision references deleted resources."
-
-    @override
-    def field_error_code(self) -> FieldErrorCode:
-        return FieldErrorCode(
-            DeploymentRevisionFieldType(),
-            ActionOperationType.GET,
-            ErrorDetail.INVALID_PARAMETERS,
-        )
-
-
 class InvalidDeploymentStrategy(FieldError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-deployment-strategy"
     error_title = "Unknown or invalid deployment strategy."
@@ -187,17 +151,6 @@ class RouteSessionTerminated(EntityError):
     def entity_error_code(self) -> EntityErrorCode:
         return EntityErrorCode(
             SessionEntityType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
-        )
-
-
-class RouteUnhealthy(FieldError):
-    error_type = "https://api.backend.ai/probs/route-unhealthy"
-    error_title = "Route health check failed."
-
-    @override
-    def field_error_code(self) -> FieldErrorCode:
-        return FieldErrorCode(
-            ReplicaFieldType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
         )
 
 

--- a/src/ai/backend/manager/errors/service.py
+++ b/src/ai/backend/manager/errors/service.py
@@ -151,7 +151,7 @@ class ModelServiceDependencyNotCleared(EntityError, web.HTTPBadRequest):
     @override
     def entity_error_code(self) -> EntityErrorCode:
         return EntityErrorCode(
-            VFolderEntityType(), ActionOperationType.DELETE, ErrorDetail.CONFLICT
+            VFolderEntityType(), ActionOperationType.DELETE, ErrorDetail.BAD_REQUEST
         )
 
 

--- a/src/ai/backend/manager/errors/service.py
+++ b/src/ai/backend/manager/errors/service.py
@@ -13,7 +13,6 @@ from ai.backend.common.data.entity.deployment import DeploymentEntityType
 from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyFieldType
 from ai.backend.common.data.entity.deployment_token import DeploymentTokenFieldType
 from ai.backend.common.data.entity.replica import ReplicaFieldType
-from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -53,30 +52,6 @@ class EndpointNotFound(EntityError, ObjectNotFound):
         )
 
 
-class ModelDefinitionNotFound(ObjectNotFound):
-    object_name = "model_definition"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class ScalingImpossible(EntityError, web.HTTPBadRequest):
-    error_title = (
-        "Scaling operation cannot be performed due to insufficient resources or constraints."
-    )
-
-    @override
-    def entity_error_code(self) -> EntityErrorCode:
-        return EntityErrorCode(
-            DeploymentEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
-        )
-
-
 class AutoScalingRuleNotFound(FieldError, ObjectNotFound):
     object_name = "auto_scaling_rule"
 
@@ -84,18 +59,6 @@ class AutoScalingRuleNotFound(FieldError, ObjectNotFound):
     def field_error_code(self) -> FieldErrorCode:
         return FieldErrorCode(
             AutoScalingRuleFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
-        )
-
-
-class AutoScalingPolicyNotFound(ObjectNotFound):
-    object_name = "auto_scaling_policy"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
         )
 
 
@@ -143,16 +106,6 @@ class RouteNotFound(FieldError, ObjectNotFound):
     @override
     def field_error_code(self) -> FieldErrorCode:
         return FieldErrorCode(ReplicaFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
-
-
-class ModelServiceDependencyNotCleared(EntityError, web.HTTPBadRequest):
-    error_title = "Cannot delete model VFolders bound to alive model services."
-
-    @override
-    def entity_error_code(self) -> EntityErrorCode:
-        return EntityErrorCode(
-            VFolderEntityType(), ActionOperationType.DELETE, ErrorDetail.BAD_REQUEST
-        )
 
 
 class AppServiceStartFailed(BackendAIError, web.HTTPInternalServerError):

--- a/src/ai/backend/manager/errors/service.py
+++ b/src/ai/backend/manager/errors/service.py
@@ -8,6 +8,12 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.auto_scaling_rule import AutoScalingRuleFieldType
+from ai.backend.common.data.entity.deployment import DeploymentEntityType
+from ai.backend.common.data.entity.deployment_policy import DeploymentPolicyFieldType
+from ai.backend.common.data.entity.deployment_token import DeploymentTokenFieldType
+from ai.backend.common.data.entity.replica import ReplicaFieldType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -15,6 +21,9 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 
 from .common import GenericForbidden, ObjectNotFound
 
@@ -34,15 +43,13 @@ class NoUpdatesToApply(BackendAIError):
         )
 
 
-class EndpointNotFound(ObjectNotFound):
+class EndpointNotFound(EntityError, ObjectNotFound):
     object_name = "endpoint"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
@@ -58,29 +65,25 @@ class ModelDefinitionNotFound(ObjectNotFound):
         )
 
 
-class ScalingImpossible(BackendAIError, web.HTTPBadRequest):
+class ScalingImpossible(EntityError, web.HTTPBadRequest):
     error_title = (
         "Scaling operation cannot be performed due to insufficient resources or constraints."
     )
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
         )
 
 
-class AutoScalingRuleNotFound(ObjectNotFound):
+class AutoScalingRuleNotFound(FieldError, ObjectNotFound):
     object_name = "auto_scaling_rule"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            AutoScalingRuleFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
@@ -96,75 +99,59 @@ class AutoScalingPolicyNotFound(ObjectNotFound):
         )
 
 
-class DeploymentPolicyNotFound(ObjectNotFound):
+class DeploymentPolicyNotFound(FieldError, ObjectNotFound):
     object_name = "deployment_policy"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentPolicyFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class RoutingNotFound(ObjectNotFound):
+class RoutingNotFound(FieldError, ObjectNotFound):
     object_name = "routing"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROUTE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(ReplicaFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class EndpointTokenNotFound(ObjectNotFound):
+class EndpointTokenNotFound(FieldError, ObjectNotFound):
     object_name = "endpoint_token"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            DeploymentTokenFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class ModelServiceNotFound(ObjectNotFound):
+class ModelServiceNotFound(EntityError, ObjectNotFound):
     object_name = "model service"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class RouteNotFound(ObjectNotFound):
+class RouteNotFound(FieldError, ObjectNotFound):
     object_name = "route"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ROUTE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(ReplicaFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class ModelServiceDependencyNotCleared(BackendAIError, web.HTTPBadRequest):
+class ModelServiceDependencyNotCleared(EntityError, web.HTTPBadRequest):
     error_title = "Cannot delete model VFolders bound to alive model services."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_SERVICE,
-            operation=ErrorOperation.SOFT_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            VFolderEntityType(), ActionOperationType.DELETE, ErrorDetail.CONFLICT
         )
 
 
@@ -181,27 +168,23 @@ class AppServiceStartFailed(BackendAIError, web.HTTPInternalServerError):
         )
 
 
-class EndpointAccessForbiddenError(GenericForbidden):
+class EndpointAccessForbiddenError(EntityError, GenericForbidden):
     """Raised when user does not have permission to access an endpoint."""
 
     error_title = "Access to this endpoint is forbidden."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.FORBIDDEN,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentEntityType(), ActionOperationType.GET, ErrorDetail.FORBIDDEN
         )
 
 
-class EndpointAutoScalingRuleNotFound(ObjectNotFound):
+class EndpointAutoScalingRuleNotFound(FieldError, ObjectNotFound):
     object_name = "endpoint auto scaling rule"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.ENDPOINT_AUTO_SCALING,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            AutoScalingRuleFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )


### PR DESCRIPTION
## Summary
- `errors/deployment.py`, `errors/service.py` and `errors/appproxy.py` held 31 errors. Seven of them nothing raised are deleted; of the 24 that remain, 19 now inherit `EntityError` or `FieldError` and report the row's type as the code domain instead of an `ErrorDomain`.
- Deployment owns ten field kinds (`deployment_revision`, `deployment_policy`, `deployment_token`, `deployment_history`, `deployment_revision_resource_slot`, `replica`, `replica_group`, `replica_group_history`, `route_history`, `auto_scaling_rule`), so which one an error names is read from what its raise site names, not from the class name. `ReplicaFieldType` is the type of the `routings` table, which is what the route errors name.
- Five errors stay on `BackendAIError`; `errors/KNOWLEDGE.md` now lists them with the reason so the judgment is not redone.

### Outward code changes

| Error | Before | After |
|---|---|---|
| `EndpointNotFound` (`deployment.py`) | `model-service_read_not-found` | `deployment_read_not-found` |
| `EndpointNotFound` (`service.py`) | `endpoint_read_not-found` | `deployment_read_not-found` |
| `ModelServiceNotFound` | `model-service_read_not-found` | `deployment_read_not-found` |
| `EndpointAccessForbiddenError` | `endpoint_access_forbidden` | `deployment_read_forbidden` |
| `UserNotFoundInDeployment` | `model-service_read_not-found` | `user_read_not-found` |
| `NoActiveKeypairForDeployment` | `model-deployment_read_not-found` | `user-keypair_read_not-found` |
| `RouteSessionNotFound` | `model-service_read_not-found` | `session_read_not-found` |
| `RouteSessionTerminated` | `model-service_read_invalid-parameters` | `session_read_invalid-parameters` |
| `DeploymentRevisionNotFound` | `model-service_read_not-found` | `deployment-deployment-revision_read_not-found` |
| `DeploymentHasNoTargetRevision`, `RevisionMissingModelVFolder`, `IncompleteRevisionData` | `model-service_read_invalid-parameters` | `deployment-deployment-revision_read_invalid-parameters` |
| `InvalidDeploymentStrategy` | `model-service_read_invalid-parameters` | `deployment-deployment-policy_read_invalid-parameters` |
| `DeploymentPolicyNotFound` | `endpoint_read_not-found` | `deployment-deployment-policy_read_not-found` |
| `AutoScalingRuleNotFound` | `endpoint_read_not-found` | `deployment-auto-scaling-rule_read_not-found` |
| `EndpointAutoScalingRuleNotFound` | `endpoint-auto-scaling_read_not-found` | `deployment-auto-scaling-rule_read_not-found` |
| `EndpointTokenNotFound` | `endpoint_read_not-found` | `deployment-deployment-token_read_not-found` |
| `RoutingNotFound`, `RouteNotFound` | `route_read_not-found` | `deployment-replica_read_not-found` |
| `DefinitionFileNotFound`, `ModelDefinitionNotFound` | `model-service_read_not-found` | deleted |
| `RevisionNotDeployable`, `RouteUnhealthy` | `model-service_read_invalid-parameters` | deleted |
| `ScalingImpossible` | `endpoint_update_conflict` | deleted |
| `AutoScalingPolicyNotFound` | `endpoint_read_not-found` | deleted |
| `ModelServiceDependencyNotCleared` | `model-service_soft-delete_conflict` | deleted |

Every surviving code keeps its operation and detail and changes only its domain, except `EndpointAccessForbiddenError`, which reports as a read because `ErrorOperation.ACCESS` has no `ActionOperationType` counterpart and the check it guards reads the endpoint. HTTP statuses, `error_type` URLs and `error_title` are unchanged throughout.

### Errors deleted

Nothing in the repository raises these seven; the only references were a `RouteUnhealthy` string literal in a BEP illustration.

`DefinitionFileNotFound`, `RevisionNotDeployable`, `RouteUnhealthy` (`deployment.py`); `ModelDefinitionNotFound`, `ScalingImpossible`, `AutoScalingPolicyNotFound`, `ModelServiceDependencyNotCleared` (`service.py`).

### Errors left on `BackendAIError`

| Error | Why |
|---|---|
| `DeploymentDefinitionFileReadError` | a file inside a vfolder, which no `EntityType` or `FieldType` declares |
| `NoUpdatesToApply` | a modifier that changed nothing; the row is whichever one the caller was updating |
| `AppServiceStartFailed` | an app started inside a session is no row, and `ActionOperationType` has no `start` |
| `AppProxyConnectionError`, `AppProxyResponseError` | AppProxy is a system domain by the `errors/AGENTS.md` table |

## Test plan
- [x] `pants lint` over the changed files, and `pants check` over them and all transitive dependents
- [x] Constructed every surviving error in the three modules and asserted its code, HTTP status and title against the previous values
- [x] Confirmed no client branches on the changed codes — WebUI compares `error_code` only on `vfolder_create_already-exists`, `session_create_already-exists`, `storage_access_forbidden`, `vfolder_access_forbidden` and `vfolder_read_not-found`
- [x] No test, document or fixture in this repo compares the affected code strings
- [ ] Unit suite in CI

## Notes for the reviewer
- `AutoScalingRuleNotFound` and `EndpointAutoScalingRuleNotFound` now render the same code, as do `RoutingNotFound` and `RouteNotFound`, and the two `EndpointNotFound` classes. They were already pairs with one meaning; merging them is out of this issue's scope.

Resolves BA-7822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189ohUYTVVihvBS8rF78NPA
