### PR TITLE
fix(BA-7813): normalize CRLF in dotfiles and bootstrap scripts

### DIFF
--- a/changes/14555.fix.md
+++ b/changes/14555.fix.md
@@ -1,0 +1,1 @@
+Fix TLS verification and shell execution failures caused by CRLF line endings in dotfiles and bootstrap scripts

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -140,6 +140,7 @@ from ai.backend.common.json import (
     load_json,
 )
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import (
     AgentId,
     AutoPullBehavior,
@@ -964,7 +965,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             if bootstrap := self.kernel_config.get("bootstrap_script"):
 
                 def _write_user_bootstrap_script() -> None:
-                    (self.work_dir / "bootstrap.sh").write_text(bootstrap.replace("\r\n", "\n"))
+                    (self.work_dir / "bootstrap.sh").write_text(normalize_newlines(bootstrap))
                     if ouid is not None or ogid is not None:
                         self._chown_paths_if_root([self.work_dir / "bootstrap.sh"], ouid, ogid)
                     else:
@@ -1069,7 +1070,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 file_path = self.work_dir / dotfile["path"]
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            dotfile_content = dotfile["data"].replace("\r\n", "\n")
+            dotfile_content = normalize_newlines(dotfile["data"])
             if not dotfile_content.endswith("\n"):
                 dotfile_content += "\n"
             await loop.run_in_executor(None, file_path.write_text, dotfile_content)

--- a/src/ai/backend/agent/docker/agent.py
+++ b/src/ai/backend/agent/docker/agent.py
@@ -964,7 +964,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
             if bootstrap := self.kernel_config.get("bootstrap_script"):
 
                 def _write_user_bootstrap_script() -> None:
-                    (self.work_dir / "bootstrap.sh").write_text(bootstrap)
+                    (self.work_dir / "bootstrap.sh").write_text(bootstrap.replace("\r\n", "\n"))
                     if ouid is not None or ogid is not None:
                         self._chown_paths_if_root([self.work_dir / "bootstrap.sh"], ouid, ogid)
                     else:
@@ -1069,7 +1069,7 @@ class DockerKernelCreationContext(AbstractKernelCreationContext[DockerKernel]):
                 file_path = self.work_dir / dotfile["path"]
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
-            dotfile_content = dotfile["data"]
+            dotfile_content = dotfile["data"].replace("\r\n", "\n")
             if not dotfile_content.endswith("\n"):
                 dotfile_content += "\n"
             await loop.run_in_executor(None, file_path.write_text, dotfile_content)

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -561,7 +561,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
             if bootstrap := self.kernel_config.get("bootstrap_script"):
 
                 def _write_user_bootstrap_script() -> None:
-                    (self.work_dir / "bootstrap.sh").write_text(bootstrap)
+                    (self.work_dir / "bootstrap.sh").write_text(bootstrap.replace("\r\n", "\n"))
                     if KernelFeatures.UID_MATCH in self.kernel_features:
                         uid = self.local_config.container.kernel_uid
                         gid = self.local_config.container.kernel_gid
@@ -658,7 +658,9 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
             else:
                 file_path = self.work_dir / dotfile["path"]
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            await loop.run_in_executor(None, file_path.write_text, dotfile["data"])
+            await loop.run_in_executor(
+                None, file_path.write_text, dotfile["data"].replace("\r\n", "\n")
+            )
 
             tmp = Path(file_path)
             while tmp != self.work_dir:

--- a/src/ai/backend/agent/kubernetes/agent.py
+++ b/src/ai/backend/agent/kubernetes/agent.py
@@ -58,6 +58,7 @@ from ai.backend.common.dto.agent.response import PurgeImagesResp
 from ai.backend.common.dto.manager.rpc_request import PurgeImagesReq
 from ai.backend.common.events.dispatcher import EventProducer
 from ai.backend.common.plugin.monitor import ErrorPluginContext, StatsPluginContext
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import (
     AutoPullBehavior,
     ClusterInfo,
@@ -561,7 +562,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
             if bootstrap := self.kernel_config.get("bootstrap_script"):
 
                 def _write_user_bootstrap_script() -> None:
-                    (self.work_dir / "bootstrap.sh").write_text(bootstrap.replace("\r\n", "\n"))
+                    (self.work_dir / "bootstrap.sh").write_text(normalize_newlines(bootstrap))
                     if KernelFeatures.UID_MATCH in self.kernel_features:
                         uid = self.local_config.container.kernel_uid
                         gid = self.local_config.container.kernel_gid
@@ -659,7 +660,7 @@ class KubernetesKernelCreationContext(AbstractKernelCreationContext[KubernetesKe
                 file_path = self.work_dir / dotfile["path"]
             file_path.parent.mkdir(parents=True, exist_ok=True)
             await loop.run_in_executor(
-                None, file_path.write_text, dotfile["data"].replace("\r\n", "\n")
+                None, file_path.write_text, normalize_newlines(dotfile["data"])
             )
 
             tmp = Path(file_path)

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/bootstrap.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/bootstrap.py
@@ -66,7 +66,7 @@ class BootstrapProvisioner(Provisioner[BootstrapSpec, BootstrapResult]):
             return None
 
         bootstrap_path = spec.work_dir / "bootstrap.sh"
-        bootstrap_path.write_text(spec.bootstrap_script)
+        bootstrap_path.write_text(spec.bootstrap_script.replace("\r\n", "\n"))
 
         # Set proper ownership
         owner_determiner = PathOwnerDeterminer.by_kernel_features(

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/bootstrap.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/bootstrap.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import override
 
 from ai.backend.common.stage.types import ArgsSpecGenerator, Provisioner, ProvisionStage
+from ai.backend.common.text import normalize_newlines
 
 from .utils import ChownUtil, PathOwnerDeterminer
 
@@ -66,7 +67,7 @@ class BootstrapProvisioner(Provisioner[BootstrapSpec, BootstrapResult]):
             return None
 
         bootstrap_path = spec.work_dir / "bootstrap.sh"
-        bootstrap_path.write_text(spec.bootstrap_script.replace("\r\n", "\n"))
+        bootstrap_path.write_text(normalize_newlines(spec.bootstrap_script))
 
         # Set proper ownership
         owner_determiner = PathOwnerDeterminer.by_kernel_features(

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/dotfiles.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/dotfiles.py
@@ -153,6 +153,7 @@ class DotfilesProvisioner(Provisioner[DotfilesSpec, DotfilesResult]):
         return file_path
 
     def _write_dotfile(self, dotfile_content: str, dotfile_path: Path) -> None:
+        dotfile_content = dotfile_content.replace("\r\n", "\n")
         if not dotfile_content.endswith("\n"):
             dotfile_content += "\n"
         dotfile_path.write_text(dotfile_content)

--- a/src/ai/backend/agent/stage/kernel_lifecycle/docker/dotfiles.py
+++ b/src/ai/backend/agent/stage/kernel_lifecycle/docker/dotfiles.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import override
 
 from ai.backend.common.stage.types import ArgsSpecGenerator, Provisioner, ProvisionStage
+from ai.backend.common.text import normalize_newlines
 
 from .utils import ChownUtil, PathOwnerDeterminer
 
@@ -153,7 +154,7 @@ class DotfilesProvisioner(Provisioner[DotfilesSpec, DotfilesResult]):
         return file_path
 
     def _write_dotfile(self, dotfile_content: str, dotfile_path: Path) -> None:
-        dotfile_content = dotfile_content.replace("\r\n", "\n")
+        dotfile_content = normalize_newlines(dotfile_content)
         if not dotfile_content.endswith("\n"):
             dotfile_content += "\n"
         dotfile_path.write_text(dotfile_content)

--- a/src/ai/backend/common/text.py
+++ b/src/ai/backend/common/text.py
@@ -1,0 +1,3 @@
+def normalize_newlines(text: str) -> str:
+    """Convert CRLF to LF, preserving standalone CR and trailing whitespace."""
+    return text.replace("\r\n", "\n")

--- a/src/ai/backend/manager/data/dotfile/types.py
+++ b/src/ai/backend/manager/data/dotfile/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from ai.backend.common import msgpack
@@ -69,12 +69,14 @@ class DotfileEntries:
             raise DotfileAlreadyExists
         if len(self.entries) >= MAXIMUM_DOTFILE_COUNT:
             raise DotfileCreationFailed("Dotfile creation limit reached")
+        entry = replace(entry, data=entry.data.replace("\r\n", "\n"))
         return DotfileEntries(entries=(*self.entries, entry))
 
     def replaced(self, entry: DotfileEntry) -> DotfileEntries:
         kept = tuple(e for e in self.entries if e.path != entry.path)
         if len(kept) == len(self.entries):
             raise DotfileNotFound
+        entry = replace(entry, data=entry.data.replace("\r\n", "\n"))
         return DotfileEntries(entries=(*kept, entry))
 
     def removed(self, path: str) -> DotfileEntries:

--- a/src/ai/backend/manager/data/dotfile/types.py
+++ b/src/ai/backend/manager/data/dotfile/types.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import enum
 import uuid
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any
 
 from ai.backend.common import msgpack
 from ai.backend.common.dto.manager.config.types import MAXIMUM_DOTFILE_SIZE
+from ai.backend.common.text import normalize_newlines
 from ai.backend.manager.errors.storage import (
     DotfileAlreadyExists,
     DotfileCreationFailed,
@@ -30,6 +31,9 @@ class DotfileEntry:
     path: str
     perm: str
     data: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "data", normalize_newlines(self.data))
 
 
 @dataclass(frozen=True)
@@ -69,14 +73,12 @@ class DotfileEntries:
             raise DotfileAlreadyExists
         if len(self.entries) >= MAXIMUM_DOTFILE_COUNT:
             raise DotfileCreationFailed("Dotfile creation limit reached")
-        entry = replace(entry, data=entry.data.replace("\r\n", "\n"))
         return DotfileEntries(entries=(*self.entries, entry))
 
     def replaced(self, entry: DotfileEntry) -> DotfileEntries:
         kept = tuple(e for e in self.entries if e.path != entry.path)
         if len(kept) == len(self.entries):
             raise DotfileNotFound
-        entry = replace(entry, data=entry.data.replace("\r\n", "\n"))
         return DotfileEntries(entries=(*kept, entry))
 
     def removed(self, path: str) -> DotfileEntries:

--- a/src/ai/backend/manager/data/session/options.py
+++ b/src/ai/backend/manager/data/session/options.py
@@ -16,11 +16,12 @@ from __future__ import annotations
 import enum
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, Protocol
+from typing import Annotated, Any, Protocol
 
-from pydantic import ConfigDict, Field
+from pydantic import AfterValidator, ConfigDict, Field
 
 from ai.backend.common.data.entity.image import ImageID
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import (
     AgentId,
     BackendAISchema,
@@ -326,7 +327,7 @@ class KernelExecutionSpec(_OptionsBaseModel):
             "Command executed after kernel bootstrap. `None` defers to the image's declared CMD."
         ),
     )
-    bootstrap_script: str | None = Field(
+    bootstrap_script: Annotated[str, AfterValidator(normalize_newlines)] | None = Field(
         default=None,
         description=(
             "Shell script executed before `startup_command`. `None` skips the bootstrap step."

--- a/src/ai/backend/manager/models/deployment_revision/creators.py
+++ b/src/ai/backend/manager/models/deployment_revision/creators.py
@@ -15,6 +15,7 @@ from ai.backend.common.data.entity.deployment_revision import DeploymentRevision
 from ai.backend.common.data.entity.image import ImageID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.data.entity.vfolder import VFolderUUID
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import (
     MountInfoEntry,
     MountPermission,
@@ -104,7 +105,11 @@ class DeploymentRevisionCreator(
             cluster_mode=self.cluster_mode,
             cluster_size=self.cluster_size,
             startup_command=self.startup_command,
-            bootstrap_script=self.bootstrap_script,
+            bootstrap_script=(
+                normalize_newlines(self.bootstrap_script)
+                if self.bootstrap_script is not None
+                else None
+            ),
             environ=self.environ,
             callback_url=self.callback_url,
             runtime_variant_id=self.runtime_variant_id,

--- a/src/ai/backend/manager/models/deployment_revision_preset/creators.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/creators.py
@@ -13,6 +13,7 @@ from ai.backend.common.data.entity.image import ImageID
 from ai.backend.common.data.entity.preset_resource_slot import PresetResourceSlotID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import BinarySize
 from ai.backend.manager.data.deployment_revision_preset.types import (
     DeploymentRevisionPresetData,
@@ -107,7 +108,11 @@ class DeploymentPresetCreator(
             cluster_mode=self.cluster_mode,
             cluster_size=self.cluster_size,
             startup_command=self.startup_command,
-            bootstrap_script=self.bootstrap_script,
+            bootstrap_script=(
+                normalize_newlines(self.bootstrap_script)
+                if self.bootstrap_script is not None
+                else None
+            ),
             environ=self.environ,
             preset_values=self.runtime_variant_preset_values,
             open_to_public=self.open_to_public,

--- a/src/ai/backend/manager/models/deployment_revision_preset/updaters.py
+++ b/src/ai/backend/manager/models/deployment_revision_preset/updaters.py
@@ -11,6 +11,7 @@ from ai.backend.common.config import PresetModelDefinition
 from ai.backend.common.data.entity.deployment_preset import DeploymentPresetID
 from ai.backend.common.data.entity.runtime_variant import RuntimeVariantID
 from ai.backend.common.data.model_deployment.types import DeploymentStrategy
+from ai.backend.common.text import normalize_newlines
 from ai.backend.manager.data.deployment_revision_preset.types import DeploymentRevisionPresetData
 from ai.backend.manager.models.base import ResourceOptsEntry
 from ai.backend.manager.models.deployment_revision_preset.row import DeploymentRevisionPresetRow
@@ -95,7 +96,7 @@ class DeploymentPresetUpdater(
         self.cluster_mode.update_dict(to_update, "cluster_mode")
         self.cluster_size.update_dict(to_update, "cluster_size")
         self.startup_command.update_dict(to_update, "startup_command")
-        self.bootstrap_script.update_dict(to_update, "bootstrap_script")
+        self.bootstrap_script.map(normalize_newlines).update_dict(to_update, "bootstrap_script")
         self.environ.update_dict(to_update, "environ")
         # DB column name stays ``preset_values`` (ORM attr unchanged).
         self.runtime_variant_preset_values.update_dict(to_update, "preset_values")

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -417,7 +417,7 @@ class UserService:
     async def update_bootstrap_script(
         self, action: UpdateBootstrapScriptAction
     ) -> UpdateBootstrapScriptActionResult:
-        script = action.script.strip()
+        script = action.script.replace("\r\n", "\n").strip()
         if len(script) > MAXIMUM_DOTFILE_SIZE:
             raise DotfileCreationFailed("Maximum bootstrap script length reached")
         keypair = await self._user_repository.admin_get_keypair(action.access_key)

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -8,6 +8,7 @@ from ai.backend.common.data.entity.keypair import KeyPairID
 from ai.backend.common.dto.manager.config.types import MAXIMUM_DOTFILE_SIZE
 from ai.backend.common.events.event_types.kernel.types import KernelLifecycleEventReason
 from ai.backend.common.exception import InvalidAPIParameters
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import AccessKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
@@ -412,12 +413,12 @@ class UserService:
         self, action: GetBootstrapScriptAction
     ) -> GetBootstrapScriptActionResult:
         keypair = await self._user_repository.admin_get_keypair(action.access_key)
-        return GetBootstrapScriptActionResult(script=keypair.bootstrap_script)
+        return GetBootstrapScriptActionResult(script=normalize_newlines(keypair.bootstrap_script))
 
     async def update_bootstrap_script(
         self, action: UpdateBootstrapScriptAction
     ) -> UpdateBootstrapScriptActionResult:
-        script = action.script.replace("\r\n", "\n").strip()
+        script = normalize_newlines(action.script).strip()
         if len(script) > MAXIMUM_DOTFILE_SIZE:
             raise DotfileCreationFailed("Maximum bootstrap script length reached")
         keypair = await self._user_repository.admin_get_keypair(action.access_key)

--- a/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
+++ b/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from ai.backend.common.clients.valkey_client.valkey_schedule.client import ValkeyScheduleClient
 from ai.backend.common.data.entity.network import NetworkID
 from ai.backend.common.docker import ImageRef
+from ai.backend.common.text import normalize_newlines
 from ai.backend.common.types import (
     AgentId,
     AutoPullBehavior,
@@ -372,7 +373,11 @@ class SessionLauncher:
                         ],
                         "package_directory": tuple(),
                         "idle_timeout": int(idle_timeout),
-                        "bootstrap_script": k.bootstrap_script,
+                        "bootstrap_script": (
+                            normalize_newlines(k.bootstrap_script)
+                            if k.bootstrap_script is not None
+                            else None
+                        ),
                         "startup_command": k.startup_command,
                         "internal_data": k.internal_data,
                         "auto_pull": kernel_image_config.get("auto_pull", AutoPullBehavior.DIGEST),

--- a/src/ai/backend/runner/extract_dotfiles.py
+++ b/src/ai/backend/runner/extract_dotfiles.py
@@ -14,7 +14,7 @@ def extract_dotfiles() -> None:
         file_path = work_dir / dotfile["path"]
         try:
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            file_path.write_text(dotfile["data"])
+            file_path.write_text(dotfile["data"].replace("\r\n", "\n"))
         except OSError:
             print(f"failed to write dotfile: {file_path}", file=sys.stderr)
         try:

--- a/tests/component/config/test_config.py
+++ b/tests/component/config/test_config.py
@@ -238,7 +238,7 @@ class TestBootstrapScript:
         unique = secrets.token_hex(4)
         script_content = f"#!/bin/bash\necho 'hello {unique}'"
         update_result = await admin_registry.config.update_bootstrap_script(
-            UpdateBootstrapScriptRequest(script=script_content)
+            UpdateBootstrapScriptRequest(script=script_content.replace("\n", "\r\n"))
         )
         assert isinstance(update_result, UpdateBootstrapScriptResponse)
         get_result = await admin_registry.config.get_bootstrap_script()

--- a/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
+++ b/tests/component/deployment_revision_preset/test_deployment_revision_preset_crud.py
@@ -102,6 +102,7 @@ class TestDeploymentRevisionPresetCRUD:
                 runtime_variant_id=runtime_variant_id,
                 name="test-preset",
                 description="Test preset",
+                bootstrap_script="if true; then\r\n  echo ok\r\nfi",
                 image_id=ImageID(uuid.uuid4()),
                 resource_slots=[
                     ResourceSlotEntryInput(resource_type="cpu", quantity="4"),
@@ -122,6 +123,7 @@ class TestDeploymentRevisionPresetCRUD:
         get_result = await admin_v2_registry.deployment_revision_preset.get(preset.id)
         assert get_result.id == preset.id
         assert get_result.name == "test-preset"
+        assert get_result.execution.bootstrap_script == "if true; then\n  echo ok\nfi"
 
         await admin_v2_registry.deployment_revision_preset.delete(preset.id)
 
@@ -224,10 +226,12 @@ class TestDeploymentRevisionPresetCRUD:
                 id=preset_id,
                 description="After",
                 rank=50,
+                bootstrap_script="echo first\r\necho last",
             ),
         )
         assert update_result.preset.description == "After"
         assert update_result.preset.rank == 50
+        assert update_result.preset.execution.bootstrap_script == "echo first\necho last"
 
         await admin_v2_registry.deployment_revision_preset.delete(preset_id)
 

--- a/tests/unit/agent/stage/kernel_lifecycle/docker/test_script_line_endings.py
+++ b/tests/unit/agent/stage/kernel_lifecycle/docker/test_script_line_endings.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from ai.backend.agent.stage.kernel_lifecycle.docker.bootstrap import (
+    AgentConfig as BootstrapAgentConfig,
+)
+from ai.backend.agent.stage.kernel_lifecycle.docker.bootstrap import (
+    BootstrapProvisioner,
+    BootstrapSpec,
+)
+from ai.backend.agent.stage.kernel_lifecycle.docker.dotfiles import (
+    AgentConfig as DotfileAgentConfig,
+)
+from ai.backend.agent.stage.kernel_lifecycle.docker.dotfiles import (
+    DotfileInput,
+    DotfilesProvisioner,
+    DotfilesSpec,
+)
+
+
+@pytest.fixture
+def dotfile_spec(tmp_path: Path) -> DotfilesSpec:
+    return DotfilesSpec(
+        dotfiles=[],
+        scratch_dir=tmp_path,
+        work_dir=tmp_path,
+        uid_override=None,
+        gid_override=None,
+        agent_config=DotfileAgentConfig(kernel_features=frozenset(), kernel_uid=0, kernel_gid=0),
+    )
+
+
+@pytest.fixture
+def bootstrap_spec(tmp_path: Path) -> BootstrapSpec:
+    return BootstrapSpec(
+        work_dir=tmp_path,
+        bootstrap_script=None,
+        uid_override=None,
+        gid_override=None,
+        agent_config=BootstrapAgentConfig(kernel_features=frozenset(), kernel_uid=0, kernel_gid=0),
+    )
+
+
+class TestDotfilesProvisioner:
+    async def test_exported_ca_paths_have_no_carriage_return(
+        self, dotfile_spec: DotfilesSpec
+    ) -> None:
+        dotfile_spec.dotfiles = [
+            DotfileInput(
+                path=".bashrc",
+                data=(
+                    'export REQUESTS_CA_BUNDLE="/tmp/ca.crt"\r\n'
+                    'export NODE_EXTRA_CA_CERTS="/tmp/ca.crt"\r\n'
+                    'export SSL_CERT_FILE="/tmp/ca.crt"\r\n'
+                    'export LAST="ok"'
+                ),
+                perm="644",
+            ),
+        ]
+        await DotfilesProvisioner().setup(dotfile_spec)
+
+        process = await asyncio.create_subprocess_exec(
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            'source "$1"; printf "%s\\n" "$REQUESTS_CA_BUNDLE" "$NODE_EXTRA_CA_CERTS" '
+            '"$SSL_CERT_FILE" "$LAST"',
+            "bash",
+            str(dotfile_spec.work_dir / ".bashrc"),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+        assert process.returncode == 0, stderr
+        assert stderr == b""
+        assert stdout == b"/tmp/ca.crt\n/tmp/ca.crt\n/tmp/ca.crt\nok\n"
+
+
+class TestBootstrapProvisioner:
+    async def test_crlf_script_runs_with_sh(self, bootstrap_spec: BootstrapSpec) -> None:
+        bootstrap_spec.bootstrap_script = 'set -e\r\nif true; then\r\n  printf "ok"\r\nfi\r\n'
+        result = await BootstrapProvisioner().setup(bootstrap_spec)
+        assert result.bootstrap_path is not None
+
+        process = await asyncio.create_subprocess_exec(
+            "/bin/sh",
+            str(result.bootstrap_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=10)
+        assert process.returncode == 0, stderr
+        assert stderr == b""
+        assert stdout == b"ok"

--- a/tests/unit/manager/sokovan/scheduler/launcher/conftest.py
+++ b/tests/unit/manager/sokovan/scheduler/launcher/conftest.py
@@ -283,7 +283,9 @@ def _create_session_for_start(
 @pytest.fixture
 def session_for_start_single_kernel() -> SessionDataForStart:
     """Single session with one kernel for starting."""
-    return _create_session_for_start()
+    session = _create_session_for_start()
+    session.kernels[0].bootstrap_script = "if true; then\r\n  echo ok\r\nfi"
+    return session
 
 
 @pytest.fixture

--- a/tests/unit/manager/sokovan/scheduler/launcher/test_launcher.py
+++ b/tests/unit/manager/sokovan/scheduler/launcher/test_launcher.py
@@ -181,6 +181,8 @@ class TestSessionLauncherKernelCreation:
         call_args = mock_client.create_kernels.call_args
         kernel_ids = call_args[0][1]  # Second positional arg
         assert len(kernel_ids) == 1
+        kernel_configs = call_args[0][2]
+        assert kernel_configs[0]["bootstrap_script"] == "if true; then\n  echo ok\nfi"
 
     async def test_multi_kernel_cluster_session(
         self,


### PR DESCRIPTION
## Summary
- Normalize CRLF in `DotfileEntry` so user, group, and domain dotfiles have LF content on write, GET, and session preparation. Existing stored CRLF data becomes usable without a data migration, including when the WebUI resubmits an unchanged GET response.
- Normalize bootstrap scripts in user configuration reads/writes, session and resource-group options, deployment revision/preset writes, and the launcher's final Agent payload. Preserve the distinction between omitted, empty, and null preset updates.
- Share CRLF normalization between Manager and Agent while retaining file-write protection for existing queued kernel data. The standalone runner keeps its equivalent conversion. Standalone CR characters and existing trailing-newline behavior are preserved.

## Test plan
- [x] Run `pants fmt fix lint check test --changed-since=HEAD~1` and the pre-push checks for directly affected targets.
- [x] Verify the bootstrap API round trip, preset create/update, launcher payload, and actual Bash/sh execution with focused regression tests.
- [x] Verify live user/group/domain dotfile configuration, legacy CRLF GET responses without rewriting the stored row, and unchanged resaves.
- [x] Verify preset create/update, omitted and empty values through the CLI, and explicit null through a direct API request.
- [x] Verify that a new session's persisted kernel dotfiles and bootstrap script contain LF before container creation.
- [x] Verify exact file bytes and CA environment values in real Docker sessions; Python Requests/urllib and Node HTTPS succeed against a local test CA, while missing-CA and raw-CRLF controls fail.
- [x] Verify an explicitly supplied CRLF bootstrap executes successfully with `/bin/sh`; clean up temporary sessions and configuration, and check runtime logs and API metrics.

Live container execution was verified on Docker. Kubernetes, the standalone runner, and the complete deployment-revision creation flow were not exercised live. Saved-bootstrap automatic inheritance is outside this change.

Resolves BA-7813
