### PR TITLE
test(BA-7802): add the shared components the system concern scenarios use

### DIFF
--- a/changes/14510.test.md
+++ b/changes/14510.test.md
@@ -1,0 +1,1 @@
+Add the shared caller-only situation and enforcement switch the system-concern scenario tables use.

--- a/tests/scenario/bai_scenario/components/system.py
+++ b/tests/scenario/bai_scenario/components/system.py
@@ -1,0 +1,66 @@
+"""What every system-concern table says besides the call.
+
+A system entity is created in no scope, so a table lays no place for it: only the caller
+and the rows the call reads. What tells callers apart is the role. The superadmin role
+passes the global gate, the monitor role passes its reads, and a user holding nothing
+passes only the reads that ask for authentication alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, override
+
+from bai_scenario.components.domain import WAS_HERE, SomeoneOf
+from bai_scenario.seeds.domain.domain import SeedDomain
+from bai_scenario.seeds.seeder import Laid
+from bai_scenario.seeds.user.user import SeedUserOf
+
+from ai.backend.common.data.user.types import UserRole
+from ai.backend.manager.data.user.types import UserData
+from ai.backend.testutils.scenario_steps import Given
+
+ENFORCEMENT = "manager.rbac.enforcement_enabled"
+"""The switch the entity gate reads. A row that turns it off passes it as its config."""
+
+
+class Kept:
+    """A place an edit must leave as the seed laid it."""
+
+
+KEPT = Kept()
+
+
+def role_named(role: UserRole) -> str:
+    """What the report calls a user of this role, the same way the seed does."""
+    return SeedUserOf(role=role).kind()
+
+
+@dataclass(frozen=True)
+class ACaller:
+    """부를 사람 한 명."""
+
+    caller: UserData
+
+
+async def lay_a_caller(seeding: Any, role: UserRole = UserRole.USER) -> Laid[UserData]:
+    """A user of the given role, in a domain of their own."""
+    home = await seeding.creating(SeedDomain(name_hint="home", description=WAS_HERE))
+    caller: Laid[UserData] = await seeding.within(SomeoneOf(home, role=role))
+    return caller
+
+
+@dataclass(frozen=True)
+class SomeoneAlone(Given[Any, ACaller]):
+    """사용자 한 명, 그리고 아무 행도 없음."""
+
+    role: UserRole = UserRole.USER
+
+    @override
+    def describe(self) -> str:
+        return f"{role_named(self.role)} 한 명"
+
+    @override
+    async def lay(self, seeding: Any) -> ACaller:
+        caller = await lay_a_caller(seeding, self.role)
+        return ACaller(seeding.made(caller))


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the system concern scenario stack (BA-7802). **Merge in order (bottom-up):**

1. 👉 **#14510 — `test(BA-7802)`: shared components the system concern scenarios use** ← you are here
2. #14521 — `test(BA-7802)`: runtime variant
3. #14522 — `test(BA-7802)`: runtime variant preset
4. #14523 — `test(BA-7802)`: resource slot type
5. #14524 — `test(BA-7802)`: retention policy
6. #14525 — `test(BA-7802)`: login client type
7. #14526 — `test(BA-7802)`: client IP masking
8. #14527 — `test(BA-7802)`: secret

> **Fork at #14510**: #14521 → #14522 is ordered; #14523–#14527 each sit on #14510 alone and may merge in any order after it.

Part of BA-7802

## Summary
- Add `tests/scenario/bai_scenario/components/system.py`, the one piece every system-concern scenario table shares: a caller of a given role and nothing else (`SomeoneAlone`, `lay_a_caller`), the enforcement switch the entity gate reads (`ENFORCEMENT`), and the marker an edit uses for a place it must leave as laid (`KEPT`).
- A system entity is created in no scope, so its tables lay no place — only the caller and the rows the call reads. That is why this is all the stack shares; each entity PR above brings its own seed, components, `KNOWLEDGE.md`, tests and `report.md`.

Beside the stack, #14528 fills `service_catalog/KNOWLEDGE.md` alone: no write spec lays a catalog row (the registration event handler inserts it directly), so it has no tests yet and sits on `main` by itself.

The twelve `global` wirings of the concern (`EtcdConfigProcessors`, `ManagerAdminProcessors`) have no adapter package and therefore no `KNOWLEDGE.md` slot; they are out of this stack.

## Test plan
- [x] `pants check lint` on the new module
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Snp9H2jEVbB2s1C6ixUHGn
