### PR TITLE
refactor(BA-7816): move the resource errors onto EntityError

### DIFF
--- a/changes/14499.misc.md
+++ b/changes/14499.misc.md
@@ -1,0 +1,1 @@
+The resource errors now report the row type as the error code domain; three duplicate not-found classes are folded into one each, eleven errors nothing raises are removed, and a resource group that rejects a session type answers 400 instead of 422.

--- a/src/ai/backend/common/exception.py
+++ b/src/ai/backend/common/exception.py
@@ -818,19 +818,6 @@ class ProcessorNotReadyError(BackendAIError, web.HTTPInternalServerError):
         )
 
 
-class AgentNotFound(BackendAIError, web.HTTPNotFound):
-    error_type = "https://api.backend.ai/probs/agent-not-found"
-    error_title = "Agent Not Found"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
 class ScalingGroupNotFoundError(BackendAIError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/scaling-group-not-found"
     error_title = "Scaling Group Not Found"

--- a/src/ai/backend/manager/errors/KNOWLEDGE.md
+++ b/src/ai/backend/manager/errors/KNOWLEDGE.md
@@ -79,6 +79,11 @@ one place per domain.
 | `ModelCardParseError` | a model-definition file that does not parse, before any model card row exists |
 | `VFolderFilterStatusNotAvailable` | the status-set alias names no entry in a constant map; the row-status half is `VFolderFilterStatusFailed` |
 | `UnsupportedStorageTypeError`, `ObjectStorageOperationNotSupported` | a requested storage type, or a configured one offering no such operation |
+| `AppNotFound` | an app absent from a session's `service_ports`, which is a value, not a row |
+| `UnresolvableResourceGroup` | no group resolves at all, so it names none, and it reports `access` |
+| `AgentNotAllocated` | a kernel with no agent assigned yet, reported under an `access` no `ActionOperationType` maps to |
+| `InvalidUserUpdateMode`, `InvalidPresetQuery` | a request's own mode value, or a query naming neither id nor name |
+| `NoCurrentTaskContext`, `DatabaseConnectionUnavailable`, `ConfigurationLoadFailed`, `DataTransformationFailed`, `DBOperationFailed` | the asyncio context, the connection, the configuration load or the database call itself |
 
 ## The legacy neighbor is a different kind
 

--- a/src/ai/backend/manager/errors/agent.py
+++ b/src/ai/backend/manager/errors/agent.py
@@ -19,6 +19,7 @@ from ai.backend.common.exception import (
 from ai.backend.common.types import AgentId
 from ai.backend.manager.actions.types import ActionOperationType
 from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
+from ai.backend.manager.errors.common import ObjectNotFound
 
 
 class AgentConnectionUnavailable(BackendAIError, web.HTTPServiceUnavailable):
@@ -100,4 +101,31 @@ class ConflictingSessionRescheduleNotSupported(BackendAIError, web.HTTPNotImplem
             domain=ErrorDomain.AGENT,
             operation=ErrorOperation.UPDATE,
             error_detail=ErrorDetail.NOT_IMPLEMENTED,
+        )
+
+
+class AgentNotFound(EntityError, ObjectNotFound):
+    object_name = "agent"
+
+    @override
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(AgentEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
+
+
+class AgentNotAllocated(BackendAIError, web.HTTPInternalServerError):
+    """Raised when a kernel that should be placed carries no agent yet.
+
+    Stays on :class:`BackendAIError`: it reports ``access``, which
+    ``ActionOperationType`` has no value for.
+    """
+
+    error_type = "https://api.backend.ai/probs/agent-not-allocated"
+    error_title = "Agent is not allocated for the kernel."
+
+    @override
+    def error_code(self) -> ErrorCode:
+        return ErrorCode(
+            domain=ErrorDomain.AGENT,
+            operation=ErrorOperation.ACCESS,
+            error_detail=ErrorDetail.INTERNAL_ERROR,
         )

--- a/src/ai/backend/manager/errors/resource.py
+++ b/src/ai/backend/manager/errors/resource.py
@@ -8,6 +8,16 @@ from typing import override
 
 from aiohttp import web
 
+from ai.backend.common.data.entity.deployment_preset import DeploymentPresetEntityType
+from ai.backend.common.data.entity.domain import DomainEntityType
+from ai.backend.common.data.entity.model_card import ModelCardEntityType
+from ai.backend.common.data.entity.project import ProjectEntityType
+from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
+from ai.backend.common.data.entity.resource_preset import ResourcePresetEntityType
+from ai.backend.common.data.entity.runtime_variant import RuntimeVariantEntityType
+from ai.backend.common.data.entity.runtime_variant_preset import RuntimeVariantPresetEntityType
+from ai.backend.common.data.entity.session_template import SessionTemplateEntityType
+from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.exception import (
     BackendAIError,
     ErrorCode,
@@ -15,68 +25,58 @@ from ai.backend.common.exception import (
     ErrorDomain,
     ErrorOperation,
 )
+from ai.backend.manager.actions.types import ActionOperationType
+from ai.backend.manager.errors.base.entity import EntityError, EntityErrorCode
 
 from .common import ObjectNotFound
 
 
-class DomainNotFound(ObjectNotFound):
+class DomainNotFound(EntityError, ObjectNotFound):
     object_name = "domain"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(DomainEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
-class DomainPurgeInProgress(BackendAIError, web.HTTPConflict):
+class DomainPurgeInProgress(EntityError, web.HTTPConflict):
     """Raised when a write names a domain a purge is working through."""
 
     error_type = "https://api.backend.ai/probs/domain-purge-in-progress"
     error_title = "Domain is being purged."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(DomainEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT)
 
 
-class ProjectPurgeInProgress(BackendAIError, web.HTTPConflict):
+class ProjectPurgeInProgress(EntityError, web.HTTPConflict):
     """Raised when a write names a project a purge is working through."""
 
     error_type = "https://api.backend.ai/probs/project-purge-in-progress"
     error_title = "Project is being purged."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ProjectEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
         )
 
 
-class PersonalProjectMemberAdditionError(BackendAIError, web.HTTPConflict):
+class PersonalProjectMemberAdditionError(EntityError, web.HTTPConflict):
     """Raised when a write would add a member to a personal project."""
 
     error_type = "https://api.backend.ai/probs/personal-project-member-addition"
     error_title = "Personal project takes no members beyond its owner."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ProjectEntityType(), ActionOperationType.UPDATE, ErrorDetail.CONFLICT
         )
 
 
-class PersonalProjectDeletionError(BackendAIError, web.HTTPConflict):
+class PersonalProjectDeletionError(EntityError, web.HTTPConflict):
     """Raised when a personal project is deleted or purged on its own, apart from
     the user it belongs to."""
 
@@ -84,62 +84,44 @@ class PersonalProjectDeletionError(BackendAIError, web.HTTPConflict):
     error_title = "Personal project is removed with its user, not on its own."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(ProjectEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class ProjectHasActiveKernelsError(BackendAIError, web.HTTPConflict):
+class ProjectHasActiveKernelsError(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/project-has-active-kernels"
     error_title = "Project has active kernels."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(ProjectEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class ProjectHasVFoldersMountedError(BackendAIError, web.HTTPConflict):
+class ProjectHasVFoldersMountedError(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/project-has-vfolders-mounted"
     error_title = "Project has vfolders mounted to active kernels."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(ProjectEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class ProjectHasActiveEndpointsError(BackendAIError, web.HTTPConflict):
+class ProjectHasActiveEndpointsError(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/project-has-active-endpoints"
     error_title = "Project has active endpoints."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(ProjectEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class ResourceGroupNotFound(ObjectNotFound):
-    object_name = "scaling group"
+class ResourceGroupNotFound(EntityError, ObjectNotFound):
+    object_name = "resource group"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceGroupEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
@@ -159,81 +141,35 @@ class UnresolvableResourceGroup(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class DefaultResourceGroupAlreadyExists(BackendAIError, web.HTTPBadRequest):
+class DefaultResourceGroupAlreadyExists(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/default-scaling-group-already-exists"
     error_title = "Another resource group is already the default."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceGroupEntityType(), ActionOperationType.UPDATE, ErrorDetail.INVALID_PARAMETERS
         )
 
 
-class ResourceGroupSessionTypeNotAllowed(BackendAIError, web.HTTPUnprocessableEntity):
-    error_type = "https://api.backend.ai/probs/scaling-group-session-type-not-allowed"
-    error_title = "Scaling group does not allow this session type."
+class ResourceGroupSessionTypeNotAllowed(EntityError, web.HTTPBadRequest):
+    error_type = "https://api.backend.ai/probs/resource-group-session-type-not-allowed"
+    error_title = "Resource group does not allow this session type."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourceGroupEntityType(), ActionOperationType.GET, ErrorDetail.INVALID_PARAMETERS
         )
 
 
-class ResourceGroupDeletionFailure(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/scaling-group-deletion-failure"
-    error_title = "Failed to delete scaling group."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class InstanceNotFound(ObjectNotFound):
-    object_name = "agent instance"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.INSTANCE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class InstanceNotAvailable(BackendAIError, web.HTTPServiceUnavailable):
-    error_type = "https://api.backend.ai/probs/instance-not-available"
-    error_title = "There is no available instance."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.INSTANCE,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.UNAVAILABLE,
-        )
-
-
-class ProjectNotFound(BackendAIError, web.HTTPNotFound):
+class ProjectNotFound(EntityError, web.HTTPNotFound):
     error_type = "https://api.backend.ai/probs/project-not-found"
     error_title = "Project not found."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.GROUP,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(ProjectEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND)
 
 
 class PersonalProjectNotFound(ProjectNotFound):
@@ -246,19 +182,24 @@ class PersonalProjectNotFound(ProjectNotFound):
     error_title = "Personal project not found."
 
 
-class TaskTemplateNotFound(ObjectNotFound):
-    object_name = "task template"
+class SessionTemplateNotFound(EntityError, ObjectNotFound):
+    object_name = "session template"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.TEMPLATE,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            SessionTemplateEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
 class AppNotFound(ObjectNotFound):
+    """Raised when a session's ``service_ports`` names no such app.
+
+    Stays on :class:`BackendAIError`: an entry in that column is a value, not a row.
+    Its ``backendai_read_not-found`` code is load-bearing -- WebUI's app launcher
+    branches on that exact string -- so do not move it.
+    """
+
     object_name = "app service"
 
     @override
@@ -270,300 +211,157 @@ class AppNotFound(ObjectNotFound):
         )
 
 
-class DomainDataProcessingError(BackendAIError, web.HTTPInternalServerError):
-    """
-    Error that occurs when processing domain data fails.
-    This includes failures in converting database rows to domain data objects.
-    """
-
-    error_type = "https://api.backend.ai/probs/domain-data-processing-error"
-    error_title = "Failed to process domain data."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class ResourceGroupProxyTargetNotFound(ObjectNotFound):
-    object_name = "scaling group proxy target"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class ResourcePresetNotFound(ObjectNotFound):
+class ResourcePresetNotFound(EntityError, ObjectNotFound):
     object_name = "resource preset"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RESOURCE_PRESET,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ResourcePresetEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class RuntimeVariantNotFound(ObjectNotFound):
+class RuntimeVariantNotFound(EntityError, ObjectNotFound):
     object_name = "runtime variant"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RUNTIME_VARIANT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            RuntimeVariantEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class RuntimeVariantConflict(BackendAIError, web.HTTPConflict):
+class RuntimeVariantConflict(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-runtime-variant"
     error_title = "Duplicate Runtime Variant"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RUNTIME_VARIANT,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            RuntimeVariantEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )
 
 
-class RuntimeVariantPresetNotFound(ObjectNotFound):
+class RuntimeVariantPresetNotFound(EntityError, ObjectNotFound):
     object_name = "runtime variant preset"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RUNTIME_VARIANT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            RuntimeVariantPresetEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class RuntimeVariantPresetConflict(BackendAIError, web.HTTPConflict):
+class RuntimeVariantPresetConflict(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-runtime-variant-preset"
     error_title = "Duplicate Runtime Variant Preset"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.RUNTIME_VARIANT,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            RuntimeVariantPresetEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )
 
 
-class ModelCardNotFound(ObjectNotFound):
+class ModelCardNotFound(EntityError, ObjectNotFound):
     object_name = "model card"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_CARD,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ModelCardEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class ModelCardConflict(BackendAIError, web.HTTPConflict):
+class ModelCardConflict(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-model-card"
     error_title = "Duplicate Model Card"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_CARD,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ModelCardEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )
 
 
-class InvalidProjectTypeForModelCard(BackendAIError, web.HTTPBadRequest):
+class InvalidProjectTypeForModelCard(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/invalid-project-type-for-model-card"
     error_title = "Project is not a MODEL_STORE type."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_CARD,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.BAD_REQUEST,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            ProjectEntityType(), ActionOperationType.GET, ErrorDetail.BAD_REQUEST
         )
 
 
-class NotAModelVFolder(BackendAIError, web.HTTPBadRequest):
+class NotAModelVFolder(EntityError, web.HTTPBadRequest):
     error_type = "https://api.backend.ai/probs/not-a-model-vfolder"
     error_title = "VFolder usage_mode is not MODEL."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_CARD,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.BAD_REQUEST,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            VFolderEntityType(), ActionOperationType.GET, ErrorDetail.BAD_REQUEST
         )
 
 
-class DeploymentRevisionPresetNotFound(ObjectNotFound):
+class DeploymentRevisionPresetNotFound(EntityError, ObjectNotFound):
     object_name = "deployment revision preset"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_DEPLOYMENT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentPresetEntityType(), ActionOperationType.GET, ErrorDetail.NOT_FOUND
         )
 
 
-class DeploymentRevisionPresetConflict(BackendAIError, web.HTTPConflict):
+class DeploymentRevisionPresetConflict(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/duplicate-deployment-revision-preset"
     error_title = "Duplicate Deployment Revision Preset"
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.MODEL_DEPLOYMENT,
-            operation=ErrorOperation.GENERIC,
-            error_detail=ErrorDetail.CONFLICT,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DeploymentPresetEntityType(), ActionOperationType.CREATE, ErrorDetail.CONFLICT
         )
 
 
-class AgentNotFound(ObjectNotFound):
-    object_name = "agent"
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.READ,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class DomainCreationFailed(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/domain-creation-failed"
-    error_title = "Failed to create domain."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class DomainNodeCreationFailed(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/domain-node-creation-failed"
-    error_title = "Failed to create domain node."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class DomainHasActiveKernels(BackendAIError, web.HTTPConflict):
+class DomainHasActiveKernels(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/domain-has-active-kernels"
     error_title = "Domain has active kernels."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(DomainEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class DomainHasUsers(BackendAIError, web.HTTPConflict):
+class DomainHasUsers(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/domain-has-users"
     error_title = "Domain has associated users."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(DomainEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class DomainHasGroups(BackendAIError, web.HTTPConflict):
+class DomainHasGroups(EntityError, web.HTTPConflict):
     error_type = "https://api.backend.ai/probs/domain-has-groups"
     error_title = "Domain has associated groups."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.CONFLICT,
-        )
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(DomainEntityType(), ActionOperationType.PURGE, ErrorDetail.CONFLICT)
 
 
-class DomainDeletionFailed(BackendAIError, web.HTTPInternalServerError):
+class DomainDeletionFailed(EntityError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/domain-deletion-failed"
     error_title = "Failed to delete domain."
 
     @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.HARD_DELETE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class DomainUpdateNotAllowed(BackendAIError, web.HTTPBadRequest):
-    error_type = "https://api.backend.ai/probs/domain-update-not-allowed"
-    error_title = "Domain update not allowed."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
-        )
-
-
-class InvalidDomainConfiguration(BackendAIError, web.HTTPBadRequest):
-    error_type = "https://api.backend.ai/probs/invalid-domain-configuration"
-    error_title = "Invalid domain configuration."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.DOMAIN,
-            operation=ErrorOperation.UPDATE,
-            error_detail=ErrorDetail.INVALID_PARAMETERS,
-        )
-
-
-class AllocationFailed(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/allocation-failed"
-    error_title = "Failed to allocate resources."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.CREATE,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
+    def entity_error_code(self) -> EntityErrorCode:
+        return EntityErrorCode(
+            DomainEntityType(), ActionOperationType.PURGE, ErrorDetail.INTERNAL_ERROR
         )
 
 
@@ -593,45 +391,6 @@ class InvalidPresetQuery(BackendAIError, web.HTTPBadRequest):
         )
 
 
-class NoAvailableResourceGroup(BackendAIError, web.HTTPBadRequest):
-    error_type = "https://api.backend.ai/probs/no-available-scaling-group"
-    error_title = "No scaling groups available for this session."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.NOT_FOUND,
-        )
-
-
-class AgentNotAllocated(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/agent-not-allocated"
-    error_title = "Agent ID has not been allocated for the session."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.AGENT,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class SessionNotAllocated(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/session-not-allocated"
-    error_title = "Session ID is not available during allocation."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SESSION,
-            operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
 class NoCurrentTaskContext(BackendAIError, web.HTTPInternalServerError):
     error_type = "https://api.backend.ai/probs/no-current-task-context"
     error_title = "No current asyncio task context available."
@@ -654,19 +413,6 @@ class DatabaseConnectionUnavailable(BackendAIError, web.HTTPInternalServerError)
         return ErrorCode(
             domain=ErrorDomain.DATABASE,
             operation=ErrorOperation.ACCESS,
-            error_detail=ErrorDetail.INTERNAL_ERROR,
-        )
-
-
-class InvalidSchedulerState(BackendAIError, web.HTTPInternalServerError):
-    error_type = "https://api.backend.ai/probs/invalid-scheduler-state"
-    error_title = "Scheduler is in an invalid state."
-
-    @override
-    def error_code(self) -> ErrorCode:
-        return ErrorCode(
-            domain=ErrorDomain.SCALING_GROUP,
-            operation=ErrorOperation.SCHEDULE,
             error_detail=ErrorDetail.INTERNAL_ERROR,
         )
 

--- a/src/ai/backend/manager/event_dispatcher/handlers/agent.py
+++ b/src/ai/backend/manager/event_dispatcher/handlers/agent.py
@@ -18,8 +18,7 @@ from ai.backend.common.plugin.event import EventDispatcherPluginContext
 from ai.backend.common.types import AgentId
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import AgentHeartbeatUpsert
-from ai.backend.manager.errors.agent import AgentAlreadyExited
-from ai.backend.manager.errors.resource import InstanceNotFound
+from ai.backend.manager.errors.agent import AgentAlreadyExited, AgentNotFound
 from ai.backend.manager.models.agent import AgentStatus, agents
 from ai.backend.manager.models.agent.updaters import AgentExitStatusUpdater, AgentStatusUpdater
 from ai.backend.manager.models.resource_slot import AgentResourceRow
@@ -176,7 +175,7 @@ class AgentEventHandler:
             agent_query = sa.select(sa.literal(1)).select_from(agents).where(agents.c.id == source)
             agent_result = await conn.execute(agent_query)
             if agent_result.first() is None:
-                raise InstanceNotFound(source)
+                raise AgentNotFound(source)
             # Read used slots from normalized agent_resources table
             ar = AgentResourceRow.__table__
             query = sa.select(ar.c.slot_name, ar.c.used).where(ar.c.agent_id == source)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -134,6 +134,7 @@ from .agent_cache import AgentRPCCache
 from .clients.agent import AgentClientPool
 from .clients.appproxy.client import AppProxyClient
 from .defs import DEFAULT_IMAGE_ARCH, DEFAULT_ROLE
+from .errors.agent import AgentNotAllocated, AgentNotFound
 from .errors.api import InvalidAPIParameters
 from .errors.image import ImageNotFound
 from .errors.kernel import (
@@ -143,9 +144,7 @@ from .errors.kernel import (
     TooManySessionsMatched,
 )
 from .errors.resource import (
-    AgentNotAllocated,
     DatabaseConnectionUnavailable,
-    InstanceNotFound,
     NoCurrentTaskContext,
     ResourceGroupNotFound,
     ResourceGroupSessionTypeNotAllowed,
@@ -184,7 +183,7 @@ from .models.vfolder import (
 from .types import UserScope
 
 type MSetType = Mapping[str | bytes, bytes | float | int | str]
-__all__ = ["AgentRegistry", "InstanceNotFound"]
+__all__ = ["AgentRegistry"]
 
 log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
@@ -351,7 +350,7 @@ class AgentRegistry:
             result = await db_sess.execute(query)
             row = result.scalar_one_or_none()
             if row is None:
-                raise InstanceNotFound(inst_id)
+                raise AgentNotFound(inst_id)
             return AgentId(row)
 
     async def enumerate_instances(self, check_shadow: bool = True) -> list[AgentId]:
@@ -1638,7 +1637,7 @@ class AgentRegistry:
                 else session.main_kernel
             )
             if kernel.agent is None:
-                raise InstanceNotFound(
+                raise AgentNotFound(
                     "Kernel has not been assigned to an agent.", extra_data={"kernel_id": kernel_id}
                 )
             async with self._agent_client_pool.acquire(AgentId(kernel.agent)) as client:

--- a/src/ai/backend/manager/repositories/agent/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/agent/db_source/db_source.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import selectinload
 
 from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
-from ai.backend.common.exception import AgentNotFound
 from ai.backend.common.types import AgentId, ImageID
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.data.agent.types import (
@@ -23,7 +22,7 @@ from ai.backend.manager.data.agent.types import (
 )
 from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelInfo, KernelStatus
-from ai.backend.manager.errors.agent import AgentHasConflictingSessions
+from ai.backend.manager.errors.agent import AgentHasConflictingSessions, AgentNotFound
 from ai.backend.manager.errors.resource import ResourceGroupNotFound, UnresolvableResourceGroup
 from ai.backend.manager.models.agent import AgentRow, agents
 from ai.backend.manager.models.image import ImageRow

--- a/src/ai/backend/manager/repositories/agent/repository.py
+++ b/src/ai/backend/manager/repositories/agent/repository.py
@@ -27,7 +27,7 @@ from ai.backend.manager.data.agent.types import (
 )
 from ai.backend.manager.data.image.types import ImageDataWithDetails, ImageIdentifier
 from ai.backend.manager.data.kernel.types import KernelInfo
-from ai.backend.manager.errors.resource import AgentNotFound
+from ai.backend.manager.errors.agent import AgentNotFound
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.agent.lookups import AgentNameLookup
 from ai.backend.manager.models.agent.updaters import AgentExitStatusUpdater, AgentStatusUpdater

--- a/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
+++ b/src/ai/backend/manager/repositories/deployment/db_source/db_source.py
@@ -111,7 +111,6 @@ from ai.backend.manager.errors.resource import (
     DomainNotFound,
     ProjectNotFound,
     ResourceGroupNotFound,
-    ResourceGroupProxyTargetNotFound,
     RuntimeVariantNotFound,
 )
 from ai.backend.manager.errors.service import (
@@ -1558,7 +1557,7 @@ class DeploymentDBSource:
             result = await db_sess.execute(query)
             rows = result.all()
             if not rows:
-                raise ResourceGroupProxyTargetNotFound(
+                raise ResourceGroupNotFound(
                     f"Scaling group proxy target not found for groups: {resource_group}"
                 )
             resource_group_targets: defaultdict[str, ResourceGroupProxyTarget | None] = defaultdict(

--- a/src/ai/backend/manager/services/agent/service.py
+++ b/src/ai/backend/manager/services/agent/service.py
@@ -27,8 +27,7 @@ from ai.backend.manager.actions.v2.bulk.result import PartialBulkEntityResult, P
 from ai.backend.manager.actions.v2.bulk.validator.rbac import BulkOwnCheck
 from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.permission_defs import AgentPermission
-from ai.backend.manager.errors.agent import ConflictingSessionRescheduleNotSupported
-from ai.backend.manager.errors.resource import AgentNotFound
+from ai.backend.manager.errors.agent import AgentNotFound, ConflictingSessionRescheduleNotSupported
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository

--- a/src/ai/backend/manager/services/manager_admin/service.py
+++ b/src/ai/backend/manager/services/manager_admin/service.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from ai.backend.manager.data.manager_status.types import ManagerStatus
+from ai.backend.manager.errors.agent import AgentNotFound
 from ai.backend.manager.errors.api import InvalidAPIParameters
-from ai.backend.manager.errors.resource import InstanceNotFound
 from ai.backend.manager.repositories.manager_admin.health import get_manager_db_cxn_status
 
 from .actions.fetch_status import FetchManagerStatusAction, FetchManagerStatusActionResult
@@ -147,7 +147,7 @@ class ManagerAdminService:
             action.agent_ids, action.schedulable
         )
         if rowcount < len(action.agent_ids):
-            raise InstanceNotFound()
+            raise AgentNotFound()
         return PerformSchedulerOpsActionResult()
 
     async def get_db_cxn_status(self, action: GetDbCxnStatusAction) -> GetDbCxnStatusActionResult:

--- a/src/ai/backend/manager/services/session/service.py
+++ b/src/ai/backend/manager/services/session/service.py
@@ -81,6 +81,7 @@ from ai.backend.manager.data.session.options import (
 )
 from ai.backend.manager.data.session.types import SessionStatus, SessionTerminationStatus
 from ai.backend.manager.defs import DEFAULT_ROLE
+from ai.backend.manager.errors.agent import AgentNotAllocated
 from ai.backend.manager.errors.common import (
     InternalServerError,
     ServiceUnavailable,
@@ -95,10 +96,9 @@ from ai.backend.manager.errors.kernel import (
     TooManySessionsMatched,
 )
 from ai.backend.manager.errors.resource import (
-    AgentNotAllocated,
     AppNotFound,
     NoCurrentTaskContext,
-    TaskTemplateNotFound,
+    SessionTemplateNotFound,
 )
 from ai.backend.manager.errors.storage import VFolderBadRequest
 from ai.backend.manager.idle import IdleCheckerHost
@@ -500,7 +500,7 @@ class SessionService:
         template = await self._session_repository.get_template_by_id(template_id)
         log.debug("task template: {}", template)
         if not template:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
 
         try:
             user_info = await self._session_repository.query_userinfo(
@@ -657,7 +657,7 @@ class SessionService:
 
         template_info = await self._session_repository.get_template_info_by_id(template_id)
         if not template_info:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
         template = template_info["template"]
 
         group_name = None

--- a/src/ai/backend/manager/services/stream/service.py
+++ b/src/ai/backend/manager/services/stream/service.py
@@ -10,8 +10,8 @@ from ai.backend.common.clients.valkey_client.valkey_live.client import ValkeyLiv
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.common.types import AgentId, KernelId, SessionId
 from ai.backend.logging import BraceStyleAdapter
+from ai.backend.manager.errors.agent import AgentNotAllocated
 from ai.backend.manager.errors.api import NotImplementedAPI
-from ai.backend.manager.errors.resource import AgentNotAllocated
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.stream.repository import StreamRepository
 from ai.backend.manager.services.stream.actions.execute_in_stream import (

--- a/src/ai/backend/manager/services/template/service.py
+++ b/src/ai/backend/manager/services/template/service.py
@@ -6,7 +6,7 @@ from typing import Any, Final
 
 from ai.backend.common.json import load_json
 from ai.backend.logging.utils import BraceStyleAdapter
-from ai.backend.manager.errors.resource import DBOperationFailed, TaskTemplateNotFound
+from ai.backend.manager.errors.resource import DBOperationFailed, SessionTemplateNotFound
 from ai.backend.manager.models.session_template import (
     TemplateType,
     check_cluster_template,
@@ -119,7 +119,7 @@ class TemplateService:
         """Get a single task template by ID."""
         row = await self._repository.get_task_template(str(action.template_id))
         if row is None:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
         raw_template = row["template"]
         template: dict[str, Any] = (
             raw_template if isinstance(raw_template, dict) else dict(load_json(raw_template))
@@ -137,7 +137,7 @@ class TemplateService:
         """Validate and update an existing task template."""
         exists = await self._repository.task_template_exists(str(action.template_id))
         if not exists:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
 
         # Authorize owner against the pre-resolved project
         default_user_uuid, default_group_id = await self._repository.resolve_owner(
@@ -174,7 +174,7 @@ class TemplateService:
         """Soft-delete a task template."""
         exists = await self._repository.task_template_exists(str(action.template_id))
         if not exists:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
         rowcount = await self._repository.soft_delete_template(
             str(action.template_id), TemplateType.TASK
         )
@@ -232,7 +232,7 @@ class TemplateService:
         """Get a single cluster template by ID."""
         template = await self._repository.get_cluster_template(str(action.template_id))
         if template is None:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
         return GetClusterTemplateActionResult(template=template)
 
     async def update_cluster_template(
@@ -241,7 +241,7 @@ class TemplateService:
         """Validate and update an existing cluster template."""
         exists = await self._repository.cluster_template_exists(str(action.template_id))
         if not exists:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
         template_data = check_cluster_template(action.template_data)
         name = template_data["metadata"]["name"]
         rowcount = await self._repository.update_cluster_template(
@@ -257,7 +257,7 @@ class TemplateService:
         """Soft-delete a cluster template."""
         exists = await self._repository.cluster_template_exists(str(action.template_id))
         if not exists:
-            raise TaskTemplateNotFound
+            raise SessionTemplateNotFound
         rowcount = await self._repository.soft_delete_template(
             str(action.template_id), TemplateType.CLUSTER
         )

--- a/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
+++ b/src/ai/backend/manager/sokovan/scheduler/hooks/status.py
@@ -20,8 +20,8 @@ from ai.backend.common.types import (
 from ai.backend.logging import BraceStyleAdapter
 from ai.backend.manager.clients.agent.pool import AgentClientPool
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.errors.agent import AgentNotAllocated
 from ai.backend.manager.errors.common import ServerMisconfiguredError
-from ai.backend.manager.errors.resource import AgentNotAllocated
 from ai.backend.manager.models.network import NetworkType
 from ai.backend.manager.plugin.network import NetworkPluginContext
 from ai.backend.manager.sokovan.recorder.context import RecorderContext

--- a/tests/unit/manager/repositories/agent/test_repository.py
+++ b/tests/unit/manager/repositories/agent/test_repository.py
@@ -28,7 +28,6 @@ from ai.backend.common.data.entity.agent import AgentUUID
 from ai.backend.common.data.entity.domain import DomainID
 from ai.backend.common.data.entity.resource_group import ResourceGroupID
 from ai.backend.common.data.entity.resource_slot import ResourceSlotName
-from ai.backend.common.exception import AgentNotFound
 from ai.backend.common.types import (
     AgentId,
     ClusterMode,
@@ -45,7 +44,11 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.agent.types import AgentHeartbeatUpsert, AgentStatus
 from ai.backend.manager.data.kernel.types import KernelStatus
 from ai.backend.manager.data.session.types import SessionStatus
-from ai.backend.manager.errors.agent import AgentAlreadyExited, AgentHasConflictingSessions
+from ai.backend.manager.errors.agent import (
+    AgentAlreadyExited,
+    AgentHasConflictingSessions,
+    AgentNotFound,
+)
 from ai.backend.manager.errors.resource import ResourceGroupNotFound, UnresolvableResourceGroup
 from ai.backend.manager.models.agent import AgentRow
 from ai.backend.manager.models.agent.updaters import AgentExitStatusUpdater

--- a/tests/unit/manager/services/agent/test_service.py
+++ b/tests/unit/manager/services/agent/test_service.py
@@ -22,9 +22,9 @@ from ai.backend.manager.config.provider import ManagerConfigProvider
 from ai.backend.manager.data.permission.permission_defs import AgentPermission
 from ai.backend.manager.errors.agent import (
     AgentHasConflictingSessions,
+    AgentNotFound,
     ConflictingSessionRescheduleNotSupported,
 )
-from ai.backend.manager.errors.resource import AgentNotFound
 from ai.backend.manager.registry import AgentRegistry
 from ai.backend.manager.repositories.agent.repository import AgentRepository
 from ai.backend.manager.repositories.scheduler.repository import SchedulerRepository

--- a/tests/unit/manager/services/resource_group/test_resource_group_service.py
+++ b/tests/unit/manager/services/resource_group/test_resource_group_service.py
@@ -393,7 +393,7 @@ class TestCheckScalingGroup:
         self,
         mock_conn: MagicMock,
     ) -> None:
-        """Test that check_scaling_group raises ResourceGroupSessionTypeNotAllowed (422)
+        """Test that check_scaling_group raises ResourceGroupSessionTypeNotAllowed (400)
         when requesting BATCH session on INTERACTIVE-only scaling group"""
         mock_sgroup = MagicMock()
         mock_sgroup.name = "test-sgroup"
@@ -415,7 +415,7 @@ class TestCheckScalingGroup:
                     domain_name="test-domain",
                     group_id="test-group-id",
                 )
-            assert exc_info.value.status_code == 422
+            assert exc_info.value.status_code == 400
 
     async def test_check_scaling_group_succeeds_with_allowed_session_type(
         self,

--- a/tests/unit/manager/services/template/test_template_service.py
+++ b/tests/unit/manager/services/template/test_template_service.py
@@ -15,7 +15,7 @@ import pytest
 from ai.backend.common.data.entity.project import ProjectID
 from ai.backend.common.data.entity.session_template import SessionTemplateID
 from ai.backend.common.data.entity.user import UserID
-from ai.backend.manager.errors.resource import DBOperationFailed, TaskTemplateNotFound
+from ai.backend.manager.errors.resource import DBOperationFailed, SessionTemplateNotFound
 from ai.backend.manager.exceptions import InvalidArgument
 from ai.backend.manager.models.session_template import TemplateType
 from ai.backend.manager.models.user import UserRole
@@ -334,7 +334,7 @@ class TestGetTaskTemplateAction:
         mock_repo.get_task_template = AsyncMock(return_value=None)
 
         action = GetTaskTemplateAction(template_id=_template_id("nonexistent"))
-        with pytest.raises(TaskTemplateNotFound):
+        with pytest.raises(SessionTemplateNotFound):
             await service.get_task_template(action)
 
 
@@ -431,7 +431,7 @@ class TestUpdateTaskTemplateAction:
             **base_action_kwargs,
             items=[TaskTemplateItemInput(template=_make_valid_task_template())],
         )
-        with pytest.raises(TaskTemplateNotFound):
+        with pytest.raises(SessionTemplateNotFound):
             await service.update_task_template(action)
 
     async def test_invalid_template_raises_error(
@@ -504,7 +504,7 @@ class TestDeleteTaskTemplateAction:
         mock_repo.task_template_exists = AsyncMock(return_value=False)
 
         action = DeleteTaskTemplateAction(template_id=_template_id("nonexistent"))
-        with pytest.raises(TaskTemplateNotFound):
+        with pytest.raises(SessionTemplateNotFound):
             await service.delete_task_template(action)
 
     async def test_rowcount_not_one_raises_db_operation_failed(
@@ -648,7 +648,7 @@ class TestGetClusterTemplateAction:
         mock_repo.get_cluster_template = AsyncMock(return_value=None)
 
         action = GetClusterTemplateAction(template_id=_template_id("nonexistent"))
-        with pytest.raises(TaskTemplateNotFound):
+        with pytest.raises(SessionTemplateNotFound):
             await service.get_cluster_template(action)
 
 
@@ -776,7 +776,7 @@ class TestUpdateClusterTemplateAction:
             template_id=_template_id("nonexistent"),
             template_data=_make_valid_cluster_template(),
         )
-        with pytest.raises(TaskTemplateNotFound):
+        with pytest.raises(SessionTemplateNotFound):
             await service.update_cluster_template(action)
 
     async def test_no_master_node_raises_invalid_argument(
@@ -847,7 +847,7 @@ class TestDeleteClusterTemplateAction:
         mock_repo.cluster_template_exists = AsyncMock(return_value=False)
 
         action = DeleteClusterTemplateAction(template_id=_template_id("nonexistent"))
-        with pytest.raises(TaskTemplateNotFound):
+        with pytest.raises(SessionTemplateNotFound):
             await service.delete_cluster_template(action)
 
     async def test_rowcount_not_one_raises_db_operation_failed(


### PR DESCRIPTION
## Summary
- Thirty-one errors naming a domain, a project, a resource group, an agent, a session template, a resource preset, a runtime variant or its preset, a model card, a deployment preset or a vfolder now inherit `EntityError` and report the row's type as the code domain. Several carried an `ErrorDomain` that no longer matched the row it meant.
- Deleted eleven errors nothing raises, each orphaned by an earlier cleanup, and folded three duplicate classes into one each.
- Fixed names that had drifted from what they name, and moved the agent errors to `errors/agent.py`.

### Duplicates folded

The domain aliases had been hiding these; giving each class its row's type gave the pairs the same code and made them visible.

| Removed | Folded into | Why it was the same thing |
|---|---|---|
| `InstanceNotFound` | `AgentNotFound` | `object_name` was already "agent instance", and all three raise sites query `AgentRow`. `instance` is the old name for an agent |
| `common/exception.py`'s `AgentNotFound` | `AgentNotFound` | a third class for the same row, used only by manager code, which now imports the manager's |
| `ResourceGroupProxyTargetNotFound` | `ResourceGroupNotFound` | its raise site queries `resource_groups` by name and says nothing about a proxy target |

`PersonalProjectNotFound` keeps reporting its parent's code — it is left alone on purpose, since its own title is what distinguishes it.

### Names and status corrected

| Error | Change |
|---|---|
| `ResourceGroupNotFound` | `object_name` "scaling group" → "resource group" |
| `TaskTemplateNotFound` | renamed `SessionTemplateNotFound`; `object_name` → "session template". It has always raised over `session_templates` |
| `ResourceGroupSessionTypeNotAllowed` | title and `probs` URL → resource group; answers **400** instead of 422, matching every other parameter refusal in the file |
| `AppNotFound` | gains a docstring saying why it must not move (below) |

`AgentNotFound` and `AgentNotAllocated` move to `errors/agent.py`. The five system errors (`NoCurrentTaskContext`, `DatabaseConnectionUnavailable`, `ConfigurationLoadFailed`, `DataTransformationFailed`, `DBOperationFailed`) stay in `resource.py` — no module holds them yet.

### Deleted as unreferenced

`AllocationFailed`, `InstanceNotAvailable`, `SessionNotAllocated` (legacy scheduler removal); `DomainCreationFailed`, `DomainNodeCreationFailed`, `DomainDataProcessingError` (Creator ABC migration); `DomainUpdateNotAllowed`, `InvalidDomainConfiguration`, `NoAvailableResourceGroup`, `ResourceGroupDeletionFailure` (pass-through action migration); `InvalidSchedulerState` (legacy scheduler module removal).

### Outward code changes

| Before | After | Errors |
|---|---|---|
| `group_*` | `project_*` | 9 |
| `scaling-group_*` | `resource-group_*` | 3 |
| `instance_read_not-found` | `agent_read_not-found` | folded away |
| `template_read_not-found` | `session-template_read_not-found` | 1 |
| `model-deployment_*` | `deployment-preset_*` | 2 |
| `runtime-variant_*` | `runtime-variant-preset_*` | 2 |
| `model-card_read_bad-request` | `project_read_bad-request` | `InvalidProjectTypeForModelCard` |
| `model-card_generic_bad-request` | `vfolder_read_bad-request` | `NotAModelVFolder` |
| `*_generic_conflict` | `*_create_conflict` | 4 |

`generic` is the placeholder its own docstring tells callers to replace, unlike `access` or `grant`, which no `ActionOperationType` can carry at all — so a move fills in the real operation.

One `probs` URL changes: `scaling-group-session-type-not-allowed` → `resource-group-session-type-not-allowed`.

### Errors left on `BackendAIError`

Ten, listed with their reason in `errors/KNOWLEDGE.md`. The one to know about is `AppNotFound`: an app absent from a session's `service_ports` is a value, not a row, and WebUI's app launcher branches on the exact string `backendai_read_not-found` it reports (`useBackendAIAppLauncher.tsx:1119`). Moving it would have broken the launcher.

## Test plan
- [x] `pants lint` / `check` / `test` in CI
- [x] Constructed every moved, folded and untouched error and asserted its code, HTTP status and title
- [x] Confirmed the eleven deleted have no source reference anywhere in the repo, and used `git log -S` to place each one's orphaning commit
- [x] Checked WebUI for every changed domain (`group_`, `scaling-group_`, `instance_`, `template_`, `model-deployment_`, `model-card_`, `runtime-variant_`, `domain_`, `agent_read`, `resource-preset_`) and for both changed `probs` URLs — no comparison site matches. `backendai_read_not-found`, which WebUI does branch on, is unchanged
- [x] Imported `registry.py` and the session service after the import moves

Resolves BA-7816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128bKAiecc6WfVK9VBRjxBv
