### PR TITLE
test(BA-7863): run scenario tests against a real Valkey server

### DIFF
--- a/changes/14574.test.md
+++ b/changes/14574.test.md
@@ -1,0 +1,1 @@
+Run the scenario tests against a real Valkey server instead of mocked clients.

--- a/src/ai/backend/testutils/bootstrap.py
+++ b/src/ai/backend/testutils/bootstrap.py
@@ -82,7 +82,7 @@ def _wait_redis_health_check(host: str, port: int, timeout: float = 60.0) -> Non
             continue
 
 
-def _flush_redis(host: str, port: int) -> None:
+def flush_redis(host: str, port: int) -> None:
     with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.connect((host, port))
         s.send(b"*1\r\n$8\r\nFLUSHALL\r\n")
@@ -361,7 +361,7 @@ def redis_container() -> Iterator[tuple[str, HostPortPairModel]]:
             # Extra grace period to avoid intermittent connection failure
             time.sleep(0.5)
         # The previous process in this slot leaves its keys behind.
-        _flush_redis(addr.host, addr.port)
+        flush_redis(addr.host, addr.port)
         yield addr.host, addr
 
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -10,7 +10,7 @@
 | Repository / Model (real DB, `with_tables`) | `tests/unit/{component}/repositories/` |
 | HTTP API layer (real aiohttp server + DB) | `tests/component/{component}/` |
 | E2E user scenarios (Client SDK v2) | `tests/integration/` |
-| One adapter call against a real DB, seeded per scenario | `tests/scenario/` |
+| One adapter call against a real DB and Valkey, seeded per scenario | `tests/scenario/` |
 
 Each directory keeps its setup patterns in its own `AGENTS.md`.
 

--- a/tests/scenario/README.md
+++ b/tests/scenario/README.md
@@ -1,6 +1,6 @@
 # 시나리오 테스트
 
-어댑터 하나를 실제 데이터베이스와 함께 돌려, 요청 하나가 무엇을 답하는지 확인한다.
+어댑터 하나를 실제 데이터베이스와 실제 Valkey와 함께 돌려, 요청 하나가 무엇을 답하는지 확인한다.
 규칙은 `AGENTS.md`, 배경은 `KNOWLEDGE.md`에 있다.
 
 ## 한 행이 어떻게 도는가
@@ -48,7 +48,7 @@ class TheDomainNode(Then[ADomainAndACaller, DomainNode]):
 | `bai_scenario/runner/` | 시나리오 실행과 검사, 픽스처로 심는 자리 |
 | `bai_scenario/setup/` | 공용 셋업이 무엇을 만드는지 확인하는 테스트 |
 | `bai_scenario/fakes/` | 외부 서비스 대역 |
-| `bai_scenario/{db,schema,config,validators,monitors}.py` | 실행 하나가 필요로 하는 것 |
+| `bai_scenario/{db,schema,config,valkey,monitors}.py` | 실행 하나가 필요로 하는 것 |
 
 패키지는 자랄 것에만 둔다. 파일 하나로 끝나는 것은 위 모듈들처럼 평평하게 둔다.
 

--- a/tests/scenario/bai_scenario/config.py
+++ b/tests/scenario/bai_scenario/config.py
@@ -45,9 +45,10 @@ class ScenarioConfigProvider(ManagerConfigProvider):
 
 
 def base_config_dict(
-    db_addr: HostPortPairModel, dbname: str, redis_addr: HostPortPairModel | None
+    db_addr: HostPortPairModel, dbname: str, redis_addr: HostPortPairModel
 ) -> dict[str, Any]:
     raw: dict[str, Any] = {
+        "redis": {"addr": {"host": redis_addr.host, "port": redis_addr.port}},
         "db": {
             "addr": {"host": db_addr.host, "port": db_addr.port},
             "name": dbname,
@@ -73,8 +74,6 @@ def base_config_dict(
             },
         },
     }
-    if redis_addr is not None:
-        raw["redis"] = {"addr": {"host": redis_addr.host, "port": redis_addr.port}}
     return raw
 
 

--- a/tests/scenario/bai_scenario/manager/project/conftest.py
+++ b/tests/scenario/bai_scenario/manager/project/conftest.py
@@ -11,8 +11,8 @@ from typing import Any
 
 import pytest
 from bai_scenario.runner.unwired import unwired
+from bai_scenario.valkey import ScenarioValkey
 
-from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.project import ProjectEntityType
 from ai.backend.common.data.entity.user import UserEntityType
@@ -68,6 +68,7 @@ async def adapter(
     config: ManagerConfigProvider,
     validators: V2ActionValidators,
     monitors: ActionMonitors,
+    valkey: ScenarioValkey,
 ) -> ProjectAdapter:
     provider = V2DBOpsProvider(engine)
     registry: ProcessorRegistry[Any] = ProcessorRegistry(
@@ -81,7 +82,7 @@ async def adapter(
         engine,
         provider,
         config,
-        unwired(ValkeyStatClient, "only usage reads reach it"),
+        valkey.stat,
         unwired(StorageSessionManager, "only folder work reaches it"),
     )
     project = ProjectProcessors(
@@ -89,7 +90,7 @@ async def adapter(
         ProjectService(
             unwired(StorageSessionManager, "only folder work reaches it"),
             config,
-            unwired(ValkeyStatClient, "only usage reads reach it"),
+            valkey.stat,
             ProjectRepositories(project_repository),
         ),
     )
@@ -112,7 +113,7 @@ async def adapter(
         registry.group(GroupMeta(UserEntityType())),
         UserService(
             unwired(StorageSessionManager, "only folder work reaches it"),
-            unwired(ValkeyStatClient, "only usage reads reach it"),
+            valkey.stat,
             unwired(AgentRegistry, "only session work reaches the agents"),
             UserRepository(
                 engine,

--- a/tests/scenario/bai_scenario/manager/session/conftest.py
+++ b/tests/scenario/bai_scenario/manager/session/conftest.py
@@ -1,8 +1,8 @@
 """The session adapter, assembled for one row.
 
 A session read answers through a service whose constructor demands eleven dependencies.
-Ten of them are named unwired here, so a row that reaches one fails saying which rather
-than passing against a mock that answered on its own.
+Three of them run against the real database and the real Valkey server; the other eight
+are named unwired, so a row that reaches one fails saying which.
 """
 
 from __future__ import annotations
@@ -17,10 +17,9 @@ from bai_scenario.fakes.storage_proxy import (
     FakeStorageSessionManager,
 )
 from bai_scenario.runner.unwired import unwired
+from bai_scenario.valkey import ScenarioValkey
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
-from ai.backend.common.clients.valkey_client.valkey_schedule.client import ValkeyScheduleClient
-from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.entity.resource_group import ResourceGroupEntityType
 from ai.backend.common.data.entity.session import SessionEntityType
 from ai.backend.common.etcd import AbstractKVStore
@@ -76,6 +75,7 @@ async def adapter(
     validators: V2ActionValidators,
     monitors: ActionMonitors,
     storage: FakeStorageProxyManagerFacingClient,
+    valkey: ScenarioValkey,
 ) -> SessionAdapter:
     provider = V2DBOpsProvider(engine)
     registry: ProcessorRegistry[Any] = ProcessorRegistry(
@@ -88,8 +88,8 @@ async def adapter(
     scheduler_repository = SchedulerRepository(
         engine,
         ReconcileOpsProvider(engine),
-        unwired(ValkeyStatClient, "only a scheduling run reads the per-agent hints"),
-        unwired(ValkeyScheduleClient, "only a scheduling run marks work"),
+        valkey.stat,
+        valkey.schedule,
         config,
         FakeStorageSessionManager({"local": storage}),
     )
@@ -110,7 +110,7 @@ async def adapter(
                     config_provider=config,
                     storage_manager=FakeStorageSessionManager({"local": storage}),
                     event_producer=unwired(EventProducer, "nothing here waits on the event"),
-                    valkey_schedule=unwired(ValkeyScheduleClient, "only a run marks work"),
+                    valkey_schedule=valkey.schedule,
                     network_plugin_ctx=unwired(
                         NetworkPluginContext, "no session asks for a network"
                     ),

--- a/tests/scenario/bai_scenario/manager/user/conftest.py
+++ b/tests/scenario/bai_scenario/manager/user/conftest.py
@@ -10,8 +10,8 @@ from typing import Any
 
 import pytest
 from bai_scenario.runner.unwired import unwired
+from bai_scenario.valkey import ScenarioValkey
 
-from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.entity.domain import DomainEntityType
 from ai.backend.common.data.entity.user import UserEntityType
 from ai.backend.manager.actions.monitors import ActionMonitors
@@ -44,6 +44,7 @@ async def adapter(
     config: ManagerConfigProvider,
     validators: V2ActionValidators,
     monitors: ActionMonitors,
+    valkey: ScenarioValkey,
 ) -> UserAdapter:
     provider = V2DBOpsProvider(engine)
     registry: ProcessorRegistry[Any] = ProcessorRegistry(
@@ -58,7 +59,7 @@ async def adapter(
         registry.group(GroupMeta(UserEntityType())),
         UserService(
             unwired(StorageSessionManager, "only folder work reaches it"),
-            unwired(ValkeyStatClient, "only usage reads reach it"),
+            valkey.stat,
             unwired(AgentRegistry, "only session work reaches the agents"),
             UserRepository(engine, provider, ShareOpsProvider(engine), key_pool),
             unwired(SchedulingController, "only enqueue schedules"),

--- a/tests/scenario/bai_scenario/manager/vfolder/conftest.py
+++ b/tests/scenario/bai_scenario/manager/vfolder/conftest.py
@@ -12,9 +12,9 @@ from bai_scenario.fakes.storage_proxy import (
     FakeStorageSessionManager,
 )
 from bai_scenario.runner.unwired import unwired
+from bai_scenario.valkey import ScenarioValkey
 
 from ai.backend.common.bgtask.bgtask import BackgroundTaskManager
-from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
 from ai.backend.common.data.entity.vfolder import VFolderEntityType
 from ai.backend.common.etcd import AsyncEtcd
 from ai.backend.manager.actions.monitors import ActionMonitors
@@ -55,6 +55,7 @@ async def adapter(
     validators: V2ActionValidators,
     monitors: ActionMonitors,
     storage: FakeStorageProxyManagerFacingClient,
+    valkey: ScenarioValkey,
 ) -> VFolderAdapter:
     provider = V2DBOpsProvider(engine)
     share_provider = ShareOpsProvider(engine)
@@ -77,7 +78,7 @@ async def adapter(
             share_provider,
             KeyProviderPool(providers=[], write_provider_type=KeyProviderType.PLAIN),
         ),
-        valkey_stat_client=MagicMock(spec=ValkeyStatClient),
+        valkey_stat_client=valkey.stat,
     )
     return VFolderAdapter(
         VFolderProcessors(registry.group(GroupMeta(VFolderEntityType())), service),

--- a/tests/scenario/bai_scenario/valkey.py
+++ b/tests/scenario/bai_scenario/valkey.py
@@ -1,0 +1,43 @@
+"""Valkey clients for one test: the real server the container pool runs.
+
+The manager decides which role and which database each client talks to; this asks the
+config the same way, so a scenario reaches the keys the product reaches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Self
+
+from ai.backend.common.clients.valkey_client.valkey_schedule.client import ValkeyScheduleClient
+from ai.backend.common.clients.valkey_client.valkey_stat.client import ValkeyStatClient
+from ai.backend.common.defs import REDIS_LIVE_DB, REDIS_STATISTICS_DB, RedisRole
+from ai.backend.manager.config.provider import ManagerConfigProvider
+
+
+@dataclass(frozen=True)
+class ScenarioValkey:
+    """The clients an adapter under test is handed."""
+
+    stat: ValkeyStatClient
+    schedule: ValkeyScheduleClient
+
+    @classmethod
+    async def create(cls, config: ManagerConfigProvider) -> Self:
+        target = config.config.redis.to_valkey_profile_target()
+        return cls(
+            stat=await ValkeyStatClient.create(
+                target.profile_target(RedisRole.STATISTICS),
+                db_id=REDIS_STATISTICS_DB,
+                human_readable_name="scenario-stat",
+            ),
+            schedule=await ValkeyScheduleClient.create(
+                target.profile_target(RedisRole.STREAM),
+                db_id=REDIS_LIVE_DB,
+                human_readable_name="scenario-schedule",
+            ),
+        )
+
+    async def close(self) -> None:
+        await self.stat.close()
+        await self.schedule.close()

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -25,6 +25,7 @@ from bai_scenario.monitors import ActionRecorder
 from bai_scenario.runner.planting import SeedingSession
 from bai_scenario.seeds.ops import SeedOpsProvider
 from bai_scenario.seeds.seeder import Seeder
+from bai_scenario.valkey import ScenarioValkey
 
 from ai.backend.common.typed_validators import HostPortPair as HostPortPairModel
 from ai.backend.manager.actions.monitors import ActionMonitors
@@ -35,6 +36,7 @@ from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 from ai.backend.manager.repositories.permission_controller.repository import (
     PermissionControllerRepository,
 )
+from ai.backend.testutils.bootstrap import flush_redis
 from ai.backend.testutils.scenario_steps import Configured
 
 pytest_plugins = [
@@ -76,6 +78,28 @@ async def engine(template: TemplateDatabase, test_db: str) -> AsyncIterator[Any]
     await engine.dispose()
 
 
+@pytest.fixture(scope="session")
+def valkey_addr(redis_container: tuple[str, HostPortPairModel]) -> HostPortPairModel:
+    _, addr = redis_container
+    return addr
+
+
+@pytest.fixture
+async def valkey(
+    valkey_addr: HostPortPairModel, config: ManagerConfigProvider
+) -> AsyncIterator[ScenarioValkey]:
+    """The real server, cleared of what the previous test left.
+
+    The database is copied per test; a server has no such thing, so every key goes.
+    """
+    flush_redis(valkey_addr.host, valkey_addr.port)
+    clients = await ScenarioValkey.create(config)
+    try:
+        yield clients
+    finally:
+        await clients.close()
+
+
 @pytest.fixture
 def recorder() -> ActionRecorder:
     return ActionRecorder()
@@ -86,6 +110,7 @@ def config(
     request: pytest.FixtureRequest,
     template: TemplateDatabase,
     test_db: str,
+    valkey_addr: HostPortPairModel,
 ) -> ManagerConfigProvider:
     """The config this test runs under: the base, plus what a scenario overrides.
 
@@ -96,7 +121,7 @@ def config(
     asked = callspec.params.get("scenario") if callspec is not None else None
     overrides = dict(asked.config()) if isinstance(asked, Configured) else {}
     return ScenarioConfigProvider(
-        make_config(base_config_dict(template.addr, test_db, None), overrides)
+        make_config(base_config_dict(template.addr, test_db, valkey_addr), overrides)
     )
 
 


### PR DESCRIPTION
## Summary
- The scenario component conftests stood the Valkey clients up as `unwired` stand-ins and `MagicMock`s. A row that reached one either failed or let a mock value into the response, so the request never ran end to end.
- Wire the pooled redis container the way the database already is: the config carries the real address, and the kit builds the stat and schedule clients from the same roles and database ids the manager uses.
- Isolation is a flush per test — a server has no equivalent of the template-database clone.

## Test plan
- [x] `pants test tests/scenario::` passes with the containers spawned by the pool
- [x] A row reaching a Valkey call answers from the real server instead of raising `NotWired`

Resolves BA-7863

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128bKAiecc6WfVK9VBRjxBv