### PR TITLE
fix(BA-7855): honor the audit-log entity_id filter (#14553)

### DIFF
--- a/changes/14553.fix.md
+++ b/changes/14553.fix.md
@@ -1,0 +1,1 @@
+Fix the v2 audit-log `entity_id` filter, which was silently ignored so that filtering audit logs by entity id returned unfiltered results.

--- a/src/ai/backend/manager/api/adapters/audit_log/adapter.py
+++ b/src/ai/backend/manager/api/adapters/audit_log/adapter.py
@@ -154,6 +154,17 @@ class AuditLogAdapter(BaseAdapter):
             )
             if condition is not None:
                 conditions.append(condition)
+        if f.entity_id is not None:
+            condition = self.convert_string_filter(
+                f.entity_id,
+                contains_factory=AuditLogConditions.by_entity_id_contains,
+                equals_factory=AuditLogConditions.by_entity_id_equals,
+                starts_with_factory=AuditLogConditions.by_entity_id_starts_with,
+                ends_with_factory=AuditLogConditions.by_entity_id_ends_with,
+                in_factory=AuditLogConditions.by_entity_id_in,
+            )
+            if condition is not None:
+                conditions.append(condition)
         if f.operation is not None:
             condition = self.convert_string_filter(
                 f.operation,

--- a/src/ai/backend/manager/repositories/audit_log/options.py
+++ b/src/ai/backend/manager/repositories/audit_log/options.py
@@ -82,6 +82,62 @@ class AuditLogConditions:
 
     by_entity_type_in = staticmethod(make_string_in_factory(AuditLogRow.entity_type))
 
+    # --- entity_id string filters ---
+
+    @staticmethod
+    def by_entity_id_contains(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AuditLogRow.entity_id.ilike(f"%{spec.value}%")
+            else:
+                condition = AuditLogRow.entity_id.like(f"%{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_entity_id_equals(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = sa.func.lower(AuditLogRow.entity_id) == spec.value.lower()
+            else:
+                condition = AuditLogRow.entity_id == spec.value
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_entity_id_starts_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AuditLogRow.entity_id.ilike(f"{spec.value}%")
+            else:
+                condition = AuditLogRow.entity_id.like(f"{spec.value}%")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    @staticmethod
+    def by_entity_id_ends_with(spec: StringMatchSpec) -> QueryCondition:
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            if spec.case_insensitive:
+                condition = AuditLogRow.entity_id.ilike(f"%{spec.value}")
+            else:
+                condition = AuditLogRow.entity_id.like(f"%{spec.value}")
+            if spec.negated:
+                condition = sa.not_(condition)
+            return condition
+
+        return inner
+
+    by_entity_id_in = staticmethod(make_string_in_factory(AuditLogRow.entity_id))
+
     # --- operation string filters ---
 
     @staticmethod

--- a/tests/unit/manager/api/audit_log/BUILD
+++ b/tests/unit/manager/api/audit_log/BUILD
@@ -1,0 +1,3 @@
+python_tests(
+    name="tests",
+)

--- a/tests/unit/manager/api/audit_log/test_adapter.py
+++ b/tests/unit/manager/api/audit_log/test_adapter.py
@@ -1,0 +1,32 @@
+"""Tests for the audit log adapter's DTO-filter conversion."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ai.backend.common.dto.manager.query import StringFilter
+from ai.backend.common.dto.manager.v2.audit_log.request import AuditLogFilter
+from ai.backend.manager.api.adapters.audit_log.adapter import AuditLogAdapter
+
+
+def _make_adapter() -> AuditLogAdapter:
+    return AuditLogAdapter(MagicMock())
+
+
+class TestAuditLogAdapterConvertFilter:
+    def test_empty_filter_produces_no_conditions(self) -> None:
+        conditions = _make_adapter()._convert_filter(AuditLogFilter())
+        assert len(conditions) == 0
+
+    def test_entity_id_filter_produces_one_condition(self) -> None:
+        filter_dto = AuditLogFilter(entity_id=StringFilter(equals="e-1"))
+        conditions = _make_adapter()._convert_filter(filter_dto)
+        assert len(conditions) == 1
+
+    def test_entity_id_and_entity_type_produce_two_conditions(self) -> None:
+        filter_dto = AuditLogFilter(
+            entity_id=StringFilter(equals="e-1"),
+            entity_type=StringFilter(equals="user"),
+        )
+        conditions = _make_adapter()._convert_filter(filter_dto)
+        assert len(conditions) == 2


### PR DESCRIPTION
This is an auto-generated backport of #14553 to the 26.4 release.