### PR TITLE
test(BA-7838): let the scenario seeder write upserter specs

### DIFF
--- a/changes/14529.test.md
+++ b/changes/14529.test.md
@@ -1,0 +1,1 @@
+Let the scenario seeder lay rows through upserter write specs, for entities that have no creator.

--- a/tests/scenario/bai_scenario/seeds/seeder.py
+++ b/tests/scenario/bai_scenario/seeds/seeder.py
@@ -10,6 +10,8 @@ Which ops path writes a row follows from the spec's type, so no scenario names a
     RoleManagedEntityCreator        -> create_role_managed_entity
     GuardedEntityCreator            -> create_entity   (EntityCreator is one of these)
     GlobalEntityCreator             -> create_global_entity
+    EntityUpserter                  -> upsert_entity
+    GlobalEntityUpserter            -> upsert_global_entity
     GuardedDataUpdater              -> update_data
 """
 
@@ -20,6 +22,8 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, Final, cast
+
+from bai_scenario.seeds.ops import SeedOps
 
 from ai.backend.common.data.entity.role import RoleID
 from ai.backend.common.data.entity.types import FieldData
@@ -34,14 +38,16 @@ from ai.backend.manager.models.specs.creator import (
 )
 from ai.backend.manager.models.specs.relation import RelationCreator
 from ai.backend.manager.models.specs.updater import GuardedDataUpdater
+from ai.backend.manager.models.specs.upserter import EntityUpserter, GlobalEntityUpserter
 from ai.backend.manager.repositories.ops.v2.user.write import FullUserCreator
-from bai_scenario.seeds.ops import SeedOps
 
 type WriteSpec[D] = (
     GlobalEntityCreator[Any, D]
     | GuardedEntityCreator[Any, D]
     | RoleManagedGlobalEntityCreator[Any, D]
     | RoleManagedEntityCreator[Any, D]
+    | EntityUpserter[Any, D]
+    | GlobalEntityUpserter[Any, D]
     | GuardedDataUpdater[Any, D]
 )
 
@@ -239,6 +245,10 @@ async def _write(ops: SeedOps, spec: WriteSpec[Any]) -> Any:
         return await ops.create_entity(spec)
     if isinstance(spec, GlobalEntityCreator):
         return await ops.create_global_entity(spec)
+    if isinstance(spec, EntityUpserter):
+        return await ops.upsert_entity(spec)
+    if isinstance(spec, GlobalEntityUpserter):
+        return await ops.upsert_global_entity(spec)
     return await ops.update_data(spec)
 
 


### PR DESCRIPTION
## Summary
- `EntityUpserter` and `GlobalEntityUpserter` join the scenario seeder's `WriteSpec`, routed to `upsert_entity` / `upsert_global_entity`; the routing table in the module docstring lists them.
- The five seeder entrances are unchanged — only what `creating` and its siblings accept widens. A row that has no creator at all (an app config fragment is written only by an upserter) can now be laid through the manager's own spec instead of a test-side one.
- No other file changes. The first consumer, the app config seeds, lands in #14509 on top of this.

## Test plan
- [x] `pytest tests/scenario/bai_scenario/manager/domain tests/scenario/bai_scenario/setup` — 24 passed, unchanged
- [x] `pytest tests/scenario/bai_scenario/manager/app_config` on #14509 (the consumer) — 20 passed

Resolves BA-7838

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BnvoxSA2RSKgBkJ1yvC9P
