### PR TITLE
test(BA-7860): add the adding_with_nested seeder entry

### DIFF
--- a/changes/14566.test.md
+++ b/changes/14566.test.md
@@ -1,0 +1,1 @@
+Add an `adding_with_nested` entry to the scenario-test seeder, laying a field row and the rows it owns in one write.

--- a/tests/scenario/AGENTS.md
+++ b/tests/scenario/AGENTS.md
@@ -37,9 +37,11 @@
 
 ## 행을 심는 법
 
-- 행은 src의 write spec으로만 만든다. `Seeder`의 입구 다섯 — `creating`, `provisioning`,
-  `adding`, `linking`, `granting` — 외에 데이터베이스를 건드리지 않는다. 앞 행을 읽는 seed는
-  읽는 개수만큼의 입구(`creating_from`, `creating_from_two`, `creating_from_three`)를 쓴다.
+- 행은 src의 write spec으로만 만든다. `Seeder`의 입구 여섯 — `creating`, `provisioning`,
+  `adding`, `adding_with_nested`, `linking`, `granting` — 외에 데이터베이스를 건드리지
+  않는다. `adding_with_nested`는 필드 행과 그것이 소유하는 행(감사 기록과 그 스코프 행처럼)을
+  한 쓰기로 심는다. 앞 행을 읽는 seed는 읽는 개수만큼의 입구(`creating_from`,
+  `creating_from_two`, `creating_from_three`)를 쓴다.
 - seed 하나는 클래스 하나다. `SeedRow` 계열을 구현해 자기가 무엇인지(`kind`), 무엇을
   세워두는지(`detail`), 어떤 이름으로 들어가는지(`name`), 무엇을 쓰는지(`seed`)를 답한다.
 - 이름을 매니저가 못박은 행은 `name`이 그 이름을 답한다. 시더가 붙이는 번호를 받지 않는다.

--- a/tests/scenario/bai_scenario/runner/planting.py
+++ b/tests/scenario/bai_scenario/runner/planting.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from ai.backend.common.data.entity.types import FieldData
-from ai.backend.testutils.scenario_steps import Told
 from bai_scenario.seeds.ops import SeedOps
 from bai_scenario.seeds.seeder import (
     Laid,
@@ -28,6 +26,9 @@ from bai_scenario.seeds.seeder import (
     SeedRowFromTwo,
     lay,
 )
+
+from ai.backend.common.data.entity.types import FieldData
+from ai.backend.testutils.scenario_steps import Told
 
 
 class SeedingSession:

--- a/tests/scenario/bai_scenario/runner/planting.py
+++ b/tests/scenario/bai_scenario/runner/planting.py
@@ -104,9 +104,9 @@ class SeedingSession:
     async def adding[A, D: FieldData](self, one: SeedField[A, D], owner: Laid[A], /) -> Laid[D]:
         return await self._settle(self._seed.adding(one, owner))
 
-    async def adding_with_nested[Owner, FieldDataT: FieldData](
-        self, one: SeedFieldWithNestedRows[Owner, FieldDataT], owner: Laid[Owner], /
-    ) -> Laid[FieldDataT]:
+    async def adding_with_nested[A, D: FieldData](
+        self, one: SeedFieldWithNestedRows[A, D], owner: Laid[A], /
+    ) -> Laid[D]:
         return await self._settle(self._seed.adding_with_nested(one, owner))
 
     async def linking[S, T](

--- a/tests/scenario/bai_scenario/runner/planting.py
+++ b/tests/scenario/bai_scenario/runner/planting.py
@@ -17,7 +17,7 @@ from bai_scenario.seeds.seeder import (
     Laid,
     Seeder,
     SeedField,
-    SeedFieldWithNested,
+    SeedFieldWithNestedRows,
     SeedLink,
     SeedNest,
     SeedRow,
@@ -105,7 +105,7 @@ class SeedingSession:
         return await self._settle(self._seed.adding(one, owner))
 
     async def adding_with_nested[Owner, FieldDataT: FieldData](
-        self, one: SeedFieldWithNested[Owner, FieldDataT], owner: Laid[Owner], /
+        self, one: SeedFieldWithNestedRows[Owner, FieldDataT], owner: Laid[Owner], /
     ) -> Laid[FieldDataT]:
         return await self._settle(self._seed.adding_with_nested(one, owner))
 

--- a/tests/scenario/bai_scenario/runner/planting.py
+++ b/tests/scenario/bai_scenario/runner/planting.py
@@ -19,6 +19,7 @@ from bai_scenario.seeds.seeder import (
     Laid,
     Seeder,
     SeedField,
+    SeedFieldWithNested,
     SeedLink,
     SeedNest,
     SeedRow,
@@ -101,6 +102,11 @@ class SeedingSession:
 
     async def adding[A, D: FieldData](self, one: SeedField[A, D], owner: Laid[A], /) -> Laid[D]:
         return await self._settle(self._seed.adding(one, owner))
+
+    async def adding_with_nested[Owner, FieldDataT: FieldData](
+        self, one: SeedFieldWithNested[Owner, FieldDataT], owner: Laid[Owner], /
+    ) -> Laid[FieldDataT]:
+        return await self._settle(self._seed.adding_with_nested(one, owner))
 
     async def linking[S, T](
         self, one: SeedLink[S, T], scope: Laid[S], target: Laid[T], /

--- a/tests/scenario/bai_scenario/seeds/seeder.py
+++ b/tests/scenario/bai_scenario/seeds/seeder.py
@@ -125,7 +125,7 @@ class SeedUser[A, B, C](Seed, ABC):
         raise NotImplementedError
 
 
-class SeedFieldWithNestedRows[Owner, FieldDataT: FieldData](ABC):
+class SeedFieldWithNestedRows[A, D: FieldData](ABC):
     """A field row together with the rows it owns, written in one transaction.
 
     A monitor that records a scope action writes the record and its scope rows atomically;
@@ -139,11 +139,11 @@ class SeedFieldWithNestedRows[Owner, FieldDataT: FieldData](ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def owner_id(self, owner: Owner) -> Any:
+    def owner_id(self, owner: A) -> Any:
         raise NotImplementedError
 
     @abstractmethod
-    def field(self) -> FieldCreator[Any, Any, FieldDataT]:
+    def field(self) -> FieldCreator[Any, Any, D]:
         raise NotImplementedError
 
     @abstractmethod
@@ -410,9 +410,9 @@ class Seeder:
             )
         )
 
-    def adding_with_nested[Owner, FieldDataT: FieldData](
-        self, seed: SeedFieldWithNestedRows[Owner, FieldDataT], owner: Laid[Owner], /
-    ) -> Laid[FieldDataT]:
+    def adding_with_nested[A, D: FieldData](
+        self, seed: SeedFieldWithNestedRows[A, D], owner: Laid[A], /
+    ) -> Laid[D]:
         """Lay one field row and the rows it owns, in the one write a monitor uses."""
 
         async def write(ops: SeedOps, values: Sequence[Any]) -> Any:

--- a/tests/scenario/bai_scenario/seeds/seeder.py
+++ b/tests/scenario/bai_scenario/seeds/seeder.py
@@ -125,7 +125,7 @@ class SeedUser[A, B, C](Seed, ABC):
         raise NotImplementedError
 
 
-class SeedFieldWithNested[Owner, FieldDataT: FieldData](ABC):
+class SeedFieldWithNestedRows[Owner, FieldDataT: FieldData](ABC):
     """A field row together with the rows it owns, written in one transaction.
 
     A monitor that records a scope action writes the record and its scope rows atomically;
@@ -411,7 +411,7 @@ class Seeder:
         )
 
     def adding_with_nested[Owner, FieldDataT: FieldData](
-        self, seed: SeedFieldWithNested[Owner, FieldDataT], owner: Laid[Owner], /
+        self, seed: SeedFieldWithNestedRows[Owner, FieldDataT], owner: Laid[Owner], /
     ) -> Laid[FieldDataT]:
         """Lay one field row and the rows it owns, in the one write a monitor uses."""
 

--- a/tests/scenario/bai_scenario/seeds/seeder.py
+++ b/tests/scenario/bai_scenario/seeds/seeder.py
@@ -31,8 +31,10 @@ from ai.backend.common.data.entity.user import UserID
 from ai.backend.manager.data.user.types import UserData
 from ai.backend.manager.models.specs.creator import (
     FieldCreator,
+    FieldToCreate,
     GlobalEntityCreator,
     GuardedEntityCreator,
+    NestedFieldCreator,
     RoleManagedEntityCreator,
     RoleManagedGlobalEntityCreator,
 )
@@ -123,13 +125,39 @@ class SeedUser[A, B, C](Seed, ABC):
         raise NotImplementedError
 
 
+class SeedFieldWithNested[Owner, FieldDataT: FieldData](ABC):
+    """A field row together with the rows it owns, written in one transaction.
+
+    A monitor that records a scope action writes the record and its scope rows atomically;
+    a seed that lays such a record takes that whole write rather than splitting it. Like
+    :class:`SeedField`, the row's name and report line come from the owner it is laid under.
+    """
+
+    @abstractmethod
+    def kind(self) -> str:
+        """이 필드를 가진 주인이 무엇을 할 수 있게 되는지."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def owner_id(self, owner: Owner) -> Any:
+        raise NotImplementedError
+
+    @abstractmethod
+    def field(self) -> FieldCreator[Any, Any, FieldDataT]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def nested(self) -> Sequence[NestedFieldCreator[Any, Any, Any]]:
+        raise NotImplementedError
+
+
 class SeedNest[D](ABC):
     """seed 여러 개를 함께 심어 전제 하나를 준비한다.
 
     단위가 행 하나가 아니라 "폴더를 만들 수 있는 사용자" 같은 전제다. 무엇을 준비하는지는
     ``kind``가 말하고, 어떤 seed와 어떤 nest를 딛는지는 ``lay`` 안이 보여준다.
 
-    ``Seeder``를 받지만 그 다섯 입구가 전부 seed 객체를 요구하므로, nest가 행을 직접 쓰는
+    ``Seeder``를 받지만 그 입구가 전부 seed 객체를 요구하므로, nest가 행을 직접 쓰는
     길은 없다.
     """
 
@@ -369,6 +397,30 @@ class Seeder:
 
         async def write(ops: SeedOps, values: Sequence[Any]) -> Any:
             return await ops.create_field(seed.owner_id(values[0]), seed.seed())
+
+        return self._remember(
+            Laid(
+                name=owner.name,
+                kind=owner.kind,
+                nest=tuple(self._nesting),
+                describe=f"{owner.describe}({seed.kind()})",
+                states=f"{owner.describe}: {seed.kind()}",
+                sources=(owner,),
+                write=write,
+            )
+        )
+
+    def adding_with_nested[Owner, FieldDataT: FieldData](
+        self, seed: SeedFieldWithNested[Owner, FieldDataT], owner: Laid[Owner], /
+    ) -> Laid[FieldDataT]:
+        """Lay one field row and the rows it owns, in the one write a monitor uses."""
+
+        async def write(ops: SeedOps, values: Sequence[Any]) -> Any:
+            created = await ops.atomic_create_fields_with_nested(
+                [FieldToCreate(owner_id=seed.owner_id(values[0]), creator=seed.field())],
+                list(seed.nested()),
+            )
+            return created[0]
 
         return self._remember(
             Laid(


### PR DESCRIPTION
## Summary
- Add a sixth `Seeder` entry point to the scenario kit — `adding_with_nested` — that lays one field row and the rows it owns in a single `atomic_create_fields_with_nested` write, the same write a scope-action audit monitor uses.
- `SeedFieldWithNested` in `seeds/seeder.py`, the `SeedingSession` wrapper in `runner/planting.py`, and the sixth entry listed in `tests/scenario/AGENTS.md`.

Split out as a framework precursor so an entity scenario PR does not touch the shared seeder. First consumer is the audit-log scope-tag scenario under BA-7807 (#14506), which stays uncovered until this lands.

Resolves BA-7860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QM7T3buh1thJkiXFELHRgE