### PR TITLE
chore: drop the unfillable parameter from the app-proxy schema CLI group

### DIFF
--- a/changes/14502.fix.md
+++ b/changes/14502.fix.md
@@ -1,0 +1,1 @@
+Fix `app-proxy-coordinator schema oneshot` failing with a TypeError under Click 8.3, which stopped the installer at the app-proxy database step.

--- a/src/ai/backend/appproxy/coordinator/cli/dbschema.py
+++ b/src/ai/backend/appproxy/coordinator/cli/dbschema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import click
 
@@ -16,7 +16,7 @@ log = BraceStyleAdapter(logging.getLogger(__spec__.name))
 
 
 @click.group()
-def cli(args: Any) -> None:
+def cli() -> None:
     pass
 
 


### PR DESCRIPTION
### Summary
`app-proxy-coordinator schema oneshot` raises `TypeError: cli() missing 1 required positional argument: 'args'` under Click 8.3, taking the installer's app-proxy database step with it.

### Changes

**The schema CLI group takes no parameter**
- `dbschema.cli` drops the positional `args` it declared.
- Reason: no Click option or argument ever supplied that parameter, so it was only ever fillable by accident. Click 8.1 kept `invoke` on `MultiCommand`, and `LazyClickMixin` wraps whatever `vars(Group)` holds, so the function was never called directly and Click's own dispatch ran the group. Click 8.3 defines `invoke` on `Group` itself, the mixin now wraps it and delegates to the underlying group, and the call raises. The declaration was wrong before the upgrade; 8.3 only stopped hiding it.
- Every other CLI group in the repository takes no parameter, the manager's `dbschema.cli` included, so this brings the app-proxy one back in line.

**Not the installer's bug**
- The installer calls the coordinator CLI and the CLI is what fails, in both source and package mode. `install_appproxy_db` needs no change.

### Verification
Ran the real `LazyClickMixin` against both signatures under Click 8.3.3:

| `dbschema.cli` | result |
|---|---|
| `def cli(args)` | `TypeError: cli() missing 1 required positional argument: 'args'` |
| `def cli()` | dispatches normally |

The same declaration on Click 8.1.8 dispatches normally, which is why this only appeared after the pin moved. `vars(click.Group)` grows from 5 functions to 14 between those versions, and `invoke` is among the additions, which is the whole of the behavioural change.

### Follow-up, not in this PR
`LazyClickMixin` picks its wrap targets out of `vars(type(self).__mro__[2])`, so which methods get delegated depends on where a class sits in the MRO and on how the upstream library distributes its methods across base classes. This is the second thing to shift under it. Worth revisiting separately, since `web`, `agent` and others all build on `LazyGroup`.
