### PR TITLE
fix(BA-7813): normalize CRLF line endings in bootstrap scripts and dotfiles (#14554)

### DIFF
--- a/changes/14554.fix.md
+++ b/changes/14554.fix.md
@@ -1,0 +1,1 @@
+Normalize CRLF line endings in bootstrap scripts and dotfiles so they no longer break commands and environment variables inside session containers.

--- a/src/ai/backend/manager/data/dotfile/types.py
+++ b/src/ai/backend/manager/data/dotfile/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +14,13 @@ class DotfileScope(enum.StrEnum):
 
 
 DotfileEntityKey = str | uuid.UUID
+
+_CR_LINE_BREAK = re.compile(r"\r\n?")
+
+
+def normalize_newlines(text: str) -> str:
+    """Convert CRLF and lone CR line breaks to LF."""
+    return _CR_LINE_BREAK.sub("\n", text)
 
 
 @dataclass(frozen=True)
@@ -55,7 +63,8 @@ class DotfileBundle:
         result: dict[str, Any] = {}
         if self.dotfiles:
             result["dotfiles"] = [
-                {"path": e.path, "perm": e.perm, "data": e.data} for e in self.dotfiles
+                {"path": e.path, "perm": e.perm, "data": normalize_newlines(e.data)}
+                for e in self.dotfiles
             ]
         if self.ssh_keypair is not None:
             result["ssh_keypair"] = {

--- a/src/ai/backend/manager/services/dotfile/service.py
+++ b/src/ai/backend/manager/services/dotfile/service.py
@@ -7,7 +7,11 @@ from typing import Final
 from ai.backend.common import msgpack
 from ai.backend.common.dto.manager.config.types import MAXIMUM_DOTFILE_SIZE
 from ai.backend.logging.utils import BraceStyleAdapter
-from ai.backend.manager.data.dotfile.types import DotfileQueryResult, DotfileScope
+from ai.backend.manager.data.dotfile.types import (
+    DotfileQueryResult,
+    DotfileScope,
+    normalize_newlines,
+)
 from ai.backend.manager.errors.api import InvalidAPIParameters
 from ai.backend.manager.errors.resource import DomainNotFound, ProjectNotFound
 from ai.backend.manager.errors.storage import (
@@ -160,7 +164,7 @@ class DotfileService:
         self, action: UpdateBootstrapScriptAction
     ) -> UpdateBootstrapScriptActionResult:
         """Update a user's bootstrap script."""
-        script = action.script.strip()
+        script = normalize_newlines(action.script).strip()
         if len(script) > MAXIMUM_DOTFILE_SIZE:
             raise DotfileCreationFailed("Maximum bootstrap script length reached")
         await self._repository.save_bootstrap_script(action.access_key, script)

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -10,6 +10,10 @@ from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
+<<<<<<< HEAD
+=======
+from ai.backend.manager.data.dotfile.types import DotfileEntries, normalize_newlines
+>>>>>>> 7cb399f0 (fix(BA-7813): normalize CRLF line endings in bootstrap scripts and dotfiles (#14554))
 from ai.backend.manager.data.user.types import (
     BulkPurgeError,
     BulkUserPurgeResultData,
@@ -574,3 +578,60 @@ class UserService:
             access_key=action.access_key,
             ssh_public_key=ssh_public_key,
         )
+<<<<<<< HEAD
+=======
+
+    async def create_dotfile(
+        self, action: CreateKeypairDotfileAction
+    ) -> CreateKeypairDotfileActionResult:
+        if not verify_dotfile_name(action.entry.path):
+            raise InvalidAPIParameters("dotfile path is reserved for internal operations.")
+        keypair_id, current = await self._read_dotfiles(action.access_key)
+        entries = current.added(action.entry)
+        await self._write_dotfiles(keypair_id, entries)
+        return CreateKeypairDotfileActionResult(entries=entries.entries)
+
+    async def update_dotfile(
+        self, action: UpdateKeypairDotfileAction
+    ) -> UpdateKeypairDotfileActionResult:
+        keypair_id, current = await self._read_dotfiles(action.access_key)
+        entries = current.replaced(action.entry)
+        await self._write_dotfiles(keypair_id, entries)
+        return UpdateKeypairDotfileActionResult(entries=entries.entries)
+
+    async def delete_dotfile(
+        self, action: DeleteKeypairDotfileAction
+    ) -> DeleteKeypairDotfileActionResult:
+        keypair_id, current = await self._read_dotfiles(action.access_key)
+        entries = current.removed(action.path)
+        await self._write_dotfiles(keypair_id, entries)
+        return DeleteKeypairDotfileActionResult(entries=entries.entries)
+
+    async def get_bootstrap_script(
+        self, action: GetBootstrapScriptAction
+    ) -> GetBootstrapScriptActionResult:
+        keypair = await self._user_repository.admin_get_keypair(action.access_key)
+        return GetBootstrapScriptActionResult(script=keypair.bootstrap_script)
+
+    async def update_bootstrap_script(
+        self, action: UpdateBootstrapScriptAction
+    ) -> UpdateBootstrapScriptActionResult:
+        script = normalize_newlines(action.script).strip()
+        if len(script) > MAXIMUM_DOTFILE_SIZE:
+            raise DotfileCreationFailed("Maximum bootstrap script length reached")
+        keypair = await self._user_repository.admin_get_keypair(action.access_key)
+        await self._user_repository.update_keypair_column(
+            KeypairBootstrapScriptUpdater(keypair_id=keypair.id, script=script)
+        )
+        return UpdateBootstrapScriptActionResult()
+
+    async def _read_dotfiles(self, access_key: AccessKey) -> tuple[KeyPairID, DotfileEntries]:
+        """The keypair's id alongside its entries, so the write keys on the row it read."""
+        keypair = await self._user_repository.admin_get_keypair(access_key)
+        return keypair.id, DotfileEntries.unpack(keypair.dotfiles)
+
+    async def _write_dotfiles(self, keypair_id: KeyPairID, entries: DotfileEntries) -> None:
+        await self._user_repository.update_keypair_column(
+            KeypairDotfilesUpdater(keypair_id=keypair_id, dotfiles=entries.pack())
+        )
+>>>>>>> 7cb399f0 (fix(BA-7813): normalize CRLF line endings in bootstrap scripts and dotfiles (#14554))

--- a/src/ai/backend/manager/services/user/service.py
+++ b/src/ai/backend/manager/services/user/service.py
@@ -10,10 +10,6 @@ from ai.backend.common.identifier.user import UserID
 from ai.backend.common.types import AccessKey
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.storage_proxy.session_manager import StorageSessionManager
-<<<<<<< HEAD
-=======
-from ai.backend.manager.data.dotfile.types import DotfileEntries, normalize_newlines
->>>>>>> 7cb399f0 (fix(BA-7813): normalize CRLF line endings in bootstrap scripts and dotfiles (#14554))
 from ai.backend.manager.data.user.types import (
     BulkPurgeError,
     BulkUserPurgeResultData,
@@ -578,60 +574,3 @@ class UserService:
             access_key=action.access_key,
             ssh_public_key=ssh_public_key,
         )
-<<<<<<< HEAD
-=======
-
-    async def create_dotfile(
-        self, action: CreateKeypairDotfileAction
-    ) -> CreateKeypairDotfileActionResult:
-        if not verify_dotfile_name(action.entry.path):
-            raise InvalidAPIParameters("dotfile path is reserved for internal operations.")
-        keypair_id, current = await self._read_dotfiles(action.access_key)
-        entries = current.added(action.entry)
-        await self._write_dotfiles(keypair_id, entries)
-        return CreateKeypairDotfileActionResult(entries=entries.entries)
-
-    async def update_dotfile(
-        self, action: UpdateKeypairDotfileAction
-    ) -> UpdateKeypairDotfileActionResult:
-        keypair_id, current = await self._read_dotfiles(action.access_key)
-        entries = current.replaced(action.entry)
-        await self._write_dotfiles(keypair_id, entries)
-        return UpdateKeypairDotfileActionResult(entries=entries.entries)
-
-    async def delete_dotfile(
-        self, action: DeleteKeypairDotfileAction
-    ) -> DeleteKeypairDotfileActionResult:
-        keypair_id, current = await self._read_dotfiles(action.access_key)
-        entries = current.removed(action.path)
-        await self._write_dotfiles(keypair_id, entries)
-        return DeleteKeypairDotfileActionResult(entries=entries.entries)
-
-    async def get_bootstrap_script(
-        self, action: GetBootstrapScriptAction
-    ) -> GetBootstrapScriptActionResult:
-        keypair = await self._user_repository.admin_get_keypair(action.access_key)
-        return GetBootstrapScriptActionResult(script=keypair.bootstrap_script)
-
-    async def update_bootstrap_script(
-        self, action: UpdateBootstrapScriptAction
-    ) -> UpdateBootstrapScriptActionResult:
-        script = normalize_newlines(action.script).strip()
-        if len(script) > MAXIMUM_DOTFILE_SIZE:
-            raise DotfileCreationFailed("Maximum bootstrap script length reached")
-        keypair = await self._user_repository.admin_get_keypair(action.access_key)
-        await self._user_repository.update_keypair_column(
-            KeypairBootstrapScriptUpdater(keypair_id=keypair.id, script=script)
-        )
-        return UpdateBootstrapScriptActionResult()
-
-    async def _read_dotfiles(self, access_key: AccessKey) -> tuple[KeyPairID, DotfileEntries]:
-        """The keypair's id alongside its entries, so the write keys on the row it read."""
-        keypair = await self._user_repository.admin_get_keypair(access_key)
-        return keypair.id, DotfileEntries.unpack(keypair.dotfiles)
-
-    async def _write_dotfiles(self, keypair_id: KeyPairID, entries: DotfileEntries) -> None:
-        await self._user_repository.update_keypair_column(
-            KeypairDotfilesUpdater(keypair_id=keypair_id, dotfiles=entries.pack())
-        )
->>>>>>> 7cb399f0 (fix(BA-7813): normalize CRLF line endings in bootstrap scripts and dotfiles (#14554))

--- a/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
+++ b/src/ai/backend/manager/sokovan/scheduler/launcher/launcher.py
@@ -31,6 +31,7 @@ from ai.backend.common.types import (
 from ai.backend.logging.utils import BraceStyleAdapter
 from ai.backend.manager.clients.agent import AgentClientPool
 from ai.backend.manager.config.provider import ManagerConfigProvider
+from ai.backend.manager.data.dotfile.types import normalize_newlines
 from ai.backend.manager.defs import START_SESSION_TIMEOUT_SEC
 from ai.backend.manager.exceptions import convert_to_status_data
 from ai.backend.manager.metrics.scheduler import (
@@ -371,7 +372,11 @@ class SessionLauncher:
                         ],
                         "package_directory": tuple(),
                         "idle_timeout": int(idle_timeout),
-                        "bootstrap_script": k.bootstrap_script,
+                        "bootstrap_script": (
+                            normalize_newlines(k.bootstrap_script)
+                            if k.bootstrap_script is not None
+                            else None
+                        ),
                         "startup_command": k.startup_command,
                         "internal_data": k.internal_data,
                         "auto_pull": kernel_image_config.get("auto_pull", AutoPullBehavior.DIGEST),


### PR DESCRIPTION
This is an auto-generated backport of #14554 to the 26.8 release.