### PR TITLE
fix(BA-7813): normalize CRLF line endings in bootstrap scripts and dotfiles

### DIFF
--- a/changes/14554.fix.md
+++ b/changes/14554.fix.md
@@ -1,1 +1,1 @@
-Normalize CRLF line endings in bootstrap scripts so they no longer fail with `command not found` inside session containers.
+Normalize CRLF line endings in bootstrap scripts and dotfiles so they no longer break commands and environment variables inside session containers.

--- a/changes/14554.fix.md
+++ b/changes/14554.fix.md
@@ -1,0 +1,1 @@
+Normalize CRLF line endings in bootstrap scripts so they no longer fail with `command not found` inside session containers.

--- a/src/ai/backend/manager/data/dotfile/types.py
+++ b/src/ai/backend/manager/data/dotfile/types.py
@@ -127,7 +127,8 @@ class DotfileBundle:
         result: dict[str, Any] = {}
         if self.dotfiles:
             result["dotfiles"] = [
-                {"path": e.path, "perm": e.perm, "data": e.data} for e in self.dotfiles
+                {"path": e.path, "perm": e.perm, "data": normalize_newlines(e.data)}
+                for e in self.dotfiles
             ]
         if self.ssh_keypair is not None:
             result["ssh_keypair"] = {

--- a/src/ai/backend/manager/data/dotfile/types.py
+++ b/src/ai/backend/manager/data/dotfile/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -23,6 +24,13 @@ class DotfileScope(enum.StrEnum):
 
 
 DotfileEntityKey = str | uuid.UUID
+
+_CR_LINE_BREAK = re.compile(r"\r\n?")
+
+
+def normalize_newlines(text: str) -> str:
+    """Convert CRLF and lone CR line breaks to LF."""
+    return _CR_LINE_BREAK.sub("\n", text)
 
 
 @dataclass(frozen=True)

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -11,7 +11,7 @@ from ai.backend.common.exception import InvalidAPIParameters
 from ai.backend.common.types import AccessKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
-from ai.backend.manager.data.dotfile.types import DotfileEntries
+from ai.backend.manager.data.dotfile.types import DotfileEntries, normalize_newlines
 from ai.backend.manager.data.user.types import (
     BulkPurgeError,
     BulkUserPurgeResultData,
@@ -417,7 +417,7 @@ class UserService:
     async def update_bootstrap_script(
         self, action: UpdateBootstrapScriptAction
     ) -> UpdateBootstrapScriptActionResult:
-        script = action.script.strip()
+        script = normalize_newlines(action.script).strip()
         if len(script) > MAXIMUM_DOTFILE_SIZE:
             raise DotfileCreationFailed("Maximum bootstrap script length reached")
         keypair = await self._user_repository.admin_get_keypair(action.access_key)

--- a/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
+++ b/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
@@ -32,6 +32,7 @@ from ai.backend.common.types import (
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.agent import AgentClientPool
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.dotfile.types import normalize_newlines
 from ai.backend.manager.defs import START_SESSION_TIMEOUT_SEC
 from ai.backend.manager.exceptions import convert_to_status_data
 from ai.backend.manager.metrics.scheduler import (
@@ -372,7 +373,11 @@ class SessionLauncher:
                         ],
                         "package_directory": tuple(),
                         "idle_timeout": int(idle_timeout),
-                        "bootstrap_script": k.bootstrap_script,
+                        "bootstrap_script": (
+                            normalize_newlines(k.bootstrap_script)
+                            if k.bootstrap_script is not None
+                            else None
+                        ),
                         "startup_command": k.startup_command,
                         "internal_data": k.internal_data,
                         "auto_pull": kernel_image_config.get("auto_pull", AutoPullBehavior.DIGEST),


### PR DESCRIPTION
## Summary
- Bootstrap scripts and dotfiles stored with CRLF line endings reach the container as-is. A bootstrap script then fails line by line under `/bin/sh` (`command not found`), and every value exported from a `.bashrc` dotfile carries a trailing `\r`.
- Normalize CRLF and lone CR to LF on the paths that hand these to agents, which also covers content that is already stored:
  - Bootstrap script: when a keypair's script is saved (`UserService.update_bootstrap_script`) and when the launcher builds the kernel config.
  - Dotfiles: `DotfileBundle.to_internal_data()`, the only path that puts user/group/domain dotfiles into a kernel's `internal_data`.
- Add a `normalize_newlines` helper in `manager/data/dotfile/types.py`.
- Stored dotfile rows are not rewritten, so `GET /user-config/dotfiles` still returns existing CRLF content until it is saved again.

## Test plan
- [x] Save a bootstrap script with CRLF line endings via `POST /user-config/bootstrap-script`; `GET` returns it with LF only
- [x] Create a session whose bootstrap script contains CRLF; `/home/work/bootstrap.sh` in the container has no `\r` and the script runs
- [x] Store a `.bashrc` dotfile with CRLF line endings; in a new session `cat -A ~/.bashrc` shows no `^M` and exported values have no trailing `\r`
- [x] Create a session without a bootstrap script or dotfiles; `kernel_config["bootstrap_script"]` stays `None` and `internal_data` has no `dotfiles` key

Resolves BA-7813

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsGNdkS3wbsaS2isxoVGfU
