### PR TITLE
fix(BA-7858): check a registry URL on create, and check the scheme

### DIFF
--- a/changes/14563.fix.md
+++ b/changes/14563.fix.md
@@ -1,0 +1,1 @@
+Refuse a container registry address that is not an http or https URL, and check it when the registry is created rather than only when it is updated.

--- a/src/ai/backend/manager/models/container_registry/row.py
+++ b/src/ai/backend/manager/models/container_registry/row.py
@@ -67,14 +67,17 @@ class ContainerRegistryValidator:
         self._project = args.project
 
     def _is_valid_url(self, url: str) -> bool:
+        """Whether the address names an http or https host.
+
+        The scheme is part of what is checked. Prepending one to an address that
+        carries another turned `ftp://reg.example` into a host named `ftp:` and let
+        it through, which the error this raises never claimed.
+        """
         try:
-            url = url.strip()
-            if not url.startswith("http://") and not url.startswith("https://"):
-                url = "http://" + url
-            result = urlparse(url)
-            return all([result.scheme, result.netloc])
+            result = urlparse(url.strip())
         except Exception:
             return False
+        return result.scheme in ("http", "https") and bool(result.netloc)
 
     def validate(self) -> None:
         """

--- a/src/ai/backend/manager/repositories/container_registry/repository.py
+++ b/src/ai/backend/manager/repositories/container_registry/repository.py
@@ -63,7 +63,19 @@ class ContainerRegistryRepository:
         self,
         creator: ContainerRegistryCreator,
     ) -> ContainerRegistryData:
-        """Create a container registry with its own virtual entity."""
+        """Create a container registry with its own virtual entity.
+
+        The address and the project are checked here as they are on the update path.
+        Checking only there let a registry be created with an address its own update
+        would refuse.
+        """
+        ContainerRegistryValidator(
+            ContainerRegistryValidatorArgs(
+                type=creator.type,
+                project=creator.project,
+                url=creator.url,
+            )
+        ).validate()
         async with self._ops_provider.write_ops() as w:
             return await w.create_global_entity(creator)
 


### PR DESCRIPTION
Found while writing the container registry scenarios (#14519).

## Summary
- `ContainerRegistryValidator` ran only on update, so a registry could be created with an address its own update would refuse. It now runs on the create path too.
- The check looked narrower than its error said. An address starting with neither `http://` nor `https://` had `http://` prepended before parsing, so the host came out non-empty and the address passed. The scheme is now part of what is checked.

## What changes for a caller

| Address | Before | After |
|---|---|---|
| `https://reg.example.com` | accepted | accepted |
| `ftp://reg.example.com` | accepted (host parsed as `ftp:`) | refused |
| `not a url` | accepted (host parsed as `not a url`) | refused |
| `reg.example.com` | accepted | **refused** |
| `http://` | refused | refused |

## Decide this one deliberately
The fourth row is the one to look at. A bare host with no scheme used to pass, because the check prepended one before parsing while the stored value kept none. It is now refused, so:

- A row that already holds a bare host or a non-http address is refused the next time it is updated, until its address is corrected.
- If accepting a bare host is wanted, the fix is to normalise it at the write rather than at the check, so what is stored is what was validated. That is a different change and I have not made it here.

Resolves BA-7858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TYyokzEfpr9AF2NnHtyXB