### PR TITLE
fix(BA-7859): read the cursor arguments the registry search advertises (#14564)

### DIFF
--- a/changes/14564.fix.md
+++ b/changes/14564.fix.md
@@ -1,0 +1,1 @@
+Page the container registry search with a cursor: first/after and last/before are read rather than dropped, and naming a cursor and a limit at once is refused.

--- a/src/ai/backend/manager/api/adapters/container_registry/adapter.py
+++ b/src/ai/backend/manager/api/adapters/container_registry/adapter.py
@@ -23,12 +23,14 @@ from ai.backend.common.dto.manager.v2.container_registry.response import (
     UpdateContainerRegistryPayload,
 )
 from ai.backend.common.dto.manager.v2.container_registry.types import ContainerRegistryTypeFilter
+from ai.backend.manager.api.adapter_options.pagination.pagination import PaginationSpec
 from ai.backend.manager.api.adapters.base import BaseAdapter
 from ai.backend.manager.data.container_registry.types import ContainerRegistryData
 from ai.backend.manager.models.clauses import QueryCondition, QueryOrder
 from ai.backend.manager.models.container_registry import ContainerRegistryRow
 from ai.backend.manager.models.container_registry.conditions import ContainerRegistryConditions
 from ai.backend.manager.models.container_registry.orders import (
+    DEFAULT_BACKWARD_ORDER,
     DEFAULT_FORWARD_ORDER,
     TIEBREAKER_ORDER,
     resolve_order,
@@ -65,7 +67,16 @@ from ai.backend.manager.services.container_registry.actions.search_container_reg
 )
 from ai.backend.manager.types import OptionalState, TriState
 
-DEFAULT_PAGINATION_LIMIT = 10
+
+def _pagination_spec() -> PaginationSpec:
+    """How a page of registries is cut, in either mode. The order runs by id."""
+    return PaginationSpec(
+        forward_order=DEFAULT_FORWARD_ORDER,
+        backward_order=DEFAULT_BACKWARD_ORDER,
+        forward_condition_factory=ContainerRegistryConditions.by_cursor_forward,
+        backward_condition_factory=ContainerRegistryConditions.by_cursor_backward,
+        tiebreaker_order=TIEBREAKER_ORDER,
+    )
 
 
 class ContainerRegistryAdapter(BaseAdapter):
@@ -195,13 +206,25 @@ class ContainerRegistryAdapter(BaseAdapter):
         return DeleteContainerRegistryPayload(id=input.id)
 
     def build_querier(self, input: AdminSearchContainerRegistriesInput) -> BatchQuerier:
-        """Build a BatchQuerier from the search input DTO."""
-        conditions = self._convert_filter(input.filter) if input.filter else []
-        orders = self._convert_orders(input.order) if input.order else [DEFAULT_FORWARD_ORDER]
-        orders.append(TIEBREAKER_ORDER)
-        pagination = self._build_pagination(input)
+        """Build a BatchQuerier from the search input DTO.
 
-        return BatchQuerier(conditions=conditions, orders=orders, pagination=pagination)
+        Both pagination modes the request type carries are read here. Reading only
+        the offset pair dropped a caller's cursor without saying so.
+        """
+        conditions = self._convert_filter(input.filter) if input.filter else []
+        orders = self._convert_orders(input.order) if input.order else []
+
+        return self._build_querier(
+            conditions=conditions,
+            orders=orders,
+            pagination_spec=_pagination_spec(),
+            first=input.first,
+            after=input.after,
+            last=input.last,
+            before=input.before,
+            limit=input.limit,
+            offset=input.offset,
+        )
 
     def _convert_filter(self, filter: ContainerRegistryFilter) -> list[QueryCondition]:
         conditions: list[QueryCondition] = []
@@ -256,13 +279,6 @@ class ContainerRegistryAdapter(BaseAdapter):
     @staticmethod
     def _convert_orders(order: list[ContainerRegistryOrder]) -> list[QueryOrder]:
         return [resolve_order(o.field, o.direction) for o in order]
-
-    @staticmethod
-    def _build_pagination(input: AdminSearchContainerRegistriesInput) -> OffsetPagination:
-        return OffsetPagination(
-            limit=input.limit if input.limit is not None else DEFAULT_PAGINATION_LIMIT,
-            offset=input.offset if input.offset is not None else 0,
-        )
 
     async def batch_load_by_ids(
         self, ids: Sequence[uuid.UUID]

--- a/src/ai/backend/manager/models/container_registry/conditions.py
+++ b/src/ai/backend/manager/models/container_registry/conditions.py
@@ -19,6 +19,26 @@ class ContainerRegistryConditions:
     """Query conditions for container registries."""
 
     @staticmethod
+    def by_cursor_forward(cursor_id: str) -> QueryCondition:
+        """Rows after the cursor in the default order, which runs by id descending."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ContainerRegistryRow.id < cursor_uuid
+
+        return inner
+
+    @staticmethod
+    def by_cursor_backward(cursor_id: str) -> QueryCondition:
+        """Rows before the cursor, read in the order that walks back to it."""
+        cursor_uuid = uuid.UUID(cursor_id)
+
+        def inner() -> sa.sql.expression.ColumnElement[bool]:
+            return ContainerRegistryRow.id > cursor_uuid
+
+        return inner
+
+    @staticmethod
     def by_ids(registry_ids: Collection[uuid.UUID]) -> QueryCondition:
         def inner() -> sa.sql.expression.ColumnElement[bool]:
             return ContainerRegistryRow.id.in_(registry_ids)


### PR DESCRIPTION
This is an auto-generated backport of #14564 to the 26.8 release.