### PR TITLE
refactor(BA-7823): move the remaining domain errors onto EntityError

### DIFF
--- a/changes/14497.misc.md
+++ b/changes/14497.misc.md
@@ -1,0 +1,1 @@
+Report the notification, secret, retention and fair share errors under the row type they name; their error codes change accordingly.

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -59,6 +59,11 @@ type is what reopens the decision.
 | `NoUpdatesToApply` | a modifier that changed nothing; the row is whichever one the caller was updating |
 | `AppServiceStartFailed` | an app started inside a session is no row, and `ActionOperationType` has no `start` |
 | `AppProxyConnectionError`, `AppProxyResponseError` | AppProxy is a system domain by the `AGENTS.md` table |
+| `NotificationProcessingFailure` | the destination a channel points at refused the message; the failure is the external system's, not the row's |
+| `InvalidSecretKeyMaterial`, `SecretEncryptionMisconfigured` | the configured encryption keys and key providers, which no stored secret is read to reach |
+| `ExportReportNotFound`, `InvalidExportFieldKeys` | a report is a `ReportDef` in a code-declared registry, not a row, and its field keys with it |
+| `TooManyConcurrentExports` | a cap on how many exports run at once, about no one row |
+| `RetentionCategoryNotSupportedError` | a `RetentionCategory` with no cleanup wired — a gap in this build, not in a row |
 
 ## The legacy neighbor is a different kind
 

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -62,7 +62,6 @@ type is what reopens the decision.
 | `NotificationProcessingFailure` | the destination a channel points at refused the message; the failure is the external system's, not the row's |
 | `InvalidSecretKeyMaterial`, `SecretEncryptionMisconfigured` | the configured encryption keys and key providers, which no stored secret is read to reach |
 | `ExportReportNotFound`, `InvalidExportFieldKeys` | a report is a `ReportDef` in a code-declared registry, not a row, and its field keys with it |
-| `TooManyConcurrentExports` | a cap on how many exports run at once, about no one row |
 | `RetentionCategoryNotSupportedError` | a `RetentionCategory` with no cleanup wired — a gap in this build, not in a row |
 
 ## The legacy neighbor is a different kind

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -59,7 +59,7 @@ type is what reopens the decision.
 | `NoUpdatesToApply` | a modifier that changed nothing; the row is whichever one the caller was updating |
 | `AppServiceStartFailed` | an app started inside a session is no row, and `ActionOperationType` has no `start` |
 | `AppProxyConnectionError`, `AppProxyResponseError` | AppProxy is a system domain by the `AGENTS.md` table |
-| `NotificationProcessingFailure` | the destination a channel points at refused the message; the failure is the external system's, not the row's |
+| `NotificationProcessingFailure`, `NotificationTemplateRenderingFailure` | a notification is rendered and delivered, and the message that comes out is no row; only the two notification tables have a type |
 | `InvalidSecretKeyMaterial`, `SecretEncryptionMisconfigured` | the configured encryption keys and key providers, which no stored secret is read to reach |
 | `ExportReportNotFound`, `InvalidExportFieldKeys` | a report is a `ReportDef` in a code-declared registry, not a row, and its field keys with it |
 | `RetentionCategoryNotSupportedError` | a `RetentionCategory` with no cleanup wired — a gap in this build, not in a row |

--- a/src/ai/backend/manager/errors/export.py
+++ b/src/ai/backend/manager/errors/export.py
@@ -49,21 +49,3 @@ class InvalidExportFieldKeys(BackendAIError, web.HTTPBadRequest):
             operation=ErrorOperation.READ,
             error_detail=ErrorDetail.BAD_REQUEST,
         )
-
-
-class TooManyConcurrentExports(BackendAIError, web.HTTPServiceUnavailable):
-    """Raised when concurrent export limit is exceeded."""
-
-    error_type = "https://api.backend.ai/probs/too-many-concurrent-exports"
-    error_title = "Too many concurrent exports."
-
-    def __init__(self) -> None:
-        super().__init__(extra_msg="Too many concurrent export requests. Please try again later.")
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.BACKENDAI,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.UNAVAILABLE,
-        )

--- a/src/ai/backend/manager/errors/fair_share.py
+++ b/src/ai/backend/manager/errors/fair_share.py
@@ -6,59 +6,30 @@ from __future__ import annotations
 
 from typing import override
 
-from ai.backend.common.exception import (
-    BackendAIError,
-    ErrorCode,
-    ErrorDetail,
-    ErrorDomain,
-    ErrorOperation,
-)
+from aiohttp import web
+
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.exception import ErrorDetail
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 
 
-class FairShareError(BackendAIError):
-    """Base class for fair share domain errors."""
-
-    error_type = "https://api.backend.ai/probs/fair-share-error"
-    error_title = "Fair share operation failed."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.BACKENDAI,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class FairShareNotFoundError(FairShareError):
-    """Raised when a fair share entity is not found."""
-
-    error_type = "https://api.backend.ai/probs/fair-share-not-found"
-    error_title = "Fair share entity not found."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DATABASE,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class InvalidResourceWeightError(FairShareError):
+class InvalidResourceWeightError(EntityError, web.HTTPBadRequest):
     """Raised when resource_weights contains resource types not available in capacity."""
 
     error_type = "https://api.backend.ai/probs/invalid-resource-weight"
     error_title = "Invalid resource weight configuration."
+
+    invalid_types: list[str]
 
     def __init__(self, invalid_types: list[str]) -> None:
         self.invalid_types = invalid_types
         super().__init__(f"Resource types not available in capacity: {', '.join(invalid_types)}")
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceGroupEntityType(),
+            ActionOperationType.UPDATE,
+            ErrorDetail.INVALID_PARAMETERS,
         )

--- a/src/ai/backend/manager/errors/notification.py
+++ b/src/ai/backend/manager/errors/notification.py
@@ -63,16 +63,16 @@ class NotificationProcessingFailure(BackendAIError, web.HTTPInternalServerError)
         )
 
 
-class NotificationTemplateRenderingFailure(EntityError, web.HTTPBadRequest):
+class NotificationTemplateRenderingFailure(BackendAIError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/notification-template-rendering-failure"
     error_title = "Failed to render notification template."
 
     @override
-    def entity_error_code(self) -> EntityErrorCode:
-        return EntityErrorCode(
-            NotificationRuleEntityType(),
-            ActionOperationType.GET,
-            ErrorDetail.INVALID_PARAMETERS,
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.NOTIFICATION,
+            operation=ErrorOperation.GENERIC,
+            error_detail=ErrorDetail.INVALID_PARAMETERS,
         )
 
 

--- a/src/ai/backend/manager/errors/notification.py
+++ b/src/ai/backend/manager/errors/notification.py
@@ -84,7 +84,7 @@ class InvalidNotificationChannelType(EntityError, web.HTTPBadRequest):
     def entity_error_code(self) -> EntityErrorCode:
         return EntityErrorCode(
             NotificationChannelEntityType(),
-            ActionOperationType.UPDATE,
+            ActionOperationType.CREATE,
             ErrorDetail.INVALID_PARAMETERS,
         )
 

--- a/src/ai/backend/manager/errors/notification.py
+++ b/src/ai/backend/manager/errors/notification.py
@@ -84,7 +84,7 @@ class InvalidNotificationChannelType(EntityError, web.HTTPBadRequest):
     def entity_error_code(self) -> EntityErrorCode:
         return EntityErrorCode(
             NotificationChannelEntityType(),
-            ActionOperationType.CREATE,
+            ActionOperationType.UPDATE,
             ErrorDetail.INVALID_PARAMETERS,
         )
 

--- a/src/ai/backend/manager/errors/notification.py
+++ b/src/ai/backend/manager/errors/notification.py
@@ -4,6 +4,10 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.notification import (
+    NotificationChannelEntityType,
+    NotificationRuleEntityType,
+)
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -11,68 +15,38 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 
 __all__ = (
     "InvalidNotificationChannelType",
     "InvalidNotificationSpec",
-    "NotificationChannelConflict",
     "NotificationChannelNotFound",
     "NotificationProcessingFailure",
-    "NotificationRuleConflict",
     "NotificationRuleNotFound",
     "NotificationTemplateRenderingFailure",
 )
 
 
-class NotificationChannelNotFound(BackendAIError, web.HTTPNotFound):
+class NotificationChannelNotFound(EntityError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/notification-channel-not-found"
     error_title = "The notification channel does not exist."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            NotificationChannelEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class NotificationRuleNotFound(BackendAIError, web.HTTPNotFound):
+class NotificationRuleNotFound(EntityError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/notification-rule-not-found"
     error_title = "The notification rule does not exist."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class NotificationChannelConflict(BackendAIError, web.HTTPConflict):
-    error_type = "https://api.backend.ai/probs/notification-channel-conflict"
-    error_title = "The notification channel already exists."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
-
-
-class NotificationRuleConflict(BackendAIError, web.HTTPConflict):
-    error_type = "https://api.backend.ai/probs/notification-rule-conflict"
-    error_title = "The notification rule already exists."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            NotificationRuleEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
@@ -89,40 +63,40 @@ class NotificationProcessingFailure(BackendAIError, web.HTTPInternalServerError)
         )
 
 
-class NotificationTemplateRenderingFailure(BackendAIError, web.HTTPBadRequest):
+class NotificationTemplateRenderingFailure(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/notification-template-rendering-failure"
     error_title = "Failed to render notification template."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            NotificationRuleEntityType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class InvalidNotificationChannelType(BackendAIError, web.HTTPBadRequest):
+class InvalidNotificationChannelType(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-notification-channel-type"
     error_title = "Invalid notification channel type."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            NotificationChannelEntityType(),
+            ActionOperationType.CREATE,
+            ErrorDetail.INVALID_PARAMETERS,
         )
 
 
-class InvalidNotificationSpec(BackendAIError, web.HTTPBadRequest):
+class InvalidNotificationSpec(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-notification-spec"
     error_title = "Invalid notification specification."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.NOTIFICATION,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            NotificationChannelEntityType(),
+            ActionOperationType.GET,
+            ErrorDetail.INVALID_PARAMETERS,
         )

--- a/src/ai/backend/manager/errors/retention.py
+++ b/src/ai/backend/manager/errors/retention.py
@@ -6,16 +6,16 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.retention_policy import RetentionPolicyEntityType
 from ai.backend.common.exception import (
-    BackendAIError,
     ErrorCode,
     ErrorDetail,
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 from ai.backend.manager.errors.repository import RepositoryError
-
-from .common import ObjectNotFound
 
 
 class RetentionCategoryNotSupportedError(RepositoryError):
@@ -38,26 +38,12 @@ class RetentionCategoryNotSupportedError(RepositoryError):
         )
 
 
-class RetentionPolicyNotFound(ObjectNotFound):
-    object_name = "retention policy"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RETENTION_POLICY,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class RetentionPolicyConflict(BackendAIError, web.HTTPConflict):
+class RetentionPolicyConflict(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-retention-policy"
     error_title = "Duplicate Retention Policy"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RETENTION_POLICY,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            RetentionPolicyEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )

--- a/src/ai/backend/manager/errors/secret.py
+++ b/src/ai/backend/manager/errors/secret.py
@@ -6,6 +6,7 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.secret import SecretFieldType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -13,45 +14,39 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.field import FieldError, FieldErrorCode
 
 
-class InvalidEncryptedSecretFormat(BackendAIError, web.HTTPInternalServerError):
+class InvalidEncryptedSecretFormat(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/invalid-encrypted-secret-format"
     error_title = "The stored secret does not follow the encrypted secret format."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SECRET,
-            operation=ErrorOperation.PARSING,
-            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            SecretFieldType(), ActionOperationType.GET, ErrorDetail.INVALID_DATA_FORMAT
         )
 
 
-class UnsupportedSecretFormatVersion(BackendAIError, web.HTTPInternalServerError):
+class UnsupportedSecretFormatVersion(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/unsupported-secret-format-version"
     error_title = "The stored secret uses a format version this build cannot read."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SECRET,
-            operation=ErrorOperation.PARSING,
-            error_detail=ErrorDetail.INVALID_DATA_FORMAT,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            SecretFieldType(), ActionOperationType.GET, ErrorDetail.INVALID_DATA_FORMAT
         )
 
 
-class UnknownSecretKeyProvider(BackendAIError, web.HTTPInternalServerError):
+class UnknownSecretKeyProvider(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/unknown-secret-key-provider"
     error_title = "The stored secret names a key provider that is not configured."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SECRET,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(SecretFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
 class InvalidSecretKeyMaterial(BackendAIError, web.HTTPInternalServerError):
@@ -67,29 +62,23 @@ class InvalidSecretKeyMaterial(BackendAIError, web.HTTPInternalServerError):
         )
 
 
-class UnknownSecretKeyId(BackendAIError, web.HTTPInternalServerError):
+class UnknownSecretKeyId(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/unknown-secret-key-id"
     error_title = "The stored secret names a key id that is not configured."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SECRET,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(SecretFieldType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class SecretDecryptionFailed(BackendAIError, web.HTTPInternalServerError):
+class SecretDecryptionFailed(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/secret-decryption-failed"
     error_title = "The secret failed authentication during decryption."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SECRET,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            SecretFieldType(), ActionOperationType.GET, ErrorDetail.INTERNAL_ERROR
         )
 
 
@@ -106,14 +95,12 @@ class SecretEncryptionMisconfigured(BackendAIError, web.HTTPInternalServerError)
         )
 
 
-class InvalidSecretBinding(BackendAIError, web.HTTPInternalServerError):
+class InvalidSecretBinding(FieldError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/invalid-secret-binding"
     error_title = "A secret column accepts only a parsed secret value."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SECRET,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def field_error_code(self) -> FieldErrorCode:
+        return FieldErrorCode(
+            SecretFieldType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
         )

--- a/src/ai/backend/manager/errors/secret.py
+++ b/src/ai/backend/manager/errors/secret.py
@@ -102,5 +102,5 @@ class InvalidSecretBinding(FieldError, web.HTTPInternalServerError):
     @override
     def field_error_code(self) -> FieldErrorCode:
         return FieldErrorCode(
-            SecretFieldType(), ActionOperationType.CREATE, ErrorDetail.INVALID_PARAMETERS
+            SecretFieldType(), ActionOperationType.CREATE, ErrorDetail.INTERNAL_ERROR
         )


### PR DESCRIPTION
Resolves BA-7823

## Summary
- Nine notification, secret, retention and fair share errors now inherit `EntityError` or `FieldError` and report the row's type as the code domain instead of an `ErrorDomain`. Stored secrets are a `DanglingFieldType`, so those take `FieldError`.
- Deleted six errors nothing raised: `NotificationChannelConflict`, `NotificationRuleConflict`, `RetentionPolicyNotFound`, `FairShareError`, `FairShareNotFoundError`, `TooManyConcurrentExports`.
- Nine errors stay on `BackendAIError` because no row type is declared for what they are about; `errors/KNOWLEDGE.md` now lists them with the reason so the judgment is not redone.

### Outward code changes

The operation each error reports is kept wherever `ActionOperationType` has a counterpart, so most of these change only in the domain. `ErrorOperation.GENERIC` and `PARSING` have no counterpart, so an error carrying one had to pick.

| Error | Before | After |
|---|---|---|
| `NotificationChannelNotFound` | `notification_read_not-found` | `notification-channel_read_not-found` |
| `NotificationRuleNotFound` | `notification_read_not-found` | `notification-rule_read_not-found` |
| `InvalidNotificationChannelType` | `notification_create_invalid-parameters` | `notification-channel_create_invalid-parameters` |
| `InvalidNotificationSpec` | `notification_generic_invalid-parameters` | `notification-channel_read_invalid-parameters` |
| `InvalidEncryptedSecretFormat` | `secret_parsing_invalid-data-format` | `secret_read_invalid-data-format` |
| `UnsupportedSecretFormatVersion` | `secret_parsing_invalid-data-format` | `secret_read_invalid-data-format` |
| `InvalidSecretBinding` | `secret_create_invalid-parameters` | `secret_create_internal-error` |
| `RetentionPolicyConflict` | `retention-policy_generic_conflict` | `retention-policy_create_conflict` |
| `InvalidResourceWeightError` | `scaling-group_update_invalid-parameters` | `resource-group_update_invalid-parameters` |

`UnknownSecretKeyProvider`, `UnknownSecretKeyId` and `SecretDecryptionFailed` keep their codes — a dangling field kind reports its own type, which is already `secret`.

`InvalidSecretBinding` is the one error whose detail changes. A secret column is handed its value by the manager's own write path, so a value that is not a `SecretValue` is a type contract this build broke; the class already answered 500, which `invalid-parameters` contradicted.

One HTTP status changes. `InvalidResourceWeightError` inherited `FairShareError`, which carries no `web.HTTP*` mixin, so it left the manager with aiohttp's placeholder status of `-1`. It rejects an input, so it now inherits `web.HTTPBadRequest` and answers 400. Every other status, `error_type` URL and `error_title` is unchanged.

### Errors left on `BackendAIError`

| Error | Why |
|---|---|
| `NotificationProcessingFailure`, `NotificationTemplateRenderingFailure` | a notification is rendered and delivered, and the message that comes out is no row; only the two notification tables have a type |
| `InvalidSecretKeyMaterial`, `SecretEncryptionMisconfigured` | the configured encryption keys and key providers, which no stored secret is read to reach |
| `ExportReportNotFound`, `InvalidExportFieldKeys` | a report is a `ReportDef` in a code-declared registry, not a row, and its field keys with it |
| `RetentionCategoryNotSupportedError` | a `RetentionCategory` with no cleanup wired — a gap in this build, not in a row |

The export errors were checked against the target entity the export actions already declare (`ExportUsersCSVAction` answers `UserEntityType`, `GetReportAction` answers `GlobalEntityType`): those name what a report reads, while these two name the report definition itself, so nothing here conflicts with that work.

### Left for a follow-up

`InvalidNotificationChannelType` and `InvalidNotificationSpec` both report that one `notification_channels` row's `channel_type` and `spec` disagree, one from `notification_center`, the other from the adapters. That is two classes for one meaning, which `errors/AGENTS.md` rule 4 asks to collapse; the operation each reports is hard to settle while both stand. Collapsing them changes an `error_type` URL and a title, so it is not in this PR.

## Test plan
- [x] `pants fmt` / `lint` / `check` clean; the test suite runs in CI
- [x] Constructed every error touched and asserted its code, HTTP status and title
- [x] Traced every raise site of the errors that moved
- [x] Confirmed no client branches on the changed codes — WebUI compares `error_code` only on `vfolder`, `session` and `storage` codes
- [x] No test or document in this repo compares the affected code strings
- [x] Checked the deleted names against the manager, the tests and the four auth plugin checkouts — nothing constructs or catches them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPXtqWJ52Hx2aXpkT4vWd7