### PR TITLE
test(BA-7809): let the user policy seed carry a concurrent-login cap

### DIFF
--- a/changes/14534.test.md
+++ b/changes/14534.test.md
@@ -1,0 +1,1 @@
+Let the user policy scenario seed carry a concurrent-login cap.

--- a/tests/scenario/bai_scenario/seeds/resource_policy/user.py
+++ b/tests/scenario/bai_scenario/seeds/resource_policy/user.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import override
 
+from bai_scenario.seeds.seeder import Naming, SeedRow
+
 from ai.backend.manager.data.resource.types import UserResourcePolicyData
 from ai.backend.manager.models.resource_policy.creators import UserResourcePolicyCreator
-from bai_scenario.seeds.seeder import Naming, SeedRow
 
 
 @dataclass(frozen=True)
@@ -20,6 +21,7 @@ class SeedUserPolicy(SeedRow[UserResourcePolicyData]):
     max_quota_scope_size: int = -1
     max_session_count_per_model_session: int = 10
     max_customized_image_count: int = 3
+    max_concurrent_logins: int | None = None
 
     @override
     def kind(self) -> str:
@@ -27,7 +29,10 @@ class SeedUserPolicy(SeedRow[UserResourcePolicyData]):
 
     @override
     def detail(self) -> str:
-        return f"사용자 한 명당 폴더 {self.max_vfolder_count}개까지"
+        allows = [f"사용자 한 명당 폴더 {self.max_vfolder_count}개까지"]
+        if self.max_concurrent_logins is not None:
+            allows.append(f"동시 로그인 {self.max_concurrent_logins}개까지")
+        return ", ".join(allows)
 
     @override
     def name(self, naming: Naming) -> str:
@@ -41,4 +46,5 @@ class SeedUserPolicy(SeedRow[UserResourcePolicyData]):
             max_quota_scope_size=self.max_quota_scope_size,
             max_session_count_per_model_session=self.max_session_count_per_model_session,
             max_customized_image_count=self.max_customized_image_count,
+            max_concurrent_logins=self.max_concurrent_logins,
         )


### PR DESCRIPTION
## 📚 Stacked PRs

Part of the resource policy scenario stack under BA-7809. **Merge in order (bottom-up):**

1. 👉 **#14534 — `test(BA-7809)`: user policy seed carries a concurrent-login cap** ← you are here
2. #14515 — `test(BA-7809)`: project resource policy scenarios
3. #14516 — `test(BA-7809)`: keypair resource policy scenarios
4. #14517 — `test(BA-7809)`: user resource policy scenarios

Resolves BA-7809

## Summary
- The one change to the shared scenario seeds the stack needs, on its own: `SeedUserPolicy` takes a `max_concurrent_logins` and says so in its detail.
- The cap is the only value of a user policy an update may clear, so the row that clears it (#14517) needs a seeded policy holding one. The default stays `None`, so every row laid so far — and every existing `report.md` — reads the same.

## Test plan
- [x] `test-scenario` on CI for every component that lays a user policy passes with its `report.md` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vFCmtPMD6GLPBJxJoFroD