### PR TITLE
fix(BA-7859): read the cursor arguments the registry search advertises

### DIFF
--- a/changes/14564.fix.md
+++ b/changes/14564.fix.md
@@ -1,0 +1,1 @@
+Page the container registry search with a cursor: first/after and last/before are read rather than dropped, and naming a cursor and a limit at once is refused.

--- a/src/ai/backend/manager/api/adapters/container_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/container_registry/adapter.py
@@ -25,6 +25,7 @@ from ai.backend.common.dto.manager.v2.container_registry.response import (
     UpdateContainerRegistryPayload,
 )
 from ai.backend.common.dto.manager.v2.container_registry.types import ContainerRegistryTypeFilter
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.container_registry.types import ContainerRegistryData
 from ai.backend.manager.errors.image import ContainerRegistryGroupsAssociationNotFound
@@ -36,6 +37,7 @@ from ai.backend.manager.models.container_registry.creators import (
     ContainerRegistryProjectCreator,
 )
 from ai.backend.manager.models.container_registry.orders import (
+    DEFAULT_BACKWARD_ORDER,
     DEFAULT_FORWARD_ORDER,
     TIEBREAKER_ORDER,
     resolve_order,
@@ -66,7 +68,16 @@ from ai.backend.manager.services.rbac.actions.relation.purge import PurgeRelatio
 from ai.backend.manager.services.rbac.processors import RbacProcessors
 from ai.backend.manager.types import OptionalState, TriState
 
-DEFAULT_PAGINATION_LIMIT = 10
+
+def _pagination_spec() -> PaginationSpec:
+    """How a page of registries is cut, in either mode. The order runs by id."""
+    return PaginationSpec(
+        forward_order=DEFAULT_FORWARD_ORDER,
+        backward_order=DEFAULT_BACKWARD_ORDER,
+        forward_condition_factory=ContainerRegistryConditions.by_cursor_forward,
+        backward_condition_factory=ContainerRegistryConditions.by_cursor_backward,
+        tiebreaker_order=TIEBREAKER_ORDER,
+    )
 
 
 class ContainerRegistryAdapter(BaseAdapter):
@@ -237,13 +248,25 @@ class ContainerRegistryAdapter(BaseAdapter):
         return DeleteContainerRegistryPayload(id=input.id)
 
     def build_querier(self, input: AdminSearchContainerRegistriesInput) -> BatchQuerier:
-        """Build a BatchQuerier from the search input DTO."""
-        conditions = self._convert_filter(input.filter) if input.filter else []
-        orders = self._convert_orders(input.order) if input.order else [DEFAULT_FORWARD_ORDER]
-        orders.append(TIEBREAKER_ORDER)
-        pagination = self._build_pagination(input)
+        """Build a BatchQuerier from the search input DTO.
 
-        return BatchQuerier(conditions=conditions, orders=orders, pagination=pagination)
+        Both pagination modes the request type carries are read here. Reading only
+        the offset pair dropped a caller's cursor without saying so.
+        """
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
 
     def _convert_filter(self, filter: ContainerRegistryFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
@@ -298,13 +321,6 @@ class ContainerRegistryAdapter(BaseAdapter):
     @staticmethod
     def _convert_orders(order: list[ContainerRegistryOrder]) -> list[QueryOrder]:
         return [resolve_order(o.field, o.direction) for o in order]
-
-    @staticmethod
-    def _build_pagination(input: AdminSearchContainerRegistriesInput) -> OffsetPagination:
-        return OffsetPagination(
-            limit=input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT,
-            offset=input.offset if input.offset is not None else 0,
-        )
 
     async def batch_load_by_ids(
         self, ids: Sequence[ContainerRegistryID]

--- a/src/ai/backend/manager/models/container_registry/conditions.py
+++ b/src/ai/backend/manager/models/container_registry/conditions.py
@@ -19,6 +19,26 @@ class ContainerRegistryConditions:
     """Query conditions for container registries."""
 
     @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Rows after the cursor in the default order, which runs by id descending."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ContainerRegistryRow.id < cursor_uuid
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Rows before the cursor, read in the order that walks back to it."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ContainerRegistryRow.id > cursor_uuid
+
+        return inner
+
+    @staticmethod
     def by_ids(registry_ids: Collection[uuid.UUID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ContainerRegistryRow.id.in_(registry_ids)


### PR DESCRIPTION
Found while writing the container registry scenarios (#14519).

## Summary
- `AdminSearchContainerRegistriesInput` documents two pagination modes and carries `first`, `after`, `last` and `before`, but the adapter assembled offset pagination by hand and read only `limit` and `offset`. A caller paging with a cursor was served the first page again, with no error.
- The search now builds its querier through the shared builder, so it reads both modes and refuses a request naming two at once — the same answer the image search already gives.
- Adds the two cursor conditions the entity lacked. They compare ids, which is what its default order runs on.

## What changes for a caller
| Request | Before | After |
|---|---|---|
| `limit` / `offset` | a page | unchanged |
| neither | first ten | unchanged — the shared builder uses the same ten |
| `first` / `after` | **first page again, silently** | walks the list |
| `first` **and** `limit` | first page, cursor ignored | refused as `InvalidGraphQLParameters` |

The last row is a behaviour change for anyone who was sending both and relying on the cursor being dropped. Sending both has never meant anything, so I read it as worth refusing rather than guessing, which is the rule the other searches already follow.

Resolves BA-7859

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TYyokzEfpr9AF2NnHtyXB